### PR TITLE
feat(coral): Connect topic API to real backend instead of mocked one

### DIFF
--- a/coral/src/app/features/browse-topics/hooks/topic-list/useGetTopics.ts
+++ b/coral/src/app/features/browse-topics/hooks/topic-list/useGetTopics.ts
@@ -1,6 +1,4 @@
 import { useQuery, UseQueryResult } from "@tanstack/react-query";
-import { useEffect } from "react";
-import { mockTopicGetRequest } from "src/domain/topic/topic-api.msw";
 import { TopicApiResponse } from "src/domain/topic/topic-types";
 import { Environment } from "src/domain/environment";
 import { topicsQuery } from "src/domain/topic/topic-queries";
@@ -16,16 +14,6 @@ function useGetTopics({
   teamName?: string;
   searchTerm?: string;
 }): UseQueryResult<TopicApiResponse> {
-  // everything in useEffect is used to mock the api call
-  // and can be removed once the real api is connected
-  useEffect(() => {
-    const browserEnvWorker = window.msw;
-
-    if (browserEnvWorker) {
-      mockTopicGetRequest({ mswInstance: browserEnvWorker });
-    }
-  }, []);
-
   return useQuery<TopicApiResponse, Error>(
     topicsQuery({ currentPage, environment, teamName, searchTerm })
   );

--- a/coral/src/domain/topic/topic-types.ts
+++ b/coral/src/domain/topic/topic-types.ts
@@ -1,22 +1,6 @@
-type TopicDTO = {
-  topicid: number;
-  sequence: string;
-  totalNoPages: string;
-  currentPage: string;
-  allPageNos: string[];
-  topicName: string;
-  noOfPartitions: number;
-  description: string;
-  documentation: string | null;
-  noOfReplcias: string;
-  teamname: string;
-  cluster: string;
-  clusterId: number | null;
-  environmentsList: string[];
-  showEditTopic: boolean;
-  showDeleteTopic: boolean;
-  topicDeletable: boolean;
-};
+import { components } from "types/api";
+
+type TopicDTO = components["schemas"]["TopicInfo"];
 
 type TopicApiResponse = {
   totalPages: number;
@@ -24,8 +8,7 @@ type TopicApiResponse = {
   entries: Topic[];
 };
 
-// @TODO adjust to our needs
 type Topic = TopicDTO;
-type TopicDTOApiResponse = Array<Array<TopicDTO>>;
+type TopicDTOApiResponse = components["schemas"]["TopicsGetResponse"];
 
 export type { TopicDTO, TopicApiResponse, Topic, TopicDTOApiResponse };

--- a/coral/types/api.d.ts
+++ b/coral/types/api.d.ts
@@ -114,6 +114,11 @@ export type components = {
        */
       noOfReplicas?: string;
       /**
+       * Sequence
+       * @deprecated
+       */
+      sequence?: string;
+      /**
        * Team name
        * @description Topic owner team name
        * @example application-X-developers
@@ -129,7 +134,7 @@ export type components = {
        * Cluster identifier
        * @deprecated
        */
-      clusterId: string;
+      clusterId: string | null;
       /**
        * Environments list
        * @description List of environments where the topic is present.

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -233,6 +233,10 @@ components:
           description: Topic replica count
           type: string
           example: "2"
+        sequence:
+          title: Sequence
+          type: string
+          deprecated: true
         teamname:
           title: Team name
           description: Topic owner team name
@@ -245,8 +249,9 @@ components:
           example: "1"
         clusterId:
           title: Cluster identifier
-          deprecated: true
           type: string
+          deprecated: true
+          nullable: true
         environmentsList:
           title: Environments list 
           description: List of environments where the topic is present.


### PR DESCRIPTION
- Fix openapi specification for Topic resource
  - Set deprecated `clusterId` property nullable to Topic resource
  - Add `sequence` property to Topic resource
 - Use Topic types defined in OpenAPI specification in Coral
 - Remove API mock usage from browser environment 
  
Resolves: #196
