### PR TITLE
Refactor(coral): Move responsibility for environment data. 

### DIFF
--- a/coral/src/app/features/browse-topics/BrowseTopics.test.tsx
+++ b/coral/src/app/features/browse-topics/BrowseTopics.test.tsx
@@ -146,7 +146,7 @@ describe("BrowseTopics.tsx", () => {
     it("renders a select element to filter topics by Kafka environment", async () => {
       await waitForElementToBeRemoved(screen.getByText("Loading..."));
       const select = screen.getByRole("combobox", {
-        name: "Kafka Environment",
+        name: "Kafka environment",
       });
 
       expect(select).toBeEnabled();
@@ -292,7 +292,7 @@ describe("BrowseTopics.tsx", () => {
     it("shows a select element for environments with `ALL` preselected", async () => {
       await waitForElementToBeRemoved(screen.getByText("Loading..."));
       const select = screen.getByRole("combobox", {
-        name: "Kafka Environment",
+        name: "Kafka environment",
       });
 
       expect(select).toHaveValue("ALL");
@@ -301,7 +301,7 @@ describe("BrowseTopics.tsx", () => {
     it("shows an information that the list is updated after user selected an environment", async () => {
       await waitForElementToBeRemoved(screen.getByText("Loading..."));
       const select = screen.getByRole("combobox", {
-        name: "Kafka Environment",
+        name: "Kafka environment",
       });
       const option = within(select).getByRole("option", {
         name: "DEV",
@@ -317,7 +317,7 @@ describe("BrowseTopics.tsx", () => {
     it("changes active selected option when user selects `DEV`", async () => {
       await waitForElementToBeRemoved(screen.getByText("Loading..."));
       const select = screen.getByRole("combobox", {
-        name: "Kafka Environment",
+        name: "Kafka environment",
       });
       const option = within(select).getByRole("option", {
         name: "DEV",
@@ -339,7 +339,7 @@ describe("BrowseTopics.tsx", () => {
       expect(getAllTopics()).toHaveLength(10);
 
       const select = screen.getByRole("combobox", {
-        name: "Kafka Environment",
+        name: "Kafka environment",
       });
       const option = within(select).getByRole("option", {
         name: "DEV",

--- a/coral/src/app/features/browse-topics/BrowseTopics.tsx
+++ b/coral/src/app/features/browse-topics/BrowseTopics.tsx
@@ -6,27 +6,19 @@ import { useState } from "react";
 import { Flexbox, FlexboxItem } from "@aivenio/design-system";
 import { useSearchParams } from "react-router-dom";
 import SelectEnvironment from "src/app/features/browse-topics/components/select-environment/SelectEnvironment";
-import { useGetEnvironments } from "src/app/features/browse-topics/hooks/environment/useGetEnvironments";
 import { SearchTopics } from "src/app/features/browse-topics/components/search/SearchTopics";
 import { Team, TEAM_NOT_INITIALIZED } from "src/domain/team";
-
-const ALL_ENVIRONMENTS_VALUE = "ALL";
+import { ENVIRONMENT_NOT_INITIALIZED } from "src/domain/environment/environment-types";
 
 function BrowseTopics() {
   const [searchParams, setSearchParams] = useSearchParams();
   const [teamName, setTeamName] = useState<Team>(TEAM_NOT_INITIALIZED);
+  const [environment, setEnvironment] = useState(ENVIRONMENT_NOT_INITIALIZED);
+
   const initialPage = searchParams.get("page");
-  const initialEnv = searchParams.get("environment");
   const initialSearchTerm = searchParams.get("search");
-
   const [page, setPage] = useState(Number(initialPage) || 1);
-  const [environment, setEnvironment] = useState(
-    initialEnv || ALL_ENVIRONMENTS_VALUE
-  );
-
   const [searchTerm, setSearchTerm] = useState<string>(initialSearchTerm || "");
-
-  const { data: topicEnvs } = useGetEnvironments();
 
   const {
     data: topics,
@@ -46,18 +38,9 @@ function BrowseTopics() {
   return (
     <>
       <Flexbox direction={"row"} colGap={"l4"}>
-        {topicEnvs && (
-          <FlexboxItem width={"l7"}>
-            <SelectEnvironment
-              environments={[
-                { label: "All Environments", value: ALL_ENVIRONMENTS_VALUE },
-                ...topicEnvs.map((env) => ({ label: env.name, value: env.id })),
-              ]}
-              activeOption={environment}
-              selectEnvironment={selectEnvironment}
-            />
-          </FlexboxItem>
-        )}
+        <FlexboxItem width={"l7"}>
+          <SelectEnvironment onChange={setEnvironment} />
+        </FlexboxItem>
 
         <FlexboxItem width={"l7"}>
           <SelectTeam onChange={setTeamName} />
@@ -86,17 +69,6 @@ function BrowseTopics() {
       </Flexbox>
     </>
   );
-
-  function selectEnvironment(environment: string) {
-    setEnvironment(environment);
-    if (environment === ALL_ENVIRONMENTS_VALUE) {
-      searchParams.delete("environment");
-    } else {
-      searchParams.set("environment", environment);
-    }
-
-    setSearchParams(searchParams);
-  }
 
   function searchTopics(newSearchTerm: string) {
     setSearchTerm(newSearchTerm);

--- a/coral/src/app/features/browse-topics/components/select-environment/SelectEnvironment.test.tsx
+++ b/coral/src/app/features/browse-topics/components/select-environment/SelectEnvironment.test.tsx
@@ -1,67 +1,102 @@
-import { cleanup, render, screen } from "@testing-library/react";
-import userEvent from "@testing-library/user-event";
+import { cleanup, screen, waitFor } from "@testing-library/react";
+import {
+  ALL_ENVIRONMENTS_VALUE,
+  Environment,
+  EnvironmentDTO,
+  mockGetEnvironments,
+} from "src/domain/environment";
 import SelectEnvironment from "src/app/features/browse-topics/components/select-environment/SelectEnvironment";
+import { server } from "src/services/api-mocks/server";
+import { mockedEnvironmentResponse } from "src/domain/environment/environment-api.msw";
+import { customRender } from "src/services/test-utils/render-with-wrappers";
+import { waitForElementToBeRemoved } from "@testing-library/react/pure";
+import userEvent from "@testing-library/user-event";
 
 describe("SelectEnvironment.tsx", () => {
-  const environments = ["ALL", "DEV", "TST"].map((env, index) => ({
-    label: env,
-    value: index.toString(),
-  }));
+  beforeAll(() => {
+    server.listen();
+  });
+
+  afterAll(() => {
+    server.close();
+  });
+
+  const mockedEnvironmentDev: Environment = mockedEnvironmentResponse[0];
+  const mockedEnvironmentTst: Environment = mockedEnvironmentResponse[1];
 
   describe("renders all necessary elements", () => {
-    const activeOption = "ALL";
+    const mockedOnChange = jest.fn();
 
-    const requiredProps = {
-      environments,
-      activeOption,
-      selectEnvironment: jest.fn(),
-    };
-
-    beforeAll(() => {
-      render(<SelectEnvironment {...requiredProps} />);
+    beforeAll(async () => {
+      mockGetEnvironments({
+        mswInstance: server,
+        response: { data: mockedEnvironmentResponse },
+      });
+      customRender(<SelectEnvironment onChange={mockedOnChange} />, {
+        memoryRouter: true,
+        queryClient: true,
+      });
+      await waitForElementToBeRemoved(
+        screen.getByTestId("select-environment-loading")
+      );
     });
 
     afterAll(cleanup);
 
     it("shows a select element for Kafka environments", () => {
       const select = screen.getByRole("combobox", {
-        name: "Kafka Environment",
+        name: "Kafka environment",
       });
 
       expect(select).toBeEnabled();
     });
 
-    it("renders a list of given options for environments", () => {
-      environments.forEach(({ label }) => {
+    it("renders a list of options for environments plus a option for `All environments`", () => {
+      mockedEnvironmentResponse.forEach((environment: EnvironmentDTO) => {
         const option = screen.getByRole("option", {
-          name: label,
+          name: environment.name,
         });
 
         expect(option).toBeEnabled();
       });
-      expect(screen.getAllByRole("option")).toHaveLength(environments.length);
+      expect(screen.getAllByRole("option")).toHaveLength(
+        mockedEnvironmentResponse.length + 1
+      );
     });
 
-    it("shows a given environment as the active option one", () => {
+    it("shows `All environments` as the active option one", () => {
       const option = screen.getByRole("option", {
         selected: true,
       });
-      expect(option).toHaveAccessibleName(activeOption);
+      expect(option).toHaveAccessibleName("All environments");
+    });
+
+    it("updates the environment state for initial api call with value associated with `All Environments`", () => {
+      expect(mockedOnChange).toHaveBeenCalledWith(ALL_ENVIRONMENTS_VALUE);
     });
   });
 
-  describe("handles the change event for selecting", () => {
-    const optionToSelect = "DEV";
+  describe("sets the active environment based on a query param", () => {
+    const mockedOnChange = jest.fn();
 
-    const mockedSelectEnvironment = jest.fn();
-    const requiredProps = {
-      environments,
-      activeOption: "ALL",
-      selectEnvironment: mockedSelectEnvironment,
-    };
+    const mockedQueryParamDev = mockedEnvironmentDev.id;
 
-    beforeEach(() => {
-      render(<SelectEnvironment {...requiredProps} />);
+    beforeEach(async () => {
+      const routePath = `/?environment=${mockedQueryParamDev}`;
+
+      mockGetEnvironments({
+        mswInstance: server,
+        response: { data: mockedEnvironmentResponse },
+      });
+
+      customRender(<SelectEnvironment onChange={mockedOnChange} />, {
+        memoryRouter: true,
+        queryClient: true,
+        customRoutePath: routePath,
+      });
+      await waitForElementToBeRemoved(
+        screen.getByTestId("select-environment-loading")
+      );
     });
 
     afterEach(() => {
@@ -69,15 +104,127 @@ describe("SelectEnvironment.tsx", () => {
       cleanup();
     });
 
-    it("user can select a new environment", async () => {
-      const select = screen.getByRole("combobox", {
-        name: "Kafka Environment",
+    it(`shows "${mockedEnvironmentDev.name}" as the active option one`, async () => {
+      const option = await screen.findByRole("option", {
+        name: mockedEnvironmentDev.name,
+        selected: true,
       });
-      const option = screen.getByRole("option", { name: optionToSelect });
+      expect(option).toBeVisible();
+      expect(option).toHaveValue(mockedEnvironmentDev.id);
+    });
+
+    it("updates the environment state for api call", () => {
+      expect(mockedOnChange).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe("handles user selecting a environment", () => {
+    const mockedOnChange = jest.fn();
+
+    beforeEach(async () => {
+      mockGetEnvironments({
+        mswInstance: server,
+        response: { data: mockedEnvironmentResponse },
+      });
+      customRender(<SelectEnvironment onChange={mockedOnChange} />, {
+        queryClient: true,
+        memoryRouter: true,
+      });
+      await waitForElementToBeRemoved(
+        screen.getByTestId("select-environment-loading")
+      );
+    });
+
+    afterEach(() => {
+      jest.resetAllMocks();
+      cleanup();
+    });
+
+    it("updates state for api call when user selects a new environment", async () => {
+      const select = screen.getByRole("combobox", {
+        name: "Kafka environment",
+      });
+      const option = screen.getByRole("option", {
+        name: mockedEnvironmentDev.name,
+      });
 
       await userEvent.selectOptions(select, option);
 
-      expect(mockedSelectEnvironment).toHaveBeenCalledWith("1");
+      expect(mockedOnChange).toHaveBeenCalledWith("1");
+    });
+
+    it("sets the environment the user choose as active option", async () => {
+      const select = screen.getByRole("combobox", {
+        name: "Kafka environment",
+      });
+      const option = screen.getByRole("option", {
+        name: mockedEnvironmentDev.name,
+      });
+
+      await userEvent.selectOptions(select, option);
+
+      expect(select).toHaveValue(mockedEnvironmentDev.id);
+    });
+  });
+
+  describe("updates the search param to preserve environment in url", () => {
+    const mockedOnChange = jest.fn();
+
+    beforeEach(async () => {
+      mockGetEnvironments({
+        mswInstance: server,
+        response: { data: mockedEnvironmentResponse },
+      });
+      customRender(<SelectEnvironment onChange={mockedOnChange} />, {
+        queryClient: true,
+        browserRouter: true,
+      });
+      await waitForElementToBeRemoved(
+        screen.getByTestId("select-environment-loading")
+      );
+    });
+
+    afterEach(() => {
+      // resets url to get to clean state again
+      window.history.pushState({}, "No page title", "/");
+      jest.resetAllMocks();
+      cleanup();
+    });
+
+    it("shows no search param by default", async () => {
+      expect(window.location.search).toEqual("");
+    });
+
+    it(`sets "${mockedEnvironmentTst.name}" as search param when user selected it`, async () => {
+      const select = screen.getByRole("combobox", {
+        name: "Kafka environment",
+      });
+
+      const option = screen.getByRole("option", {
+        name: mockedEnvironmentTst.name,
+      });
+
+      await userEvent.selectOptions(select, option);
+
+      await waitFor(() => {
+        expect(window.location.search).toEqual(
+          `?environment=${mockedEnvironmentTst.id}`
+        );
+      });
+    });
+
+    it("removes search param when user chooses All environment", async () => {
+      const select = screen.getByRole("combobox", {
+        name: "Kafka environment",
+      });
+
+      const option = screen.getByRole("option", { name: "All environments" });
+
+      await userEvent.selectOptions(select, option);
+
+      await waitFor(() => {
+        expect(window.location.search).toEqual("");
+      });
     });
   });
 });

--- a/coral/src/app/features/browse-topics/components/select-environment/SelectEnvironment.tsx
+++ b/coral/src/app/features/browse-topics/components/select-environment/SelectEnvironment.tsx
@@ -1,31 +1,71 @@
 import { NativeSelect, Option } from "@aivenio/design-system";
-import { ChangeEvent } from "react";
+import { useEffect, useState } from "react";
+import { ALL_ENVIRONMENTS_VALUE, Environment } from "src/domain/environment";
+import { useSearchParams } from "react-router-dom";
+import { useGetEnvironments } from "src/app/features/browse-topics/hooks/environment/useGetEnvironments";
+import { ENVIRONMENT_NOT_INITIALIZED } from "src/domain/environment/environment-types";
 
 type SelectEnvProps = {
-  environments: Array<{ label: string; value: string }>;
-  activeOption: string;
-  selectEnvironment: (value: string) => void;
+  onChange: (value: string) => void;
 };
-function SelectEnv(props: SelectEnvProps) {
-  const { environments, activeOption, selectEnvironment } = props;
 
-  function onChangeEnv(event: ChangeEvent<HTMLSelectElement>) {
-    selectEnvironment(event.target.value);
+function SelectEnv(props: SelectEnvProps) {
+  const [searchParams, setSearchParams] = useSearchParams();
+
+  const initialEnvironment = searchParams.get("environment");
+  const [environment, setEnvironment] = useState<string>(
+    ENVIRONMENT_NOT_INITIALIZED
+  );
+  const { onChange } = props;
+
+  const { data: environments } = useGetEnvironments();
+
+  useEffect(() => {
+    if (initialEnvironment) {
+      setEnvironment(initialEnvironment);
+    }
+    // updates `environment` in BrowseTopics
+    // which will trigger the api call
+    onChange(initialEnvironment || ALL_ENVIRONMENTS_VALUE);
+  }, [initialEnvironment]);
+
+  function onChangeEnv(newEnvironment: string) {
+    const isAllTeams = newEnvironment === ALL_ENVIRONMENTS_VALUE;
+    if (isAllTeams) {
+      searchParams.delete("environment");
+    } else {
+      searchParams.set("environment", newEnvironment);
+    }
+    setEnvironment(newEnvironment);
+    onChange(newEnvironment);
+    setSearchParams(searchParams);
   }
 
-  return (
-    <NativeSelect
-      labelText="Kafka Environment"
-      value={activeOption}
-      onChange={(event) => onChangeEnv(event)}
-    >
-      {environments.map(({ label, value }) => (
-        <Option key={value} value={value}>
-          {label}
+  if (!environments || !environment) {
+    return (
+      <div data-testid={"select-environment-loading"}>
+        <NativeSelect.Skeleton />
+      </div>
+    );
+  } else {
+    return (
+      <NativeSelect
+        labelText="Kafka environment"
+        value={environment}
+        onChange={(event) => onChangeEnv(event.target.value)}
+      >
+        <Option key={ALL_ENVIRONMENTS_VALUE} value={ALL_ENVIRONMENTS_VALUE}>
+          All environments
         </Option>
-      ))}
-    </NativeSelect>
-  );
+
+        {environments.map((env: Environment) => (
+          <Option key={env.id} value={env.id}>
+            {env.name}
+          </Option>
+        ))}
+      </NativeSelect>
+    );
+  }
 }
 
 export default SelectEnv;

--- a/coral/src/app/features/browse-topics/components/select-team/SelectTeam.tsx
+++ b/coral/src/app/features/browse-topics/components/select-team/SelectTeam.tsx
@@ -1,7 +1,7 @@
 import { NativeSelect, Option } from "@aivenio/design-system";
 import { useEffect, useState } from "react";
 import { useGetTeams } from "src/app/features/browse-topics/hooks/teams/useGetTeams";
-import { Team } from "src/domain/team";
+import { Team, TEAM_NOT_INITIALIZED } from "src/domain/team";
 import { useSearchParams } from "react-router-dom";
 import { ALL_TEAMS_VALUE } from "src/domain/team/team-types";
 
@@ -13,7 +13,7 @@ function SelectTeam(props: SelectTeamProps) {
   const [searchParams, setSearchParams] = useSearchParams();
 
   const initialTeam = searchParams.get("team");
-  const [team, setTeam] = useState<Team>(ALL_TEAMS_VALUE);
+  const [team, setTeam] = useState<Team>(TEAM_NOT_INITIALIZED);
   const { onChange } = props;
 
   const { data: topicTeams } = useGetTeams();

--- a/coral/src/app/features/browse-topics/hooks/topic-list/useGetTopics.ts
+++ b/coral/src/app/features/browse-topics/hooks/topic-list/useGetTopics.ts
@@ -1,6 +1,7 @@
 import { useQuery, UseQueryResult } from "@tanstack/react-query";
 import { TopicApiResponse } from "src/domain/topic/topic-types";
 import { topicsQuery } from "src/domain/topic/topic-queries";
+import { Team } from "src/domain/team";
 
 function useGetTopics({
   currentPage,
@@ -10,7 +11,7 @@ function useGetTopics({
 }: {
   currentPage: number;
   environment: string;
-  teamName: string;
+  teamName: Team;
   searchTerm?: string;
 }): UseQueryResult<TopicApiResponse> {
   return useQuery<TopicApiResponse, Error>(

--- a/coral/src/app/pages/topics/index.test.tsx
+++ b/coral/src/app/pages/topics/index.test.tsx
@@ -62,7 +62,7 @@ describe("Topics", () => {
 
     it("renders a select element to filter topics by Kafka environment", async () => {
       const select = screen.getByRole("combobox", {
-        name: "Kafka Environment",
+        name: "Kafka environment",
       });
 
       expect(select).toBeEnabled();

--- a/coral/src/domain/environment/environment-types.ts
+++ b/coral/src/domain/environment/environment-types.ts
@@ -9,4 +9,8 @@ type Environment = {
   id: string;
 };
 
+const ALL_ENVIRONMENTS_VALUE = "ALL";
+const ENVIRONMENT_NOT_INITIALIZED = "d3a914ff-cff6-42d4-988e-b0425128e770";
+
 export type { Environment, EnvironmentDTO, EnvironmentsGetResponse };
+export { ALL_ENVIRONMENTS_VALUE, ENVIRONMENT_NOT_INITIALIZED };

--- a/coral/src/domain/environment/index.ts
+++ b/coral/src/domain/environment/index.ts
@@ -1,9 +1,10 @@
 import { getEnvironments } from "src/domain/environment/environment-api";
 import { mockGetEnvironments } from "src/domain/environment/environment-api.msw";
 import {
+  ALL_ENVIRONMENTS_VALUE,
   Environment,
   EnvironmentDTO,
 } from "src/domain/environment/environment-types";
 
-export { getEnvironments, mockGetEnvironments };
+export { getEnvironments, mockGetEnvironments, ALL_ENVIRONMENTS_VALUE };
 export type { Environment, EnvironmentDTO };

--- a/coral/src/domain/topic/topic-api.ts
+++ b/coral/src/domain/topic/topic-api.ts
@@ -4,9 +4,9 @@ import {
   TopicDTOApiResponse,
 } from "src/domain/topic/topic-types";
 import { transformTopicApiResponse } from "src/domain/topic/topic-transformer";
+import { ALL_ENVIRONMENTS_VALUE } from "src/domain/environment";
 import { Team } from "src/domain/team";
 import { ALL_TEAMS_VALUE } from "src/domain/team/team-types";
-import isString from "lodash/isString";
 
 const getTopics = async ({
   currentPage = 1,
@@ -23,11 +23,11 @@ const getTopics = async ({
   // the optional team parameter
   // where we still need a way to represent an
   // option for "Select all teams" to users
-  const team = isString(teamName) && teamName !== ALL_TEAMS_VALUE && teamName;
+  const team = teamName !== ALL_TEAMS_VALUE && teamName;
 
   const params: Record<string, string> = {
     pageNo: currentPage.toString(),
-    env: environment,
+    env: environment || ALL_ENVIRONMENTS_VALUE,
     ...(team && { teamName: team }),
     ...(searchTerm && { topicnamesearch: searchTerm }),
   };

--- a/coral/src/domain/topic/topic-queries.ts
+++ b/coral/src/domain/topic/topic-queries.ts
@@ -1,5 +1,6 @@
 import { getTopics } from "src/domain/topic/topic-api";
 import { Team, TEAM_NOT_INITIALIZED } from "src/domain/team";
+import { ENVIRONMENT_NOT_INITIALIZED } from "src/domain/environment/environment-types";
 
 export const topicsQuery = ({
   currentPage,
@@ -9,10 +10,6 @@ export const topicsQuery = ({
 }: {
   currentPage: number;
   environment: string;
-  // null represents the initial state
-  // for teamName to avoid fetching
-  // until the value from searchQuery is not
-  // evaluated
   teamName: Team;
   searchTerm?: string;
 }) => {
@@ -21,6 +18,8 @@ export const topicsQuery = ({
     queryFn: () =>
       getTopics({ currentPage, environment, teamName, searchTerm }),
     keepPreviousData: true,
-    enabled: teamName !== TEAM_NOT_INITIALIZED,
+    enabled:
+      teamName !== TEAM_NOT_INITIALIZED &&
+      environment !== ENVIRONMENT_NOT_INITIALIZED,
   };
 };


### PR DESCRIPTION
# About this change - What it does

 - `SelectEnvironment` is responsible for fetching
       environments, getting environment value from potential
       search query and update query of needed
    - `BrowseTopics` is responsible for holding
       the environmentName state to handle api calls
    - `getBrowseTopcis` query will only call api
       when environmentName value is set by BrowseTopics
       to prevent too much requests
       
Resolves: [#245](https://github.com/aiven/klaw/issues/245)

## Why this way
It's implemented following this PR: #262 