### PR TITLE
refactor(coral): Move team api mocks.

### DIFF
--- a/coral/src/app/features/topics/BrowseTopics.test.tsx
+++ b/coral/src/app/features/topics/BrowseTopics.test.tsx
@@ -2,7 +2,6 @@ import { server } from "src/services/api-mocks/server";
 import {
   mockedResponseSinglePage,
   mockedResponseTransformed,
-  mockGetTeams,
   mockTopicGetRequest,
 } from "src/domain/topic/topic-api.msw";
 import { renderWithQueryClient } from "src/services/test-utils";
@@ -11,6 +10,7 @@ import BrowseTopics from "src/app/features/topics/BrowseTopics";
 import { waitForElementToBeRemoved } from "@testing-library/react/pure";
 import userEvent from "@testing-library/user-event";
 import { mockGetEnvironments } from "src/domain/environment";
+import { mockGetTeams } from "src/domain/team/team-api.msw";
 
 jest.mock("@aivenio/design-system", () => {
   return {

--- a/coral/src/app/features/topics/hooks/teams/useGetTeams.test.tsx
+++ b/coral/src/app/features/topics/hooks/teams/useGetTeams.test.tsx
@@ -2,8 +2,8 @@ import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { renderHook, waitFor } from "@testing-library/react";
 import { ReactElement } from "react";
 import { server } from "src/services/api-mocks/server";
-import { mockGetTeams } from "src/domain/topic/topic-api.msw";
 import { useGetTeams } from "src/app/features/topics/hooks/teams/useGetTeams";
+import { mockGetTeams } from "src/domain/team/team-api.msw";
 
 const queryClient = new QueryClient({
   defaultOptions: {

--- a/coral/src/app/features/topics/hooks/teams/useGetTeams.tsx
+++ b/coral/src/app/features/topics/hooks/teams/useGetTeams.tsx
@@ -1,7 +1,7 @@
 import { useQuery, UseQueryResult } from "@tanstack/react-query";
 import { useEffect } from "react";
 import { getTeams, Team } from "src/domain/team";
-import { mockGetTeams } from "src/domain/topic/topic-api.msw";
+import { mockGetTeams } from "src/domain/team/team-api.msw";
 
 function useGetTeams(): UseQueryResult<Team[]> {
   // everything in useEffect is used to mock the api call

--- a/coral/src/app/pages/topics/index.test.tsx
+++ b/coral/src/app/pages/topics/index.test.tsx
@@ -10,10 +10,10 @@ import { server } from "src/services/api-mocks/server";
 import {
   mockedResponseSinglePage,
   mockedResponseTransformed,
-  mockGetTeams,
   mockTopicGetRequest,
 } from "src/domain/topic/topic-api.msw";
 import { mockGetEnvironments } from "src/domain/environment";
+import { mockGetTeams } from "src/domain/team/team-api.msw";
 
 // This mirrors the formatting formation used in `/domain`
 // it's a temp implementation here and will be removed

--- a/coral/src/domain/team/team-api.msw.ts
+++ b/coral/src/domain/team/team-api.msw.ts
@@ -1,0 +1,25 @@
+import { rest } from "msw";
+import { MswInstance } from "src/services/api-mocks/types";
+
+function mockGetTeams({
+  mswInstance,
+  scenario,
+}: {
+  mswInstance: MswInstance;
+  scenario?: "error";
+}) {
+  mswInstance.use(
+    rest.get("getAllTeamsSUOnly", async (req, res, ctx) => {
+      if (scenario === "error") {
+        return res(ctx.status(400), ctx.json(""));
+      }
+
+      return res(
+        ctx.status(200),
+        ctx.json(["TEST_TEAM_01", "TEST_TEAM_02", "TEST_TEAM_03"])
+      );
+    })
+  );
+}
+
+export { mockGetTeams };

--- a/coral/src/domain/topic/topic-api.msw.ts
+++ b/coral/src/domain/topic/topic-api.msw.ts
@@ -126,30 +126,8 @@ const mockedResponseTransformed = transformTopicApiResponse(
   mockedResponseSinglePage
 );
 
-function mockGetTeams({
-  mswInstance,
-  scenario,
-}: {
-  mswInstance: MswInstance;
-  scenario?: "error";
-}) {
-  mswInstance.use(
-    rest.get("getAllTeamsSUOnly", async (req, res, ctx) => {
-      if (scenario === "error") {
-        return res(ctx.status(400), ctx.json(""));
-      }
-
-      return res(
-        ctx.status(200),
-        ctx.json(["TEST_TEAM_01", "TEST_TEAM_02", "TEST_TEAM_03"])
-      );
-    })
-  );
-}
-
 export {
   mockTopicGetRequest,
-  mockGetTeams,
   mockedResponseTransformed,
   mockedResponseMultiplePageTransformed,
   mockedResponseSinglePage,


### PR DESCRIPTION
# About this change - What it does
Moves the mocked `getTeams` api response to the right directory.
