### PR TITLE
feat(coral): Add "Request A New Topic" action in Topics index header

### DIFF
--- a/coral/src/app/pages/topics/index.test.tsx
+++ b/coral/src/app/pages/topics/index.test.tsx
@@ -26,10 +26,25 @@ describe("Topics", () => {
   beforeAll(() => {
     server.listen();
     mockIntersectionObserver();
+
+    // This TS disabling is because of "The operand of a 'delete' operator must be optional." TS error.
+    // But this delete is necessary to correctly mock window.location
+    // Without it, we get "Error: Not implemented: navigation (except hash changes)" in JSDOM
+    // Sources:
+    //  https://stackoverflow.com/questions/54090231/how-to-fix-error-not-implemented-navigation-except-hash-changes
+    //  https://remarkablemark.org/blog/2021/04/14/jest-mock-window-location-href/
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-ignore
+    delete window.location;
+    window.location = {
+      href: "/topics",
+    } as Location;
   });
 
   afterAll(() => {
     server.close();
+
+    window.location = location;
   });
 
   describe("renders default view with data from API", () => {
@@ -73,55 +88,25 @@ describe("Topics", () => {
     });
 
     it("navigates to '/requestTopics' when user clicks the button 'Request A New Topic'", async () => {
-      // This TS disabling is because of "The operand of a 'delete' operator must be optional." TS error.
-      // But this delete is necessary to correctly mock window.location
-      // Without it, we get "Error: Not implemented: navigation (except hash changes)" in JSDOM
-      // Sources:
-      //  https://stackoverflow.com/questions/54090231/how-to-fix-error-not-implemented-navigation-except-hash-changes
-      //  https://remarkablemark.org/blog/2021/04/14/jest-mock-window-location-href/
-      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-      // @ts-ignore
-      delete window.location;
-      window.location = {
-        href: "/topics",
-      } as Location;
-
       const button = screen.getByRole("button", {
         name: "Request A New Topic",
       });
 
-      userEvent.click(button);
+      await userEvent.click(button);
 
       await waitFor(() => expect(window.location.href).toBe("/requestTopics"));
-
-      window.location = location;
     });
 
     it("navigates to '/requestTopics' when user presses Enter while 'Request A New Topic' button is focused", async () => {
-      // This TS disabling is because of "The operand of a 'delete' operator must be optional." TS error.
-      // But this delete is necessary to correctly mock window.location
-      // Without it, we get "Error: Not implemented: navigation (except hash changes)" in JSDOM
-      // Sources:
-      //  https://stackoverflow.com/questions/54090231/how-to-fix-error-not-implemented-navigation-except-hash-changes
-      //  https://remarkablemark.org/blog/2021/04/14/jest-mock-window-location-href/
-      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-      // @ts-ignore
-      delete window.location;
-      window.location = {
-        href: "/topics",
-      } as Location;
-
       const button = screen.getByRole("button", {
         name: "Request A New Topic",
       });
 
       tabNavigateTo({ targetElement: button });
 
-      userEvent.keyboard("{Enter}");
+      await userEvent.keyboard("{Enter}");
 
       await waitFor(() => expect(window.location.href).toBe("/requestTopics"));
-
-      window.location = location;
     });
 
     it("renders a select element to filter topics by Kafka environment", async () => {

--- a/coral/src/app/pages/topics/index.test.tsx
+++ b/coral/src/app/pages/topics/index.test.tsx
@@ -21,9 +21,13 @@ import { customRender } from "src/services/test-utils/render-with-wrappers";
 
 const { location } = window;
 
-const tabNavigateTo = ({ targetElement }: { targetElement: HTMLElement }) => {
+const tabNavigateTo = async ({
+  targetElement,
+}: {
+  targetElement: HTMLElement;
+}) => {
   while (document.activeElement !== targetElement) {
-    userEvent.tab();
+    await userEvent.tab();
   }
 };
 

--- a/coral/src/app/pages/topics/index.test.tsx
+++ b/coral/src/app/pages/topics/index.test.tsx
@@ -3,6 +3,8 @@ import {
   within,
   cleanup,
   waitForElementToBeRemoved,
+  fireEvent,
+  waitFor,
 } from "@testing-library/react/pure";
 import Topics from "src/app/pages/topics";
 import { customRender } from "src/services/test-utils/render-with-wrappers";
@@ -16,6 +18,8 @@ import { mockGetEnvironments } from "src/domain/environment";
 import { mockedTeamResponse, mockGetTeams } from "src/domain/team/team-api.msw";
 import { mockedEnvironmentResponse } from "src/domain/environment/environment-api.msw";
 import { mockIntersectionObserver } from "src/services/test-utils/mock-intersection-observer";
+
+const { location } = window;
 
 describe("Topics", () => {
   beforeAll(() => {
@@ -56,6 +60,47 @@ describe("Topics", () => {
       });
 
       expect(headline).toBeVisible();
+    });
+
+    it("renders 'Request A New Topic' primary action in heading", async () => {
+      const headline = screen.getByRole("button", {
+        name: "Request A New Topic",
+      });
+
+      expect(headline).toBeVisible();
+    });
+
+    it("renders 'Request A New Topic' primary action in heading", async () => {
+      const primaryAction = screen.getByRole("button", {
+        name: "Request A New Topic",
+      });
+
+      expect(primaryAction).toBeVisible();
+    });
+
+    it("navigates to '/requestTopics' on clicking the primary action in heading", async () => {
+      // This TS disabling is because of "The operand of a 'delete' operator must be optional." TS error.
+      // But this delete is necessary to correctly mock window.location
+      // Without it, we get "Error: Not implemented: navigation (except hash changes)" in JSDOM
+      // Sources:
+      //  https://stackoverflow.com/questions/54090231/how-to-fix-error-not-implemented-navigation-except-hash-changes
+      //  https://remarkablemark.org/blog/2021/04/14/jest-mock-window-location-href/
+      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+      // @ts-ignore
+      delete window.location;
+      window.location = {
+        href: "/topics",
+      } as Location;
+
+      const primaryAction = screen.getByRole("button", {
+        name: "Request A New Topic",
+      });
+
+      fireEvent.click(primaryAction);
+
+      waitFor(() => expect(window.location.href).toBe("/requestTopics"));
+
+      window.location = location;
     });
 
     it("renders a select element to filter topics by Kafka environment", async () => {

--- a/coral/src/app/pages/topics/index.test.tsx
+++ b/coral/src/app/pages/topics/index.test.tsx
@@ -18,18 +18,9 @@ import {
 import { server } from "src/services/api-mocks/server";
 import { mockIntersectionObserver } from "src/services/test-utils/mock-intersection-observer";
 import { customRender } from "src/services/test-utils/render-with-wrappers";
+import { tabNavigateTo } from "src/services/test-utils/tabbing";
 
 const { location } = window;
-
-const tabNavigateTo = async ({
-  targetElement,
-}: {
-  targetElement: HTMLElement;
-}) => {
-  while (document.activeElement !== targetElement) {
-    await userEvent.tab();
-  }
-};
 
 describe("Topics", () => {
   beforeAll(() => {

--- a/coral/src/app/pages/topics/index.test.tsx
+++ b/coral/src/app/pages/topics/index.test.tsx
@@ -21,6 +21,12 @@ import { customRender } from "src/services/test-utils/render-with-wrappers";
 
 const { location } = window;
 
+const tabNavigateTo = ({ targetElement }: { targetElement: HTMLElement }) => {
+  while (document.activeElement !== targetElement) {
+    userEvent.tab();
+  }
+};
+
 describe("Topics", () => {
   beforeAll(() => {
     server.listen();
@@ -114,7 +120,7 @@ describe("Topics", () => {
         name: "Request A New Topic",
       });
 
-      button.focus();
+      tabNavigateTo({ targetElement: button });
 
       userEvent.keyboard("{Enter}");
 

--- a/coral/src/app/pages/topics/index.tsx
+++ b/coral/src/app/pages/topics/index.tsx
@@ -1,13 +1,22 @@
-import BrowseTopics from "src/app/features/browse-topics/BrowseTopics";
 import { PageHeader } from "@aivenio/design-system";
-import Layout from "src/app/layout/Layout";
+import add from "@aivenio/design-system/dist/src/icons/add";
 import AuthenticationRequiredBoundary from "src/app/components/AuthenticationRequiredBoundary";
+import BrowseTopics from "src/app/features/browse-topics/BrowseTopics";
+import Layout from "src/app/layout/Layout";
 
 const Topics = () => {
   return (
     <AuthenticationRequiredBoundary>
       <Layout>
-        <PageHeader title={"Browse all topics"} />
+        <PageHeader
+          title={"Browse all topics"}
+          primaryAction={{
+            text: "Request A New Topic",
+            // @TODO Replace by useNavigate once the request page is implemented in coral
+            onClick: () => (window.location.href = "/requestTopics"),
+            icon: add,
+          }}
+        />
         <BrowseTopics />
       </Layout>
     </AuthenticationRequiredBoundary>

--- a/coral/src/services/test-utils/tabbing.tsx
+++ b/coral/src/services/test-utils/tabbing.tsx
@@ -12,4 +12,14 @@ async function tabThroughBackward(times: number) {
   }
 }
 
-export { tabThroughForward, tabThroughBackward };
+async function tabNavigateTo({
+  targetElement,
+}: {
+  targetElement: HTMLElement;
+}) {
+  while (document.activeElement !== targetElement) {
+    await userEvent.tab();
+  }
+}
+
+export { tabThroughForward, tabThroughBackward, tabNavigateTo };


### PR DESCRIPTION
## About this change - What it does

- Add a primary action `Request A New Topic` to the topics index page `PageHeader`

<img width="1512" alt="Screenshot 2022-12-07 at 17 30 33" src="https://user-images.githubusercontent.com/20607294/206235779-eb099756-6489-47c9-a170-8990f08fde74.png">



Resolves: #257

