### PR TITLE
refactor(coral): Check css file format in pre-commit hook.

### DIFF
--- a/coral/package.json
+++ b/coral/package.json
@@ -26,6 +26,9 @@
     "**/*.ts?(x)": [
       "prettier --check",
       "eslint"
+    ],
+    "**/*.css": [
+      "prettier --check"
     ]
   },
   "dependencies": {


### PR DESCRIPTION
# About this change - What it does
Pre-commit hook didn't check for `.css`, but we're using a few `.css` files now. 

