### PR TITLE
Removed allowed port range from label

### DIFF
--- a/src/main/resources/templates/addCluster.html
+++ b/src/main/resources/templates/addCluster.html
@@ -501,7 +501,7 @@
 										<!--/span-->
 										<div class="col-md-6" ng-show="addNewCluster.clusterType == 'kafka'">
 											<div class="form-group">
-												<label>Bootstrap servers (Allowed port range 6090 - 9099)</label>
+												<label>Bootstrap servers</label>
 												<input type="text" class="form-control" required ng-model="addNewCluster.host" minlength="3" placeholder="server:9092">
 												<small class="form-control-feedback">Comma separated. Ex : server1:9092,server2:9092,server3:9092</small>
 											</div>


### PR DESCRIPTION
Removed the notice about acceptable port ranges from the bootstrap servers section of Kafka clusters. 

This validation is not enforced anyway - it would not work with Aiven for Apache Kafka clusters whose service ports are always outside this range. 
