### PR TITLE
refactor(coral): Enable custom setup and teardown in React tests.

### DIFF
--- a/coral/jest.config.ts
+++ b/coral/jest.config.ts
@@ -7,6 +7,7 @@ export default {
   moduleFileExtensions: ["js", "jsx", "ts", "tsx"],
   preset: "ts-jest",
   testEnvironment: "jsdom",
+  setupFiles: ["@testing-library/react/dont-cleanup-after-each"],
   setupFilesAfterEnv: ["<rootDir>/test-setup/setup-files-after-env.ts"],
   moduleNameMapper: {
     ".+\\.(png|jpg|ttf|woff|woff2|svg)$": "jest-transform-stub",

--- a/coral/src/app/pages/Hello.test.tsx
+++ b/coral/src/app/pages/Hello.test.tsx
@@ -2,13 +2,12 @@ import Hello from "src/app/pages/Hello";
 import { render, cleanup, screen } from "@testing-library/react";
 
 describe("Hello", () => {
-  beforeEach(() => {
+  beforeAll(() => {
     render(<Hello />);
   });
 
-  afterEach(() => {
-    cleanup();
-  });
+  afterAll(cleanup);
+
   it("shoud render dummy content", () => {
     expect(screen.getByText("Hello")).toBeVisible();
   });

--- a/coral/src/app/pages/Login.test.tsx
+++ b/coral/src/app/pages/Login.test.tsx
@@ -1,13 +1,14 @@
 import Login from "src/app/pages/Login";
-import { screen } from "@testing-library/react";
+import { cleanup, screen } from "@testing-library/react";
 import { renderWithQueryClient } from "src/services/test-utils";
 
 describe("Login", () => {
-  beforeEach(() => {
-    renderWithQueryClient(<Login />);
-  });
-
   describe("renders all necessary elements", () => {
+    beforeAll(() => {
+      renderWithQueryClient(<Login />);
+    });
+    afterAll(cleanup);
+
     it("shows a headline", () => {
       const headline = screen.getByRole("heading", { name: "Login page" });
       expect(headline).toBeVisible();

--- a/coral/src/app/pages/index.test.tsx
+++ b/coral/src/app/pages/index.test.tsx
@@ -1,11 +1,13 @@
 import HomePage from "src/app/pages";
-import { screen } from "@testing-library/react";
+import { cleanup, screen } from "@testing-library/react";
 import { renderWithQueryClient } from "src/services/test-utils";
 
 describe("HomePage", () => {
-  beforeEach(() => {
+  beforeAll(() => {
     renderWithQueryClient(<HomePage />);
   });
+
+  afterAll(cleanup);
 
   it("renders dummy content", () => {
     const heading = screen.getByRole("heading", { name: "Index" });


### PR DESCRIPTION
# About this change - What it does
- remove auto cleanup afterEach in jest config, see: https://testing-library.com/docs/react-testing-library/setup/#skipping-auto-cleanup
- update existing tests

# Why this way
Samuli and I discussed this yesterday:
- using custom setup and teardowns for rendered components instead of using a automated cleanup after each

## Benefits
-  reduces the time a component in a test needs to be rendered, e.g. when checking different things on an unchanging state of a rendered component
- in the last (professional) app we used that approach, we had in a still small number of tests ( ~ 150) a more then 30% reduced number of renders
- based on my experience, this will speed up tests, especially for CI when they run without cache 
- this setting _enables_ to do custom cleanup, but people can also use a `beforeEach(cleanup)` at the outermost scope of their testsuite and get the same behavior as with the auto-cleanup

## Drawbacks
- people need to remember to `cleanup` their state to have clean test states

✨ We decided to try this approach and see how it works for us (and contributors) and are open to revers this decision if it leads to problems. After a trial period we also will add that to the frontend documentation. 
