### PR TITLE
add cluster-api as submodule and makefile to simplify initial setup

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "cluster-api"]
+	path = cluster-api
+	url = git@github.com:aiven/klaw-cluster-api.git

--- a/Makefile
+++ b/Makefile
@@ -5,8 +5,7 @@ klaw:
 	mvn clean verify
 
 api:
-	cd cluster-api && mvn clean install
-	cd cluster-api && mvn clean package
+	cd cluster-api && mvn clean verify
 
 edit-config:
 	${EDITOR} target/classes/application.properties

--- a/Makefile
+++ b/Makefile
@@ -2,8 +2,7 @@
 all: klaw api
 
 klaw:
-	mvn clean install
-	mvn clean package
+	mvn clean verify
 
 api:
 	cd cluster-api && mvn clean install

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,22 @@
+
+all: klaw api
+
+klaw:
+	mvn clean install
+	mvn clean package
+
+api:
+	cd cluster-api && mvn clean install
+	cd cluster-api && mvn clean package
+
+edit-config:
+	${EDITOR} target/classes/application.properties
+
+edit-api-config:
+	${EDITOR} cluster-api/target/classes/application.properties
+
+run:
+	java -jar target/klaw-1.0.0.jar
+
+run-api:
+	java -jar cluster-api/target/klaw-clusterapi-1.0.0.jar --spring.config.location=cluster-api/target/classes/application.properties

--- a/README.md
+++ b/README.md
@@ -1,16 +1,16 @@
 # Klaw
 
-Klaw is fully opensource. 🥳 
+Klaw is fully opensource. 🥳
 
 Klaw is a self-service Apache Kafka® Topic Management/Governance tool/portal. It is a web application which automates the process of creating and browsing Apache Kafka topics, acls, avro schemas, connectors by introducing roles/authorizations to users of various teams of an organization.
 
-With several downloads every week, many more companies which did not adopt a solution, can happily move away from managing Apache Kafka configs in excelsheets, confluence, wiki pages, git etc. 
+With several downloads every week, many more companies which did not adopt a solution, can happily move away from managing Apache Kafka configs in excelsheets, confluence, wiki pages, git etc.
 
 ## Built With
 
