### PR TITLE
Add topics search tests

### DIFF
--- a/coral/src/app/features/browse-topics/BrowseTopics.test.tsx
+++ b/coral/src/app/features/browse-topics/BrowseTopics.test.tsx
@@ -1,18 +1,19 @@
-import { server } from "src/services/api-mocks/server";
+import { cleanup, screen, within } from "@testing-library/react";
+import { waitForElementToBeRemoved } from "@testing-library/react/pure";
+import userEvent from "@testing-library/user-event";
+import BrowseTopics from "src/app/features/browse-topics/BrowseTopics";
+import { mockGetEnvironments } from "src/domain/environment";
+import { mockedEnvironmentResponse } from "src/domain/environment/environment-api.msw";
+import { mockedTeamResponse, mockGetTeams } from "src/domain/team/team-api.msw";
 import {
   mockedResponseSinglePage,
   mockedResponseTransformed,
   mockTopicGetRequest,
 } from "src/domain/topic/topic-api.msw";
-import { customRender } from "src/services/test-utils/render-with-wrappers";
-import { cleanup, within, screen } from "@testing-library/react";
-import BrowseTopics from "src/app/features/browse-topics/BrowseTopics";
-import { waitForElementToBeRemoved } from "@testing-library/react/pure";
-import userEvent from "@testing-library/user-event";
-import { mockGetEnvironments } from "src/domain/environment";
-import { mockedTeamResponse, mockGetTeams } from "src/domain/team/team-api.msw";
-import { mockedEnvironmentResponse } from "src/domain/environment/environment-api.msw";
+import { server } from "src/services/api-mocks/server";
 import { mockIntersectionObserver } from "src/services/test-utils/mock-intersection-observer";
