### PR TITLE
Added support for SASL_SSL/SCRAM authentication

### DIFF
--- a/src/main/resources/templates/addCluster.html
+++ b/src/main/resources/templates/addCluster.html
@@ -562,9 +562,10 @@
 												<select required class="form-control custom-select" ng-change="onChangeProtocol(addNewCluster.protocol)" ng-model="addNewCluster.protocol">
 													<option value="PLAINTEXT">PLAINTEXT</option>
 													<option value="SSL">SSL</option>
-													<option value="SASL_PLAIN">SASL_PLAIN</option>
-													<option value="SASL_SSL-PLAINMECHANISM">SASL_SSL(PLAIN-MECHANISM)</option>
-													<option value="SASL_SSL-GSSAPIMECHANISM">SASL_SSL(GSSAPI-MECHANISM)</option>
+													<option value="SASL_PLAIN">SASL/PLAIN</option>
+													<option value="SASL_SSL-PLAINMECHANISM">SASL_SSL/PLAIN</option>
+													<option value="SASL_SSL-GSSAPIMECHANISM">SASL_SSL/GSSAPI</option>
+													<option value="SASL_SSL-SCRAMMECHANISM">SASL_SSL/SCRAM-SHA-256</option>
 												</select>
 											</div>
 											<div ng-show="sslparams=='true'">

--- a/src/main/resources/templates/modifyCluster.html
+++ b/src/main/resources/templates/modifyCluster.html
@@ -499,8 +499,9 @@
 													<option value="PLAINTEXT">PLAINTEXT</option>
 													<option value="SSL">SSL</option>
 													<option value="SASL_PLAIN">SASL_PLAIN</option>
-													<option value="SASL_SSL-PLAINMECHANISM">SASL_SSL(PLAIN-MECHANISM)</option>
-													<option value="SASL_SSL-GSSAPIMECHANISM">SASL_SSL(GSSAPI-MECHANISM)</option>
+													<option value="SASL_SSL-PLAINMECHANISM">SASL_SSL/PLAIN</option>
+													<option value="SASL_SSL-GSSAPIMECHANISM">SASL_SSL/GSSAPI</option>
+													<option value="SASL_SSL-SCRAMMECHANISM">SASL_SSL/SCRAM-SHA-256</option>
 												</select>
 											</div>
 											<div ng-show="sslparams=='true'">


### PR DESCRIPTION
Companion change of https://github.com/aiven/klaw-cluster-api/pull/10. Adds new option to protocol selection to allow SASL_SSL/SCRAM authentication. 

