### PR TITLE
Remove duplicated dependency

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -69,10 +69,6 @@
             <artifactId>spring-boot-starter-cache</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-oauth2-client</artifactId>
-        </dependency>
-        <dependency>
             <groupId>com.mysql</groupId>
             <artifactId>mysql-connector-j</artifactId>
         </dependency>


### PR DESCRIPTION
Currently there is a duplicated dependency in pom leading to warning in `mvn` output
```
[WARNING] Some problems were encountered while building the effective model for io.aiven:klaw:jar:1.1.0
[WARNING] 'dependencies.dependency.(groupId:artifactId:type:classifier)' must be unique: org.springframework.boot:spring-boot-starter-oauth2-client:jar -> duplicate declaration of version (?) @ line 71, column 21
[WARNING] 
[WARNING] It is highly recommended to fix these problems because they threaten the stability of your build.
[WARNING] 
[WARNING] For this reason, future Maven versions might no longer support building such malformed projects.
[WARNING] 
```
This PR fixes this