### PR TITLE
feat: require authentication for Coral application paths

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,8 +42,8 @@ node_modules/
 
 # Coral build artefacts
 coral/dist*
-src/main/resources/static/assets/coral*
-src/main/resources/templates/coral*
+core/src/main/resources/static/assets/coral*
+core/src/main/resources/templates/coral*
 
 # Coral development mode against remote Klaw API
 coral/.env.remote-api

--- a/coral/Makefile
+++ b/coral/Makefile
@@ -1,26 +1,33 @@
-CORAL_DIST_PATH = coral/dist
+ROOT = ../
+CORAL_DIST_PATH = dist
 
-default:
+
+EMBEDDED_INDEX_HTML = $(ROOT)core/src/main/resources/templates/coral/index.html
+EMBEDDED_CORAL_ASSETS = $(ROOT)core/src/main/resources/static/assets/coral
+KLAW_APPLICATION_PROPERTIES_PATH = $(ROOT)core/src/main/resources/application.properties
+
+default: $(EMBEDDED_INDEX_HTML)
 	@echo "TODO: ADD USAGE INSTRUCTIONS"
 
-$(CORAL_DIST_PATH): coral/index.html coral/src/*
-	pnpm  --prefix coral build --assetsDir assets/coral --mode springboot
+$(CORAL_DIST_PATH): index.html $(wildcard src/**/*)
+	pnpm build --assetsDir assets/coral --mode springboot
 
-src/main/resources/templates/coral/index.html: $(CORAL_DIST_PATH)
+$(EMBEDDED_INDEX_HTML): $(CORAL_DIST_PATH)
 	mkdir -p $(shell dirname $@)
 	cp -r $(CORAL_DIST_PATH)/index.html $@
 
-src/main/resources/static/assets/coral: $(CORAL_DIST_PATH)
+$(EMBEDDED_CORAL_ASSETS): $(CORAL_DIST_PATH)
 	cp -r $(CORAL_DIST_PATH)/assets/* $@
 
 .PHONY: enable-coral-in-springboot
-enable-coral-in-springboot: src/main/resources/templates/coral/index.html src/main/resources/static/assets/coral
-	sed -i "" 's/klaw\.coral\.enabled=false/klaw\.coral\.enabled=true/' src/main/resources/application.properties
+enable-coral-in-springboot: $(EMBEDDED_INDEX_HTML) $(EMBEDDED_CORAL_ASSETS)
+	sed -i "" 's/klaw\.coral\.enabled=false/klaw\.coral\.enabled=true/' $(KLAW_APPLICATION_PROPERTIES_PATH)
 
 .PHONY: disable-coral-in-springboot
 disable-coral-in-springboot:
-	sed -i "" 's/klaw\.coral\.enabled=true/klaw\.coral\.enabled=false/' src/main/resources/application.properties
+	sed -i "" 's/klaw\.coral\.enabled=true/klaw\.coral\.enabled=false/' $(KLAW_APPLICATION_PROPERTIES_PATH)
 
 clean:
-	rm -rf src/main/resources/templates/coral
-	rm -rf src/main/resources/static/assets/coral
+	rm -rf $(CORAL_DIST_PATH)
+	rm -rf $(EMBEDDED_INDEX_HTML)
+	rm -rf $(EMBEDDED_CORAL_ASSETS)

--- a/core/src/main/java/io/aiven/klaw/config/ConfigUtils.java
+++ b/core/src/main/java/io/aiven/klaw/config/ConfigUtils.java
@@ -39,7 +39,6 @@ public class ConfigUtils {
                 "/getActivationInfo**"));
 
     if (coralEnabled) {
-      staticResourcesHtmlArray.add("/coral/**");
       staticResourcesHtmlArray.add("/assets/coral/**");
     }
 


### PR DESCRIPTION
- Fix .gitignore for embdeded Coral asset paths in Klaw core resources 
- Fix make targets to toggle embedded Coral with Klaw core.
- Require authentication for Coral application paths. 

Resolves: #185