### PR TITLE
Add alias for absolute imports in coral.

### DIFF
--- a/coral/.eslintrc.cjs
+++ b/coral/.eslintrc.cjs
@@ -29,8 +29,7 @@ module.exports = {
     },
     "rules": {
         "no-relative-import-paths/no-relative-import-paths": [
-            "warn",
-            { "allowSameFolder": true, "rootDir": "src" }
+            "error"
         ]
     }
 }

--- a/coral/.eslintrc.cjs
+++ b/coral/.eslintrc.cjs
@@ -19,7 +19,8 @@ module.exports = {
     },
     "plugins": [
         "react",
-        "@typescript-eslint"
+        "@typescript-eslint",
+        "no-relative-import-paths"
     ],
     "settings": {
         "react": {
@@ -27,5 +28,9 @@ module.exports = {
         }
     },
     "rules": {
+        "no-relative-import-paths/no-relative-import-paths": [
+            "warn",
+            { "allowSameFolder": true, "rootDir": "src" }
+        ]
     }
 }

--- a/coral/jest.config.ts
+++ b/coral/jest.config.ts
@@ -7,10 +7,10 @@ export default {
   moduleFileExtensions: ["js", "jsx", "ts", "tsx"],
   preset: "ts-jest",
   testEnvironment: "jsdom",
-  setupFilesAfterEnv: ['<rootDir>/test-setup/setup-files-after-env.ts'],
+  setupFilesAfterEnv: ["<rootDir>/test-setup/setup-files-after-env.ts"],
   moduleNameMapper: {
     ".+\\.(png|jpg|ttf|woff|woff2|svg)$": "jest-transform-stub",
     "\\.css$": "identity-obj-proxy",
-    "^@/(.*)$": "<rootDir>/src/$1",
+    "^src/(.*)$": "<rootDir>/src/$1",
   },
 };

--- a/coral/package.json
+++ b/coral/package.json
@@ -46,6 +46,7 @@
     "@vitejs/plugin-react": "^2.1.0",
     "eslint": "^8.25.0",
     "eslint-config-prettier": "^8.5.0",
+    "eslint-plugin-no-relative-import-paths": "^1.4.0",
     "eslint-plugin-react": "^7.31.10",
     "husky": "^8.0.1",
     "identity-obj-proxy": "^3.0.0",

--- a/coral/pnpm-lock.yaml
+++ b/coral/pnpm-lock.yaml
@@ -14,6 +14,7 @@ specifiers:
   '@vitejs/plugin-react': ^2.1.0
   eslint: ^8.25.0
   eslint-config-prettier: ^8.5.0
+  eslint-plugin-no-relative-import-paths: ^1.4.0
   eslint-plugin-react: ^7.31.10
   husky: ^8.0.1
   identity-obj-proxy: ^3.0.0
@@ -49,6 +50,7 @@ devDependencies:
   '@vitejs/plugin-react': 2.1.0_vite@3.1.8
   eslint: 8.25.0
   eslint-config-prettier: 8.5.0_eslint@8.25.0
+  eslint-plugin-no-relative-import-paths: 1.4.0
   eslint-plugin-react: 7.31.10_eslint@8.25.0
   husky: 8.0.1
   identity-obj-proxy: 3.0.0
@@ -2133,6 +2135,10 @@ packages:
       eslint: '>=7.0.0'
     dependencies:
       eslint: 8.25.0
+    dev: true
+
+  /eslint-plugin-no-relative-import-paths/1.4.0:
+    resolution: {integrity: sha512-J/ok26KqJM+20VsxNEcHc9kyW0dcFHBlihOO5FFv/GQqwcW+G1UngbHLpnPAdOQ1dJg5Ljk/40csqfZ3mnneUw==}
     dev: true
 
   /eslint-plugin-react/7.31.10_eslint@8.25.0:

--- a/coral/src/main.tsx
+++ b/coral/src/main.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import ReactDOM from "react-dom/client";
 import { RouterProvider } from "react-router-dom";
-import router from "./router";
+import router from "src/router";
 
 import "@aivenio/design-system/dist/styles.css";
 

