### PR TITLE
feat[coral]: no-restricted-imports for page components

### DIFF
--- a/coral/.eslintrc.cjs
+++ b/coral/.eslintrc.cjs
@@ -30,6 +30,12 @@ module.exports = {
     "rules": {
         "no-relative-import-paths/no-relative-import-paths": [
             "error"
-        ]
+        ],
+        "no-restricted-imports": ["error", {
+            "patterns": [{
+              "group": ["src/pages*"],
+              "message": "Pages should be only imported from '/src/router.tsx'"
+            }]
+        }]
     }
 }

--- a/coral/.eslintrc.cjs
+++ b/coral/.eslintrc.cjs
@@ -1,3 +1,47 @@
+const NO_RESTRICTED_IMPORTS_RULES = ["error", {
+    patterns: [{
+        id: "DENY_PAGES_IMPORT",
+        group: ["src/pages*"],
+        message: "Pages should be only imported from '/src/router.tsx'"
+    }]
+}]
+
+function isObject(value) {
+    return typeof value === 'object' &&
+    !Array.isArray(value) &&
+    value !== null
+}
+
+const hasPatterns = (value) => isObject(value) && "patterns" in value;
+const dropIdFromPatterns = (patterns) => patterns.map(({group, message}) => ({group, message}))
+
+function filterPatternsByIds(patterns, ids) {
+    return patterns.filter(pattern => {
+        if ("id" in pattern) {
+            return !ids.includes(pattern.id)
+        }
+        return true
+    })
+}
+
+function strip_ids_from_no_restricted_imports(configuration) {
+    return configuration.map((rule) => {
+        if (hasPatterns(rule)) {
+            return {...rule, patterns: dropIdFromPatterns(rule.patterns)}
+        }
+        return rule
+    })
+}
+
+function filter_patterns_for_ids(configuration, ids) {
+    return configuration.map(rule => {
+        if (hasPatterns(rule)) {
+            return {...rule, patterns: dropIdFromPatterns(filterPatternsByIds(rule.patterns, ids))}
+        }
+        return rule
+    })
+}
+
 module.exports = {
     "env": {
         "browser": true,
@@ -11,6 +55,12 @@ module.exports = {
         "prettier"
     ],
     "overrides": [
+        {
+            "files": ["src/router.tsx", "src/pages/**/*.test.tsx"],
+            "rules": {
+                "no-restricted-imports": filter_patterns_for_ids(NO_RESTRICTED_IMPORTS_RULES, ["DENY_PAGES_IMPORT"])
+            }
+        }
     ],
     "parser": "@typescript-eslint/parser",
     "parserOptions": {
@@ -31,11 +81,6 @@ module.exports = {
         "no-relative-import-paths/no-relative-import-paths": [
             "error"
         ],
-        "no-restricted-imports": ["error", {
-            "patterns": [{
-              "group": ["src/pages*"],
-              "message": "Pages should be only imported from '/src/router.tsx'"
-            }]
-        }]
+        "no-restricted-imports": strip_ids_from_no_restricted_imports(NO_RESTRICTED_IMPORTS_RULES)
     }
 }

--- a/coral/src/router.tsx
+++ b/coral/src/router.tsx
@@ -1,6 +1,8 @@
 import { createBrowserRouter, Navigate, RouteObject } from "react-router-dom";
+/* eslint-disable no-restricted-imports */
 import HomePage from "src/pages";
 import HelloPage from "src/pages/hello";
+/* eslint-enable */
 
 const routes: Array<RouteObject> = [
   {

--- a/coral/src/router.tsx
+++ b/coral/src/router.tsx
@@ -1,8 +1,6 @@
 import { createBrowserRouter, Navigate, RouteObject } from "react-router-dom";
-/* eslint-disable no-restricted-imports */
 import HomePage from "src/pages";
 import HelloPage from "src/pages/hello";
-/* eslint-enable */
 
 const routes: Array<RouteObject> = [
   {


### PR DESCRIPTION
Page components should be only imported from a `router.tsx` file. In order to be able to enforce that,
we need to introduce `no-restricted-imports` rule that disallows all imports from `/src/pages` folder
with a single exception.

Currently the exception is implemented with a `overrides` and actual Javascript. It is not pretty, but it
seems to get the job done.


Resolves: #155