### PR TITLE
Cluster Api security

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -54,11 +54,12 @@
         <commons-text.version>1.10.0</commons-text.version>
         <exec-maven-plugin.version>3.1.0</exec-maven-plugin.version>
         <gson.version>2.9.0</gson.version>
+        <google-java-format.version>1.15.0</google-java-format.version>
         <guava.version>31.1-jre</guava.version>
         <h2.version>2.1.214</h2.version>
-        <google-java-format.version>1.15.0</google-java-format.version>
         <jacoco-maven-plugin.version>0.8.8</jacoco-maven-plugin.version>
         <jasyptencrypt.version>3.0.4</jasyptencrypt.version>
+        <jjwt.version>0.11.5</jjwt.version>
         <maven-surefire-plugin.version>2.22.2</maven-surefire-plugin.version>
         <maven-failsafe-plugin.version>2.22.2</maven-failsafe-plugin.version>
         <netty-all.version>4.1.80.Final</netty-all.version>
@@ -66,7 +67,6 @@
         <sonar-maven-plugin.version>3.9.1.2184</sonar-maven-plugin.version>
         <spotless-maven-plugin.version>2.27.2</spotless-maven-plugin.version>
         <swagger-annotations.version>2.1.0</swagger-annotations.version>
-        <jjwt.version>0.11.5</jjwt.version>
     </properties>
 
     <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -66,6 +66,9 @@
         <sonar-maven-plugin.version>3.9.1.2184</sonar-maven-plugin.version>
         <spotless-maven-plugin.version>2.27.2</spotless-maven-plugin.version>
         <swagger-annotations.version>2.1.0</swagger-annotations.version>
+        <jjwt-api.version>0.11.5</jjwt-api.version>
+        <jjwt-impl.version>0.11.5</jjwt-impl.version>
+        <jjwt-jackson.version>0.11.5</jjwt-jackson.version>
     </properties>
 
     <dependencies>
@@ -233,6 +236,23 @@
         <dependency>
             <groupId>javax.mail</groupId>
             <artifactId>javax.mail-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.jsonwebtoken</groupId>
