### PR TITLE
Disable approval/declines for users on same reqs

### DIFF
--- a/core/src/main/resources/templates/execAcls.html
+++ b/core/src/main/resources/templates/execAcls.html
@@ -502,7 +502,7 @@
 
 													<h3 ng-show="aclRequest.aclPatternType == 'PREFIXED'" class="card-title">Topic : <a href="topicOverview?topicname={{aclRequest.topicname}}">{{ aclRequest.topicname }}</a> (PREFIXED)</h3>
 												</td>
-												<td align="right" ng-show="aclRequest.aclstatus == 'created'">
+												<td align="right" ng-show="aclRequest.aclstatus == 'created' && userlogged != aclRequest.username">
 													<button type="button" ng-click="execAclRequest(aclRequest.req_no);" class="btn btn-success btn-circle"><i class="fa fa-check"></i>
 													</button>
 													<button type="button" ng-click="execAclRequestDecline(aclRequest.req_no);" class="btn btn-danger btn-circle"><i class="fa fa-times"></i>

--- a/core/src/main/resources/templates/execConnectors.html
+++ b/core/src/main/resources/templates/execConnectors.html
@@ -496,7 +496,7 @@
 										<table width="100%">
 											<tr>
 												<td align="left"><h3 class="card-title">Connector : {{ topicRequest.connectorName }}</h3></td>
-												<td align="right" ng-show="topicRequest.connectorStatus == 'created'">
+												<td align="right" ng-show="topicRequest.connectorStatus == 'created' && userlogged != topicRequest.requestor">
 													<button type="button" ng-click="execConnectorRequestUp(topicRequest.connectorId);" class="btn btn-success btn-circle"><i class="fa fa-check"></i>
 													</button>
 													<button type="button" ng-click="execConnectorRequestReject(topicRequest.connectorId);" class="btn btn-danger btn-circle"><i class="fa fa-times"></i>

--- a/core/src/main/resources/templates/execSchemas.html
+++ b/core/src/main/resources/templates/execSchemas.html
@@ -497,7 +497,7 @@
 									<div>
 										<table width="100%">
 											<tr>
-												<td align="left"><h3 class="card-title">Topic : {{ schemaRequest.topicname }}</h3></td>
+												<td align="right"  ng-show="schemaRequest.topicstatus == 'created' && userlogged != schemaRequest.username">
 												<td align="right"  ng-show="schemaRequest.topicstatus == 'created'">
 													<button type="button" ng-click="execSchemaRequest(schemaRequest.req_no);" class="btn btn-success btn-circle"><i class="fa fa-check"></i>
 													</button>

--- a/core/src/main/resources/templates/execSchemas.html
+++ b/core/src/main/resources/templates/execSchemas.html
@@ -497,8 +497,8 @@
 									<div>
 										<table width="100%">
 											<tr>
+												<td align="left"><h3 class="card-title">Topic : {{ schemaRequest.topicname }}</h3></td>
 												<td align="right"  ng-show="schemaRequest.topicstatus == 'created' && userlogged != schemaRequest.username">
-												<td align="right"  ng-show="schemaRequest.topicstatus == 'created'">
 													<button type="button" ng-click="execSchemaRequest(schemaRequest.req_no);" class="btn btn-success btn-circle"><i class="fa fa-check"></i>
 													</button>
 													<button type="button" ng-click="execSchemaRequestDecline(schemaRequest.req_no);" class="btn btn-danger btn-circle"><i class="fa fa-times"></i>

--- a/core/src/main/resources/templates/execTopics.html
+++ b/core/src/main/resources/templates/execTopics.html
@@ -496,7 +496,7 @@
 										<table width="100%">
 											<tr>
 												<td align="left"><h3 class="card-title">Topic : {{ topicRequest.topicname }}</h3></td>
-												<td align="right" ng-show="topicRequest.topicstatus == 'created'">
+												<td align="right" ng-show="topicRequest.topicstatus == 'created' && userlogged != topicRequest.requestor">
 													<button type="button" ng-click="execTopicRequestUp(topicRequest.topicid);" class="btn btn-success btn-circle"><i class="fa fa-check"></i>
 													</button>
 													<button type="button" ng-click="execTopicRequestReject(topicRequest.topicid);" class="btn btn-danger btn-circle"><i class="fa fa-times"></i>


### PR DESCRIPTION
About this change - What it does

When a user submits a request, he is not allowed to see the buttons of approving/declining, even though there are validations on the backend.

Resolves: https://github.com/aiven/klaw/issues/290
Why this way
It is only a FE issue, and backend validation is in place already.

Signed-off-by: muralibasani <muralidahr.basani@aiven.io>