### PR TITLE
refactor(coral): improve MSW response mocking

### DIFF
--- a/coral/src/app/features/topics/BrowseTopics.test.tsx
+++ b/coral/src/app/features/topics/BrowseTopics.test.tsx
@@ -1,5 +1,6 @@
 import { server } from "src/services/api-mocks/server";
 import {
+  mockedResponseSinglePage,
   mockedResponseTransformed,
   mockGetTeams,
   mockTopicGetRequest,
@@ -34,7 +35,7 @@ describe("BrowseTopics.tsx", () => {
       mockGetTeams({ mswInstance: server });
       mockTopicGetRequest({
         mswInstance: server,
-        scenario: "single-page-static",
+        response: { status: 200, data: mockedResponseSinglePage },
       });
       renderWithQueryClient(<BrowseTopics />);
     });
@@ -101,7 +102,7 @@ describe("BrowseTopics.tsx", () => {
       mockGetTeams({ mswInstance: server });
       mockTopicGetRequest({
         mswInstance: server,
-        scenario: "single-page-static",
+        response: { status: 200, data: mockedResponseSinglePage },
       });
       renderWithQueryClient(<BrowseTopics />);
     });

--- a/coral/src/app/features/topics/BrowseTopics.test.tsx
+++ b/coral/src/app/features/topics/BrowseTopics.test.tsx
@@ -79,7 +79,10 @@ describe("BrowseTopics.tsx", () => {
     beforeEach(() => {
       mockGetEnvironments({ mswInstance: server });
       mockGetTeams({ mswInstance: server });
-      mockTopicGetRequest({ mswInstance: server, scenario: "empty" });
+      mockTopicGetRequest({
+        mswInstance: server,
+        response: { status: 200, data: [] },
+      });
       renderWithQueryClient(<BrowseTopics />);
     });
 

--- a/coral/src/app/features/topics/BrowseTopics.test.tsx
+++ b/coral/src/app/features/topics/BrowseTopics.test.tsx
@@ -57,7 +57,10 @@ describe("BrowseTopics.tsx", () => {
       console.error = jest.fn();
       mockGetEnvironments({ mswInstance: server });
       mockGetTeams({ mswInstance: server });
-      mockTopicGetRequest({ mswInstance: server, scenario: "error" });
+      mockTopicGetRequest({
+        mswInstance: server,
+        response: { status: 400, data: { message: "Not relevant" } },
+      });
       renderWithQueryClient(<BrowseTopics />);
     });
 

--- a/coral/src/app/features/topics/hooks/list/useGetTopics.test.tsx
+++ b/coral/src/app/features/topics/hooks/list/useGetTopics.test.tsx
@@ -80,7 +80,10 @@ describe("useGetTopics", () => {
     it("returns an error when request fails", async () => {
       console.error = jest.fn();
 
-      mockTopicGetRequest({ mswInstance: server, scenario: "error" });
+      mockTopicGetRequest({
+        mswInstance: server,
+        response: { status: 400, data: { message: "Not relevant" } },
+      });
 
       const { result } = await renderHook(
         () => useGetTopics({ currentPage: 1, environment: "ALL" }),

--- a/coral/src/app/features/topics/hooks/list/useGetTopics.test.tsx
+++ b/coral/src/app/features/topics/hooks/list/useGetTopics.test.tsx
@@ -4,11 +4,13 @@ import { ReactElement } from "react";
 import { server } from "src/services/api-mocks/server";
 import {
   mockedResponseMultiplePageTransformed,
+  mockedResponseSinglePage,
   mockedResponseTransformed,
   mockTopicGetRequest,
 } from "src/domain/topic/topic-api.msw";
 
 import { useGetTopics } from "src/app/features/topics/hooks/list/useGetTopics";
+import { createMockTopic } from "src/domain/topic/topic-test-helper";
 
 const queryClient = new QueryClient({
   defaultOptions: {
@@ -39,11 +41,23 @@ describe("useGetTopics", () => {
     server.close();
   });
 
-  describe("handles loading and error state", () => {
+  describe.only("handles loading and error state", () => {
     it("returns a loading state before starting to fetch data", async () => {
+      const responseData = [
+        [
+          createMockTopic({
+            topicName: "Topic 1",
+            topicId: 1,
+            environmentsList: ["DEV"],
+          }),
+        ],
+      ];
       mockTopicGetRequest({
         mswInstance: server,
-        scenario: "single-page-static",
+        response: {
+          status: 200,
+          data: responseData,
+        },
       });
 
       const { result } = await renderHook(
@@ -86,7 +100,7 @@ describe("useGetTopics", () => {
     it("returns a list of topics with one page if api call is successful", async () => {
       mockTopicGetRequest({
         mswInstance: server,
-        scenario: "single-page-static",
+        response: { status: 200, data: mockedResponseSinglePage },
       });
 
       const { result } = await renderHook(

--- a/coral/src/app/pages/topics/index.test.tsx
+++ b/coral/src/app/pages/topics/index.test.tsx
@@ -8,6 +8,7 @@ import Topics from "src/app/pages/topics";
 import { renderWithQueryClient } from "src/services/test-utils";
 import { server } from "src/services/api-mocks/server";
 import {
+  mockedResponseSinglePage,
   mockedResponseTransformed,
   mockGetTeams,
   mockTopicGetRequest,
@@ -33,7 +34,7 @@ describe("Topics", () => {
       mockGetTeams({ mswInstance: server });
       mockTopicGetRequest({
         mswInstance: server,
-        scenario: "single-page-static",
+        response: { status: 200, data: mockedResponseSinglePage },
       });
       renderWithQueryClient(<Topics />);
       await waitForElementToBeRemoved(screen.getByText("Loading..."));

--- a/coral/src/domain/topic/topic-api.msw.ts
+++ b/coral/src/domain/topic/topic-api.msw.ts
@@ -19,8 +19,11 @@ function mockTopicGetRequest({
   response,
 }: {
   mswInstance: MswInstance;
-  scenario?: "error" | "multiple-pages-static" | "single-page-env-dev";
-  response?: { status: number; data: TopicDTOApiResponse };
+  scenario?: "multiple-pages-static" | "single-page-env-dev";
+  response?: {
+    status: number;
+    data: TopicDTOApiResponse | { message: string };
+  };
 }) {
   const base = getHTTPBaseAPIUrl();
   mswInstance.use(
@@ -34,10 +37,7 @@ function mockTopicGetRequest({
         return res(ctx.status(response.status), ctx.json(response.data));
       }
 
-      // error path
-      if (scenario === "error") {
-        return res(ctx.status(400), ctx.json(""));
-      } else if (scenario === "multiple-pages-static") {
+      if (scenario === "multiple-pages-static") {
         return res(ctx.status(200), ctx.json(mockedResponseMultiplePage));
       } else if (scenario === "single-page-env-dev") {
         return res(ctx.status(200), ctx.json(mockedResponseTopicEnv));
@@ -65,7 +65,7 @@ function mockTopicGetRequest({
   );
 }
 
-export const mockedResponseSinglePage: TopicDTOApiResponse =
+const mockedResponseSinglePage: TopicDTOApiResponse =
   createMockTopicApiResponse({
     entries: 10,
   });
@@ -152,4 +152,5 @@ export {
   mockGetTeams,
   mockedResponseTransformed,
   mockedResponseMultiplePageTransformed,
+  mockedResponseSinglePage,
 };

--- a/coral/src/domain/topic/topic-api.msw.ts
+++ b/coral/src/domain/topic/topic-api.msw.ts
@@ -19,11 +19,7 @@ function mockTopicGetRequest({
   response,
 }: {
   mswInstance: MswInstance;
-  scenario?:
-    | "error"
-    | "empty"
-    | "multiple-pages-static"
-    | "single-page-env-dev";
+  scenario?: "error" | "multiple-pages-static" | "single-page-env-dev";
   response?: { status: number; data: TopicDTOApiResponse };
 }) {
   const base = getHTTPBaseAPIUrl();
@@ -41,12 +37,6 @@ function mockTopicGetRequest({
       // error path
       if (scenario === "error") {
         return res(ctx.status(400), ctx.json(""));
-      }
-      // response empty
-      else if (scenario === "empty") {
-        return res(ctx.status(200), ctx.json([]));
-
-        // response total pages 4, current page based on api
       } else if (scenario === "multiple-pages-static") {
         return res(ctx.status(200), ctx.json(mockedResponseMultiplePage));
       } else if (scenario === "single-page-env-dev") {

--- a/coral/src/domain/topic/topic-api.msw.ts
+++ b/coral/src/domain/topic/topic-api.msw.ts
@@ -8,6 +8,7 @@ import {
 } from "src/domain/topic/topic-test-helper";
 import { getHTTPBaseAPIUrl } from "src/config";
 
+import { isObject } from "lodash";
 // @TODO
 // create visible mocked responses and easy responses for different scenarios to use in tests
 // use json files from real api for mocked responses for web worker (more realistic(
@@ -15,14 +16,15 @@ import { getHTTPBaseAPIUrl } from "src/config";
 function mockTopicGetRequest({
   mswInstance,
   scenario,
+  response,
 }: {
   mswInstance: MswInstance;
   scenario?:
     | "error"
     | "empty"
     | "multiple-pages-static"
-    | "single-page-static"
     | "single-page-env-dev";
+  response?: { status: number; data: TopicDTOApiResponse };
 }) {
   const base = getHTTPBaseAPIUrl();
   mswInstance.use(
@@ -30,6 +32,12 @@ function mockTopicGetRequest({
       const currentPage = req.url.searchParams.get("pageNo");
       const env = req.url.searchParams.get("env");
       const team = req.url.searchParams.get("teamName");
+
+      // Passing an response will the precedence over scenario.
+      if (isObject(response)) {
+        return res(ctx.status(response.status), ctx.json(response.data));
+      }
+
       // error path
       if (scenario === "error") {
         return res(ctx.status(400), ctx.json(""));
@@ -41,8 +49,6 @@ function mockTopicGetRequest({
         // response total pages 4, current page based on api
       } else if (scenario === "multiple-pages-static") {
         return res(ctx.status(200), ctx.json(mockedResponseMultiplePage));
-      } else if (scenario === "single-page-static") {
-        return res(ctx.status(200), ctx.json(mockedResponseSinglePage));
       } else if (scenario === "single-page-env-dev") {
         return res(ctx.status(200), ctx.json(mockedResponseTopicEnv));
       }
@@ -69,7 +75,7 @@ function mockTopicGetRequest({
   );
 }
 
-const mockedResponseSinglePage: TopicDTOApiResponse =
+export const mockedResponseSinglePage: TopicDTOApiResponse =
   createMockTopicApiResponse({
     entries: 10,
   });


### PR DESCRIPTION
The mocked API payload shape should defined closer where it is relevant. If we would use the scenario model, we would have ever growing list of hard coded mocks whereas we could have it more "dynamic".