### PR TITLE
fix[coral]: Include required font weights to Inter import

### DIFF
--- a/coral/index.html
+++ b/coral/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Inter" />
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;700" />
     <title>Klaw</title>
   </head>
   <body>


### PR DESCRIPTION
Google font resource includes only 400 with the default import whereas we
use 400, 500 and 700 with Aiven Design System.