-* Bootstrap UI, Angular, Javascript, HTML, CSS 
-* [Maven](https://maven.apache.org/) - Dependency Management
-* Java, Spring boot, Spring security, SQL, Apache Kafka Admin client 
+- Bootstrap UI, Angular, Javascript, HTML, CSS
+- [Maven](https://maven.apache.org/) - Dependency Management
+- Java, Spring boot, Spring security, SQL, Apache Kafka Admin client
 
 ## Versioning
 
@@ -23,17 +23,19 @@ For the versions available, see the [tags on this repository](https://github.com
 ## Dependency project:
 
 ### ClusterApi
+
 https://github.com/aiven/klaw-cluster-api
 
 ## Features:
 
 - Topics (approval): Create, Update, Delete, Promote
-- Acls (approval):  Create,Delete
+- Acls (approval): Create,Delete
 - Connectors (approval): Create
-  - Any connector can be created as long as the required plugin libraries are installed on the server.  
+  - Any connector can be created as long as the required plugin libraries are installed on the server.
 - Avro Schemas (approval): Create
   - View all available versions of the subjects per topic
 - Topic Overview :
+
   - Topic Config
   - Promote
   - Literal and Prefixed subscriptions
@@ -50,49 +52,59 @@ https://github.com/aiven/klaw-cluster-api
 - Reconciliation and email notifications on differences between Klaw and Clusters
 - Restore configuration (topics, acls)
 
-- Login 
+- Login
+
   - Active directory integration
   - Single Sign-on (OAuth2)
   - Based on database
-  
+
 - Configure Clusters and Environments
+
   - Clusters can be created connecting to Apache Kafka clusters. (Cluster Management Api should be configured)
   - Environments are wrappers over clusters, enforcing flexible configs like prefix, suffix etc
 
 - Users, Teams & Authorizations
+
   - Configurable users, teams
   - More than 35 permissions
   - Configurable roles (Roles can be pulled from AD for authorization)
 
 - Topic naming conventions
+
   - Enforce prefix and suffixes per environment
 
 - Excel report (for your team and all teams, depending on the role)
+
   - Topics per cluster (for teams)
   - Partitions per cluster
   - Overall topics in all clusters
   - Acls per cluster (for teams)
-  - Producer Acls  (for teams)
-  - Consumer Acls  (for teams)
+  - Producer Acls (for teams)
+  - Consumer Acls (for teams)
   - Consumer groups of all environments
   - Requests per day
 
 - Analytics
+
   - View charts of topics, partitions, acls, requests
 
 - Multi tenancy
+
   - Each tenant can manage their topics with their own teams in isolation.
   - Every tenant can have their own set of Kafka environments, and users
     of one tenant cannot view/access topics, acls or any from other tenants.
   - It provides an isolation avoiding any security breach.
 
 - Apache Kafka Connectivity
+
   - PLAINTEXT, SSL, SASL
 
 - Audit
+
   - All topic, acl, schema and connector requests
 
 - Email notifications when
+
   - requests are created, approved, declined
   - users are created, approved
 
@@ -102,13 +114,16 @@ https://github.com/aiven/klaw-cluster-api
 
 ## Install
 
-mvn clean install
+1. Clone this repo with submodules: `git clone --recursive git@github.com:aiven/klaw.git`
+2. Run `make` to install dependencies and setup both Klaw and the Klaw-Cluster-API
+3. [Optional] edit any configs using `make edit-config` for Klaw or `make edit-api-config` for Klaw-Cluster-API
+4. To run, you can use `make run` and `make run-api` in different terminal windows or you can run `make -j2 run run-api` to execute both (NOTE: this will mix output and make debugging harder)
 
-and follow steps defined at https://klaw-project.io/docs
+Check https://klaw-project.io/docs for more information and references for configuration
 
 ## License
 
-Klaw is licensed under the Apache license, version 2.0.  Full license text is
+Klaw is licensed under the Apache license, version 2.0. Full license text is
 available in the [LICENSE.md](LICENSE.md) file.
 
 Please note that the project explicitly does not require a CLA (Contributor
@@ -123,13 +138,12 @@ maintainers <opensource@aiven.io>.
 
 ## Trademark
 
-Apache Kafka is either a registered trademark or trademark of the Apache Software Foundation in the United States and/or other countries. 
+Apache Kafka is either a registered trademark or trademark of the Apache Software Foundation in the United States and/or other countries.
 All product and service names used in this page are for identification purposes only and do not imply endorsement.
 
 ## Credits
 
 Klaw (formerly Kafkawize) is maintained by, [Aiven](https://aiven.io/) open source developers.
-
 
 Recent contributors are listed on the GitHub project page,
 https://github.com/aiven/klaw/graphs/contributors

--- a/README.md
+++ b/README.md
@@ -114,6 +114,14 @@ https://github.com/aiven/klaw-cluster-api
 
 ## Install
 
+### Manual
+
+1. Clone this repo with submodules: `git clone --recursive git@github.com:aiven/klaw.git`
+2. In the `klaw` directory, run `mvn clean install`
+3. In the `cluster-api` directory, run `mvn clean install`
+
+### With `make`
+
 1. Clone this repo with submodules: `git clone --recursive git@github.com:aiven/klaw.git`
 2. Run `make` to install dependencies and setup both Klaw and the Klaw-Cluster-API
 3. [Optional] edit any configs using `make edit-config` for Klaw or `make edit-api-config` for Klaw-Cluster-API


### PR DESCRIPTION
## About this change - What it does

Adds the Cluster-API as a submodule and automates commands for setup and running using a Makefile.

Resolves: Setup, config and running of Klaw and the dependencies
## Why this way

Current approach requires cloning 2 repos, viewing 2 README files and then heading to a docs site. This allows setup to be automated and simplifies the editing of config files to add clusters or change ports, for example.