+import { customRender } from "src/services/test-utils/render-with-wrappers";
+import { tabNavigateTo } from "src/services/test-utils/tabbing";
 
 jest.mock("@aivenio/design-system", () => {
   return {
@@ -427,6 +428,125 @@ describe("BrowseTopics.tsx", () => {
       });
 
       await userEvent.selectOptions(select, option);
+      await waitForElementToBeRemoved(screen.getByText("Filtering list..."));
+
+      expect(getAllTopics()).toHaveLength(2);
+    });
+  });
+
+  describe("handles user searching by topic name with search input", () => {
+    const testSearchInput = "Searched for topic";
+    const getAllTopics = () =>
+      within(
+        screen.getByRole("table", { name: /Topics overview/ })
+      ).getAllByRole("rowheader");
+
+    beforeEach(() => {
+      mockTopicGetRequest({
+        mswInstance: server,
+      });
+      customRender(<BrowseTopics />, { memoryRouter: true, queryClient: true });
+    });
+
+    afterEach(() => {
+      server.resetHandlers();
+      cleanup();
+    });
+
+    it("fetches new data when user enters text in input and clicks the search button", async () => {
+      const input = screen.getByRole("searchbox", {
+        name: "Search by topic name",
+      });
+      const submitButton = screen.getByRole("button", {
+        name: "Submit search",
+      });
+
+      await waitForElementToBeRemoved(screen.getByText("Loading..."));
+
+      expect(getAllTopics()).toHaveLength(10);
+      expect(input).toHaveValue("");
+      expect(submitButton).toBeEnabled();
+
+      await userEvent.type(input, testSearchInput);
+
+      expect(input).toHaveValue(testSearchInput);
+
+      await userEvent.click(submitButton);
+      await waitForElementToBeRemoved(screen.getByText("Filtering list..."));
+
+      expect(getAllTopics()).toHaveLength(2);
+    });
+
+    it("fetches new data when when user enters text in input and presses 'Enter'", async () => {
+      const input = screen.getByRole("searchbox", {
+        name: "Search by topic name",
+      });
+
+      await waitForElementToBeRemoved(screen.getByText("Loading..."));
+
+      expect(getAllTopics()).toHaveLength(10);
+      expect(input).toHaveValue("");
+
+      await userEvent.type(input, testSearchInput);
+
+      expect(input).toHaveValue(testSearchInput);
+
+      await userEvent.keyboard("{Enter}");
+      await waitForElementToBeRemoved(screen.getByText("Filtering list..."));
+
+      expect(getAllTopics()).toHaveLength(2);
+    });
+
+    it("can navigate to search input and submit button with keyboard", async () => {
+      const input = screen.getByRole("searchbox", {
+        name: "Search by topic name",
+      });
+      const submitButton = screen.getByRole("button", {
+        name: "Submit search",
+      });
+
+      await waitForElementToBeRemoved(screen.getByText("Loading..."));
+
+      expect(getAllTopics()).toHaveLength(10);
+      expect(input).toHaveValue("");
+      expect(submitButton).toBeEnabled();
+
+      await tabNavigateTo({ targetElement: input });
+
+      expect(input).toHaveFocus();
+
+      await userEvent.tab();
+
+      expect(submitButton).toHaveFocus();
+    });
+
+    it("fetches new data when user enters text in input and presses 'Enter' on focused submit button", async () => {
+      const input = screen.getByRole("searchbox", {
+        name: "Search by topic name",
+      });
+      const submitButton = screen.getByRole("button", {
+        name: "Submit search",
+      });
+
+      await waitForElementToBeRemoved(screen.getByText("Loading..."));
+
+      expect(getAllTopics()).toHaveLength(10);
+      expect(input).toHaveValue("");
+      expect(submitButton).toBeEnabled();
+
+      await tabNavigateTo({ targetElement: input });
+
+      expect(input).toHaveFocus();
+
+      await userEvent.type(input, testSearchInput);
+
+      expect(input).toHaveValue(testSearchInput);
+
+      await userEvent.tab();
+
+      expect(submitButton).toHaveFocus();
+
+      await userEvent.keyboard("{Enter}");
       await waitForElementToBeRemoved(screen.getByText("Filtering list..."));
 
       expect(getAllTopics()).toHaveLength(2);

--- a/coral/src/app/features/browse-topics/components/search/SearchTopics.test.tsx
+++ b/coral/src/app/features/browse-topics/components/search/SearchTopics.test.tsx
@@ -19,13 +19,17 @@ describe("SearchTopics.tsx", () => {
     });
 
     it("shows a search input", () => {
-      const input = screen.getByRole("searchbox", { name: "Search topics" });
+      const input = screen.getByRole("searchbox", {
+        name: "Search by topic name",
+      });
 
       expect(input).toBeEnabled();
     });
 
     it("shows a given search term as value", () => {
-      const input = screen.getByRole("searchbox", { name: "Search topics" });
+      const input = screen.getByRole("searchbox", {
+        name: "Search by topic name",
+      });
 
       expect(input).toHaveValue(testSearchTerm);
     });
@@ -61,7 +65,9 @@ describe("SearchTopics.tsx", () => {
     });
 
     it("updates value for user input", async () => {
-      const input = screen.getByRole("searchbox", { name: "Search topics" });
+      const input = screen.getByRole("searchbox", {
+        name: "Search by topic name",
+      });
       expect(input).toHaveValue("");
 
       await userEvent.type(input, testSearchInput);
@@ -70,7 +76,9 @@ describe("SearchTopics.tsx", () => {
     });
 
     it("submits search term when user clicks button", async () => {
-      const input = screen.getByRole("searchbox", { name: "Search topics" });
+      const input = screen.getByRole("searchbox", {
+        name: "Search by topic name",
+      });
       const submitButton = screen.getByRole("button", {
         name: "Submit search",
       });
@@ -82,7 +90,9 @@ describe("SearchTopics.tsx", () => {
     });
 
     it("submits search term when user presses enter", async () => {
-      const input = screen.getByRole("searchbox", { name: "Search topics" });
+      const input = screen.getByRole("searchbox", {
+        name: "Search by topic name",
+      });
 
       await userEvent.type(input, testSearchInput);
       await userEvent.keyboard("{Enter}");
@@ -91,7 +101,9 @@ describe("SearchTopics.tsx", () => {
     });
 
     it("removes spaces at beginning and end of search term when users submits", async () => {
-      const input = screen.getByRole("searchbox", { name: "Search topics" });
+      const input = screen.getByRole("searchbox", {
+        name: "Search by topic name",
+      });
 
       await userEvent.type(input, " awesome topic ");
       await userEvent.keyboard("{Enter}");

--- a/coral/src/app/features/browse-topics/components/search/SearchTopics.tsx
+++ b/coral/src/app/features/browse-topics/components/search/SearchTopics.tsx
@@ -21,7 +21,7 @@ function SearchTopics(props: SearchTopicsProps) {
   return (
     <form role={"search"} onSubmit={onSearchSubmit} aria-label={"Topics"}>
       <label className={"visually-hidden"} htmlFor={"topics-search"}>
-        Search topics
+        Search by topic name
       </label>
       <Grid
         cols={"2"}
@@ -30,7 +30,7 @@ function SearchTopics(props: SearchTopicsProps) {
       >
         <InputBase
           type={"search"}
-          placeholder="Search for…"
+          placeholder="Search by topic name"
           value={searchTerm}
           onChange={(event) => setSearchTerm(event.target.value)}
           id={"topics-search"}

--- a/coral/src/app/pages/topics/index.test.tsx
+++ b/coral/src/app/pages/topics/index.test.tsx
@@ -102,7 +102,7 @@ describe("Topics", () => {
         name: "Request A New Topic",
       });
 
-      tabNavigateTo({ targetElement: button });
+      await tabNavigateTo({ targetElement: button });
 
       await userEvent.keyboard("{Enter}");
 


### PR DESCRIPTION
# About this change - What it does

`BrowseTopics.tsx` did not have test cases for when a user searches a topic through the search input. This PR adds cases for:
- entering a search and clicking the search button
- entering a search and pressing `enter`
- the above two but with keyboard navigation

Resolves: #292

# Why this way

The internal functionality of the search `SearchTopics` is already tested in `SearchTopics.test.tsx`, this is only testing that the correct API call is dispatched and that the table renders the correct data.

# Additional notes

- updated the placeholder text which was ambiguous (as well as the visually hidden accessibility label)
- added a missing `await` in another test use `tabNavigateTo`