### PR TITLE
Move ObjectMapper to static final

### DIFF
--- a/src/main/java/io/aiven/klaw/config/ManageDatabase.java
+++ b/src/main/java/io/aiven/klaw/config/ManageDatabase.java
@@ -28,6 +28,7 @@ import org.springframework.context.annotation.Configuration;
 @Slf4j
 public class ManageDatabase implements ApplicationContextAware {
 
+  public static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
   private HandleDbRequests handleDbRequests;
 
   private static Map<Integer, Map<String, Map<String, List<String>>>> envParamsMapPerTenant;
@@ -712,10 +713,9 @@ public class ManageDatabase implements ApplicationContextAware {
         if (kwPropertiesMapPerTenant.get(tenantId).get(TENANT_CONFIG) != null) {
           String kwTenantConfig =
               kwPropertiesMapPerTenant.get(tenantId).get(TENANT_CONFIG).get("kwvalue");
-          ObjectMapper objectMapper = new ObjectMapper();
           TenantConfig dynamicObj;
 
-          dynamicObj = objectMapper.readValue(kwTenantConfig, TenantConfig.class);
+          dynamicObj = OBJECT_MAPPER.readValue(kwTenantConfig, TenantConfig.class);
           setTenantConfig(dynamicObj);
         }
       }

--- a/src/main/java/io/aiven/klaw/service/AclControllerService.java
+++ b/src/main/java/io/aiven/klaw/service/AclControllerService.java
@@ -9,6 +9,7 @@ import static org.springframework.beans.BeanUtils.copyProperties;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.ObjectWriter;
 import io.aiven.klaw.config.ManageDatabase;
 import io.aiven.klaw.dao.Acl;
 import io.aiven.klaw.dao.AclRequests;
@@ -51,6 +52,9 @@ import org.springframework.stereotype.Service;
 @Service
 @Slf4j
 public class AclControllerService {
+  public static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+  public static final ObjectWriter WRITER_WITH_DEFAULT_PRETTY_PRINTER =
+      OBJECT_MAPPER.writerWithDefaultPrettyPrinter();
   @Autowired ManageDatabase manageDatabase;
 
   @Autowired private final MailUtils mailService;
@@ -901,7 +905,6 @@ public class AclControllerService {
     List<TopicInfo> topicInfoList = new ArrayList<>();
     ArrayList<TopicHistory> topicHistoryFromTopic;
     List<TopicHistory> topicHistoryList = new ArrayList<>();
-    ObjectMapper objectMapper = new ObjectMapper();
 
     for (Topic topic : topics) {
       TopicInfo topicInfo = new TopicInfo();
@@ -918,7 +921,7 @@ public class AclControllerService {
 
       if (topic.getHistory() != null) {
         try {
-          topicHistoryFromTopic = objectMapper.readValue(topic.getHistory(), ArrayList.class);
+          topicHistoryFromTopic = OBJECT_MAPPER.readValue(topic.getHistory(), ArrayList.class);
           topicHistoryList.addAll(topicHistoryFromTopic);
         } catch (JsonProcessingException e) {
           log.error("Unable to parse topicHistory");
@@ -1049,13 +1052,11 @@ public class AclControllerService {
       boolean retrieveSchemas,
       TopicOverview topicOverview,
       int tenantId) {
-    ObjectMapper objectMapper;
     if (topicOverview.isTopicExists() && retrieveSchemas) {
       List<Map<String, String>> schemaDetails = new ArrayList<>();
       Map<String, String> schemaMap = new HashMap<>();
       List<Env> schemaEnvs = handleDb.selectAllSchemaRegEnvs(tenantId);
       Object dynamicObj;
-      objectMapper = new ObjectMapper();
       Map<String, Object> hashMapSchemaObj;
       String schemaOfObj;
       for (Env schemaEnv : schemaEnvs) {
@@ -1123,9 +1124,8 @@ public class AclControllerService {
           }
 
           schemaMap.put("env", schemaEnv.getName());
-          dynamicObj = objectMapper.readValue(schemaOfObj, Object.class);
-          schemaOfObj =
-              objectMapper.writerWithDefaultPrettyPrinter().writeValueAsString(dynamicObj);
+          dynamicObj = OBJECT_MAPPER.readValue(schemaOfObj, Object.class);
+          schemaOfObj = WRITER_WITH_DEFAULT_PRETTY_PRINTER.writeValueAsString(dynamicObj);
           schemaMap.put("content", schemaOfObj);
 
           schemaDetails.add(schemaMap);

--- a/src/main/java/io/aiven/klaw/service/ClusterApiService.java
+++ b/src/main/java/io/aiven/klaw/service/ClusterApiService.java
@@ -63,6 +63,7 @@ import org.springframework.web.client.RestTemplate;
 @Slf4j
 public class ClusterApiService {
 
+  public static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
   @Autowired ManageDatabase manageDatabase;
 
   @Value("${server.ssl.trust-store:null}")
@@ -561,8 +562,7 @@ public class ClusterApiService {
 
         if (Objects.equals(AclOperation.DELETE.value, aclReq.getAclType())
             && null != aclReq.getJsonParams()) {
-          ObjectMapper objectMapper = new ObjectMapper();
-          Map<String, String> jsonObj = objectMapper.readValue(aclReq.getJsonParams(), Map.class);
+          Map<String, String> jsonObj = OBJECT_MAPPER.readValue(aclReq.getJsonParams(), Map.class);
           String aivenAclKey = "aivenaclid";
           if (jsonObj.containsKey(aivenAclKey)) params.add(aivenAclKey, jsonObj.get(aivenAclKey));
           else {

--- a/src/main/java/io/aiven/klaw/service/KafkaConnectSyncControllerService.java
+++ b/src/main/java/io/aiven/klaw/service/KafkaConnectSyncControllerService.java
@@ -2,6 +2,7 @@ package io.aiven.klaw.service;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.ObjectWriter;
 import io.aiven.klaw.config.ManageDatabase;
 import io.aiven.klaw.dao.Env;
 import io.aiven.klaw.dao.KwClusters;
@@ -29,6 +30,9 @@ import org.springframework.stereotype.Service;
 @Slf4j
 public class KafkaConnectSyncControllerService {
 
+  public static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+  public static final ObjectWriter WRITER_WITH_DEFAULT_PRETTY_PRINTER =
+      OBJECT_MAPPER.writerWithDefaultPrettyPrinter();
   @Autowired private CommonUtilsService commonUtilsService;
 
   @Autowired ClusterApiService clusterApiService;
@@ -50,9 +54,8 @@ public class KafkaConnectSyncControllerService {
         clusterApiService.getConnectorDetails(
             connectorName, kwClusters.getBootstrapServers(), kwClusters.getProtocol(), tenantId);
 
-    ObjectMapper objectMapper = new ObjectMapper();
     try {
-      String schemaOfObj = objectMapper.writerWithDefaultPrettyPrinter().writeValueAsString(res);
+      String schemaOfObj = OBJECT_MAPPER.writerWithDefaultPrettyPrinter().writeValueAsString(res);
       response.put("result", schemaOfObj);
       return response;
     } catch (JsonProcessingException e) {
@@ -255,8 +258,7 @@ public class KafkaConnectSyncControllerService {
             .getConnectorDetails(
                 connectorName, kwClusters.getBootstrapServers(), kwClusters.getProtocol(), tenantId)
             .get("config");
-    ObjectMapper om = new ObjectMapper();
-    return om.writerWithDefaultPrettyPrinter().writeValueAsString(configMap);
+    return WRITER_WITH_DEFAULT_PRETTY_PRINTER.writeValueAsString(configMap);
   }
 
   private List<SyncConnectorUpdates> handleConnectorDeletes(

--- a/src/main/java/io/aiven/klaw/service/ServerConfigService.java
+++ b/src/main/java/io/aiven/klaw/service/ServerConfigService.java
@@ -3,6 +3,7 @@ package io.aiven.klaw.service;
 import static org.springframework.beans.BeanUtils.copyProperties;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.ObjectWriter;
 import io.aiven.klaw.config.ManageDatabase;
 import io.aiven.klaw.dao.Env;
 import io.aiven.klaw.dao.KwProperties;
@@ -31,6 +32,9 @@ import org.springframework.stereotype.Service;
 @Slf4j
 public class ServerConfigService {
 
+  public static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+  public static final ObjectWriter WRITER_WITH_DEFAULT_PRETTY_PRINTER =
+      OBJECT_MAPPER.writerWithDefaultPrettyPrinter();
   @Autowired private Environment env;
 
   @Autowired ManageDatabase manageDatabase;
@@ -115,12 +119,11 @@ public class ServerConfigService {
       resultMap.put("kwkey", kwKey);
 
       if (KwConstants.TENANT_CONFIG_PROPERTY.equals(kwKey)) {
-        ObjectMapper objectMapper = new ObjectMapper();
         TenantConfig dynamicObj;
         try {
-          dynamicObj = objectMapper.readValue(kwVal, TenantConfig.class);
+          dynamicObj = OBJECT_MAPPER.readValue(kwVal, TenantConfig.class);
           updateEnvNameValues(dynamicObj, tenantId);
-          kwVal = objectMapper.writerWithDefaultPrettyPrinter().writeValueAsString(dynamicObj);
+          kwVal = WRITER_WITH_DEFAULT_PRETTY_PRINTER.writeValueAsString(dynamicObj);
           resultMap.put("kwvalue", kwVal);
           resultMap.put("kwdesc", stringStringEntry.getValue().get("kwdesc"));
 
@@ -171,13 +174,12 @@ public class ServerConfigService {
 
     try {
       if (KwConstants.TENANT_CONFIG_PROPERTY.equals(kwKey)) {
-        ObjectMapper objectMapper = new ObjectMapper();
         TenantConfig dynamicObj;
         try {
-          dynamicObj = objectMapper.readValue(kwVal, TenantConfig.class);
+          dynamicObj = OBJECT_MAPPER.readValue(kwVal, TenantConfig.class);
           if (validateTenantConfig(dynamicObj, tenantId)) {
             updateEnvIdValues(dynamicObj);
-            kwPropertiesModel.setKwValue(objectMapper.writeValueAsString(dynamicObj));
+            kwPropertiesModel.setKwValue(OBJECT_MAPPER.writeValueAsString(dynamicObj));
           } else {
             response.put(
                 "result",

--- a/src/main/java/io/aiven/klaw/service/TopicControllerService.java
+++ b/src/main/java/io/aiven/klaw/service/TopicControllerService.java
@@ -49,6 +49,7 @@ import org.springframework.stereotype.Service;
 @Slf4j
 public class TopicControllerService {
 
+  public static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
   @Autowired private final ClusterApiService clusterApiService;
 
   @Autowired ManageDatabase manageDatabase;
@@ -746,7 +747,6 @@ public class TopicControllerService {
 
   private void setTopicHistory(TopicRequest topicRequest, String userName, int tenantId) {
     try {
-      ObjectMapper objectMapper = new ObjectMapper();
       AtomicReference<String> existingHistory = new AtomicReference<>("");
       List<TopicHistory> existingTopicHistory;
       List<TopicHistory> topicHistoryList = new ArrayList<>();
@@ -758,7 +758,7 @@ public class TopicControllerService {
             .filter(topic -> Objects.equals(topic.getEnvironment(), topicRequest.getEnvironment()))
             .findFirst()
             .ifPresent(a -> existingHistory.set(a.getHistory()));
-        existingTopicHistory = objectMapper.readValue(existingHistory.get(), ArrayList.class);
+        existingTopicHistory = OBJECT_MAPPER.readValue(existingHistory.get(), ArrayList.class);
         topicHistoryList.addAll(existingTopicHistory);
       }
 
@@ -775,7 +775,7 @@ public class TopicControllerService {
       topicHistory.setRemarks(topicRequest.getTopictype());
       topicHistoryList.add(topicHistory);
 
-      topicRequest.setHistory(objectMapper.writer().writeValueAsString(topicHistoryList));
+      topicRequest.setHistory(OBJECT_MAPPER.writer().writeValueAsString(topicHistoryList));
     } catch (Exception e) {
       log.error("Exception: ", e);
     }

--- a/src/test/java/io/aiven/klaw/EnvsClustersTenantsControllerIT.java
+++ b/src/test/java/io/aiven/klaw/EnvsClustersTenantsControllerIT.java
@@ -36,6 +36,7 @@ import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 @DirtiesContext
 public class EnvsClustersTenantsControllerIT {
 
+  public static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
   private static MockMethods mockMethods;
   private static final String superAdmin = "superadmin";
   private static final String superAdminPwd = "kwsuperadmin123$$";
@@ -62,7 +63,7 @@ public class EnvsClustersTenantsControllerIT {
             .getResponse()
             .getContentAsString();
 
-    List<KwTenantModel> teamModel = new ObjectMapper().readValue(response, List.class);
+    List<KwTenantModel> teamModel = OBJECT_MAPPER.readValue(response, List.class);
     assertThat(teamModel).hasSize(1);
   }
 
@@ -71,7 +72,7 @@ public class EnvsClustersTenantsControllerIT {
   @Order(2)
   public void addTenantSuccess() throws Exception {
     KwTenantModel kwTenantModel = mockMethods.getTenantModel("nltenant12345678");
-    String jsonReq = new ObjectMapper().writer().writeValueAsString(kwTenantModel);
+    String jsonReq = OBJECT_MAPPER.writer().writeValueAsString(kwTenantModel);
 
     String response =
         mvc.perform(
@@ -98,7 +99,7 @@ public class EnvsClustersTenantsControllerIT {
             .getResponse()
             .getContentAsString();
 
-    List<KwTenantModel> teamModel = new ObjectMapper().readValue(response, List.class);
+    List<KwTenantModel> teamModel = OBJECT_MAPPER.readValue(response, List.class);
     assertThat(teamModel).hasSize(2);
   }
 
@@ -107,7 +108,7 @@ public class EnvsClustersTenantsControllerIT {
   @Order(3)
   public void addClusterSuccess() throws Exception {
     KwClustersModel kwClustersModel = mockMethods.getClusterModel("DEV_CLUSTER");
-    String jsonReq = new ObjectMapper().writer().writeValueAsString(kwClustersModel);
+    String jsonReq = OBJECT_MAPPER.writer().writeValueAsString(kwClustersModel);
 
     String response =
         mvc.perform(
@@ -135,7 +136,7 @@ public class EnvsClustersTenantsControllerIT {
             .getResponse()
             .getContentAsString();
 
-    List<KwClustersModel> teamModel = new ObjectMapper().readValue(response, List.class);
+    List<KwClustersModel> teamModel = OBJECT_MAPPER.readValue(response, List.class);
     assertThat(teamModel).hasSize(1);
   }
 
@@ -155,7 +156,7 @@ public class EnvsClustersTenantsControllerIT {
             .getResponse()
             .getContentAsString();
 
-    List clusterModels = new ObjectMapper().readValue(response, List.class);
+    List clusterModels = OBJECT_MAPPER.readValue(response, List.class);
     assertThat(clusterModels).hasSize(1);
 
     Map<String, Integer> linkedHashMap = (Map<String, Integer>) clusterModels.get(0);
@@ -163,7 +164,7 @@ public class EnvsClustersTenantsControllerIT {
     KwClustersModel kwClustersModel = mockMethods.getClusterModel("DEV_CLUSTER");
     kwClustersModel.setClusterId(linkedHashMap.get("clusterId"));
     kwClustersModel.setBootstrapServers("localhost:9093");
-    String jsonReq = new ObjectMapper().writer().writeValueAsString(kwClustersModel);
+    String jsonReq = OBJECT_MAPPER.writer().writeValueAsString(kwClustersModel);
     response =
         mvc.perform(
                 MockMvcRequestBuilders.post("/addNewCluster")
@@ -196,7 +197,7 @@ public class EnvsClustersTenantsControllerIT {
             .getResponse()
             .getContentAsString();
 
-    KwClustersModel clusterModel = new ObjectMapper().readValue(response, KwClustersModel.class);
+    KwClustersModel clusterModel = OBJECT_MAPPER.readValue(response, KwClustersModel.class);
     assertThat(clusterModel.getClusterName()).contains("DEV_CLUSTER");
   }
 
@@ -205,7 +206,7 @@ public class EnvsClustersTenantsControllerIT {
   @Order(6)
   public void addAndDeleteClusterSuccess() throws Exception {
     KwClustersModel kwClustersModel = mockMethods.getClusterModel("TST_CLUSTER");
-    String jsonReq = new ObjectMapper().writer().writeValueAsString(kwClustersModel);
+    String jsonReq = OBJECT_MAPPER.writer().writeValueAsString(kwClustersModel);
 
     String response =
         mvc.perform(
@@ -233,7 +234,7 @@ public class EnvsClustersTenantsControllerIT {
             .getResponse()
             .getContentAsString();
 
-    List clusterModels = new ObjectMapper().readValue(response, List.class);
+    List clusterModels = OBJECT_MAPPER.readValue(response, List.class);
     assertThat(clusterModels).hasSize(2);
 
     Map<String, Integer> linkedHashMap = (Map) clusterModels.get(0);
@@ -265,7 +266,7 @@ public class EnvsClustersTenantsControllerIT {
             .getResponse()
             .getContentAsString();
 
-    clusterModels = new ObjectMapper().readValue(response, List.class);
+    clusterModels = OBJECT_MAPPER.readValue(response, List.class);
     assertThat(clusterModels).hasSize(1);
   }
 
@@ -275,7 +276,7 @@ public class EnvsClustersTenantsControllerIT {
   public void addNewEnvSuccess() throws Exception {
     EnvModel envModel = mockMethods.getEnvModel("DEV");
     envModel.setClusterId(2);
-    String jsonReq = new ObjectMapper().writer().writeValueAsString(envModel);
+    String jsonReq = OBJECT_MAPPER.writer().writeValueAsString(envModel);
 
     String response =
         mvc.perform(
@@ -302,7 +303,7 @@ public class EnvsClustersTenantsControllerIT {
             .getResponse()
             .getContentAsString();
 
-    List clusterModels = new ObjectMapper().readValue(response, List.class);
+    List clusterModels = OBJECT_MAPPER.readValue(response, List.class);
     assertThat(clusterModels).hasSize(1);
   }
 
@@ -322,7 +323,7 @@ public class EnvsClustersTenantsControllerIT {
             .getResponse()
             .getContentAsString();
 
-    List clusterModels = new ObjectMapper().readValue(response, List.class);
+    List clusterModels = OBJECT_MAPPER.readValue(response, List.class);
     Map<String, Object> envModel1 = (Map<String, Object>) clusterModels.get(0);
     String envId = (String) envModel1.get("id");
     assertThat(clusterModels).hasSize(1);
@@ -333,7 +334,7 @@ public class EnvsClustersTenantsControllerIT {
     envModel.setId(envId);
     envModel.setClusterId(2);
     envModel.setOtherParams(otherParams);
-    String jsonReq = new ObjectMapper().writer().writeValueAsString(envModel);
+    String jsonReq = OBJECT_MAPPER.writer().writeValueAsString(envModel);
 
     response =
         mvc.perform(
@@ -360,7 +361,7 @@ public class EnvsClustersTenantsControllerIT {
             .getResponse()
             .getContentAsString();
 
-    clusterModels = new ObjectMapper().readValue(response, List.class);
+    clusterModels = OBJECT_MAPPER.readValue(response, List.class);
     Map<String, Object> envModel3 = (Map<String, Object>) clusterModels.get(0);
     String updatedOtherParams = (String) envModel3.get("otherParams");
     assertThat(updatedOtherParams).isEqualTo(otherParams);
@@ -384,7 +385,7 @@ public class EnvsClustersTenantsControllerIT {
             .getResponse()
             .getContentAsString();
 
-    EnvModel envModel = new ObjectMapper().readValue(response, EnvModel.class);
+    EnvModel envModel = OBJECT_MAPPER.readValue(response, EnvModel.class);
     assertThat(envModel.getName()).isEqualTo("DEV");
   }
 
@@ -393,7 +394,7 @@ public class EnvsClustersTenantsControllerIT {
   @Order(10)
   public void deleteEnvSuccess() throws Exception {
     EnvModel envModel = mockMethods.getEnvModel("ACC");
-    String jsonReq = new ObjectMapper().writer().writeValueAsString(envModel);
+    String jsonReq = OBJECT_MAPPER.writer().writeValueAsString(envModel);
 
     String response =
         mvc.perform(
@@ -420,7 +421,7 @@ public class EnvsClustersTenantsControllerIT {
             .getResponse()
             .getContentAsString();
 
-    List clusterModels = new ObjectMapper().readValue(response, List.class);
+    List clusterModels = OBJECT_MAPPER.readValue(response, List.class);
     assertThat(clusterModels).hasSize(1);
 
     response =
@@ -457,7 +458,7 @@ public class EnvsClustersTenantsControllerIT {
             .getResponse()
             .getContentAsString();
 
-    HashMap clusterModels = new ObjectMapper().readValue(response, HashMap.class);
+    HashMap clusterModels = OBJECT_MAPPER.readValue(response, HashMap.class);
     ArrayList<String> defaultPartitions = (ArrayList) clusterModels.get("defaultPartitions");
     assertThat(defaultPartitions.get(0)).isEqualTo("4");
   }
@@ -478,7 +479,7 @@ public class EnvsClustersTenantsControllerIT {
             .getResponse()
             .getContentAsString();
 
-    List clusterModels = new ObjectMapper().readValue(response, List.class);
+    List clusterModels = OBJECT_MAPPER.readValue(response, List.class);
     assertThat(clusterModels.get(0)).isEqualTo("ACC");
   }
 }

--- a/src/test/java/io/aiven/klaw/TopicAclControllerIT.java
+++ b/src/test/java/io/aiven/klaw/TopicAclControllerIT.java
@@ -60,6 +60,7 @@ public class TopicAclControllerIT {
 
   private static final String INFRATEAM = "INFRATEAM";
   private static final String PASSWORD = "user";
+  public static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
   private static UtilMethods utilMethods;
 
   private static MockMethods mockMethods;
@@ -90,7 +91,7 @@ public class TopicAclControllerIT {
   public void createRequiredUsers() throws Exception {
     String role = "USER";
     UserInfoModel userInfoModel = mockMethods.getUserInfoModel(user1, role, INFRATEAM);
-    String jsonReq = new ObjectMapper().writer().writeValueAsString(userInfoModel);
+    String jsonReq = OBJECT_MAPPER.writer().writeValueAsString(userInfoModel);
 
     String response =
         mvc.perform(
@@ -107,7 +108,7 @@ public class TopicAclControllerIT {
     assertThat(response).contains("success");
 
     userInfoModel = mockMethods.getUserInfoModel(user2, role, "INFRATEAM");
-    jsonReq = new ObjectMapper().writer().writeValueAsString(userInfoModel);
+    jsonReq = OBJECT_MAPPER.writer().writeValueAsString(userInfoModel);
 
     response =
         mvc.perform(
@@ -126,7 +127,7 @@ public class TopicAclControllerIT {
   @Order(2)
   public void addNewCluster() throws Exception {
     KwClustersModel kwClustersModel = mockMethods.getClusterModel("DEV_CLUSTER");
-    String jsonReq = new ObjectMapper().writer().writeValueAsString(kwClustersModel);
+    String jsonReq = OBJECT_MAPPER.writer().writeValueAsString(kwClustersModel);
 
     String response =
         mvc.perform(
@@ -154,7 +155,7 @@ public class TopicAclControllerIT {
             .getResponse()
             .getContentAsString();
 
-    List<KwClustersModel> teamModel = new ObjectMapper().readValue(response, List.class);
+    List<KwClustersModel> teamModel = OBJECT_MAPPER.readValue(response, List.class);
     assertThat(teamModel).hasSize(1);
   }
 
@@ -162,7 +163,7 @@ public class TopicAclControllerIT {
   @Order(3)
   public void createEnv() throws Exception {
     EnvModel envModel = mockMethods.getEnvModel("DEV");
-    String jsonReq = new ObjectMapper().writer().writeValueAsString(envModel);
+    String jsonReq = OBJECT_MAPPER.writer().writeValueAsString(envModel);
 
     String response =
         mvc.perform(
@@ -189,7 +190,7 @@ public class TopicAclControllerIT {
             .getResponse()
             .getContentAsString();
 
-    List clusterModels = new ObjectMapper().readValue(response, List.class);
+    List clusterModels = OBJECT_MAPPER.readValue(response, List.class);
     assertThat(clusterModels).hasSize(1);
   }
 
@@ -208,7 +209,7 @@ public class TopicAclControllerIT {
             + "      \"requestTopicsEnvironmentsList\": [\"DEV\"]\n"
             + "    }\n"
             + "}");
-    String jsonReq = new ObjectMapper().writer().writeValueAsString(kwPropertiesModel);
+    String jsonReq = OBJECT_MAPPER.writer().writeValueAsString(kwPropertiesModel);
 
     String response =
         mvc.perform(
@@ -230,7 +231,7 @@ public class TopicAclControllerIT {
   @Order(5)
   public void createTopicRequest() throws Exception {
     TopicRequestModel addTopicRequest = utilMethods.getTopicRequestModel(topicId);
-    String jsonReq = new ObjectMapper().writer().writeValueAsString(addTopicRequest);
+    String jsonReq = OBJECT_MAPPER.writer().writeValueAsString(addTopicRequest);
     login(user1, PASSWORD, "USER");
     String response =
         mvc.perform(
@@ -263,7 +264,7 @@ public class TopicAclControllerIT {
             .getResponse()
             .getContentAsString();
 
-    List<TopicRequest> response = new ObjectMapper().readValue(res, List.class);
+    List<TopicRequest> response = OBJECT_MAPPER.readValue(res, List.class);
     assertThat(response).hasSize(1);
   }
 
@@ -283,7 +284,7 @@ public class TopicAclControllerIT {
             .getResponse()
             .getContentAsString();
 
-    List<TopicRequest> response = new ObjectMapper().readValue(res, List.class);
+    List<TopicRequest> response = OBJECT_MAPPER.readValue(res, List.class);
     assertThat(response).hasSize(1);
   }
 
@@ -319,7 +320,7 @@ public class TopicAclControllerIT {
   public void declineTopicRequest() throws Exception {
     int topicIdLocal = 1002;
     TopicRequestModel addTopicRequest = utilMethods.getTopicRequestModel(topicIdLocal);
-    String jsonReq = new ObjectMapper().writer().writeValueAsString(addTopicRequest);
+    String jsonReq = OBJECT_MAPPER.writer().writeValueAsString(addTopicRequest);
     login(user1, PASSWORD, "USER");
     String response =
         mvc.perform(
@@ -378,7 +379,7 @@ public class TopicAclControllerIT {
   public void deleteTopicRequest() throws Exception {
 
     TopicRequestModel addTopicRequest = utilMethods.getTopicRequestModel(1003);
-    String jsonReq = new ObjectMapper().writer().writeValueAsString(addTopicRequest);
+    String jsonReq = OBJECT_MAPPER.writer().writeValueAsString(addTopicRequest);
     login(user1, PASSWORD, "USER");
     String response =
         mvc.perform(
@@ -430,7 +431,7 @@ public class TopicAclControllerIT {
             .getResponse()
             .getContentAsString();
 
-    List<List<TopicInfo>> response = new ObjectMapper().readValue(res, List.class);
+    List<List<TopicInfo>> response = OBJECT_MAPPER.readValue(res, List.class);
     assertThat(response).hasSize(1);
     assertThat(response.get(0)).hasSize(1);
   }
@@ -454,7 +455,7 @@ public class TopicAclControllerIT {
             .getResponse()
             .getContentAsString();
 
-    List<String> response = new ObjectMapper().readValue(res, List.class);
+    List<String> response = OBJECT_MAPPER.readValue(res, List.class);
     assertThat(response).hasSize(1);
     assertThat(response.get(0)).isEqualTo("testtopic1001");
   }
@@ -476,7 +477,7 @@ public class TopicAclControllerIT {
             .getResponse()
             .getContentAsString();
 
-    List<AclRequests> response = new ObjectMapper().readValue(res, List.class);
+    List<AclRequests> response = OBJECT_MAPPER.readValue(res, List.class);
     assertThat(response).isEmpty();
   }
 
@@ -496,7 +497,7 @@ public class TopicAclControllerIT {
             .getResponse()
             .getContentAsString();
 
-    List<List<AclRequests>> response = new ObjectMapper().readValue(res, List.class);
+    List<List<AclRequests>> response = OBJECT_MAPPER.readValue(res, List.class);
     assertThat(response).isEmpty();
   }
 
@@ -505,7 +506,7 @@ public class TopicAclControllerIT {
   @Test
   public void aclRequest() throws Exception {
     AclRequestsModel addAclRequest = utilMethods.getAclRequestModel(topicName + topicId);
-    String jsonReq = new ObjectMapper().writer().writeValueAsString(addAclRequest);
+    String jsonReq = OBJECT_MAPPER.writer().writeValueAsString(addAclRequest);
 
     String response =
         mvc.perform(
@@ -539,7 +540,7 @@ public class TopicAclControllerIT {
             .getResponse()
             .getContentAsString();
 
-    List<List<AclRequests>> response = new ObjectMapper().readValue(res, List.class);
+    List<List<AclRequests>> response = OBJECT_MAPPER.readValue(res, List.class);
     assertThat(response).hasSize(1);
   }
 
@@ -559,7 +560,7 @@ public class TopicAclControllerIT {
             .getResponse()
             .getContentAsString();
 
-    List response = new ObjectMapper().readValue(res, List.class);
+    List response = OBJECT_MAPPER.readValue(res, List.class);
     Object obj = response.get(0);
     LinkedHashMap<String, Integer> hMap = (LinkedHashMap) obj;
 
@@ -590,7 +591,7 @@ public class TopicAclControllerIT {
   @Test
   public void requestAnAcl() throws Exception {
     AclRequestsModel addAclRequest = utilMethods.getAclRequestModel(topicName + topicId);
-    String jsonReq = new ObjectMapper().writer().writeValueAsString(addAclRequest);
+    String jsonReq = OBJECT_MAPPER.writer().writeValueAsString(addAclRequest);
 
     String response =
         mvc.perform(
@@ -623,7 +624,7 @@ public class TopicAclControllerIT {
             .getResponse()
             .getContentAsString();
 
-    List response = new ObjectMapper().readValue(res, List.class);
+    List response = OBJECT_MAPPER.readValue(res, List.class);
     Object obj = response.get(0);
     LinkedHashMap<String, Integer> hMap = (LinkedHashMap) obj;
     Integer reqNo = hMap.get("req_no");
@@ -660,7 +661,7 @@ public class TopicAclControllerIT {
             .getResponse()
             .getContentAsString();
 
-    List<AclRequests> response = new ObjectMapper().readValue(res, List.class);
+    List<AclRequests> response = OBJECT_MAPPER.readValue(res, List.class);
     Object obj = response.get(0);
     LinkedHashMap<String, Integer> hMap = (LinkedHashMap) obj;
 
@@ -699,7 +700,7 @@ public class TopicAclControllerIT {
             .getResponse()
             .getContentAsString();
 
-    TopicOverview response = new ObjectMapper().readValue(res, TopicOverview.class);
+    TopicOverview response = OBJECT_MAPPER.readValue(res, TopicOverview.class);
     assertThat(response.getAclInfoList()).hasSize(1);
   }
 
@@ -725,7 +726,7 @@ public class TopicAclControllerIT {
             .getResponse()
             .getContentAsString();
 
-    List<AclInfo> response = new ObjectMapper().readValue(res, List.class);
+    List<AclInfo> response = OBJECT_MAPPER.readValue(res, List.class);
     assertThat(response).hasSize(1);
   }
 

--- a/src/test/java/io/aiven/klaw/UsersTeamsControllerIT.java
+++ b/src/test/java/io/aiven/klaw/UsersTeamsControllerIT.java
@@ -32,6 +32,7 @@ import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 public class UsersTeamsControllerIT {
 
   private static final String INFRATEAM_ID = "1001";
+  public static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
 
   private static MockMethods mockMethods;
 
@@ -57,7 +58,7 @@ public class UsersTeamsControllerIT {
   public void createRequiredUsers() throws Exception {
     String role = "USER";
     UserInfoModel userInfoModel = mockMethods.getUserInfoModel(user1, role, INFRATEAM);
-    String jsonReq = new ObjectMapper().writer().writeValueAsString(userInfoModel);
+    String jsonReq = OBJECT_MAPPER.writer().writeValueAsString(userInfoModel);
 
     String response =
         mvc.perform(
@@ -74,7 +75,7 @@ public class UsersTeamsControllerIT {
     //        assertThat(response, CoreMatchers.containsString("success"));
 
     userInfoModel = mockMethods.getUserInfoModel(user2, role, "INFRATEAM");
-    jsonReq = new ObjectMapper().writer().writeValueAsString(userInfoModel);
+    jsonReq = OBJECT_MAPPER.writer().writeValueAsString(userInfoModel);
 
     response =
         mvc.perform(
@@ -96,7 +97,7 @@ public class UsersTeamsControllerIT {
   @Order(1)
   public void createTeamSuccess() throws Exception {
     TeamModel teamModelRequest = mockMethods.getTeamModel(teamName);
-    String jsonReq = new ObjectMapper().writer().writeValueAsString(teamModelRequest);
+    String jsonReq = OBJECT_MAPPER.writer().writeValueAsString(teamModelRequest);
 
     String response =
         mvc.perform(
@@ -125,7 +126,7 @@ public class UsersTeamsControllerIT {
             .getResponse()
             .getContentAsString();
 
-    TeamModel teamModel = new ObjectMapper().readValue(response, TeamModel.class);
+    TeamModel teamModel = OBJECT_MAPPER.readValue(response, TeamModel.class);
     assertThat(teamModel.getTeamname()).isEqualTo(teamName);
   }
 
@@ -134,7 +135,7 @@ public class UsersTeamsControllerIT {
   @Order(2)
   public void createSameTeamAgainFailure() throws Exception {
     TeamModel teamModelRequest = mockMethods.getTeamModel(teamName);
-    String jsonReq = new ObjectMapper().writer().writeValueAsString(teamModelRequest);
+    String jsonReq = OBJECT_MAPPER.writer().writeValueAsString(teamModelRequest);
 
     String response =
         mvc.perform(
@@ -156,7 +157,7 @@ public class UsersTeamsControllerIT {
   @Order(3)
   public void createTeamWithInvalidEmailId() throws Exception {
     TeamModel teamModelRequest = mockMethods.getTeamModelFailure(teamName);
-    String jsonReq = new ObjectMapper().writer().writeValueAsString(teamModelRequest);
+    String jsonReq = OBJECT_MAPPER.writer().writeValueAsString(teamModelRequest);
 
     String response =
         mvc.perform(
@@ -181,7 +182,7 @@ public class UsersTeamsControllerIT {
     teamModelRequest.setTeamId(1003);
     teamModelRequest.setTeammail(emailId);
 
-    String jsonReq = new ObjectMapper().writer().writeValueAsString(teamModelRequest);
+    String jsonReq = OBJECT_MAPPER.writer().writeValueAsString(teamModelRequest);
 
     String response =
         mvc.perform(
@@ -210,7 +211,7 @@ public class UsersTeamsControllerIT {
             .getResponse()
             .getContentAsString();
 
-    TeamModel teamModel = new ObjectMapper().readValue(response, TeamModel.class);
+    TeamModel teamModel = OBJECT_MAPPER.readValue(response, TeamModel.class);
     assertThat(teamModel.getTeammail()).isEqualTo(emailId);
   }
 
@@ -219,7 +220,7 @@ public class UsersTeamsControllerIT {
   @Order(6)
   public void createTeamFailureNotAuthorized() throws Exception {
     TeamModel teamModelRequest = mockMethods.getTeamModel(teamName);
-    String jsonReq = new ObjectMapper().writer().writeValueAsString(teamModelRequest);
+    String jsonReq = OBJECT_MAPPER.writer().writeValueAsString(teamModelRequest);
 
     String response =
         mvc.perform(
@@ -242,7 +243,7 @@ public class UsersTeamsControllerIT {
   public void deleteTeamSuccess() throws Exception {
     String newTeam = "Testteam";
     TeamModel teamModelRequest = mockMethods.getTeamModel(newTeam);
-    String jsonReq = new ObjectMapper().writer().writeValueAsString(teamModelRequest);
+    String jsonReq = OBJECT_MAPPER.writer().writeValueAsString(teamModelRequest);
 
     String response =
         mvc.perform(
@@ -357,7 +358,7 @@ public class UsersTeamsControllerIT {
             .getResponse()
             .getContentAsString();
 
-    List<TeamModel> teamModels = new ObjectMapper().readValue(response, List.class);
+    List<TeamModel> teamModels = OBJECT_MAPPER.readValue(response, List.class);
     assertThat(teamModels).hasSize(3);
   }
 }

--- a/src/test/java/io/aiven/klaw/controller/AclControllerTest.java
+++ b/src/test/java/io/aiven/klaw/controller/AclControllerTest.java
@@ -31,6 +31,7 @@ import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
 public class AclControllerTest {
 
+  public static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
   @MockBean private AclControllerService aclControllerService;
 
   private UtilMethods utilMethods;
@@ -54,7 +55,7 @@ public class AclControllerTest {
   @Order(1)
   public void createAcl() throws Exception {
     AclRequestsModel addAclRequest = utilMethods.getAclRequestModel(topicName + topicId);
-    String jsonReq = new ObjectMapper().writer().writeValueAsString(addAclRequest);
+    String jsonReq = OBJECT_MAPPER.writer().writeValueAsString(addAclRequest);
     when(aclControllerService.createAcl(any())).thenReturn("success");
 
     String response =
@@ -75,7 +76,7 @@ public class AclControllerTest {
   public void updateSyncAcls() throws Exception {
     List<SyncAclUpdates> syncUpdates = utilMethods.getSyncAclsUpdates();
 
-    String jsonReq = new ObjectMapper().writer().writeValueAsString(syncUpdates);
+    String jsonReq = OBJECT_MAPPER.writer().writeValueAsString(syncUpdates);
     Map<String, String> result = new HashMap<>();
     result.put("result", "success");
     when(aclControllerService.updateSyncAcls(any())).thenReturn(result);
@@ -115,7 +116,7 @@ public class AclControllerTest {
             .getResponse()
             .getContentAsString();
 
-    List<AclRequestsModel> response = new ObjectMapper().readValue(res, List.class);
+    List<AclRequestsModel> response = OBJECT_MAPPER.readValue(res, List.class);
     assertThat(response).hasSize(1);
   }
 
@@ -137,7 +138,7 @@ public class AclControllerTest {
             .getResponse()
             .getContentAsString();
 
-    List<List<AclRequestsModel>> response = new ObjectMapper().readValue(res, List.class);
+    List<List<AclRequestsModel>> response = OBJECT_MAPPER.readValue(res, List.class);
     assertThat(response).hasSize(1);
   }
 
@@ -213,7 +214,7 @@ public class AclControllerTest {
             .getResponse()
             .getContentAsString();
 
-    TopicOverview response = new ObjectMapper().readValue(res, TopicOverview.class);
+    TopicOverview response = OBJECT_MAPPER.readValue(res, TopicOverview.class);
     assertThat(response.getAclInfoList()).hasSize(1);
   }
 
@@ -253,7 +254,7 @@ public class AclControllerTest {
             .getResponse()
             .getContentAsString();
 
-    List<AclInfo> response = new ObjectMapper().readValue(res, List.class);
+    List<AclInfo> response = OBJECT_MAPPER.readValue(res, List.class);
     assertThat(response).hasSize(1);
   }
 }

--- a/src/test/java/io/aiven/klaw/controller/SchemaRegstryControllerTest.java
+++ b/src/test/java/io/aiven/klaw/controller/SchemaRegstryControllerTest.java
@@ -29,6 +29,7 @@ import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
 public class SchemaRegstryControllerTest {
 
+  public static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
   @MockBean private SchemaRegstryControllerService schemaRegstryControllerService;
 
   private SchemaRegstryController schemaRegstryController;
@@ -65,7 +66,7 @@ public class SchemaRegstryControllerTest {
             .getResponse()
             .getContentAsString();
 
-    List<SchemaRequestModel> response = new ObjectMapper().readValue(res, List.class);
+    List<SchemaRequestModel> response = OBJECT_MAPPER.readValue(res, List.class);
     assertThat(response).hasSize(1);
   }
 
@@ -111,7 +112,7 @@ public class SchemaRegstryControllerTest {
   @Order(4)
   public void uploadSchema() throws Exception {
     SchemaRequestModel schemaRequest = utilMethods.getSchemaRequests().get(0);
-    String jsonReq = new ObjectMapper().writer().writeValueAsString(schemaRequest);
+    String jsonReq = OBJECT_MAPPER.writer().writeValueAsString(schemaRequest);
 
     when(schemaRegstryControllerService.uploadSchema(any())).thenReturn("success");
 

--- a/src/test/java/io/aiven/klaw/controller/ServerConfigControllerTest.java
+++ b/src/test/java/io/aiven/klaw/controller/ServerConfigControllerTest.java
@@ -27,6 +27,7 @@ import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
 public class ServerConfigControllerTest {
 
+  public static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
   @MockBean private ServerConfigService serverConfigService;
 
   UtilMethods utilMethods;
@@ -57,7 +58,7 @@ public class ServerConfigControllerTest {
             .getResponse()
             .getContentAsString();
 
-    List<ServerConfigProperties> response = new ObjectMapper().readValue(res, List.class);
+    List<ServerConfigProperties> response = OBJECT_MAPPER.readValue(res, List.class);
     assertThat(response).hasSize(1);
   }
 }

--- a/src/test/java/io/aiven/klaw/controller/TopicControllerTest.java
+++ b/src/test/java/io/aiven/klaw/controller/TopicControllerTest.java
@@ -38,6 +38,7 @@ import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
 public class TopicControllerTest {
 
+  public static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
   @MockBean private TopicControllerService topicControllerService;
 
   @MockBean private TopicSyncControllerService topicSyncControllerService;
@@ -67,7 +68,7 @@ public class TopicControllerTest {
   @Order(1)
   public void createTopics() throws Exception {
     TopicRequestModel addTopicRequest = utilMethods.getTopicRequestModel(1001);
-    String jsonReq = new ObjectMapper().writer().writeValueAsString(addTopicRequest);
+    String jsonReq = OBJECT_MAPPER.writer().writeValueAsString(addTopicRequest);
     Map<String, String> resMap = new HashMap<>();
     resMap.put("result", "success");
     when(topicControllerService.createTopicsRequest(any())).thenReturn(resMap);
@@ -91,7 +92,7 @@ public class TopicControllerTest {
   @Order(2)
   public void updateSyncTopics() throws Exception {
     List<SyncTopicUpdates> syncTopicUpdates = utilMethods.getSyncTopicUpdates();
-    String jsonReq = new ObjectMapper().writer().writeValueAsString(syncTopicUpdates);
+    String jsonReq = OBJECT_MAPPER.writer().writeValueAsString(syncTopicUpdates);
     Map<String, String> resultMap = new HashMap<>();
     resultMap.put("result", "success");
     when(topicSyncControllerService.updateSyncTopics(any())).thenReturn(resultMap);
@@ -132,7 +133,7 @@ public class TopicControllerTest {
             .getResponse()
             .getContentAsString();
 
-    List<TopicRequest> response = new ObjectMapper().readValue(res, List.class);
+    List<TopicRequest> response = OBJECT_MAPPER.readValue(res, List.class);
     assertThat(response).hasSize(1);
   }
 
@@ -176,7 +177,7 @@ public class TopicControllerTest {
             .getResponse()
             .getContentAsString();
 
-    List<TopicRequestModel> response = new ObjectMapper().readValue(res, List.class);
+    List<TopicRequestModel> response = OBJECT_MAPPER.readValue(res, List.class);
     assertThat(response).hasSize(1);
   }
 
@@ -263,7 +264,7 @@ public class TopicControllerTest {
             .getResponse()
             .getContentAsString();
 
-    List<List<TopicInfo>> response = new ObjectMapper().readValue(res, List.class);
+    List<List<TopicInfo>> response = OBJECT_MAPPER.readValue(res, List.class);
     assertThat(response).hasSize(1);
   }
 
@@ -283,7 +284,7 @@ public class TopicControllerTest {
             .getResponse()
             .getContentAsString();
 
-    List<String> response = new ObjectMapper().readValue(res, List.class);
+    List<String> response = OBJECT_MAPPER.readValue(res, List.class);
     assertThat(response).hasSize(2);
   }
 
@@ -313,7 +314,7 @@ public class TopicControllerTest {
             .getResponse()
             .getContentAsString();
 
-    HashMap response = new ObjectMapper().readValue(res, HashMap.class);
+    HashMap response = OBJECT_MAPPER.readValue(res, HashMap.class);
     assertThat(response).hasSize(1);
   }
 }

--- a/src/test/java/io/aiven/klaw/controller/UiConfigControllerTest.java
+++ b/src/test/java/io/aiven/klaw/controller/UiConfigControllerTest.java
@@ -41,6 +41,7 @@ import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
 public class UiConfigControllerTest {
 
+  public static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
   @MockBean private UiConfigControllerService uiConfigControllerService;
 
   @MockBean private EnvsClustersTenantsControllerService envsClustersTenantsControllerService;
@@ -100,7 +101,7 @@ public class UiConfigControllerTest {
             .getResponse()
             .getContentAsString();
 
-    List<Env> response = new ObjectMapper().readValue(res, List.class);
+    List<Env> response = OBJECT_MAPPER.readValue(res, List.class);
     assertThat(response).hasSize(1);
   }
 
@@ -121,7 +122,7 @@ public class UiConfigControllerTest {
             .getResponse()
             .getContentAsString();
 
-    List<Map<String, String>> response = new ObjectMapper().readValue(res, List.class);
+    List<Map<String, String>> response = OBJECT_MAPPER.readValue(res, List.class);
     assertThat(response).hasSize(2);
     assertThat(response.get(0)).hasSize(2);
   }
@@ -143,7 +144,7 @@ public class UiConfigControllerTest {
             .getResponse()
             .getContentAsString();
 
-    List<Env> response = new ObjectMapper().readValue(res, List.class);
+    List<Env> response = OBJECT_MAPPER.readValue(res, List.class);
     assertThat(response).hasSize(1);
   }
 
@@ -164,7 +165,7 @@ public class UiConfigControllerTest {
             .getResponse()
             .getContentAsString();
 
-    List<Env> response = new ObjectMapper().readValue(res, List.class);
+    List<Env> response = OBJECT_MAPPER.readValue(res, List.class);
     assertThat(response).hasSize(1);
   }
 
@@ -185,7 +186,7 @@ public class UiConfigControllerTest {
             .getResponse()
             .getContentAsString();
 
-    List<Team> response = new ObjectMapper().readValue(res, List.class);
+    List<Team> response = OBJECT_MAPPER.readValue(res, List.class);
     assertThat(response).hasSize(1);
   }
 
@@ -206,7 +207,7 @@ public class UiConfigControllerTest {
             .getResponse()
             .getContentAsString();
 
-    List<Team> response = new ObjectMapper().readValue(res, List.class);
+    List<Team> response = OBJECT_MAPPER.readValue(res, List.class);
     assertThat(response).hasSize(2);
   }
 
@@ -214,7 +215,7 @@ public class UiConfigControllerTest {
   @Order(8)
   public void addNewEnv() throws Exception {
     EnvModel env = utilMethods.getEnvList().get(0);
-    String jsonReq = new ObjectMapper().writer().writeValueAsString(env);
+    String jsonReq = OBJECT_MAPPER.writer().writeValueAsString(env);
     when(envsClustersTenantsControllerService.addNewEnv(any())).thenReturn("success");
 
     String response =
@@ -302,7 +303,7 @@ public class UiConfigControllerTest {
     Map<String, String> result = new HashMap<>();
     result.put("result", "success");
     UserInfoModel userInfo = utilMethods.getUserInfoMock();
-    String jsonReq = new ObjectMapper().writer().writeValueAsString(userInfo);
+    String jsonReq = OBJECT_MAPPER.writer().writeValueAsString(userInfo);
     when(usersTeamsControllerService.addNewUser(any(), anyBoolean())).thenReturn(result);
 
     String response =
@@ -324,7 +325,7 @@ public class UiConfigControllerTest {
   @Order(13)
   public void addNewTeam() throws Exception {
     Team team = utilMethods.getTeams().get(0);
-    String jsonReq = new ObjectMapper().writer().writeValueAsString(team);
+    String jsonReq = OBJECT_MAPPER.writer().writeValueAsString(team);
     String result = "{ \"status\": \"" + "success" + "\" }";
     when(usersTeamsControllerService.addNewTeam(any(), anyBoolean())).thenReturn(result);
 
@@ -382,7 +383,7 @@ public class UiConfigControllerTest {
             .getResponse()
             .getContentAsString();
 
-    List<UserInfo> response = new ObjectMapper().readValue(res, List.class);
+    List<UserInfo> response = OBJECT_MAPPER.readValue(res, List.class);
     assertThat(response).hasSize(1);
   }
 
@@ -403,7 +404,7 @@ public class UiConfigControllerTest {
             .getResponse()
             .getContentAsString();
 
-    UserInfoModel response = new ObjectMapper().readValue(res, UserInfoModel.class);
+    UserInfoModel response = OBJECT_MAPPER.readValue(res, UserInfoModel.class);
     assertThat(response.getTeam()).isEqualTo("Seahorses");
   }
 
@@ -426,7 +427,7 @@ public class UiConfigControllerTest {
             .getResponse()
             .getContentAsString();
 
-    List<ActivityLog> response = new ObjectMapper().readValue(res, List.class);
+    List<ActivityLog> response = OBJECT_MAPPER.readValue(res, List.class);
     assertThat(response).hasSize(1);
   }
 }

--- a/src/test/java/io/aiven/klaw/controller/UtilControllerTest.java
+++ b/src/test/java/io/aiven/klaw/controller/UtilControllerTest.java
@@ -21,6 +21,7 @@ import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
 public class UtilControllerTest {
 
+  public static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
   @MockBean private UtilControllerService utilControllerService;
 
   private MockMvc mvc;
@@ -49,7 +50,7 @@ public class UtilControllerTest {
             .getResponse()
             .getContentAsString();
 
-    HashMap<String, String> response = new ObjectMapper().readValue(res, HashMap.class);
+    HashMap<String, String> response = OBJECT_MAPPER.readValue(res, HashMap.class);
     assertThat(response).containsEntry("status", "Authorized");
   }
 


### PR DESCRIPTION
About this change - What it does
Since `ObjectMapper` is a threadsafe as stated in its javadoc
```
 * Mapper instances are fully thread-safe provided that ALL configuration of the
 * instance occurs before ANY read or write calls. If configuration of a mapper instance
 * is modified after first usage, changes may or may not take effect, and configuration
 * calls themselves may fail.
```
It does not make sense to create these objects each time
Resolves: #xxxxx
Why this way
