### PR TITLE
refactor(coral): use API client with GET topics request 

### DIFF
--- a/coral/src/app/features/topics/BrowseTopics.tsx
+++ b/coral/src/app/features/topics/BrowseTopics.tsx
@@ -33,7 +33,7 @@ function BrowseTopics() {
   } = useGetTopics({
     currentPage: page,
     environment,
-    teamName: team,
+    ...(team !== ALL_TEAMS_VALUE && { teamName: team }),
   });
 
   const hasTopics = topics && topics.entries.length > 0;

--- a/coral/src/app/features/topics/hooks/list/useGetTopics.ts
+++ b/coral/src/app/features/topics/hooks/list/useGetTopics.ts
@@ -1,9 +1,9 @@
 import { useQuery, UseQueryResult } from "@tanstack/react-query";
 import { useEffect } from "react";
 import { mockTopicGetRequest } from "src/domain/topic/topic-api.msw";
-import { getTopics } from "src/domain/topic";
 import { TopicApiResponse } from "src/domain/topic/topic-types";
 import { Environment } from "src/domain/environment";
+import { topicsQuery } from "src/domain/topic/topic-queries";
 
 function useGetTopics({
   currentPage,
@@ -24,11 +24,9 @@ function useGetTopics({
     }
   }, []);
 
-  return useQuery<TopicApiResponse, Error>({
-    queryKey: ["topics", currentPage, environment, teamName],
-    queryFn: () => getTopics({ currentPage, environment, teamName }),
-    keepPreviousData: true,
-  });
+  return useQuery<TopicApiResponse, Error>(
+    topicsQuery({ currentPage, environment, teamName })
+  );
 }
 
 export { useGetTopics };

--- a/coral/src/domain/topic/topic-api.msw.ts
+++ b/coral/src/domain/topic/topic-api.msw.ts
@@ -6,6 +6,7 @@ import {
   createMockTopic,
   createMockTopicApiResponse,
 } from "src/domain/topic/topic-test-helper";
+import { getHTTPBaseAPIUrl } from "src/config";
 
 // @TODO
 // create visible mocked responses and easy responses for different scenarios to use in tests
@@ -23,8 +24,9 @@ function mockTopicGetRequest({
     | "single-page-static"
     | "single-page-env-dev";
 }) {
+  const base = getHTTPBaseAPIUrl();
   mswInstance.use(
-    rest.get("getTopics", async (req, res, ctx) => {
+    rest.get(`${base}/getTopics`, async (req, res, ctx) => {
       const currentPage = req.url.searchParams.get("pageNo");
       const env = req.url.searchParams.get("env");
       const team = req.url.searchParams.get("teamName");

--- a/coral/src/domain/topic/topic-api.ts
+++ b/coral/src/domain/topic/topic-api.ts
@@ -1,3 +1,4 @@
+import api from "src/services/api-client";
 import {
   TopicApiResponse,
   TopicDTOApiResponse,
@@ -21,22 +22,9 @@ const getTopics = async ({
     ...(team && { teamName: team }),
   };
 
-  return fetch(`/getTopics?${new URLSearchParams(params)}`, {
-    method: "GET",
-    headers: {
-      "Content-Type": "application/json",
-    },
-  })
-    .then(async (response) => {
-      if (!response.ok) {
-        throw new Error(`msw error: ${response.statusText}`);
-      }
-      const test: TopicDTOApiResponse = await response.json();
-      return transformTopicApiResponse(test);
-    })
-    .catch((error) => {
-      throw new Error(error);
-    });
+  return api
+    .get<TopicDTOApiResponse>(`/getTopics?${new URLSearchParams(params)}`)
+    .then(transformTopicApiResponse);
 };
 
 export { getTopics };

--- a/coral/src/domain/topic/topic-queries.ts
+++ b/coral/src/domain/topic/topic-queries.ts
@@ -1,0 +1,17 @@
+import { getTopics } from "src/domain/topic/topic-api";
+
+export const topicsQuery = ({
+  currentPage,
+  environment,
+  teamName,
+}: {
+  currentPage: number;
+  environment: string;
+  teamName?: string;
+}) => {
+  return {
+    queryKey: ["topics", currentPage, environment, teamName],
+    queryFn: () => getTopics({ currentPage, environment, teamName }),
+    keepPreviousData: true,
+  };
+};

--- a/coral/src/services/api-client/index.ts
+++ b/coral/src/services/api-client/index.ts
@@ -7,7 +7,10 @@ export enum HTTPMethod {
   PATCH = "PATCH",
   DELETE = "DELETE",
 }
-type SomeObject = Record<string, unknown> | Record<string, never>;
+type SomeObject =
+  | Record<string, unknown>
+  | Record<string, never>
+  | Array<unknown>;
 export type AbsolutePathname = `/${string}`;
 const CONTENT_TYPE_JSON = "application/json" as const;
 
@@ -172,8 +175,8 @@ function withoutPayloadandWithVerb<TResponse extends SomeObject>(
   );
 }
 
-const get = (pathname: AbsolutePathname) =>
-  withoutPayloadandWithVerb(HTTPMethod.GET, pathname);
+const get = <T extends SomeObject>(pathname: AbsolutePathname) =>
+  withoutPayloadandWithVerb<T>(HTTPMethod.GET, pathname);
 
 const post = <
   TResponse extends SomeObject,


### PR DESCRIPTION
Switch `/getTopics` API call from manually created native fetch call to Coral API client.