### PR TITLE
Fixed principal typos

### DIFF
--- a/ReleaseNotes.txt
+++ b/ReleaseNotes.txt
@@ -14,7 +14,7 @@ Release Notes:
 
 - The below changes are part of release 5.0.3
 
-- ACLs can be added based on Usernames (plain text principles). Ex : alice, john
+- ACLs can be added based on Usernames (plain text principals). Ex : alice, john
     On kafka cluster, Producer acls reflects like below for user 'alice' for a topic.
     (principal=User:alice, host=*, operation=WRITE, permissionType=ALLOW)
     (principal=User:alice, host=*, operation=WRITE, permissionType=ALLOW)
@@ -29,7 +29,7 @@ Release Notes:
 
 - The below changes are part of release 5.0.1
 
-- Now users can request for multiple acls in one request. Earlier it was either one IP address or one Principle in one request.
+- Now users can request for multiple acls in one request. Earlier it was either one IP address or one principal in one request.
 - Minor bug fix
 
 -----------------------------------------------------------------------------------

--- a/src/main/resources/templates/browseAcls.html
+++ b/src/main/resources/templates/browseAcls.html
@@ -662,7 +662,7 @@
 																<h6 class="text-primary">IP Address</h6><b>*</b>
 															</div>
 															<div ng-show="aclRequest.acl_ssl != null" class="p-2 border-right" style="width:30%">
-																<h6 class="text-primary">Principle / Username</h6><b>{{ aclRequest.acl_ssl }}</b>
+																<h6 class="text-primary">Principal / Username</h6><b>{{ aclRequest.acl_ssl }}</b>
 															</div>
 
 															<div class="p-2" style="width:15%">
@@ -717,7 +717,7 @@
 																<th width="10%">Owned by</th>
 																<th width="15%">ConsumerGroup</th>
 																<th width="15%">Hosts</th>
-																<th width="25%">Principle</th>
+																<th width="25%">Principal</th>
 																<th width="5%">Delete</th>
 															</tr>
 															</thead>
@@ -769,7 +769,7 @@
 																<th width="10%">Environment</th>
 																<th width="10%">Owned by</th>
 																<th width="15%">Hosts</th>
-																<th width="25%">Principle</th>
+																<th width="25%">Principal</th>
 																<th width="5%">Delete</th>
 															</tr>
 															</thead>

--- a/src/main/resources/templates/execAcls.html
+++ b/src/main/resources/templates/execAcls.html
@@ -543,7 +543,7 @@
 											<h6 class="text-primary">IP Address</h6><b>*</b>
 										</div>
 										<div ng-show="aclRequest.acl_ssl != null" class="p-2 border-right" style="width:30%">
-											<h6 class="text-primary">Principle / Username</h6>
+											<h6 class="text-primary">Principal / Username</h6>
 											<table>
 												<tr ng-repeat="onessl in aclRequest.acl_ssl">
 													<td>

--- a/src/main/resources/templates/myAclRequests.html
+++ b/src/main/resources/templates/myAclRequests.html
@@ -520,7 +520,7 @@
 										<h6 class="text-primary">IP Address</h6><b>*</b>
 									</div>
 									<div ng-show="aclRequest.acl_ssl != null" class="p-2 border-right" style="width:30%">
-										<h6 class="text-primary">Principle / Username</h6>
+										<h6 class="text-primary">Principal / Username</h6>
 										<table>
 											<tr ng-repeat="onessl in aclRequest.acl_ssl">
 												<td>

--- a/src/main/resources/templates/requestAcls.html
+++ b/src/main/resources/templates/requestAcls.html
@@ -580,14 +580,14 @@
 									<div ng-show="aivenCluster=='false'" class="row">
 										<div class="col-md-12">
 											<div class="form-group">
-												<label class="control-label">Acl IP or Principle Or Username based</label>
+												<label class="control-label">Acl IP or Principal Or Username based</label>
 												<div class="demo-radio-button" ng-init="acl_ip_ssl='IP'">
 													<input class="radio-col-orange" ng-change="onSelectAcl('IP')" ng-model="acl_ip_ssl" name="aclipgroup1"
 														   type="radio" id="radio_11" value="IP" checked/>
 													<label for="radio_11">IP Address</label>
 													<input class="radio-col-orange" ng-change="onSelectAcl('SSL')" ng-model="acl_ip_ssl"
 														   name="aclipgroup1" type="radio" id="radio_31" value="SSL" />
-													<label for="radio_31">Principle / Username</label>
+													<label for="radio_31">Principal / Username</label>
 												</div>
 
 											</div>
@@ -641,7 +641,7 @@
 
 										<div class="col-md-6">
 											<div class="form-group">
-												<label>Principle / Username</label>
+												<label>Principal / Username</label>
 												<table>
 													<tr valign="top" ng-repeat="onessl in acl_ssl track by $index">
 														<td width="95%">

--- a/src/main/resources/templates/syncBackAcls.html
+++ b/src/main/resources/templates/syncBackAcls.html
@@ -532,7 +532,7 @@
 										<th>Environments</th>
 										<th>ConsumerGroup</th>
 										<th>Hosts</th>
-										<th>Principle</th>
+										<th>Principal</th>
 										<th>AclType</th>
 										<th>Pattern</th>
 										<th>Team</th>

--- a/src/main/resources/templates/synchronizeAcls.html
+++ b/src/main/resources/templates/synchronizeAcls.html
@@ -527,7 +527,7 @@
 										<th>TopicName</th>
 										<th>ConsumerGroup</th>
 										<th>Hosts</th>
-										<th>Principle / User</th>
+										<th>Principal / User</th>
 										<th>AclType</th>
 										<th>Team</th>
 									</tr>


### PR DESCRIPTION
Incorrect spelling "principle" has been fixed wherever it would be visible on screen. For now I have left similar typos in variable names and other code usages alone to avoid breaking anything. 

