### PR TITLE
feat(coral): handle 401 API responses with a dialog

### DIFF
--- a/coral/src/app/components/AuthenticationRequiredBoundary.tsx
+++ b/coral/src/app/components/AuthenticationRequiredBoundary.tsx
@@ -1,0 +1,31 @@
+import { Component, ReactElement } from "react";
+import { isUnauthorizedError } from "src/services/api";
+
+class AuthenticationRequiredBoundary extends Component<{
+  children: ReactElement;
+}> {
+  public state = {
+    hasError: false,
+  };
+  constructor(props: { children: ReactElement }) {
+    super(props);
+    this.state = { hasError: false };
+  }
+
+  static getDerivedStateFromError(error: unknown) {
+    if (isUnauthorizedError(error)) {
+      return { hasError: true };
+    }
+  }
+
+  render() {
+    if (this.state.hasError) {
+      window.location.assign("/login");
+      return <div>Redirecting to login...</div>;
+    }
+
+    return this.props.children;
+  }
+}
+
+export default AuthenticationRequiredBoundary;

--- a/coral/src/app/main.tsx
+++ b/coral/src/app/main.tsx
@@ -15,6 +15,7 @@ const root = createRoot(document.getElementById("root") as HTMLElement);
 const queryClient = new QueryClient({
   defaultOptions: {
     queries: {
+      useErrorBoundary: (error: unknown) => isUnauthorizedError(error),
       retry: (failureCount: number, error: unknown) => {
         if (isUnauthorizedError(error)) {
           return false;

--- a/coral/src/app/main.tsx
+++ b/coral/src/app/main.tsx
@@ -6,12 +6,24 @@ import "@aivenio/design-system/dist/styles.css";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { ReactQueryDevtools } from "@tanstack/react-query-devtools";
 import "/src/app/main.module.css";
+import { UnauthorizedError } from "src/services/api";
 
 const DEV_MODE = import.meta.env.DEV;
 
 const root = createRoot(document.getElementById("root") as HTMLElement);
 
-const queryClient = new QueryClient();
+const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: {
+      retry: (failureCount: number, error: unknown) => {
+        if (error instanceof UnauthorizedError) {
+          return false;
+        }
+        return failureCount < 2;
+      },
+    },
+  },
+});
 
 function prepare(): Promise<void | ServiceWorkerRegistration> {
   if (DEV_MODE) {

--- a/coral/src/app/main.tsx
+++ b/coral/src/app/main.tsx
@@ -6,7 +6,7 @@ import "@aivenio/design-system/dist/styles.css";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { ReactQueryDevtools } from "@tanstack/react-query-devtools";
 import "/src/app/main.module.css";
-import { UnauthorizedError } from "src/services/api";
+import { isUnauthorizedError } from "src/services/api";
 
 const DEV_MODE = import.meta.env.DEV;
 
@@ -16,7 +16,7 @@ const queryClient = new QueryClient({
   defaultOptions: {
     queries: {
       retry: (failureCount: number, error: unknown) => {
-        if (error instanceof UnauthorizedError) {
+        if (isUnauthorizedError(error)) {
           return false;
         }
         return failureCount < 2;

--- a/coral/src/app/pages/topics/index.tsx
+++ b/coral/src/app/pages/topics/index.tsx
@@ -1,12 +1,15 @@
 import BrowseTopics from "src/app/features/browse-topics/BrowseTopics";
 import { Flexbox, PageHeader } from "@aivenio/design-system";
+import AuthenticationRequiredBoundary from "src/app/components/AuthenticationRequiredBoundary";
 
 const Topics = () => {
   return (
-    <Flexbox direction={"column"} rowGap={"l2"}>
-      <PageHeader title={"Browse all topics"} />
-      <BrowseTopics />
-    </Flexbox>
+    <AuthenticationRequiredBoundary>
+      <Flexbox direction={"column"} rowGap={"l2"}>
+        <PageHeader title={"Browse all topics"} />
+        <BrowseTopics />
+      </Flexbox>
+    </AuthenticationRequiredBoundary>
   );
 };
 

--- a/coral/src/app/router.tsx
+++ b/coral/src/app/router.tsx
@@ -1,13 +1,8 @@
 import { createBrowserRouter, Navigate, RouteObject } from "react-router-dom";
-import HomePage from "src/app/pages";
 import Topics from "src/app/pages/topics";
 import { getRouterBasename } from "src/config";
 
 const routes: Array<RouteObject> = [
-  {
-    path: "/",
-    element: <HomePage />,
-  },
   // Login is currently the responsibility of the
   // Angular Klaw app
   // {
@@ -19,7 +14,7 @@ const routes: Array<RouteObject> = [
   },
   {
     path: "*",
-    element: <Navigate to="/" />,
+    element: <Navigate to="/topics" />,
   },
 ];
 

--- a/coral/src/services/api.test.ts
+++ b/coral/src/services/api.test.ts
@@ -1,9 +1,9 @@
 import api, {
   AbsolutePathname,
   HTTPMethod,
-  UnauthorizedError,
-  ClientError,
-  ServerError,
+  isClientError,
+  isServerError,
+  isUnauthorizedError,
 } from "src/services/api";
 import { server } from "src/services/api-mocks/server";
 import { rest } from "msw";
@@ -126,8 +126,8 @@ describe("API client", () => {
         describe("When request done without authentication", () => {
           it("should throw UnauthorizedError", async () => {
             const isExpectedError = await unauthorized().catch(
-              (error: Error) => {
-                if (error instanceof UnauthorizedError) {
+              (error: unknown) => {
+                if (isUnauthorizedError(error)) {
                   expect(error.status).toBe(401);
                   expect(error.statusText).toBe("Unauthorized");
                   return true;
@@ -149,7 +149,7 @@ describe("API client", () => {
         describe("when request fails due 4xx status code", () => {
           it("should throw ClientError", async () => {
             const isExpectedError = await badRequest().catch((error: Error) => {
-              if (error instanceof ClientError) {
+              if (isClientError(error)) {
                 expect(error.status).toBe(400);
                 expect(error.statusText).toBe("Bad Request");
                 return true;
@@ -164,7 +164,7 @@ describe("API client", () => {
           it("should throw ServerError", async () => {
             const isExpectedError = await internalError().catch(
               (error: Error) => {
-                if (error instanceof ServerError) {
+                if (isServerError(error)) {
                   expect(error.status).toBe(500);
                   expect(error.statusText).toBe("Internal Server Error");
                   return true;

--- a/coral/src/services/api.ts
+++ b/coral/src/services/api.ts
@@ -94,9 +94,9 @@ function withPayload<TBody extends SomeObject | URLSearchParams>(
   data: TBody
 ): Partial<RequestInit> {
   if (data instanceof URLSearchParams) {
-    return { method, redirect: "manual", ...withFormPayload(data) };
+    return { method, ...withFormPayload(data) };
   } else {
-    return { method, redirect: "manual", ...withJSONPayload(data) };
+    return { method, ...withJSONPayload(data) };
   }
 }
 
@@ -105,7 +105,6 @@ function withoutPayload(
 ): Partial<RequestInit> {
   return {
     method,
-    redirect: "manual",
     headers: {
       accept: CONTENT_TYPE_JSON,
     },

--- a/coral/src/services/api.ts
+++ b/coral/src/services/api.ts
@@ -1,4 +1,5 @@
 import { getHTTPBaseAPIUrl } from "src/config";
+import isPlainObject from "lodash/isPlainObject";
 
 enum HTTPMethod {
   GET = "GET",
@@ -16,29 +17,86 @@ const CONTENT_TYPE_JSON = "application/json" as const;
 
 const API_BASE_URL = getHTTPBaseAPIUrl();
 
-class HTTPError extends Error {
+type HTTPError = {
   status: number;
   statusText: string;
-  constructor(
-    status: number,
-    statusText: string,
-    message?: string,
-    options?: ErrorOptions
-  ) {
-    super(message, options);
-    this.status = status;
-    this.statusText = statusText;
-  }
+  data: SomeObject | string;
+  headers: Headers;
+};
+
+type UnauthorizedError = HTTPError & { status: 401 };
+type ClientError = HTTPError & {
+  status:
+    | 400
+    | 402
+    | 403
+    | 404
+    | 405
+    | 406
+    | 407
+    | 408
+    | 409
+    | 410
+    | 411
+    | 412
+    | 413
+    | 414
+    | 415
+    | 416
+    | 417
+    | 418
+    | 421
+    | 422
+    | 423
+    | 424
+    | 426
+    | 428
+    | 429
+    | 431
+    | 444
+    | 451
+    | 499;
+};
+type ServerError = HTTPError & {
+  status: 500 | 501 | 502 | 503 | 504 | 505 | 506 | 507 | 508 | 510 | 511 | 599;
+};
+
+function hasHTTPErrorProperties(
+  value: Record<string, unknown>
+): value is Record<keyof HTTPError, unknown> {
+  return (
+    "status" in value &&
+    "statusText" in value &&
+    "data" in value &&
+    "headers" in value
+  );
 }
 
-class ServerError extends HTTPError {}
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return isPlainObject(value);
+}
 
-class ClientError extends HTTPError {}
-
-class UnauthorizedError extends ClientError {
-  constructor(message?: string, options?: ErrorOptions) {
-    super(401, "Unauthorized", message, options);
+function isHTTPError(value: unknown): value is HTTPError {
+  if (isRecord(value) && hasHTTPErrorProperties(value)) {
+    return (
+      typeof value.status === "number" &&
+      typeof value.statusText === "string" &&
+      (typeof value.data === "string" || typeof value.data === "object")
+    );
   }
+  return false;
+}
+
+function isUnauthorizedError(value: unknown): value is UnauthorizedError {
+  return isHTTPError(value) && value.status === 401;
+}
+
+function isClientError(value: unknown): value is ClientError {
+  return isHTTPError(value) && value.status >= 400 && value.status < 500;
+}
+
+function isServerError(value: unknown): value is ServerError {
+  return isHTTPError(value) && value.status >= 500;
 }
 
 function isRedirectToPathname(response: Response, pathname: string): boolean {
@@ -51,7 +109,10 @@ function isRedirectToPathname(response: Response, pathname: string): boolean {
 
 function transformHTTPRedirectToLoginTo401(response: Response): Response {
   if (isRedirectToPathname(response, "/login")) {
-    throw new UnauthorizedError();
+    return new Response("Unauthorized", {
+      status: 401,
+      statusText: "Unauthorized",
+    });
   }
   return response;
 }
@@ -111,34 +172,41 @@ function withoutPayload(
   };
 }
 
-const checkStatus = (response: Response): Response => {
+const checkStatus = (response: Response): Promise<Response> => {
   if (!response.ok) {
-    if (response.status === 401) {
-      throw new UnauthorizedError();
-    } else if (response.status >= 500) {
-      throw new ServerError(response.status, response.statusText);
-    } else if (response.status >= 400) {
-      throw new ClientError(response.status, response.statusText);
-    }
+    return Promise.reject(response);
   }
-  return response;
+  return Promise.resolve(response);
 };
 
-function parseResponseBody<T extends SomeObject>(response: Response): T {
+function parseResponseBody<T extends SomeObject>(
+  response: Response
+): Promise<T> {
   const contentType = response.headers.get("content-type");
   if (contentType === CONTENT_TYPE_JSON) {
     if (response.status === 204) {
-      return {} as unknown as T;
+      return Promise.resolve({} as unknown as T);
     } else {
-      return response.json() as unknown as T;
+      return response.json().then((data) => data as unknown as T);
     }
   } else {
-    return response.text() as unknown as T;
+    return response.text().then((data) => data as unknown as T);
   }
 }
 
-function handleHTTPError(error: Error): never {
-  throw error;
+function handleHTTPError(errorOrResponse: Error | Response): Promise<never> {
+  if (errorOrResponse instanceof Response) {
+    return parseResponseBody(errorOrResponse).then((body) => {
+      const httpError: HTTPError = {
+        data: body,
+        status: errorOrResponse.status,
+        statusText: errorOrResponse.statusText,
+        headers: errorOrResponse.headers,
+      };
+      return Promise.reject(httpError);
+    });
+  }
+  return Promise.reject(errorOrResponse);
 }
 
 function handleResponse<TResponse extends SomeObject>(
@@ -207,5 +275,5 @@ export default {
   delete: delete_,
 };
 
-export type { AbsolutePathname };
-export { HTTPMethod, ServerError, ClientError, UnauthorizedError };
+export type { AbsolutePathname, HTTPError };
+export { HTTPMethod, isUnauthorizedError, isServerError, isClientError };


### PR DESCRIPTION
In https://github.com/aiven/klaw/pull/243 we introduces a guard that forced users without active session to authenticate with AngularJS application before being able to view coral routes. That implementation works flawlessly with the initial load, but it does not offer any error handling after the start of the React application. This PR aims to fill the gaps by showing an error dialog for user if any API request returns `401`.  

![Screenshot 2022-12-05 at 13 39 35](https://user-images.githubusercontent.com/1408173/205628483-7b896cd7-ac05-4911-b8e3-cee0679e22ce.png)

After we have introduce the base layout, we should include that in the `ErrorBoundary`.

References: https://github.com/aiven/klaw/issues/185