### PR TITLE
feat: run coral inside Klaw springboot application

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,5 @@ node_modules/
 
 # Coral build artefacts
 coral/dist*
+src/main/resources/static/assets/coral*
+src/main/resources/templates/coral*

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,27 @@
+CORAL_DIST_PATH = coral/dist
+
+default:
+	@echo "TODO: ADD USAGE INSTRUCTIONS"
+
+$(CORAL_DIST_PATH): coral/index.html coral/src/*
+	pnpm  --prefix coral build --assetsDir assets/coral --mode springboot
+
+src/main/resources/templates/coral/index.html: $(CORAL_DIST_PATH)
+	mkdir -p $(shell dirname $@)
+	cp -r $(CORAL_DIST_PATH)/index.html $@
+
+src/main/resources/static/assets/coral: $(CORAL_DIST_PATH)
+	cp -r $(CORAL_DIST_PATH)/assets/* $@
+
+.PHONY: enable-coral-in-springboot 
+enable-coral-in-springboot: src/main/resources/templates/coral/index.html src/main/resources/static/assets/coral
+	sed -i "" 's/klaw\.coral\.enabled=false/klaw\.coral\.enabled=true/' src/main/resources/application.properties
+
+.PHONY: disable-coral-in-springboot 
+disable-coral-in-springboot:
+	sed -i "" 's/klaw\.coral\.enabled=true/klaw\.coral\.enabled=false/' src/main/resources/application.properties
+
+clean:
+	rm -rf src/main/resources/templates/coral
+	rm -rf src/main/resources/static/assets/coral
+

--- a/coral/.env.springboot
+++ b/coral/.env.springboot
@@ -1,0 +1,3 @@
+NODE_ENV=production
+VITE_ROUTER_BASENAME=/coral/
+

--- a/coral/src/app/router.tsx
+++ b/coral/src/app/router.tsx
@@ -22,6 +22,8 @@ const routes: Array<RouteObject> = [
   },
 ];
 
-const router = createBrowserRouter(routes);
+const router = createBrowserRouter(routes, {
+  basename: import.meta.env.VITE_ROUTER_BASENAME,
+});
 
 export default router;

--- a/coral/src/vite-env.d.ts
+++ b/coral/src/vite-env.d.ts
@@ -1,1 +1,9 @@
 /// <reference types="vite/client" />
+
+interface ImportMetaEnv {
+  readonly VITE_ROUTER_BASENAME: string;
+}
+
+interface ImportMeta {
+  readonly env: ImportMetaEnv;
+}

--- a/src/main/java/io/aiven/klaw/config/SecurityConfigNoSSO.java
+++ b/src/main/java/io/aiven/klaw/config/SecurityConfigNoSSO.java
@@ -77,6 +77,9 @@ public class SecurityConfigNoSSO extends WebSecurityConfigurerAdapter {
   @Value("${klaw.jasypt.encryptor.secretkey}")
   private String encryptorSecretKey;
 
+  @Value("${klaw.coral.enabled:false}")
+  private boolean coralEnabled;
+
   @Autowired LdapTemplate ldapTemplate;
 
   @Autowired private KwRequestFilter kwRequestFilterup;
@@ -87,35 +90,41 @@ public class SecurityConfigNoSSO extends WebSecurityConfigurerAdapter {
 
   @Override
   protected void configure(HttpSecurity http) throws Exception {
+    List<String> staticResourcesHtmlArray =
+        new ArrayList<>(
+            List.of(
+                "/assets/**",
+                "/lib/**",
+                "/js/**",
+                "/home",
+                "/home/**",
+                "/register**",
+                "/authenticate",
+                "/login**",
+                "/terms**",
+                "/registrationReview**",
+                "/forgotPassword",
+                "/getDbAuth",
+                "/feedback**",
+                "/resetPassword",
+                "/getRoles",
+                "/getTenantsInfo",
+                "/getBasicInfo",
+                "/getAllTeamsSUFromRegisterUsers",
+                "/registerUser",
+                "/resetMemoryCache/**",
+                "/userActivation**",
+                "/getActivationInfo**"));
 
-    String[] staticResources = {
-      "/lib/**",
-      "/assets/**",
-      "/js/**",
-      "/home",
-      "/home/**",
-      "/register**",
-      "/login**",
-      "/terms**",
-      "/registrationReview**",
-      "/forgotPassword",
-      "/getDbAuth",
-      "/feedback**",
-      "/resetPassword",
-      "/getRoles",
-      "/getTenantsInfo",
-      "/getBasicInfo",
-      "/getAllTeamsSUFromRegisterUsers",
-      "/registerUser",
-      "/resetMemoryCache/**",
-      "/userActivation**",
-      "/getActivationInfo**"
-    };
+    if (coralEnabled) {
+      staticResourcesHtmlArray.add("/coral/**");
+      staticResourcesHtmlArray.add("/assets/coral/**");
+    }
 
     http.csrf()
         .disable()
         .authorizeRequests()
-        .antMatchers(staticResources)
+        .antMatchers(staticResourcesHtmlArray.toArray(new String[0]))
         .permitAll()
         .anyRequest()
         .fullyAuthenticated()

--- a/src/main/java/io/aiven/klaw/controller/CoralController.java
+++ b/src/main/java/io/aiven/klaw/controller/CoralController.java
@@ -1,0 +1,19 @@
+package io.aiven.klaw.controller;
+
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
+
+@ConditionalOnProperty(name = "klaw.coral.enabled", havingValue = "true")
+@Controller
+@RequestMapping("/coral")
+public class CoralController {
+
+  public static final String CORAL_INDEX = "coral/index";
+
+  @RequestMapping(value = "/**", method = RequestMethod.GET)
+  public String any() {
+    return CORAL_INDEX;
+  }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -168,6 +168,9 @@ server.compression.min-response-size=1024
 #maximum tenants can be created
 klaw.max.tenants=200
 
+# Enable new Klaw user interface
+klaw.coral.enabled=false
+
 # log file settings
 #logging.level.root=debug
 logging.level.org.hibernate.SQL=off


### PR DESCRIPTION
Introduce a Makefile with a default target that builds `coral` project into Klaw springboot application. If the user has set `klaw.coral.enabled=true` in `application.properties` they are able to access the Coral application from `/coral` paths inside the springboot app.

Resolves: #157