### PR TITLE
feat: Add rudimentary style and behavior for login page.

### DIFF
--- a/coral/src/app/components/Form.test.tsx
+++ b/coral/src/app/components/Form.test.tsx
@@ -6,6 +6,7 @@ import React from "react";
 import type { DeepPartial, FieldValues } from "react-hook-form";
 import {
   Form,
+  PasswordInput,
   SubmitErrorHandler,
   SubmitHandler,
   TextInput,
@@ -147,6 +148,52 @@ describe("Form", () => {
       await waitFor(() => expect(screen.queryByText("error")).toBeVisible());
 
       await typeText("abc{tab}");
+      await waitFor(() => expect(screen.queryByText("error")).toBeNull());
+    });
+  });
+
+  describe("<PasswordInput>", () => {
+    const schema = z.object({ password: z.string().min(3, "error") });
+    type Schema = z.infer<typeof schema>;
+
+    beforeEach(() => {
+      results = renderForm(
+        <PasswordInput<Schema> name="password" labelText="PasswordInput" />,
+        { schema }
+      );
+    });
+
+    it("should render <PasswordInput>", () => {
+      expect(results.container).toMatchSnapshot();
+    });
+
+    it("should render label", () => {
+      expect(screen.queryByLabelText("PasswordInput")).toBeVisible();
+    });
+
+    it("should sync value to form state", async () => {
+      // For security reasons, there is no role password
+      // -> https://github.com/w3c/aria/issues/166
+      // the recommended way to query is using byLabel
+      const passwordInput = screen.getByLabelText("PasswordInput");
+      await user.clear(passwordInput);
+      await user.type(passwordInput, "value{tab}");
+
+      await submit();
+      assertSubmitted({ password: "value" });
+    });
+
+    it("should render errors after blur event and hide them after valid input", async () => {
+      // For security reasons, there is no role password
+      // -> https://github.com/w3c/aria/issues/166
+      // the recommended way to query is using byLabel
+      const passwordInput = screen.getByLabelText("PasswordInput");
+      await user.clear(passwordInput);
+      await user.type(passwordInput, "a{tab}");
+      await waitFor(() => expect(screen.queryByText("error")).toBeVisible());
+
+      await user.clear(passwordInput);
+      await user.type(passwordInput, "abc{tab}");
       await waitFor(() => expect(screen.queryByText("error")).toBeNull());
     });
   });

