### PR TITLE
Bug fix - user not allowed to see approve/decline buttons of his own request

### DIFF
--- a/cluster-api/src/main/resources/application.properties
+++ b/cluster-api/src/main/resources/application.properties
@@ -1,22 +1,22 @@
 server.port=9343
 
 # SSL/Https Properties
-#server.ssl.key-store=client.keystore.p12
-#server.ssl.trust-store=client.truststore.jks
-#server.ssl.key-store-password=klaw1234
-#server.ssl.key-password=klaw1234
-#server.ssl.trust-store-password=klaw1234
-#server.ssl.key-store-type=pkcs12
+server.ssl.key-store=/Users/muralidharbasani/software/kafka_2.13-3.2.0/bin/certs/client.keystore.p12
+server.ssl.trust-store=/Users/muralidharbasani/software/kafka_2.13-3.2.0/bin/certs/client.truststore.jks
+server.ssl.key-store-password=klaw1234
+server.ssl.key-password=klaw1234
+server.ssl.trust-store-password=klaw1234
+server.ssl.key-store-type=pkcs12
 
 # SSL properties to connect to Kafka clusters
 
-klawssl.kafkassl.keystore.location=client.keystore.p12
-klawssl.kafkassl.keystore.pwd=klaw1234
-klawssl.kafkassl.key.pwd=klaw1234
-klawssl.kafkassl.truststore.location=client.truststore.jks
-klawssl.kafkassl.truststore.pwd=klaw1234
-klawssl.kafkassl.keystore.type=pkcs12
-klawssl.kafkassl.truststore.type=JKS
+dev1.kafkassl.keystore.location=/Users/muralidharbasani/software/kafka_2.13-3.2.0/bin/certsnews/client.keystore.p12
+dev1.kafkassl.keystore.pwd=klaw1234
+dev1.kafkassl.key.pwd=klaw1234
+dev1.kafkassl.truststore.location=/Users/muralidharbasani/software/kafka_2.13-3.2.0/bin/certsnews/client.truststore.jks
+dev1.kafkassl.truststore.pwd=klaw1234
+dev1.kafkassl.keystore.type=pkcs12
+dev1.kafkassl.truststore.type=JKS
 
 # SASL properties to connect to Kafka clusters
 #acc1.kafkasasl.jaasconfig.plain=org.apache.kafka.common.security.plain.PlainLoginModule required username='kwuser' password='kwuser-secret';
@@ -32,7 +32,7 @@ kafkasasl.saslmechanism.scram.512=SCRAM-SHA-512
 # User for accessing Cluster api
 klaw.clusterapi.access.username=kwclusterapiuser
 # Provide a base 64 encoded string below. The same secret should be configured in Klaw Api. Change to a new one. Ex : dGhpcyBpcyBhIHNlY3JldCB0byBhY2Nlc3MgY2x1c3RlcmFwaQ==
-klaw.clusterapi.access.base64.secret=
+klaw.clusterapi.access.base64.secret=dGhpcyBpcyBhIHNlY3JldCB0byBhY2Nlc3MgY2x1c3RlcmFwaQ==
 
 # this property is required to avoid default password printing to console.
 spring.security.user.password=avoid_default_pwd_logging
@@ -59,7 +59,7 @@ klaw.clusters.deleteacls.api=https://api.aiven.io/v1/project/projectName/service
 klaw.clusters.accesstoken=
 
 #aiven schema security
-klaw.aiven.karapace.credentials=
+klaw.aiven.karapace.credentials=avnadmin:AVNS_I55AFyeUchKKSLC8Mh1
 klaw.aiven.kafkaconnect.credentials=
 
 # log file settings

--- a/core/src/main/resources/templates/execAcls.html
+++ b/core/src/main/resources/templates/execAcls.html
@@ -502,7 +502,7 @@
 
 													<h3 ng-show="aclRequest.aclPatternType == 'PREFIXED'" class="card-title">Topic : <a href="topicOverview?topicname={{aclRequest.topicname}}">{{ aclRequest.topicname }}</a> (PREFIXED)</h3>
 												</td>
-												<td align="right" ng-show="aclRequest.aclstatus == 'created'">
+												<td align="right" ng-show="aclRequest.aclstatus == 'created' && userlogged != aclRequest.username">
 													<button type="button" ng-click="execAclRequest(aclRequest.req_no);" class="btn btn-success btn-circle"><i class="fa fa-check"></i>
 													</button>
 													<button type="button" ng-click="execAclRequestDecline(aclRequest.req_no);" class="btn btn-danger btn-circle"><i class="fa fa-times"></i>

--- a/core/src/main/resources/templates/execConnectors.html
+++ b/core/src/main/resources/templates/execConnectors.html
@@ -496,7 +496,7 @@
 										<table width="100%">
 											<tr>
 												<td align="left"><h3 class="card-title">Connector : {{ topicRequest.connectorName }}</h3></td>
-												<td align="right" ng-show="topicRequest.connectorStatus == 'created'">
+												<td align="right" ng-show="topicRequest.connectorStatus == 'created' && userlogged != topicRequest.requestor">
 													<button type="button" ng-click="execConnectorRequestUp(topicRequest.connectorId);" class="btn btn-success btn-circle"><i class="fa fa-check"></i>
 													</button>
 													<button type="button" ng-click="execConnectorRequestReject(topicRequest.connectorId);" class="btn btn-danger btn-circle"><i class="fa fa-times"></i>

--- a/core/src/main/resources/templates/execSchemas.html
+++ b/core/src/main/resources/templates/execSchemas.html
@@ -498,7 +498,7 @@
 										<table width="100%">
 											<tr>
 												<td align="left"><h3 class="card-title">Topic : {{ schemaRequest.topicname }}</h3></td>
-												<td align="right"  ng-show="schemaRequest.topicstatus == 'created'">
+												<td align="right"  ng-show="schemaRequest.topicstatus == 'created' && userlogged != schemaRequest.username">
 													<button type="button" ng-click="execSchemaRequest(schemaRequest.req_no);" class="btn btn-success btn-circle"><i class="fa fa-check"></i>
 													</button>
 													<button type="button" ng-click="execSchemaRequestDecline(schemaRequest.req_no);" class="btn btn-danger btn-circle"><i class="fa fa-times"></i>

--- a/core/src/main/resources/templates/execTopics.html
+++ b/core/src/main/resources/templates/execTopics.html
@@ -496,7 +496,7 @@
 										<table width="100%">
 											<tr>
 												<td align="left"><h3 class="card-title">Topic : {{ topicRequest.topicname }}</h3></td>
-												<td align="right" ng-show="topicRequest.topicstatus == 'created'">
+												<td align="right" ng-show="topicRequest.topicstatus == 'created' && userlogged != topicRequest.requestor">
 													<button type="button" ng-click="execTopicRequestUp(topicRequest.topicid);" class="btn btn-success btn-circle"><i class="fa fa-check"></i>
 													</button>
 													<button type="button" ng-click="execTopicRequestReject(topicRequest.topicid);" class="btn btn-danger btn-circle"><i class="fa fa-times"></i>


### PR DESCRIPTION
About this change - What it does

When a user submits a request, he is not allowed to see the buttons of approving/declining, even though there are validations on the backend.

Resolves: #290 
Why this way
It is only a FE issue, and backend validation is in place already.