+            <artifactId>jjwt-api</artifactId>
+            <version>${jjwt-api.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.jsonwebtoken</groupId>
+            <artifactId>jjwt-impl</artifactId>
+            <version>${jjwt-impl.version}</version>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.jsonwebtoken</groupId>
+            <artifactId>jjwt-jackson</artifactId>
+            <version>${jjwt-jackson.version}</version>
+            <scope>runtime</scope>
         </dependency>
 
     </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -66,9 +66,7 @@
         <sonar-maven-plugin.version>3.9.1.2184</sonar-maven-plugin.version>
         <spotless-maven-plugin.version>2.27.2</spotless-maven-plugin.version>
         <swagger-annotations.version>2.1.0</swagger-annotations.version>
-        <jjwt-api.version>0.11.5</jjwt-api.version>
-        <jjwt-impl.version>0.11.5</jjwt-impl.version>
-        <jjwt-jackson.version>0.11.5</jjwt-jackson.version>
+        <jjwt.version>0.11.5</jjwt.version>
     </properties>
 
     <dependencies>
@@ -240,18 +238,18 @@
         <dependency>
             <groupId>io.jsonwebtoken</groupId>
             <artifactId>jjwt-api</artifactId>
-            <version>${jjwt-api.version}</version>
+            <version>${jjwt.version}</version>
         </dependency>
         <dependency>
             <groupId>io.jsonwebtoken</groupId>
             <artifactId>jjwt-impl</artifactId>
-            <version>${jjwt-impl.version}</version>
+            <version>${jjwt.version}</version>
             <scope>runtime</scope>
         </dependency>
         <dependency>
             <groupId>io.jsonwebtoken</groupId>
             <artifactId>jjwt-jackson</artifactId>
-            <version>${jjwt-jackson.version}</version>
+            <version>${jjwt.version}</version>
             <scope>runtime</scope>
         </dependency>
 

--- a/src/main/java/io/aiven/klaw/service/ClusterApiService.java
+++ b/src/main/java/io/aiven/klaw/service/ClusterApiService.java
@@ -98,7 +98,7 @@ public class ClusterApiService {
   @Value("${klaw.clusterapi.access.username}")
   private String clusterApiUser;
 
-  @Value("${klaw.clusterapi.access.base64.secret:null}")
+  @Value("${klaw.clusterapi.access.base64.secret:#{''}}")
   private String clusterApiAccessBase64Secret;
 
   private static String clusterConnUrl;

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -115,16 +115,17 @@ spring.cache.type=NONE
 spring.thymeleaf.cache=false
 
 # application shutdown and health properties
-management.endpoints.web.exposure.include=*
+management.endpoints.web.exposure.include=health,info,metrics
+management.endpoints.web.exposure.exclude=
 management.health.ldap.enabled=false
-management.endpoint.shutdown.enabled=true
+management.endpoint.shutdown.enabled=false
 
 #jasypt encryption pwd secret key
 klaw.jasypt.encryptor.secretkey=kw2021secretkey
 
 # ClusterApi access
 klaw.clusterapi.access.username=kwclusterapiuser
-klaw.clusterapi.access.password=d7DtnvRR7jq05ODBkvxLIGO6Qa/bVpkW
+klaw.clusterapi.access.base64.secret=
 
 # Monitoring
 klaw.monitoring.metrics.enable=false

--- a/src/test/java/io/aiven/klaw/service/ClusterApiServiceTest.java
+++ b/src/test/java/io/aiven/klaw/service/ClusterApiServiceTest.java
@@ -76,6 +76,12 @@ public class ClusterApiServiceTest {
     this.env = new Env();
     env.setName("DEV");
     ReflectionTestUtils.setField(clusterApiService, "httpRestTemplate", restTemplate);
+    ReflectionTestUtils.setField(clusterApiService, "clusterApiUser", "testuser");
+    ReflectionTestUtils.setField(
+        clusterApiService,
+        "clusterApiAccessBase64Secret",
+        "dGhpcyBpcyBhIHNlY3JldCB0byBhY2Nlc3MgY2x1c3RlcmFwaQ=="); // any base64 string
+
     when(manageDatabase.getHandleDbRequests()).thenReturn(handleDbRequests);
     when(manageDatabase.getKwPropertyValue(anyString(), anyInt())).thenReturn("http://cluster");
   }

--- a/src/test/java/io/aiven/klaw/service/ServerConfigServiceTest.java
+++ b/src/test/java/io/aiven/klaw/service/ServerConfigServiceTest.java
@@ -1,20 +1,31 @@
 package io.aiven.klaw.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
 
 import io.aiven.klaw.model.ServerConfigProperties;
 import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.Mockito;
 import org.springframework.context.annotation.AnnotationConfigApplicationContext;
 import org.springframework.core.env.Environment;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 @ExtendWith(SpringExtension.class)
 public class ServerConfigServiceTest {
 
+  @Mock private CommonUtilsService commonUtilsService;
   ServerConfigService serverConfigService;
+
+  @Mock private UserDetails userDetails;
 
   private Environment env;
 
@@ -22,14 +33,24 @@ public class ServerConfigServiceTest {
   public void setUp() {
     AnnotationConfigApplicationContext context = new AnnotationConfigApplicationContext();
     this.env = context.getEnvironment();
+    loginMock();
 
-    serverConfigService = new ServerConfigService(env);
+    serverConfigService = new ServerConfigService(env, commonUtilsService);
   }
 
   @Test
   public void getAllProps() {
+    when(commonUtilsService.isNotAuthorizedUser(any(), any())).thenReturn(false);
     serverConfigService.getAllProperties();
     List<ServerConfigProperties> list = serverConfigService.getAllProps();
-    assertThat(list).isNotEmpty();
+    assertThat(list).isEmpty(); // filtering for spring. and klaw.
+  }
+
+  private void loginMock() {
+    Authentication authentication = Mockito.mock(Authentication.class);
+    SecurityContext securityContext = Mockito.mock(SecurityContext.class);
+    when(securityContext.getAuthentication()).thenReturn(authentication);
+    when(authentication.getPrincipal()).thenReturn(userDetails);
+    SecurityContextHolder.setContext(securityContext);
   }
 }


### PR DESCRIPTION
About this change - What it does

Connects to Klaw ClusterApi with a jwt token
getServerConfig security issue fixed. normal users should not get any server configuration
Actuator endpoints to show fewer than wildcard
Resolves:
Why this way : token based authentication is better. getServerconfig restriction based on role.