### PR TITLE
docs(coral): Move documentation links to coral/docs/README.md

### DIFF
--- a/coral/README.md
+++ b/coral/README.md
@@ -4,19 +4,17 @@
 
 ## Table of content
 
-* [About](#about)
-* [Installation and usage](#installation-and-usage)
-  + [Usage: How to run Coral in development](#usage-how-to-run-coral-in-development)
+- [About](#about)
+- [Installation and usage](#installation-and-usage)
+  - [Usage: How to run Coral in development](#usage-how-to-run-coral-in-development)
     - [Scripts used and what they execute](#scripts-used-and-what-they-execute)
-  + [Usage: How to run the Coral in build](#usage-how-to-run-the-frontend-app-in-development)
-* [Tech stack](#tech-stack)
-  + [App development](#app-development)
-  + [Testing](#testing)
-  + [Linting and code formatting](#linting-and-code-formatting)
-* [Styling](#styling)
-* [Documentation](#documentation)
-  + [Tip](#tip)
-* [More detailed documentation](#more-detailed-documentation)
+  - [Usage: How to run Coral inside the Klaw application](#usage-how-to-run-coral-inside-the-klaw-application)
+- [Tech stack](#tech-stack)
+  - [App development](#app-development)
+  - [Testing](#testing)
+  - [Linting and code formatting](#linting-and-code-formatting)
+- [Styling](#styling)
+- [Documentation](#documentation)
 
 ## About
 
@@ -45,6 +43,7 @@ Please see our documentation: [Mocking an API for development](docs/mock-api-for
 You can also run `pnpm` in your console to get a list of all available scripts.
 
 #### Scripts used and what they execute
+
 - `build`: builds the frontend app for production
 - `dev`: starts the frontend app for development
 - `lint`: runs a code format check and if no error is found, lints the code.
@@ -57,24 +56,27 @@ You can also run `pnpm` in your console to get a list of all available scripts.
 
 ### Usage: How to run Coral inside the Klaw application
 
-1. in `/coral`, run `make enable-coral-in-springboot` (see our [Makefile](Makefile)). This will enable Coral in Klaw. It also add the current Coral build files in the right place. 
+1. in `/coral`, run `make enable-coral-in-springboot` (see our [Makefile](Makefile)). This will enable Coral in Klaw. It also add the current Coral build files in the right place.
 2. go to the root directory and follow the [instructions on how to run Klaw](../README.md#Install)
 3. Klaw will run in `http://localhost:9097` (note: it's `http` instead of `https`!)
 
 ## Tech stack
 
 ### App development
+
 - TypeScript - 📃 [documentation](https://www.typescriptlang.org/) | 🐙 [repository](https://github.com/microsoft/TypeScript)
 - React - 📃 [documentation](https://reactjs.org/docs/getting-started.html) | 🐙 [repository](https://github.com/facebook/react/)
 - Vite - 📃 [documentation](https://vitejs.dev/guide/) | 🐙 [repository](https://github.com/vitejs/vite)
 
 ### Testing
+
 - Jest - 📃 [documentation](https://jestjs.io/docs/getting-started) | 🐙 [repository](https://github.com/facebook/jest)
 - React Testing Library - 📃 [documentation](https://testing-library.com/docs/react-testing-library/intro/) | 🐙 [repository](https://github.com/testing-library/react-testing-library)
 
 📃 You can find more detailed information about testing in our docs for [Frontend Testing](docs/frontend-testing.md).
 
 ### Linting and code formatting
+
 How we keep our app's codebase looking consistent and nice 💅🏼
 
 - [Prettier](https://prettier.io/) for code formatting
@@ -90,32 +92,17 @@ The script `lint` runs a prettier check and eslint after. It does not mutate you
 ## Styling
 
 We use the component library of Aiven's design system:
+
 - 📃 [documentation](https://aiven-ds.netlify.app/)
 - the repository is open source, but `private` at the moment
 
 As a rule, please don't use css classes from the design system. All styles should be created by using the existing components and their properties.
 
-__🔄 Work in progress related to styles__
+**🔄 Work in progress related to styles**
+
 - We plan to add css variables based on the design system's tokens.
 - We plan to have a custom theme for Klaw. This will be used instead of the Aiven theme.
 
 ## Documentation
 
-We've a more detailed document about our thinking about [Docmentation](docs/documentation.md).
-
-### Tip
-You can use `alex` ( 📃 [documentation]( https://alexjs.com/) | 🐙 [repository](https://github.com/get-alex/alex)) as an **optional** linting tool. It checks text documents and highlights language that potentially could be insensitive or inconsiderate.
-
-- run it with `pnpm --silent dlx alex` to lint text files.
-
-
-## More detailed documentation
-
-We provide more documentation on:
-
-- Our commitment to [Accessibility](docs/accessibility.md)
-- Detailed overview of the [Directory Structure](docs/directory-structure.md)
-- Our thinking about [Docmentation](docs/documentation.md)
-- More information about [Frontend Testing](docs/frontend-testing.md)
-- [Development with remote API](docs/development-with-remote-api.md)
-
+[More detailed documentation](docs) about `coral` can be found in the `docs` folder

--- a/coral/README.md
+++ b/coral/README.md
@@ -105,4 +105,4 @@ As a rule, please don't use css classes from the design system. All styles shoul
 
 ## Documentation
 
-[More detailed documentation](docs) about `coral` can be found in the `docs` folder
+[More detailed documentation](docs) about `coral` can be found in the `docs` folder.

--- a/coral/README.md
+++ b/coral/README.md
@@ -105,4 +105,4 @@ As a rule, please don't use css classes from the design system. All styles shoul
 
 ## Documentation
 
-[More detailed documentation](docs) about `coral` can be found in the `docs` folder.
+[More detailed documentation](docs/README.md) about `coral` can be found in the `docs` folder.

--- a/coral/docs/README.md
+++ b/coral/docs/README.md
@@ -1,0 +1,14 @@
+## Table of content
+
+- [Notes about documentation](development-with-remote-api.md)
+- [Directory structure](directory-structure.md)
+- [Frontend Testing](frontend-testing.md)
+- [Accessibility for FE app](accessibility.md)
+- [Development with a remote API](development-with-remote-api.md)
+- [Development without a remote API: mocking an API](mock-api-for-development.md)
+
+## Tip
+
+You can use `alex` ( 📃 [documentation](https://alexjs.com/) | 🐙 [repository](https://github.com/get-alex/alex)) as an **optional** linting tool. It checks text documents and highlights language that potentially could be insensitive or inconsiderate.
+
+- run it with `pnpm --silent dlx alex` to lint text files.


### PR DESCRIPTION
# About this change - What it does

This adds a `README` to the root of the `coral/docs` folder, linking to individual articles. It also has the Tip regarding the `alex` docs linting tool.

This `README` is linked under the `Documentation` section in the `README` at the `coral` root. Consequently, all individual links are removed from the root `README`.

# Why this way

As more `docs` articles are added, the root `README` will grow exponentially, which is undesirable. It is also easier to remember adding new articles to a list of link when it is located in the same folder.