### PR TITLE
Update permissions bugfix and acl command fix

### DIFF
--- a/src/main/java/io/aiven/klaw/service/RolesPermissionsControllerService.java
+++ b/src/main/java/io/aiven/klaw/service/RolesPermissionsControllerService.java
@@ -125,6 +125,7 @@ public class RolesPermissionsControllerService {
     String delimiter = "-----";
     int indexOfDelimiter;
     String isPermEnabled;
+    int tenantId = commonUtilsService.getTenantId(getUserName());
 
     try {
       for (String permKey : uniqueMap.keySet()) {
@@ -134,6 +135,7 @@ public class RolesPermissionsControllerService {
         tmpKwRolePermModel = new KwRolesPermissions();
         tmpKwRolePermModel.setRoleId(permKey.substring(0, indexOfDelimiter));
         tmpKwRolePermModel.setPermission(permKey.substring(indexOfDelimiter + 5));
+        tmpKwRolePermModel.setTenantId(tenantId);
 
         if ("true".equals(isPermEnabled)) {
           kwRolesPermissionsAdd.add(tmpKwRolePermModel);

--- a/src/main/java/io/aiven/klaw/service/RolesPermissionsControllerService.java
+++ b/src/main/java/io/aiven/klaw/service/RolesPermissionsControllerService.java
@@ -10,7 +10,6 @@ import io.aiven.klaw.model.PermissionType;
 import java.util.*;
 import java.util.stream.Collectors;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Service;
@@ -19,14 +18,21 @@ import org.springframework.stereotype.Service;
 @Service
 public class RolesPermissionsControllerService {
 
-  @Autowired private CommonUtilsService commonUtilsService;
+  private final CommonUtilsService commonUtilsService;
 
-  @Autowired ManageDatabase manageDatabase;
+  final ManageDatabase manageDatabase;
 
-  @Autowired private MailUtils mailService;
+  private final MailUtils mailService;
 
   @Value("${klaw.installation.type:onpremise}")
   private String kwInstallationType;
+
+  public RolesPermissionsControllerService(
+      CommonUtilsService commonUtilsService, ManageDatabase manageDatabase, MailUtils mailService) {
+    this.commonUtilsService = commonUtilsService;
+    this.manageDatabase = manageDatabase;
+    this.mailService = mailService;
+  }
 
   private String getUserName() {
     return mailService.getUserName(

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -145,7 +145,7 @@ klaw.saas.ssl.pubkey=C:/location/Klaw_PublicKey.zip
 klaw.saas.ssl.clientcerts.location=C:/location/clientcerts
 klaw.saas.ssl.clusterapi.truststore=C:/location/client.truststore.jks
 klaw.saas.ssl.clusterapi.truststore.pwd=klaw
-klaw.saas.plaintext.aclcommand=kafka-acls --authorizer-properties bootstrap.server=host:port --add --allow-principal --operation All --allow-host 172.31.88.205 --cluster Cluster:kafka-cluster --topic "*"
+klaw.saas.plaintext.aclcommand=kafka-acls --authorizer-properties bootstrap.server=host:port --add --allow-principal User:'*' --operation All --allow-host hostname_ip --cluster Cluster:kafka-cluster --topic "*"
 
 klaw.uiapi.servers=https://localhost:9097
 

--- a/src/test/java/io/aiven/klaw/MockMethods.java
+++ b/src/test/java/io/aiven/klaw/MockMethods.java
@@ -71,4 +71,23 @@ public class MockMethods {
 
     return envModel;
   }
+
+  protected KwRolesPermissionsModel[] getPermissions(String role) {
+    KwRolesPermissionsModel[] permissionsList = new KwRolesPermissionsModel[3];
+    KwRolesPermissionsModel kwRolesPermissionsModel1 = new KwRolesPermissionsModel();
+    kwRolesPermissionsModel1.setRolePermission(role + "-----ADD_EDIT_DELETE_CLUSTERS");
+    kwRolesPermissionsModel1.setPermissionEnabled("true");
+    permissionsList[0] = kwRolesPermissionsModel1;
+
+    KwRolesPermissionsModel kwRolesPermissionsModel2 = new KwRolesPermissionsModel();
+    kwRolesPermissionsModel2.setRolePermission(role + "-----ADD_EDIT_DELETE_ENVS");
+    kwRolesPermissionsModel2.setPermissionEnabled("true");
+    permissionsList[1] = kwRolesPermissionsModel2;
+
+    KwRolesPermissionsModel kwRolesPermissionsModel3 = new KwRolesPermissionsModel();
+    kwRolesPermissionsModel3.setRolePermission(role + "-----VIEW_TOPICS");
+    kwRolesPermissionsModel3.setPermissionEnabled("false");
+    permissionsList[2] = kwRolesPermissionsModel3;
+    return permissionsList;
+  }
 }

--- a/src/test/java/io/aiven/klaw/RolesPermissionsControllerIT.java
+++ b/src/test/java/io/aiven/klaw/RolesPermissionsControllerIT.java
@@ -1,0 +1,175 @@
+package io.aiven.klaw;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.user;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.aiven.klaw.model.ApiResultStatus;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+
+@SpringBootTest(
+    webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
+    classes = UiapiApplication.class)
+@AutoConfigureMockMvc
+@TestPropertySource(locations = "classpath:test-application-rdbms.properties")
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+@DirtiesContext
+public class RolesPermissionsControllerIT {
+
+  private static final String INFRATEAM_ID = "1001";
+  public static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+  private static MockMethods mockMethods;
+  @Autowired private MockMvc mvc;
+  private static final String superAdmin = "superadmin";
+  private static final String superAdminPwd = "kwsuperadmin123$$";
+
+  @BeforeAll
+  public static void setup() {
+    mockMethods = new MockMethods();
+  }
+
+  // Create a role
+  @Test
+  @Order(1)
+  public void addNewRole() throws Exception {
+    String testRole = "TESTROLE";
+    String response =
+        mvc.perform(
+                MockMvcRequestBuilders.post("/addRoleId")
+                    .with(user(superAdmin).password(superAdminPwd))
+                    .param("roleId", testRole)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .accept(MediaType.APPLICATION_JSON))
+            .andExpect(status().isOk())
+            .andReturn()
+            .getResponse()
+            .getContentAsString();
+    assertThat(response).contains(ApiResultStatus.SUCCESS.value);
+
+    response =
+        mvc.perform(
+                MockMvcRequestBuilders.get("/getRolesFromDb")
+                    .with(user(superAdmin).password(superAdminPwd))
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .accept(MediaType.APPLICATION_JSON))
+            .andExpect(status().isOk())
+            .andReturn()
+            .getResponse()
+            .getContentAsString();
+
+    List<String> rolesList = new ObjectMapper().readValue(response, new TypeReference<>() {});
+    assertThat(rolesList).contains(testRole);
+  }
+
+  // Assign permissions to new role
+  @Test
+  @Order(2)
+  public void addPermissionsToNewRole() throws Exception {
+    String testRole = "TESTROLE";
+    String response =
+        mvc.perform(
+                MockMvcRequestBuilders.get("/getPermissions")
+                    .with(user(superAdmin).password(superAdminPwd))
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .accept(MediaType.APPLICATION_JSON))
+            .andExpect(status().isOk())
+            .andReturn()
+            .getResponse()
+            .getContentAsString();
+
+    Map<String, Boolean> firstEntry = new HashMap<>();
+    firstEntry.put("VIEW_TOPICS", true);
+    Map<String, Boolean> secondEntry = new HashMap<>();
+    secondEntry.put("ADD_EDIT_DELETE_CLUSTERS", false);
+
+    Map<String, List<Map<String, Boolean>>> permissionsList =
+        new ObjectMapper().readValue(response, new TypeReference<>() {});
+    assertThat(permissionsList.get(testRole)).contains(firstEntry);
+    assertThat(permissionsList.get(testRole)).contains(secondEntry);
+
+    String jsonReq =
+        OBJECT_MAPPER.writer().writeValueAsString(mockMethods.getPermissions(testRole));
+    response =
+        mvc.perform(
+                MockMvcRequestBuilders.post("/updatePermissions")
+                    .with(user(superAdmin).password(superAdminPwd))
+                    .content(jsonReq)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .accept(MediaType.APPLICATION_JSON))
+            .andExpect(status().isOk())
+            .andReturn()
+            .getResponse()
+            .getContentAsString();
+    assertThat(response).contains(ApiResultStatus.SUCCESS.value);
+
+    response =
+        mvc.perform(
+                MockMvcRequestBuilders.get("/getPermissions")
+                    .with(user(superAdmin).password(superAdminPwd))
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .accept(MediaType.APPLICATION_JSON))
+            .andExpect(status().isOk())
+            .andReturn()
+            .getResponse()
+            .getContentAsString();
+
+    firstEntry = new HashMap<>();
+    firstEntry.put("VIEW_TOPICS", false);
+    secondEntry = new HashMap<>();
+    secondEntry.put("ADD_EDIT_DELETE_CLUSTERS", true);
+
+    permissionsList = new ObjectMapper().readValue(response, new TypeReference<>() {});
+    assertThat(permissionsList.get(testRole)).contains(firstEntry);
+    assertThat(permissionsList.get(testRole)).contains(secondEntry);
+  }
+
+  // Delete the role
+  @Test
+  @Order(3)
+  public void deleteRole() throws Exception {
+    String testRole = "TESTROLE";
+    String response =
+        mvc.perform(
+                MockMvcRequestBuilders.post("/deleteRole")
+                    .with(user(superAdmin).password(superAdminPwd))
+                    .param("roleId", testRole)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .accept(MediaType.APPLICATION_JSON))
+            .andExpect(status().isOk())
+            .andReturn()
+            .getResponse()
+            .getContentAsString();
+    assertThat(response).contains(ApiResultStatus.SUCCESS.value);
+
+    response =
+        mvc.perform(
+                MockMvcRequestBuilders.get("/getRolesFromDb")
+                    .with(user(superAdmin).password(superAdminPwd))
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .accept(MediaType.APPLICATION_JSON))
+            .andExpect(status().isOk())
+            .andReturn()
+            .getResponse()
+            .getContentAsString();
+
+    List<String> rolesList = new ObjectMapper().readValue(response, new TypeReference<>() {});
+    assertThat(rolesList).doesNotContain(testRole);
+  }
+}

--- a/src/test/resources/test-application-rdbms.properties
+++ b/src/test/resources/test-application-rdbms.properties
@@ -3,8 +3,8 @@ server.port=9097
 #server.servlet.context-path=/klaw
 
 # SSL Properties
-#server.ssl.key-store=C:/Software/confluent-5.3.1-2.12/certs/newpair/client.keystore.jks
-#server.ssl.trust-store=C:/Software/confluent-5.3.1-2.12/certs/newpair/client.truststore.jks
+#server.ssl.key-store=./client.keystore.jks
+#server.ssl.trust-store=./client.truststore.jks
 #server.ssl.key-store-password=klaw
 #server.ssl.key-password=klaw
 #server.ssl.trust-store-password=klaw
@@ -122,18 +122,18 @@ klaw.superadmin.defaultpassword=kwsuperadmin123$$
 
 #kw saas admin
 klaw.saas.ssl.aclcommand=kafka-acls --authorizer-properties bootstrap.server=host:port --add --allow-principal User:"CN=abc..." --operation All  --cluster Cluster:kafka-cluster --topic "*"
-klaw.saas.ssl.pubkey=C:/Software/confluent-5.3.1-2.12/certs/Klaw_PublicKey.zip
-klaw.saas.ssl.clientcerts.location=C:/Software/confluent-5.3.1-2.12/certs/clientcerts
-klaw.saas.ssl.clusterapi.truststore=C:/Software/confluent-5.3.1-2.12/certs/clientcerts/client.truststore.jks
+klaw.saas.ssl.pubkey=./certs/Klaw_PublicKey.zip
+klaw.saas.ssl.clientcerts.location=./clientcerts
+klaw.saas.ssl.clusterapi.truststore=./client.truststore.jks
 klaw.saas.ssl.clusterapi.truststore.pwd=klaw
 klaw.saas.plaintext.aclcommand=kafka-acls --authorizer-properties bootstrap.server=host:port --add --allow-principal User:'*' --operation All --allow-host hostname_ip --cluster Cluster:kafka-cluster --topic "*"
 
 klaw.uiapi.servers=https://localhost:9097
 
 #google recaptcha settings
-google.recaptcha.sitekey=6Lf-Jj8dAAAAAE587eOkzRUSPwvxy4oQ4WR1XGW_
+google.recaptcha.sitekey=sitekey
 google.recaptcha.verification.endpoint=https://www.google.com/recaptcha/api/siteverify
-google.recaptcha.secret=6Lf-Jj8dAAAAAAQau56vT1MJ3_gB8TVATHdPLZzC
+google.recaptcha.secret=secret
 
 
 # Enable response compression

--- a/src/test/resources/test-application-rdbms.properties
+++ b/src/test/resources/test-application-rdbms.properties
@@ -126,7 +126,7 @@ klaw.saas.ssl.pubkey=C:/Software/confluent-5.3.1-2.12/certs/Klaw_PublicKey.zip
 klaw.saas.ssl.clientcerts.location=C:/Software/confluent-5.3.1-2.12/certs/clientcerts
 klaw.saas.ssl.clusterapi.truststore=C:/Software/confluent-5.3.1-2.12/certs/clientcerts/client.truststore.jks
 klaw.saas.ssl.clusterapi.truststore.pwd=klaw
-klaw.saas.plaintext.aclcommand=kafka-acls --authorizer-properties bootstrap.server=host:port --add --allow-principal --operation All --allow-host 172.31.88.205 --cluster Cluster:kafka-cluster --topic "*"
+klaw.saas.plaintext.aclcommand=kafka-acls --authorizer-properties bootstrap.server=host:port --add --allow-principal User:'*' --operation All --allow-host hostname_ip --cluster Cluster:kafka-cluster --topic "*"
 
 klaw.uiapi.servers=https://localhost:9097
 

--- a/src/test/resources/test-application-rdbms1.properties
+++ b/src/test/resources/test-application-rdbms1.properties
@@ -3,8 +3,8 @@ server.port=9097
 #server.servlet.context-path=/klaw
 
 # SSL Properties
-#server.ssl.key-store=C:/Software/confluent-5.3.1-2.12/certs/newpair/client.keystore.jks
-#server.ssl.trust-store=C:/Software/confluent-5.3.1-2.12/certs/newpair/client.truststore.jks
+#server.ssl.key-store=./client.keystore.jks
+#server.ssl.trust-store=./client.truststore.jks
 #server.ssl.key-store-password=klaw
 #server.ssl.key-password=klaw
 #server.ssl.trust-store-password=klaw
@@ -122,18 +122,18 @@ klaw.superadmin.defaultpassword=kwsuperadmin123$$
 
 #kw saas admin
 klaw.saas.ssl.aclcommand=kafka-acls --authorizer-properties bootstrap.server=host:port --add --allow-principal User:"CN=abc..." --operation All  --cluster Cluster:kafka-cluster --topic "*"
-klaw.saas.ssl.pubkey=C:/Software/confluent-5.3.1-2.12/certs/Klaw_PublicKey.zip
-klaw.saas.ssl.clientcerts.location=C:/Software/confluent-5.3.1-2.12/certs/clientcerts
-klaw.saas.ssl.clusterapi.truststore=C:/Software/confluent-5.3.1-2.12/certs/clientcerts/client.truststore.jks
+klaw.saas.ssl.pubkey=./certs/Klaw_PublicKey.zip
+klaw.saas.ssl.clientcerts.location=./clientcerts
+klaw.saas.ssl.clusterapi.truststore=./client.truststore.jks
 klaw.saas.ssl.clusterapi.truststore.pwd=klaw
 klaw.saas.plaintext.aclcommand=kafka-acls --authorizer-properties bootstrap.server=host:port --add --allow-principal User:'*' --operation All --allow-host hostname_ip --cluster Cluster:kafka-cluster --topic "*"
 
 klaw.uiapi.servers=https://localhost:9097
 
 #google recaptcha settings
-google.recaptcha.sitekey=6Lf-Jj8dAAAAAE587eOkzRUSPwvxy4oQ4WR1XGW_
+google.recaptcha.sitekey=sitekey
 google.recaptcha.verification.endpoint=https://www.google.com/recaptcha/api/siteverify
-google.recaptcha.secret=6Lf-Jj8dAAAAAAQau56vT1MJ3_gB8TVATHdPLZzC
+google.recaptcha.secret=secret
 
 
 # Enable response compression

--- a/src/test/resources/test-application-rdbms1.properties
+++ b/src/test/resources/test-application-rdbms1.properties
@@ -126,7 +126,7 @@ klaw.saas.ssl.pubkey=C:/Software/confluent-5.3.1-2.12/certs/Klaw_PublicKey.zip
 klaw.saas.ssl.clientcerts.location=C:/Software/confluent-5.3.1-2.12/certs/clientcerts
 klaw.saas.ssl.clusterapi.truststore=C:/Software/confluent-5.3.1-2.12/certs/clientcerts/client.truststore.jks
 klaw.saas.ssl.clusterapi.truststore.pwd=klaw
-klaw.saas.plaintext.aclcommand=kafka-acls --authorizer-properties bootstrap.server=host:port --add --allow-principal --operation All --allow-host 172.31.88.205 --cluster Cluster:kafka-cluster --topic "*"
+klaw.saas.plaintext.aclcommand=kafka-acls --authorizer-properties bootstrap.server=host:port --add --allow-principal User:'*' --operation All --allow-host hostname_ip --cluster Cluster:kafka-cluster --topic "*"
 
 klaw.uiapi.servers=https://localhost:9097
 


### PR DESCRIPTION
About this change - What it does

There was an issue when new role is created and adding new permissions. this change fixes it and permissions are saved.

Resolves: #73 #75 
Why this way
There was no tenant id set when saving permissions, and hence permissions are being added randomly to a unexisting tenantid. It's a bug, and fixed now.