### PR TITLE
fix(coral): Send environment id instead of name as topic filter parameter

### DIFF
--- a/coral/src/app/features/browse-topics/BrowseTopics.test.tsx
+++ b/coral/src/app/features/browse-topics/BrowseTopics.test.tsx
@@ -283,7 +283,7 @@ describe("BrowseTopics.tsx", () => {
 
       await userEvent.selectOptions(select, option);
 
-      expect(select).toHaveValue("DEV");
+      expect(select).toHaveValue("1");
     });
 
     it("fetches new data when user selects `DEV`", async () => {

--- a/coral/src/app/features/browse-topics/BrowseTopics.tsx
+++ b/coral/src/app/features/browse-topics/BrowseTopics.tsx
@@ -5,7 +5,6 @@ import TopicList from "src/app/features/browse-topics/components/topic-list/Topi
 import { useState } from "react";
 import { Flexbox, FlexboxItem } from "@aivenio/design-system";
 import { useSearchParams } from "react-router-dom";
-import { Environment } from "src/domain/environment";
 import SelectEnvironment from "src/app/features/browse-topics/components/select-environment/SelectEnvironment";
 import { useGetEnvironments } from "src/app/features/browse-topics/hooks/environment/useGetEnvironments";
 import { SearchTopics } from "src/app/features/browse-topics/components/search/SearchTopics";
@@ -21,7 +20,7 @@ function BrowseTopics() {
   const initialSearchTerm = searchParams.get("search");
 
   const [page, setPage] = useState(Number(initialPage) || 1);
-  const [environment, setEnvironment] = useState<Environment>(
+  const [environment, setEnvironment] = useState(
     initialEnv || ALL_ENVIRONMENTS_VALUE
   );
 
@@ -52,7 +51,7 @@ function BrowseTopics() {
             <SelectEnvironment
               environments={[
                 { label: "All Environments", value: ALL_ENVIRONMENTS_VALUE },
-                ...topicEnvs.map((env) => ({ label: env, value: env })),
+                ...topicEnvs.map((env) => ({ label: env.name, value: env.id })),
               ]}
               activeOption={environment}
               selectEnvironment={selectEnvironment}
@@ -88,7 +87,7 @@ function BrowseTopics() {
     </>
   );
 
-  function selectEnvironment(environment: Environment) {
+  function selectEnvironment(environment: string) {
     setEnvironment(environment);
     if (environment === ALL_ENVIRONMENTS_VALUE) {
       searchParams.delete("environment");

--- a/coral/src/app/features/browse-topics/components/select-environment/SelectEnvironment.test.tsx
+++ b/coral/src/app/features/browse-topics/components/select-environment/SelectEnvironment.test.tsx
@@ -1,16 +1,15 @@
 import { cleanup, render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { Environment } from "src/domain/environment";
 import SelectEnvironment from "src/app/features/browse-topics/components/select-environment/SelectEnvironment";
 
 describe("SelectEnvironment.tsx", () => {
-  const environments = ["ALL", "DEV", "TST"].map((env) => ({
+  const environments = ["ALL", "DEV", "TST"].map((env, index) => ({
     label: env,
-    value: env,
+    value: index.toString(),
   }));
 
   describe("renders all necessary elements", () => {
-    const activeOption: Environment = "ALL";
+    const activeOption = "ALL";
 
     const requiredProps = {
       environments,
@@ -78,7 +77,7 @@ describe("SelectEnvironment.tsx", () => {
 
       await userEvent.selectOptions(select, option);
 
-      expect(mockedSelectEnvironment).toHaveBeenCalledWith(optionToSelect);
+      expect(mockedSelectEnvironment).toHaveBeenCalledWith("1");
     });
   });
 });

--- a/coral/src/app/features/browse-topics/components/select-environment/SelectEnvironment.tsx
+++ b/coral/src/app/features/browse-topics/components/select-environment/SelectEnvironment.tsx
@@ -1,17 +1,16 @@
 import { NativeSelect, Option } from "@aivenio/design-system";
 import { ChangeEvent } from "react";
-import { Environment } from "src/domain/environment";
 
 type SelectEnvProps = {
-  environments: Array<{ label: string; value: Environment }>;
-  activeOption: Environment;
-  selectEnvironment: (value: Environment) => void;
+  environments: Array<{ label: string; value: string }>;
+  activeOption: string;
+  selectEnvironment: (value: string) => void;
 };
 function SelectEnv(props: SelectEnvProps) {
   const { environments, activeOption, selectEnvironment } = props;
 
   function onChangeEnv(event: ChangeEvent<HTMLSelectElement>) {
-    selectEnvironment(event.target.value as Environment);
+    selectEnvironment(event.target.value);
   }
 
   return (

--- a/coral/src/app/features/browse-topics/hooks/environment/useGetEnvironments.test.tsx
+++ b/coral/src/app/features/browse-topics/hooks/environment/useGetEnvironments.test.tsx
@@ -74,7 +74,10 @@ describe("useGetEnvironments", () => {
         expect(result.current.isSuccess).toBe(true);
       });
 
-      expect(result.current.data).toEqual(["DEV", "TST"]);
+      expect(result.current.data).toEqual([
+        { name: "DEV", id: "1" },
+        { name: "TST", id: "2" },
+      ]);
     });
   });
 });

--- a/coral/src/app/features/browse-topics/hooks/topic-list/useGetTopics.ts
+++ b/coral/src/app/features/browse-topics/hooks/topic-list/useGetTopics.ts
@@ -1,6 +1,5 @@
 import { useQuery, UseQueryResult } from "@tanstack/react-query";
 import { TopicApiResponse } from "src/domain/topic/topic-types";
-import { Environment } from "src/domain/environment";
 import { topicsQuery } from "src/domain/topic/topic-queries";
 
 function useGetTopics({
@@ -10,7 +9,7 @@ function useGetTopics({
   searchTerm,
 }: {
   currentPage: number;
-  environment: Environment;
+  environment: string;
   teamName: string;
   searchTerm?: string;
 }): UseQueryResult<TopicApiResponse> {

--- a/coral/src/domain/environment/environment-api.msw.ts
+++ b/coral/src/domain/environment/environment-api.msw.ts
@@ -20,8 +20,8 @@ function mockGetEnvironments({
       return res(
         ctx.status(200),
         ctx.json([
-          createMockEnvironmentDTO("DEV"),
-          createMockEnvironmentDTO("TST"),
+          createMockEnvironmentDTO({ name: "DEV", id: "1" }),
+          createMockEnvironmentDTO({ name: "TST", id: "2" }),
         ])
       );
     })

--- a/coral/src/domain/environment/environment-test-helper.test.ts
+++ b/coral/src/domain/environment/environment-test-helper.test.ts
@@ -26,7 +26,7 @@ describe("environment-test-helper.ts", () => {
         type: "kafka",
       };
 
-      expect(createMockEnvironmentDTO(nameToTest)).toEqual(result);
+      expect(createMockEnvironmentDTO({ name: nameToTest })).toEqual(result);
     });
   });
 });

--- a/coral/src/domain/environment/environment-test-helper.ts
+++ b/coral/src/domain/environment/environment-test-helper.ts
@@ -1,30 +1,31 @@
-import {
-  Environment,
-  EnvironmentDTO,
-} from "src/domain/environment/environment-types";
+import { EnvironmentDTO } from "src/domain/environment/environment-types";
 
-function createMockEnvironmentDTO(name: Environment): EnvironmentDTO {
-  return {
-    id: "1",
-    name,
-    type: "kafka",
-    tenantId: 101,
-    topicprefix: null,
-    topicsuffix: null,
-    clusterId: 1,
-    tenantName: "default",
-    clusterName: "DEV",
-    envStatus: "ONLINE",
-    otherParams:
-      "default.partitions=2,max.partitions=2,default.replication.factor=1,max.replication.factor=1,topic.prefix=,topic.suffix=",
-    defaultPartitions: null,
-    maxPartitions: null,
-    defaultReplicationFactor: null,
-    maxReplicationFactor: null,
-    showDeleteEnv: false,
-    totalNoPages: "1",
-    allPageNos: ["1"],
-  };
+const defaultEnvironmentDTO: EnvironmentDTO = {
+  id: "1",
+  name: "DEV",
+  type: "kafka",
+  tenantId: 101,
+  topicprefix: null,
+  topicsuffix: null,
+  clusterId: 1,
+  tenantName: "default",
+  clusterName: "DEV",
+  envStatus: "ONLINE",
+  otherParams:
+    "default.partitions=2,max.partitions=2,default.replication.factor=1,max.replication.factor=1,topic.prefix=,topic.suffix=",
+  defaultPartitions: null,
+  maxPartitions: null,
+  defaultReplicationFactor: null,
+  maxReplicationFactor: null,
+  showDeleteEnv: false,
+  totalNoPages: "1",
+  allPageNos: ["1"],
+};
+
+function createMockEnvironmentDTO(
+  environment: Partial<EnvironmentDTO>
+): EnvironmentDTO {
+  return { ...defaultEnvironmentDTO, ...environment };
 }
 
 export { createMockEnvironmentDTO };

--- a/coral/src/domain/environment/environment-transformer.test.ts
+++ b/coral/src/domain/environment/environment-transformer.test.ts
@@ -2,31 +2,13 @@ import { transformEnvironmentApiResponse } from "src/domain/environment/environm
 import { createMockEnvironmentDTO } from "src/domain/environment/environment-test-helper";
 
 describe("environment-transformer.ts", () => {
-  describe("'transformEnvironmentApiResponse' transforms API response into list of environments", () => {
-    it("transforms list of 4 environments with 2 unique environment values", () => {
-      const testInput = [
-        createMockEnvironmentDTO("DEV"),
-        createMockEnvironmentDTO("TST"),
-        createMockEnvironmentDTO("DEV"),
-        createMockEnvironmentDTO("DEV"),
-      ];
+  describe("transformEnvironmentApiResponse", () => {
+    it("transforms API response objects into application domain model", () => {
+      const testInput = [createMockEnvironmentDTO({ name: "DEV", id: "1001" })];
 
       expect(transformEnvironmentApiResponse(testInput)).toEqual([
-        "DEV",
-        "TST",
+        { name: "DEV", id: "1001" },
       ]);
-    });
-
-    it("transforms list of 3 environments with 1 unique environment value", () => {
-      const testInput = [
-        createMockEnvironmentDTO("DEV"),
-        createMockEnvironmentDTO("DEV"),
-        createMockEnvironmentDTO("DEV"),
-        createMockEnvironmentDTO("DEV"),
-        createMockEnvironmentDTO("DEV"),
-      ];
-
-      expect(transformEnvironmentApiResponse(testInput)).toEqual(["DEV"]);
     });
   });
 });

--- a/coral/src/domain/environment/environment-transformer.ts
+++ b/coral/src/domain/environment/environment-transformer.ts
@@ -1,3 +1,4 @@
+import pick from "lodash/pick";
 import {
   Environment,
   EnvironmentsGetResponse,
@@ -6,7 +7,7 @@ import {
 function transformEnvironmentApiResponse(
   apiResponse: EnvironmentsGetResponse
 ): Environment[] {
-  return [...new Set(apiResponse.map((topicEnv) => topicEnv.name))].sort();
+  return apiResponse.map((environment) => pick(environment, ["name", "id"]));
 }
 
 export { transformEnvironmentApiResponse };

--- a/coral/src/domain/environment/environment-types.ts
+++ b/coral/src/domain/environment/environment-types.ts
@@ -4,6 +4,9 @@ type EnvironmentsGetResponse =
   operations["environmentsGet"]["responses"]["200"]["content"]["application/json"];
 type EnvironmentDTO = components["schemas"]["Environment"];
 
-type Environment = string;
+type Environment = {
+  name: string;
+  id: string;
+};
 
 export type { Environment, EnvironmentDTO, EnvironmentsGetResponse };

--- a/coral/src/domain/topic/topic-api.msw.ts
+++ b/coral/src/domain/topic/topic-api.msw.ts
@@ -44,7 +44,8 @@ function mockTopicGetRequest({
         return res(ctx.status(200), ctx.json(mockedResponseTopicEnv));
       }
 
-      if (env === "DEV") {
+      // "DEV"
+      if (env === "1") {
         return res(ctx.status(200), ctx.json(mockedResponseTopicEnv));
       }
 

--- a/coral/src/domain/topic/topic-api.ts
+++ b/coral/src/domain/topic/topic-api.ts
@@ -4,7 +4,6 @@ import {
   TopicDTOApiResponse,
 } from "src/domain/topic/topic-types";
 import { transformTopicApiResponse } from "src/domain/topic/topic-transformer";
-import { Environment } from "src/domain/environment";
 import { Team } from "src/domain/team";
 import { ALL_TEAMS_VALUE } from "src/domain/team/team-types";
 import isString from "lodash/isString";
@@ -16,7 +15,7 @@ const getTopics = async ({
   searchTerm,
 }: {
   currentPage: number;
-  environment: Environment;
+  environment: string;
   teamName: Team;
   searchTerm?: string;
 }): Promise<TopicApiResponse> => {

--- a/coral/src/domain/topic/topic-test-helper.ts
+++ b/coral/src/domain/topic/topic-test-helper.ts
@@ -1,5 +1,4 @@
 import { Topic, TopicDTOApiResponse } from "src/domain/topic/topic-types";
-import { Environment } from "src/domain/environment";
 
 // currently this file is used in code (topcis-api.msw.ts)
 // so "expect" is not defined there
@@ -36,7 +35,7 @@ function createMockTopic({
   topicId: number;
   totalNoPages?: number;
   currentPage?: number;
-  environmentsList?: Environment[];
+  environmentsList?: string[];
 }): Topic {
   return {
     topicid: topicId,


### PR DESCRIPTION
Extend our domain model for environment from plain string into object with name and id.

Resolves: #268