### PR TITLE
fix(coral): Fix TopicCard css module import path

### DIFF
--- a/coral/src/app/features/topics/components/list/TopicCard.tsx
+++ b/coral/src/app/features/topics/components/list/TopicCard.tsx
@@ -7,7 +7,7 @@ import {
   Flexbox,
   ExternalLinkButton,
 } from "@aivenio/design-system";
-import classes from "src/app/features/topics/list/components/TopicCard.module.css";
+import classes from "src/app/features/topics/components/list/TopicCard.module.css";
 import { Topic } from "src/domain/topics";
 import { createTopicOverviewLink } from "src/app/features/topics/utils/create-topic-overview-link";
 


### PR DESCRIPTION
Fix simple import error introduced in https://github.com/aiven/klaw/pull/218.

CSS module import path before https://github.com/aiven/klaw/pull/218:
`src/app/features/topics/components/TopicCard.module.css`
CSS module import path after https://github.com/aiven/klaw/pull/218:
`src/app/features/topics/list/components/TopicCard.module.css`

CSS module path before https://github.com/aiven/klaw/pull/218:
`src/app/features/topics/components/TopicCard.module.css`
CSS module path after https://github.com/aiven/klaw/pull/218:
`src/app/features/topics/components/list/TopicCard.module.css`