--- a/coral/src/pages/hello/index.test.tsx
+++ b/coral/src/pages/hello/index.test.tsx
@@ -1,4 +1,4 @@
-import HelloPage from "src/pages/hello/index";
+import HelloPage from "src/pages/hello";
 import { render, cleanup, screen } from "@testing-library/react";
 
 describe("HelloPage", () => {

--- a/coral/src/pages/hello/index.test.tsx
+++ b/coral/src/pages/hello/index.test.tsx
@@ -1,4 +1,4 @@
-import HelloPage from "./index";
+import HelloPage from "src/pages/hello/index";
 import { render, cleanup, screen } from "@testing-library/react";
 
 describe("HelloPage", () => {

--- a/coral/src/pages/index.test.tsx
+++ b/coral/src/pages/index.test.tsx
@@ -1,4 +1,4 @@
-import HomePage from "src/pages/index";
+import HomePage from "src/pages";
 import { render, cleanup, screen } from "@testing-library/react";
 
 describe("HomePage", () => {

--- a/coral/src/pages/index.test.tsx
+++ b/coral/src/pages/index.test.tsx
@@ -1,4 +1,4 @@
-import HomePage from "./index";
+import HomePage from "src/pages/index";
 import { render, cleanup, screen } from "@testing-library/react";
 
 describe("HomePage", () => {

--- a/coral/src/router.tsx
+++ b/coral/src/router.tsx
@@ -1,5 +1,5 @@
 import { createBrowserRouter, Navigate, RouteObject } from "react-router-dom";
-import HomePage from "src/pages/index";
+import HomePage from "src/pages";
 import HelloPage from "src/pages/hello";
 
 const routes: Array<RouteObject> = [

--- a/coral/src/router.tsx
+++ b/coral/src/router.tsx
@@ -1,6 +1,6 @@
 import { createBrowserRouter, Navigate, RouteObject } from "react-router-dom";
-import HomePage from "./pages/index";
-import HelloPage from "./pages/hello";
+import HomePage from "src/pages/index";
+import HelloPage from "src/pages/hello";
 
 const routes: Array<RouteObject> = [
   {

--- a/coral/tsconfig.json
+++ b/coral/tsconfig.json
@@ -1,5 +1,9 @@
 {
   "compilerOptions": {
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["src/*"]
+    },
     "target": "ESNext",
     "useDefineForClassFields": true,
     "lib": ["DOM", "DOM.Iterable", "ESNext"],

--- a/coral/tsconfig.json
+++ b/coral/tsconfig.json
@@ -1,9 +1,6 @@
 {
   "compilerOptions": {
     "baseUrl": ".",
-    "paths": {
-      "@/*": ["src/*"]
-    },
     "target": "ESNext",
     "useDefineForClassFields": true,
     "lib": ["DOM", "DOM.Iterable", "ESNext"],

--- a/coral/vite.config.ts
+++ b/coral/vite.config.ts
@@ -1,7 +1,11 @@
 import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react";
+import { resolve } from "path";
 
+const rootPath = resolve(__dirname);
 // https://vitejs.dev/config/
+
+// console.log("rootPath", rootPath);
 export default defineConfig({
   plugins: [react()],
   define: {
@@ -14,6 +18,11 @@ export default defineConfig({
     // ⛔️ Don't do that! This can expose unwanted env vars in production builds.
     "process.env": {
       EXAMPLE: "",
+    },
+  },
+  resolve: {
+    alias: {
+      "@": resolve(rootPath, "./src"),
     },
   },
 });

--- a/coral/vite.config.ts
+++ b/coral/vite.config.ts
@@ -2,10 +2,7 @@ import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react";
 import { resolve } from "path";
 
-const rootPath = resolve(__dirname);
 // https://vitejs.dev/config/
-
-// console.log("rootPath", rootPath);
 export default defineConfig({
   plugins: [react()],
   define: {
@@ -22,7 +19,7 @@ export default defineConfig({
   },
   resolve: {
     alias: {
-      "@": resolve(rootPath, "./src"),
+      src: resolve(resolve(__dirname), "./src"),
     },
   },
 });


### PR DESCRIPTION
**About this change - What it does**
Configures TS and vite to use absolut imports where  "@/" maps to `coral/src`. 
Adds a eslint rule to restrict imports using relative paths except from the same directory.

**Why this way**
Avoiding relative imports is making potential refactoring more smooth. It also adds readability for the imports. 