--- a/coral/src/app/components/Form.tsx
+++ b/coral/src/app/components/Form.tsx
@@ -73,6 +73,41 @@ export const Form = <T extends FieldValues = FieldValues>({
 };
 
 //
+// <PasswordInput>
+// This not part of Aiven core implementation but an input
+// custom for Klaw use cases. It's exactly the same as <TextInput>
+// with the only difference being the type (password) to have
+// a more secure way for users to enter password (input obscured)
+function _PasswordInput<T extends FieldValues>({
+  name,
+  formContext: form,
+  ...props
+}: BaseInputProps & FormInputProps<T> & FormRegisterProps<T>) {
+  const { errors } = form.formState;
+  const error = get(errors, name)?.message as string;
+  return (
+    <BaseInput
+      {...props}
+      type="password"
+      {...form.register(name)}
+      valid={error ? false : undefined}
+      error={error}
+    />
+  );
+}
+
+const PasswordInputMemo = memo(_PasswordInput) as typeof _PasswordInput;
+
+export const PasswordInput = <T extends FieldValues>(
+  props: FormInputProps<T> & BaseInputProps
+): React.ReactElement<FormInputProps<T> & BaseInputProps> => {
+  const ctx = useFormContext<T>();
+  return <PasswordInputMemo formContext={ctx} {...props} />;
+};
+
+PasswordInput.Skeleton = BaseInput.Skeleton;
+
+//
 // <TextInput>
 //
 function _TextInput<T extends FieldValues>({

--- a/coral/src/app/components/__snapshots__/Form.test.tsx.snap
+++ b/coral/src/app/components/__snapshots__/Form.test.tsx.snap
@@ -1,5 +1,47 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Form <PasswordInput> should render <PasswordInput> 1`] = `
+<div>
+  <form>
+    <div
+      style="display: flex; flex-direction: column;"
+    >
+      <label
+        class="w-full"
+        for="input-45"
+        id="input-45-label"
+      >
+        <span
+          class="inline-block mb-2 font-medium typography-body-small text-grey-60"
+        >
+          PasswordInput
+        </span>
+        <span
+          class="relative block"
+        >
+          <input
+            class="block w-full rounded-sm disabled:cursor-not-allowed disabled:border-grey-20 disabled:bg-grey-5 typography-body-small text-grey-70 disabled:text-grey-40 placeholder:text-grey-40 focus:outline-none px-3 py-3 border border-grey-20 hover:border-grey-50 focus:border-info-70"
+            id="input-45"
+            name="password"
+            type="password"
+          />
+        </span>
+      </label>
+      <p
+        class="block mt-1 mb-3 typography-caption-default"
+      >
+         
+      </p>
+    </div>
+    <button
+      class="text-white bg-primary-80 active:bg-primary-90 active:ring-0 focus-visible:ring-2 focus-visible:ring-primary-100 focus-visible:ring-inset hover:bg-primary-70 disabled:bg-primary-5 inline-block border-0 rounded-sm transition whitespace-nowrap focus:outline-none relative typography-body-default py-3 px-4"
+      title="Submit"
+      type="submit"
+    />
+  </form>
+</div>
+`;
+
 exports[`Form <TextInput> should render <TextInput> 1`] = `
 <div>
   <form>

--- a/coral/src/app/pages/Login.test.tsx
+++ b/coral/src/app/pages/Login.test.tsx
@@ -1,0 +1,83 @@
+import Login from "src/app/pages/Login";
+import { render, cleanup, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+describe("Login", () => {
+  beforeEach(() => {
+    render(<Login />);
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  describe("renders all necessary elements", () => {
+    it("shows a headline", () => {
+      const headline = screen.getByRole("heading", { name: "Login page" });
+      expect(headline).toBeVisible();
+    });
+
+    it("shows an input field for username", () => {
+      const input = screen.getByRole("textbox", { name: /Username/ });
+      expect(input).toBeEnabled();
+    });
+
+    it("shows an input field for password", () => {
+      // For security reasons, there is no role password
+      // -> https://github.com/w3c/aria/issues/166
+      // the recommended way to query is using byLabel
+      const input = screen.getByLabelText(/Password/);
+      expect(input).toBeEnabled();
+    });
+
+    it("shows a disabled submit button for the form", () => {
+      const button = screen.getByRole("button", { name: "Submit" });
+      expect(button).toBeDisabled();
+    });
+  });
+
+  describe("provides form control", () => {
+    it("user can fill username and password and submit form", async () => {
+      const usernameInput = screen.getByRole("textbox", { name: /Username/ });
+      const passwordInput = screen.getByLabelText(/Password/);
+      const submitButton = screen.getByRole("button", { name: "Submit" });
+
+      await userEvent.type(usernameInput, "my username");
+      await userEvent.tab();
+      await userEvent.type(passwordInput, "badpassword123");
+      await userEvent.tab();
+      await userEvent.click(submitButton);
+
+      const successMessage = await screen.findByText("Login successful!");
+      expect(successMessage).toBeVisible();
+    });
+
+    it("user can not submit form if not all inputs are filled", async () => {
+      const usernameInput = screen.getByRole("textbox", { name: /Username/ });
+      const submitButton = screen.getByRole("button", { name: "Submit" });
+
+      await userEvent.type(usernameInput, "my username");
+      await userEvent.tab();
+      await userEvent.click(submitButton);
+
+      await waitFor(() => {
+        expect(screen.queryByText("Login successful!")).not.toBeInTheDocument();
+      });
+    });
+
+    it("user gets an error message telling them what fields are missing", async () => {
+      const usernameInput = screen.getByRole("textbox", { name: /Username/ });
+      const submitButton = screen.getByRole("button", { name: "Submit" });
+
+      await userEvent.type(usernameInput, "my username");
+      await userEvent.tab();
+      await userEvent.click(submitButton);
+
+      const passwordInput = screen.getByLabelText(/Password/);
+      const errorMessage = await screen.findByText("Password is required");
+
+      expect(passwordInput).toBeInvalid();
+      expect(errorMessage).toBeVisible();
+    });
+  });
+});

--- a/coral/src/app/pages/Login.tsx
+++ b/coral/src/app/pages/Login.tsx
@@ -1,43 +1,62 @@
 import z from "zod";
 import {
   Form,
+  PasswordInput,
   SubmitButton,
   TextInput,
   useForm,
 } from "src/app/components/Form";
 import { FieldErrors } from "react-hook-form";
+import { useState } from "react";
+import { Flexbox, FlexboxItem } from "@aivenio/design-system";
 
 const formSchema = z.object({
-  username: z.string(),
-  password: z.string(),
+  username: z.string().min(1, { message: "Username is required" }),
+  password: z.string().min(1, { message: "Password is required" }),
 });
 
 type Schema = z.infer<typeof formSchema>;
 
-const Login = () => {
+const LoginPage = () => {
+  const [success, setSuccess] = useState<boolean>(false);
   const form = useForm<Schema>({
     schema: formSchema,
   });
 
-  function onSubmitForm() {
-    console.log("submit");
+  function onSubmitForm(userInput: Schema) {
+    setSuccess(true);
+    return userInput;
   }
 
   function onErrorForm(arg: FieldErrors) {
-    console.error(arg);
+    return arg;
   }
 
   return (
     <>
       <h1>Login page</h1>
-
-      <Form {...form} onSubmit={onSubmitForm} onError={onErrorForm}>
-        <TextInput<Schema> name={"username"} />
-        <TextInput<Schema> name={"password"} />
-        <SubmitButton>Submit</SubmitButton>
-      </Form>
+      <Flexbox direction={"column"} alignItems={"center"}>
+        <FlexboxItem width={"3/5"}>
+          <Form {...form} onSubmit={onSubmitForm} onError={onErrorForm}>
+            <TextInput<Schema>
+              name={"username"}
+              labelText="Username"
+              placeholder="Your username"
+              required
+            />
+            <PasswordInput<Schema>
+              name={"password"}
+              labelText="Password"
+              placeholder="Your password"
+              required
+            />
+            <SubmitButton>Submit</SubmitButton>
+          </Form>
+          {success && <div>Login successful!</div>}
+        </FlexboxItem>
+      </Flexbox>
     </>
   );
 };
 
-export default Login;
+export default LoginPage;


### PR DESCRIPTION
## About this change - What it does
- Adds styles (based on Aiven DS) and rudimentary behavior for `Login` page
- Adds tests for the current behavior
- Adds a new component `PasswordInput` to `Form`. The component is a 1:1 copy from `TextInput` with only difference being `type="password"`. This adds extra security for users when they type in their password, because it obscures what they type in.

Resolves: #142 

## Why this way
- tests are not 100% necessary right now, but I wanted to add them to see if we have all libs etc. in place