### PR TITLE
feat(coral): improve browse topic a11y

### DIFF
--- a/coral/src/app/accessibility.module.css
+++ b/coral/src/app/accessibility.module.css
@@ -10,11 +10,11 @@
  *   -> can be removed if styles in DS
  *       or custom theme are covered
 */
-
 :root {
   --hover-indicator-primary-80: #e41a4a;
   --active-indicator-primary-100: #a70045;
   --focus-indicator-info-70: #0399e3;
+  --text-color-grey-70: #4a4b57;
 }
 
 /************************************************

--- a/coral/src/app/accessibility.module.css
+++ b/coral/src/app/accessibility.module.css
@@ -1,0 +1,75 @@
+/*
+ * Styles and classes in this file are use to
+ * improve overall accessibility of Klaw.
+ * Styles are separated into
+ * - global rules
+ *   -> not available by DS yet)
+ * - additional a11y-related custom classes
+ *   -> not available by DS yet)
+ * - overwriting DS styles
+ *   -> can be removed if styles in DS
+ *       or custom theme are covered
+*/
+
+:root {
+  --hover-indicator-primary-80: #e41a4a;
+  --active-indicator-primary-100: #a70045;
+  --focus-indicator-info-70: #0399e3;
+}
+
+/************************************************
+ * global styles, not covered by DS yet
+ ************************************************
+*/
+
+/*make border-radius and focus styles consistent for buttons that*/
+/*are used instead of DS (e.g. submenu)*/
+button {
+  border-radius: 0.125rem !important;
+}
+
+button:focus-visible {
+  outline: 2px solid var(--focus-indicator-info-70) !important;
+  outline-offset: 2px !important;
+}
+
+a:focus-visible {
+  outline-offset: 2px;
+  /*represents info-70*/
+  outline-color: var(--focus-indicator-info-70);
+  box-shadow: 0 0 3px 0 #ddd;
+}
+
+/****************************************
+ * a11y-related custom classes
+ ****************************************
+*/
+
+:global(.visually-hidden) {
+  position: absolute !important;
+  width: 1px !important;
+  height: 1px !important;
+  padding: 0 !important;
+  margin: -1px !important;
+  overflow: hidden !important;
+  clip: rect(0, 0, 0, 0) !important;
+  white-space: nowrap !important;
+  border: 0 !important;
+  font-size: 18px;
+}
+
+/****************************************
+ * DS overwrites
+ ****************************************
+*/
+
+:root input:focus-visible,
+:root select:focus-visible {
+  outline: 1px solid var(--focus-indicator-info-70) !important;
+  outline-offset: 0 !important;
+}
+
+:root button:focus {
+  outline: 2px solid var(--focus-indicator-info-70) !important;
+  outline-offset: 0 !important;
+}

--- a/coral/src/app/accessibility.module.css
+++ b/coral/src/app/accessibility.module.css
@@ -73,3 +73,10 @@ a:focus-visible {
   outline: 2px solid var(--focus-indicator-info-70) !important;
   outline-offset: 0 !important;
 }
+
+:root label span {
+  /*represents grey-70 */
+  color: #4a4b57 !important;
+  /*represents body-small*/
+  font-size: 12px !important;
+}

--- a/coral/src/app/components/AuthenticationRequiredBoundary.tsx
+++ b/coral/src/app/components/AuthenticationRequiredBoundary.tsx
@@ -1,3 +1,4 @@
+import { Flexbox, Typography } from "@aivenio/design-system";
 import { Component, ReactElement } from "react";
 import { isUnauthorizedError } from "src/services/api";
 
@@ -21,7 +22,31 @@ class AuthenticationRequiredBoundary extends Component<{
   render() {
     if (this.state.hasError) {
       window.location.assign("/login");
-      return <div>Redirecting to login...</div>;
+      return (
+        <Flexbox
+          paddingTop={"l6"}
+          justifyContent={"center"}
+          alignItems={"center"}
+        >
+          <div
+            role="alertdialog"
+            aria-labelledby={"authentication-required-heading"}
+            aria-describedby={"authentication-required-text"}
+          >
+            <Typography.Heading color={"secondary-100"}>
+              <span id={"authentication-required-heading"}>
+                Authentication session expired
+              </span>
+            </Typography.Heading>
+
+            <Typography.LargeText>
+              <span id={"authentication-required-text"}>
+                Redirecting to login page.
+              </span>
+            </Typography.LargeText>
+          </div>
+        </Flexbox>
+      );
     }
 
     return this.props.children;

--- a/coral/src/app/components/Pagination.test.tsx
+++ b/coral/src/app/components/Pagination.test.tsx
@@ -14,100 +14,216 @@ jest.mock("@aivenio/design-system", () => {
 });
 
 function getNavigationElement() {
-  return screen.getByRole("navigation", { name: "Pagination" });
+  return screen.getByRole("navigation", { name: /Pagination/ });
 }
 
 describe("Pagination.tsx", () => {
   describe("renders the pagination by default with active page `1`", () => {
+    const activePage = 1;
     const totalPages = 5;
 
-    beforeAll(() => {
-      render(
-        <Pagination
-          activePage={1}
-          totalPages={totalPages}
-          setActivePage={jest.fn()}
-        />
-      );
-    });
-
-    afterAll(cleanup);
-
-    it("shows a navigation element", () => {
-      const navigation = getNavigationElement();
-
-      expect(navigation).toBeVisible();
-    });
-
-    it("shows list for navigation items", () => {
-      const list = within(getNavigationElement()).getByRole("list");
-
-      expect(list).toBeVisible();
-    });
-
-    it("renders visually hidden text to inform assistive tech about active and all pages", () => {
-      const info = within(getNavigationElement()).getByText(
-        `You are on page 1 of ${totalPages}`
-      );
-
-      expect(info).toBeVisible();
-    });
-
-    it("shows no button to get the first page for assistive technology", () => {
-      const button = within(getNavigationElement()).queryByRole("button", {
-        name: "Go to first page",
+    describe("shows all necessary elements", () => {
+      beforeAll(() => {
+        render(
+          <Pagination
+            activePage={activePage}
+            totalPages={totalPages}
+            setActivePage={jest.fn()}
+          />
+        );
       });
 
-      expect(button).not.toBeInTheDocument();
-    });
+      afterAll(cleanup);
 
-    it("disables button to get the first page", () => {
-      const button = within(getNavigationElement()).queryByRole("button", {
-        name: "Go to first page",
-        hidden: true,
+      it("shows a navigation element", () => {
+        const navigation = getNavigationElement();
+
+        expect(navigation).toBeVisible();
       });
 
-      expect(button).toBeDisabled();
-    });
+      it("gives information about current and total pages for assistive technology", () => {
+        const navigation = getNavigationElement();
 
-    it("shows no button to get the previous page for assistive technology", () => {
-      const button = within(getNavigationElement()).queryByRole("button", {
-        name: /Go to previous page/,
+        expect(navigation).toHaveAccessibleName(
+          "Pagination navigation, you're on page 1 of 5"
+        );
       });
 
-      expect(button).not.toBeInTheDocument();
-    });
+      it("shows list for navigation items", () => {
+        const list = within(getNavigationElement()).getByRole("list");
 
-    it("disables button to get the previous page", () => {
-      const button = within(getNavigationElement()).getByRole("button", {
-        name: /Go to previous page/,
-        hidden: true,
+        expect(list).toBeVisible();
       });
 
-      expect(button).toBeDisabled();
-    });
+      it("shows no button to get the first page for assistive technology", () => {
+        const button = within(getNavigationElement()).queryByRole("button", {
+          name: "Go to first page",
+        });
 
-    it("shows a button to get to the next page", () => {
-      const button = within(getNavigationElement()).getByRole("button", {
-        name: "Go to next page, page 2",
+        expect(button).not.toBeInTheDocument();
       });
 
-      expect(button).toBeEnabled();
-    });
+      it("disables button to get the first page", () => {
+        const button = within(getNavigationElement()).queryByRole("button", {
+          name: "Go to first page",
+          hidden: true,
+        });
 
-    it("shows a button to get to the last page", () => {
-      const button = within(getNavigationElement()).getByRole("button", {
-        name: `Go to last page, page ${totalPages}`,
+        expect(button).toBeDisabled();
       });
 
-      expect(button).toBeEnabled();
+      it("shows no button to get the previous page for assistive technology", () => {
+        const button = within(getNavigationElement()).queryByRole("button", {
+          name: /Go to previous page/,
+        });
+
+        expect(button).not.toBeInTheDocument();
+      });
+
+      it("disables button to get the previous page", () => {
+        const button = within(getNavigationElement()).getByRole("button", {
+          name: /Go to previous page/,
+          hidden: true,
+        });
+
+        expect(button).toBeDisabled();
+      });
+
+      it("shows visual only information about current page and total pages", () => {
+        const text = within(getNavigationElement()).getByText("Page 1 of 5");
+
+        expect(text).toBeVisible();
+        expect(text).toHaveAttribute("aria-hidden", "true");
+      });
+
+      it("shows a button to get to the next page", () => {
+        const button = within(getNavigationElement()).getByRole("button", {
+          name: "Go to next page, page 2",
+        });
+
+        expect(button).toBeEnabled();
+      });
+
+      it("shows a button to get to the last page", () => {
+        const button = within(getNavigationElement()).getByRole("button", {
+          name: `Go to last page, page ${totalPages}`,
+        });
+
+        expect(button).toBeEnabled();
+      });
+
+      it("renders all icons", () => {
+        // makes sure that the right amount of icons has been used
+        // will break if icons are missing / not used
+        // does NOT check if the right icons are rendered
+        expect(mockIconRender).toHaveBeenCalledTimes(4);
+      });
     });
 
-    it("renders all icons", () => {
-      // makes sure that the right amount of icons has been used
-      // will break if icons are missing / not used
-      // does NOT check if the right icons are rendered
-      expect(mockIconRender).toHaveBeenCalledTimes(4);
+    describe("handles updating the pages`", () => {
+      const mockedSetActivePage = jest.fn();
+      beforeEach(() => {
+        render(
+          <Pagination
+            activePage={activePage}
+            totalPages={totalPages}
+            setActivePage={mockedSetActivePage}
+          />
+        );
+      });
+
+      afterEach(() => {
+        jest.resetAllMocks();
+        cleanup();
+      });
+
+      it('does not update page when user clicks "Go to first page"', async () => {
+        const button = within(getNavigationElement()).getByRole("button", {
+          name: "Go to first page",
+          hidden: true,
+        });
+        await userEvent.click(button);
+
+        expect(mockedSetActivePage).not.toHaveBeenCalled();
+      });
+
+      it('does not update page when user clicks "Go to previous page"', async () => {
+        const button = within(getNavigationElement()).getByRole("button", {
+          name: /Go to previous page/,
+          hidden: true,
+        });
+        await userEvent.click(button);
+
+        expect(mockedSetActivePage).not.toHaveBeenCalled();
+      });
+
+      it('calls "setActivePage" with "3" if user clicks "Go to next page"', async () => {
+        const button = within(getNavigationElement()).getByRole("button", {
+          name: /Go to next page/,
+        });
+        await userEvent.click(button);
+
+        expect(mockedSetActivePage).toHaveBeenCalledWith(2);
+      });
+
+      it('calls "setActivePage" with "4" if user clicks "Go to last page"', async () => {
+        const button = within(getNavigationElement()).getByRole("button", {
+          name: /Go to last page/,
+        });
+        await userEvent.click(button);
+
+        expect(mockedSetActivePage).toHaveBeenCalledWith(5);
+      });
+    });
+
+    describe("enables keyboard only navigation", () => {
+      const mockSetActivePage = jest.fn();
+      beforeEach(() => {
+        render(
+          <Pagination
+            activePage={activePage}
+            totalPages={totalPages}
+            setActivePage={mockSetActivePage}
+          />
+        );
+        const navigation = getNavigationElement();
+        navigation.focus();
+      });
+
+      afterEach(() => {
+        jest.resetAllMocks();
+        cleanup();
+      });
+
+      it('focuses "Go to next page" button first', async () => {
+        const button = screen.getByRole("button", { name: /Go to next page/ });
+
+        await userEvent.tab();
+        expect(button).toHaveFocus();
+      });
+
+      it('updates to page 2 when user presses enter on "Go to next page" button', async () => {
+        await userEvent.tab();
+        await userEvent.keyboard("{Enter}");
+
+        expect(mockSetActivePage).toHaveBeenCalledWith(2);
+      });
+
+      it('focuses "Go to last page" button next', async () => {
+        const button = screen.getByRole("button", { name: /Go to last page/ });
+        await userEvent.tab();
+        await userEvent.tab();
+
+        expect(button).toHaveFocus();
+      });
+
+      it('updates to page 5 when user presses enter on "Go to last page" button', async () => {
+        await userEvent.tab();
+        await userEvent.tab();
+        await userEvent.keyboard("{Enter}");
+
+        expect(mockSetActivePage).toHaveBeenCalledWith(5);
+      });
     });
   });
 
@@ -115,48 +231,209 @@ describe("Pagination.tsx", () => {
     const activePage = 3;
     const totalPages = 6;
 
-    beforeAll(() => {
-      render(
-        <Pagination
-          activePage={activePage}
-          totalPages={totalPages}
-          setActivePage={jest.fn()}
-        />
-      );
-    });
-
-    afterAll(cleanup);
-
-    it("shows a button to get the first page", () => {
-      const button = within(getNavigationElement()).getByRole("button", {
-        name: "Go to first page",
+    describe("shows all necessary elements", () => {
+      beforeAll(() => {
+        render(
+          <Pagination
+            activePage={activePage}
+            totalPages={totalPages}
+            setActivePage={jest.fn()}
+          />
+        );
       });
 
-      expect(button).toBeEnabled();
-    });
+      afterAll(cleanup);
 
-    it("shows a button to get the previous page", () => {
-      const button = within(getNavigationElement()).getByRole("button", {
-        name: `Go to previous page, page ${activePage - 1}`,
+      it("gives information about current and total pages for assistive technology", () => {
+        const navigation = getNavigationElement();
+
+        expect(navigation).toHaveAccessibleName(
+          "Pagination navigation, you're on page 3 of 6"
+        );
       });
 
-      expect(button).toBeEnabled();
-    });
+      it("shows a button to get the first page", () => {
+        const button = within(getNavigationElement()).getByRole("button", {
+          name: "Go to first page",
+        });
 
-    it("shows a button to get to the next page", () => {
-      const button = within(getNavigationElement()).getByRole("button", {
-        name: `Go to next page, page ${activePage + 1}`,
+        expect(button).toBeEnabled();
       });
 
-      expect(button).toBeVisible();
-    });
+      it("shows a button to get the previous page", () => {
+        const button = within(getNavigationElement()).getByRole("button", {
+          name: `Go to previous page, page ${activePage - 1}`,
+        });
 
-    it("shows a button to get to the last page", () => {
-      const button = within(getNavigationElement()).getByRole("button", {
-        name: `Go to last page, page ${totalPages}`,
+        expect(button).toBeEnabled();
       });
 
-      expect(button).toBeVisible();
+      it("shows visual only information about current page and total pages", () => {
+        const text = within(getNavigationElement()).getByText("Page 3 of 6");
+
+        expect(text).toBeVisible();
+        expect(text).toHaveAttribute("aria-hidden", "true");
+      });
+
+      it("shows a button to get to the next page", () => {
+        const button = within(getNavigationElement()).getByRole("button", {
+          name: `Go to next page, page ${activePage + 1}`,
+        });
+
+        expect(button).toBeVisible();
+      });
+
+      it("shows a button to get to the last page", () => {
+        const button = within(getNavigationElement()).getByRole("button", {
+          name: `Go to last page, page ${totalPages}`,
+        });
+
+        expect(button).toBeVisible();
+      });
+    });
+
+    describe("handles updating the pages`", () => {
+      const mockedSetActivePage = jest.fn();
+      beforeEach(() => {
+        render(
+          <Pagination
+            activePage={activePage}
+            totalPages={totalPages}
+            setActivePage={mockedSetActivePage}
+          />
+        );
+      });
+
+      afterEach(() => {
+        jest.resetAllMocks();
+        cleanup();
+      });
+
+      it('calls "setActivePage" with "1" if user clicks "Go to first page"', async () => {
+        const button = within(getNavigationElement()).getByRole("button", {
+          name: "Go to first page",
+        });
+        await userEvent.click(button);
+
+        expect(mockedSetActivePage).toHaveBeenCalledWith(1);
+      });
+
+      it('calls "setActivePage" with "2" if user clicks "Go to previous page"', async () => {
+        const button = within(getNavigationElement()).getByRole("button", {
+          name: /Go to previous page/,
+        });
+        await userEvent.click(button);
+
+        expect(mockedSetActivePage).toHaveBeenCalledWith(2);
+      });
+
+      it('calls "setActivePage" with "4" if user clicks "Go to next page"', async () => {
+        const button = within(getNavigationElement()).getByRole("button", {
+          name: /Go to next page/,
+        });
+        await userEvent.click(button);
+
+        expect(mockedSetActivePage).toHaveBeenCalledWith(4);
+      });
+
+      it('calls "setActivePage" with "6" if user clicks "Go to last page"', async () => {
+        const button = within(getNavigationElement()).getByRole("button", {
+          name: /Go to last page/,
+        });
+        await userEvent.click(button);
+
+        expect(mockedSetActivePage).toHaveBeenCalledWith(6);
+      });
+    });
+
+    describe("enables keyboard only navigation", () => {
+      const mockSetActivePage = jest.fn();
+      beforeEach(() => {
+        render(
+          <Pagination
+            activePage={activePage}
+            totalPages={totalPages}
+            setActivePage={mockSetActivePage}
+          />
+        );
+        const navigation = getNavigationElement();
+        navigation.focus();
+      });
+
+      afterEach(() => {
+        jest.resetAllMocks();
+        cleanup();
+      });
+
+      it('focuses "Go to first page" button first', async () => {
+        const button = screen.getByRole("button", { name: /Go to first page/ });
+
+        await userEvent.tab();
+        expect(button).toHaveFocus();
+      });
+
+      it('updates to page 1 when user presses enter on "Go to first page"', async () => {
+        await userEvent.tab();
+        await userEvent.keyboard("{Enter}");
+
+        expect(mockSetActivePage).toHaveBeenCalledWith(1);
+      });
+
+      it('focuses "Go to previous page" button next', async () => {
+        const button = screen.getByRole("button", {
+          name: /Go to previous page/,
+        });
+        await userEvent.tab();
+        await userEvent.tab();
+
+        expect(button).toHaveFocus();
+      });
+
+      it('updates to page 1 when user presses enter on "Go to previous page"', async () => {
+        await userEvent.tab();
+        await userEvent.tab();
+        await userEvent.keyboard("{Enter}");
+
+        expect(mockSetActivePage).toHaveBeenCalledWith(2);
+      });
+
+      it('focuses "Go to next page" button next', async () => {
+        const button = screen.getByRole("button", { name: /Go to next page/ });
+        await userEvent.tab();
+        await userEvent.tab();
+        await userEvent.tab();
+
+        expect(button).toHaveFocus();
+      });
+
+      it('updates to page 4 when user presses enter on "Go to next page" button', async () => {
+        await userEvent.tab();
+        await userEvent.tab();
+        await userEvent.tab();
+        await userEvent.keyboard("{Enter}");
+
+        expect(mockSetActivePage).toHaveBeenCalledWith(4);
+      });
+
+      it('focuses "Go to last page" button last', async () => {
+        const button = screen.getByRole("button", { name: /Go to last page/ });
+        await userEvent.tab();
+        await userEvent.tab();
+        await userEvent.tab();
+        await userEvent.tab();
+
+        expect(button).toHaveFocus();
+      });
+
+      it('updates to page 6 when user presses enter on "Go to last page" button', async () => {
+        await userEvent.tab();
+        await userEvent.tab();
+        await userEvent.tab();
+        await userEvent.tab();
+        await userEvent.keyboard("{Enter}");
+
+        expect(mockSetActivePage).toHaveBeenCalledWith(6);
+      });
     });
   });
 
@@ -164,123 +441,220 @@ describe("Pagination.tsx", () => {
     const activePage = 4;
     const totalPages = 4;
 
-    beforeAll(() => {
-      render(
-        <Pagination
-          activePage={activePage}
-          totalPages={totalPages}
-          setActivePage={jest.fn()}
-        />
-      );
-    });
-
-    afterAll(cleanup);
-
-    it("shows a button to get the first page", () => {
-      const button = within(getNavigationElement()).getByRole("button", {
-        name: "Go to first page",
+    describe("shows all necessary elements", () => {
+      beforeAll(() => {
+        render(
+          <Pagination
+            activePage={activePage}
+            totalPages={totalPages}
+            setActivePage={jest.fn()}
+          />
+        );
       });
 
-      expect(button).toBeEnabled();
-    });
+      afterAll(cleanup);
 
-    it("shows a button to get the previous page", () => {
-      const button = within(getNavigationElement()).getByRole("button", {
-        name: `Go to previous page, page ${activePage - 1}`,
+      it("gives information about current and total pages for assistive technology", () => {
+        const navigation = getNavigationElement();
+
+        expect(navigation).toHaveAccessibleName(
+          "Pagination navigation, you're on page 4 of 4"
+        );
       });
 
-      expect(button).toBeEnabled();
-    });
+      it("shows a button to get the first page", () => {
+        const button = within(getNavigationElement()).getByRole("button", {
+          name: "Go to first page",
+        });
 
-    it("shows no button to get to the next page for assistive technology", () => {
-      const button = within(getNavigationElement()).queryByRole("button", {
-        name: /Go to next page, page/,
+        expect(button).toBeEnabled();
       });
 
-      expect(button).not.toBeInTheDocument();
-    });
+      it("shows a button to get the previous page", () => {
+        const button = within(getNavigationElement()).getByRole("button", {
+          name: `Go to previous page, page ${activePage - 1}`,
+        });
 
-    it("disables button to get to next page", () => {
-      const button = within(getNavigationElement()).getByRole("button", {
-        name: /Go to next page, page/,
-        hidden: true,
+        expect(button).toBeEnabled();
       });
 
-      expect(button).toBeDisabled();
-    });
+      it("shows visual only information about current page and total pages", () => {
+        const text = within(getNavigationElement()).getByText("Page 4 of 4");
 
-    it("shows no button to get to the last page  for assistive technology", () => {
-      const button = within(getNavigationElement()).queryByRole("button", {
-        name: /Go to last page, page/,
+        expect(text).toBeVisible();
+        expect(text).toHaveAttribute("aria-hidden", "true");
       });
 
-      expect(button).not.toBeInTheDocument();
-    });
+      it("shows no button to get to the next page for assistive technology", () => {
+        const button = within(getNavigationElement()).queryByRole("button", {
+          name: /Go to next page, page/,
+        });
 
-    it("disables button to get to last page", () => {
-      const button = within(getNavigationElement()).getByRole("button", {
-        name: /Go to next page, page/,
-        hidden: true,
+        expect(button).not.toBeInTheDocument();
       });
 
-      expect(button).toBeDisabled();
-    });
-  });
+      it("disables button to get to next page", () => {
+        const button = within(getNavigationElement()).getByRole("button", {
+          name: /Go to next page, page/,
+          hidden: true,
+        });
 
-  describe("handles updating the page when active page is `2`", () => {
-    const activePage = 2;
-    const totalPages = 4;
-
-    const mockedSetActivePage = jest.fn();
-    beforeEach(() => {
-      render(
-        <Pagination
-          activePage={activePage}
-          totalPages={totalPages}
-          setActivePage={mockedSetActivePage}
-        />
-      );
-    });
-
-    afterEach(() => {
-      jest.resetAllMocks();
-      cleanup();
-    });
-
-    it("calls `setActivePage` with `1` if user clicks `Go to page`", async () => {
-      const button = within(getNavigationElement()).getByRole("button", {
-        name: "Go to first page",
+        expect(button).toBeDisabled();
       });
-      await userEvent.click(button);
 
-      expect(mockedSetActivePage).toHaveBeenCalledWith(1);
+      it("shows no button to get to the last page  for assistive technology", () => {
+        const button = within(getNavigationElement()).queryByRole("button", {
+          name: /Go to last page, page/,
+        });
+
+        expect(button).not.toBeInTheDocument();
+      });
+
+      it("disables button to get to last page", () => {
+        const button = within(getNavigationElement()).getByRole("button", {
+          name: /Go to next page, page/,
+          hidden: true,
+        });
+
+        expect(button).toBeDisabled();
+      });
     });
 
-    it("calls `setActivePage` with `1` if user clicks `Go to previous page`", async () => {
-      const button = within(getNavigationElement()).getByRole("button", {
-        name: `Go to previous page, page ${activePage - 1}`,
+    describe("handles updating the pages`", () => {
+      const mockedSetActivePage = jest.fn();
+      beforeEach(() => {
+        render(
+          <Pagination
+            activePage={activePage}
+            totalPages={totalPages}
+            setActivePage={mockedSetActivePage}
+          />
+        );
       });
-      await userEvent.click(button);
 
-      expect(mockedSetActivePage).toHaveBeenCalledWith(1);
+      afterEach(() => {
+        jest.resetAllMocks();
+        cleanup();
+      });
+
+      it('calls "setActivePage" with "1" if user clicks "Go to first page"', async () => {
+        const button = within(getNavigationElement()).getByRole("button", {
+          name: "Go to first page",
+        });
+        await userEvent.click(button);
+
+        expect(mockedSetActivePage).toHaveBeenCalledWith(1);
+      });
+
+      it('calls "setActivePage" with "3" if user clicks "Go to previous page"', async () => {
+        const button = within(getNavigationElement()).getByRole("button", {
+          name: /Go to previous page/,
+        });
+        await userEvent.click(button);
+
+        expect(mockedSetActivePage).toHaveBeenCalledWith(3);
+      });
+
+      it('does not update page when user clicks "Go to next page"', async () => {
+        const button = within(getNavigationElement()).getByRole("button", {
+          name: /Go to next page/,
+          hidden: true,
+        });
+        await userEvent.click(button);
+
+        expect(mockedSetActivePage).not.toHaveBeenCalled();
+      });
+
+      it('does not update page when user clicks "Go to last page"', async () => {
+        const button = within(getNavigationElement()).getByRole("button", {
+          name: /Go to last page/,
+          hidden: true,
+        });
+        await userEvent.click(button);
+
+        expect(mockedSetActivePage).not.toHaveBeenCalled();
+      });
     });
 
-    it("calls `setActivePage` with `3` if user clicks `Go to next page`", async () => {
-      const button = within(getNavigationElement()).getByRole("button", {
-        name: /Go to next page, page/,
+    describe("enables keyboard only navigation", () => {
+      const mockSetActivePage = jest.fn();
+      beforeEach(() => {
+        render(
+          <Pagination
+            activePage={activePage}
+            totalPages={totalPages}
+            setActivePage={mockSetActivePage}
+          />
+        );
+        const navigation = getNavigationElement();
+        navigation.focus();
       });
-      await userEvent.click(button);
 
-      expect(mockedSetActivePage).toHaveBeenCalledWith(3);
-    });
-
-    it("calls `setActivePage` with `4` if user clicks `Go to last page`", async () => {
-      const button = within(getNavigationElement()).getByRole("button", {
-        name: /Go to last page, page/,
+      afterEach(() => {
+        jest.resetAllMocks();
+        cleanup();
       });
-      await userEvent.click(button);
 
-      expect(mockedSetActivePage).toHaveBeenCalledWith(4);
+      it('focuses "Go to first page" button first', async () => {
+        const button = screen.getByRole("button", { name: /Go to first page/ });
+
+        await userEvent.tab();
+        expect(button).toHaveFocus();
+      });
+
+      it('updates to page 1 when user presses enter on "Go to first page"', async () => {
+        await userEvent.tab();
+        await userEvent.keyboard("{Enter}");
+
+        expect(mockSetActivePage).toHaveBeenCalledWith(1);
+      });
+
+      it('focuses "Go to previous page" button next', async () => {
+        const button = screen.getByRole("button", {
+          name: /Go to previous page/,
+        });
+        await userEvent.tab();
+        await userEvent.tab();
+
+        expect(button).toHaveFocus();
+      });
+
+      it('updates to page 3 when user presses enter on "Go to previous page"', async () => {
+        await userEvent.tab();
+        await userEvent.tab();
+        await userEvent.keyboard("{Enter}");
+
+        expect(mockSetActivePage).toHaveBeenCalledWith(3);
+      });
+
+      it('does not focus on "Go to next page"', async () => {
+        const button = screen.getByRole("button", {
+          name: /Go to next page/,
+          hidden: true,
+        });
+        await userEvent.tab();
+        await userEvent.tab();
+        await userEvent.tab();
+
+        expect(button).not.toHaveFocus();
+        expect(document.body).toHaveFocus();
+      });
+
+      it('does not focus on "Go to last page"', async () => {
+        const button = screen.getByRole("button", {
+          name: /Go to next page/,
+          hidden: true,
+        });
+        await userEvent.tab();
+        await userEvent.tab();
+        await userEvent.tab();
+        await userEvent.tab();
+
+        expect(button).not.toHaveFocus();
+        expect(
+          screen.getByRole("button", { name: /Go to first page/ })
+        ).toHaveFocus();
+      });
     });
   });
 });

--- a/coral/src/app/components/Pagination.tsx
+++ b/coral/src/app/components/Pagination.tsx
@@ -21,17 +21,14 @@ function Pagination(props: PaginationProps) {
   const currentPageIsLastPage = activePage === totalPages;
 
   return (
-    <nav role="navigation" aria-label="Pagination">
+    <nav
+      role="navigation"
+      aria-label={`Pagination navigation, you're on page ${activePage} of ${totalPages}`}
+    >
       <Flexbox htmlTag={"ul"} colGap={"l1"} alignItems={"center"}>
-        <li>
-          <span tabIndex={0} className={"visually-hidden"}>
-            {`You are on page ${activePage} of ${totalPages}`}
-          </span>
-        </li>
         <li aria-hidden={currentPageIsFirstPage}>
           <GhostButton
             disabled={currentPageIsFirstPage}
-            tabIndex={0}
             onClick={() => onUpdatePage(1)}
           >
             <span className={"visually-hidden"}>Go to first page</span>
@@ -41,7 +38,6 @@ function Pagination(props: PaginationProps) {
         <li aria-hidden={currentPageIsFirstPage}>
           <GhostButton
             disabled={currentPageIsFirstPage}
-            tabIndex={0}
             onClick={() => onUpdatePage(activePage - 1)}
           >
             <span className={"visually-hidden"}>
@@ -50,14 +46,12 @@ function Pagination(props: PaginationProps) {
             <Icon aria-hidden={true} icon={chevronLeft} />
           </GhostButton>
         </li>
-        <li>
-          <span tabIndex={-1} aria-hidden={true} />
+        <li aria-hidden={true}>
           Page {activePage} of {totalPages}
         </li>
         <li aria-hidden={currentPageIsLastPage}>
           <GhostButton
             disabled={currentPageIsLastPage}
-            tabIndex={0}
             onClick={() => onUpdatePage(activePage + 1)}
           >
             <span className={"visually-hidden"}>
@@ -69,7 +63,6 @@ function Pagination(props: PaginationProps) {
         <li aria-hidden={currentPageIsLastPage}>
           <GhostButton
             disabled={currentPageIsLastPage}
-            tabIndex={0}
             onClick={() => onUpdatePage(totalPages)}
           >
             <span className={"visually-hidden"}>

--- a/coral/src/app/features/browse-topics/BrowseTopics.test.tsx
+++ b/coral/src/app/features/browse-topics/BrowseTopics.test.tsx
@@ -189,7 +189,7 @@ describe("BrowseTopics.tsx", () => {
     it("does not render the pagination", async () => {
       await waitForElementToBeRemoved(screen.getByText("Loading..."));
       const pagination = screen.queryByRole("navigation", {
-        name: "Pagination",
+        name: /Pagination/,
       });
 
       expect(pagination).not.toBeInTheDocument();
@@ -229,7 +229,7 @@ describe("BrowseTopics.tsx", () => {
     it("shows a pagination", async () => {
       await waitForElementToBeRemoved(screen.getByText("Loading..."));
       const pagination = screen.getByRole("navigation", {
-        name: "Pagination",
+        name: /Pagination/,
       });
 
       expect(pagination).toBeVisible();
@@ -237,9 +237,11 @@ describe("BrowseTopics.tsx", () => {
 
     it("shows page 2 as currently active page and the total page number", async () => {
       await waitForElementToBeRemoved(screen.getByText("Loading..."));
-      const activePageInformation = screen.getByText("You are on page 2 of 4");
+      const pagination = screen.getByRole("navigation", { name: /Pagination/ });
 
-      expect(activePageInformation).toBeVisible();
+      expect(pagination).toHaveAccessibleName(
+        "Pagination navigation, you're on page 2 of 4"
+      );
     });
   });
 
@@ -265,9 +267,11 @@ describe("BrowseTopics.tsx", () => {
     it("shows page 1 as currently active page and the total page number", async () => {
       await waitForElementToBeRemoved(screen.getByText("Loading..."));
 
-      const activePageInformation = screen.getByText("You are on page 1 of 10");
+      const pagination = screen.getByRole("navigation", { name: /Pagination/ });
 
-      expect(activePageInformation).toBeVisible();
+      expect(pagination).toHaveAccessibleName(
+        "Pagination navigation, you're on page 1 of 10"
+      );
     });
 
     it("fetches new data when user clicks on next page", async () => {
@@ -278,10 +282,10 @@ describe("BrowseTopics.tsx", () => {
 
       await userEvent.click(pageTwoButton);
 
-      const activePageInformation = await screen.findByText(
-        "You are on page 2 of 10"
-      );
-      expect(activePageInformation).toBeVisible();
+      const pagination = await screen.findByRole("navigation", {
+        name: "Pagination navigation, you're on page 1 of 10",
+      });
+      expect(pagination).toBeVisible();
     });
   });
 

--- a/coral/src/app/features/browse-topics/BrowseTopics.test.tsx
+++ b/coral/src/app/features/browse-topics/BrowseTopics.test.tsx
@@ -220,12 +220,13 @@ describe("BrowseTopics.tsx", () => {
 
     it("renders the topic table with information about the pages", async () => {
       await waitForElementToBeRemoved(screen.getByText("Loading..."));
-      const pagination = screen.getByRole("table", {
+      const table = screen.getByRole("table", {
         name: "Topics overview, page 2 of 4",
       });
 
-      expect(pagination).toBeVisible();
+      expect(table).toBeVisible();
     });
+
     it("shows a pagination", async () => {
       await waitForElementToBeRemoved(screen.getByText("Loading..."));
       const pagination = screen.getByRole("navigation", {

--- a/coral/src/app/layout/main-navigation/MainNavigation.tsx
+++ b/coral/src/app/layout/main-navigation/MainNavigation.tsx
@@ -64,12 +64,16 @@ function MainNavigation() {
             />
           </MainNavigationSubmenuList>
         </li>
-        <MainNavigationSubmenuList icon={people} text={"Users and Teams"}>
-          <MainNavigationLink href={`/users`} linkText={"Users"} />
-          <MainNavigationLink href={`/teams`} linkText={"Teams"} />
-          <MainNavigationLink href={`/execUsers`} linkText={"User Requests"} />
-        </MainNavigationSubmenuList>
-
+        <li>
+          <MainNavigationSubmenuList icon={people} text={"Users and Teams"}>
+            <MainNavigationLink href={`/users`} linkText={"Users"} />
+            <MainNavigationLink href={`/teams`} linkText={"Teams"} />
+            <MainNavigationLink
+              href={`/execUsers`}
+              linkText={"User Requests"}
+            />
+          </MainNavigationSubmenuList>
+        </li>
         <li>
           <MainNavigationLink
             icon={list}

--- a/coral/src/app/layout/main-navigation/MainNavigationLink.module.css
+++ b/coral/src/app/layout/main-navigation/MainNavigationLink.module.css
@@ -2,17 +2,12 @@
    defined and active styles is not meeting
    accessibility standards */
 
-/*temp class until we have a solution for that*/
 .main-navigation-link:hover,
 .main-navigation-link:focus-within {
-  /*Primary*/
-  color: #e41a4a;
+  color: var(--hover-indicator-primary-80);
 }
 
-/*//@TODO color contrast from DS is not AA or AAA conform
-      main-100 is used in the meantime */
 .main-navigation-link-active {
-  /*Primary*/
   background-color: white;
-  color: #a70045;
+  color: var(--active-indicator-primary-100);
 }

--- a/coral/src/app/layout/main-navigation/MainNavigationSubmenuList.module.css
+++ b/coral/src/app/layout/main-navigation/MainNavigationSubmenuList.module.css
@@ -1,0 +1,8 @@
+.main-navigation-submenu-button {
+  margin-left: 7px;
+}
+/*temp class until we have a solution for that*/
+.main-navigation-submenu-button:hover,
+.main-navigation-submenu-button:focus-within {
+  color: var(--hover-indicator-primary-80);
+}

--- a/coral/src/app/layout/main-navigation/MainNavigationSubmenuList.tsx
+++ b/coral/src/app/layout/main-navigation/MainNavigationSubmenuList.tsx
@@ -1,6 +1,6 @@
 import { Box, Flexbox, Icon } from "@aivenio/design-system";
 import data from "@aivenio/design-system/dist/src/icons/console";
-import classes from "src/app/layout/main-navigation/MainNavigationLink.module.css";
+import classes from "src/app/layout/main-navigation/MainNavigationSubmenuList.module.css";
 import { ReactElement, useState } from "react";
 import caretDown from "@aivenio/design-system/dist/src/icons/caretDown";
 import caretUp from "@aivenio/design-system/dist/src/icons/caretUp";
@@ -27,13 +27,13 @@ function MainNavigationSubmenuList(props: MainNavigationSubmenuItemProps) {
   return (
     <>
       <button
-        className={classes.mainNavigationLink}
+        className={classes.mainNavigationSubmenuButton}
         aria-expanded={open ? "true" : "false"}
         onClick={() => setOpen(!open)}
       >
         <Icon
           icon={open ? caretUp : caretDown}
-          style={{ position: "absolute", marginTop: "5px", marginLeft: "7px" }}
+          style={{ position: "absolute", marginTop: "5px", marginLeft: "2px" }}
         />
         <span className={"visually-hidden"}>{buttonText}</span>
         <div aria-hidden={"true"}>
@@ -41,7 +41,7 @@ function MainNavigationSubmenuList(props: MainNavigationSubmenuItemProps) {
             direction={"row"}
             alignItems={"center"}
             colGap={"l1"}
-            paddingLeft={"l3"}
+            paddingLeft={"l2"}
             marginRight={"l2"}
           >
             <Icon icon={icon} />

--- a/coral/src/app/main.module.css
+++ b/coral/src/app/main.module.css
@@ -1,17 +1,3 @@
-/*@TODO use aiven-ds based values or global utility class*/
-:global(.visually-hidden) {
-  position: absolute !important;
-  width: 1px !important;
-  height: 1px !important;
-  padding: 0 !important;
-  margin: -1px !important;
-  overflow: hidden !important;
-  clip: rect(0, 0, 0, 0) !important;
-  white-space: nowrap !important;
-  border: 0 !important;
-  font-size: 18px;
-}
-
 /* @TODO check design system */
 /*TEMP browser reset*!*/
 *,

--- a/coral/src/app/main.module.css
+++ b/coral/src/app/main.module.css
@@ -1,5 +1,7 @@
-/* @TODO check design system */
-/*TEMP browser reset*!*/
+/* TEMP browser reset and general vars
+ * until we can consume that from the DS
+*/
+
 *,
 *::before,
 *::after {
@@ -16,6 +18,6 @@ body {
   /*  to be grey-60 but that does not meet*/
   /*  accessibility standards*/
   /*represents grey-70*/
-  color: #4a4b57;
+  color: var(--text-color-grey-70);
   -webkit-text-size-adjust: 100%;
 }

--- a/coral/src/app/main.tsx
+++ b/coral/src/app/main.tsx
@@ -5,8 +5,9 @@ import router from "src/app/router";
 import "@aivenio/design-system/dist/styles.css";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { ReactQueryDevtools } from "@tanstack/react-query-devtools";
-import "/src/app/main.module.css";
 import { isUnauthorizedError } from "src/services/api";
+import "/src/app/main.module.css";
+import "/src/app/accessibility.module.css";
 
 const DEV_MODE = import.meta.env.DEV;
 


### PR DESCRIPTION
# About this change - What it does

- commit [Improve pagination.](https://github.com/aiven/klaw/pull/312/commits/35028c0a60f8af4ebb7dceb2d5e34a3890bba28f)
Improves usability for screenreader for pagination. Removes unneccessary handling of tabindex. Adds better tests. 

- commit [Fix main nav list.](https://github.com/aiven/klaw/pull/312/commits/ee6d2000fc9dcc0ab198000a1b2997cd245e7932)
semantic error, forgot to wrap one submenu button in a <li> item

- commit [Introduce custom class for a11y improvments for interactive indicators.](https://github.com/aiven/klaw/pull/312/commits/d5bfad7a92d90d0d5b816437028ce2b2abfae8f4)
- adds a global `accessiblity.module.css` where we add styles etc. to improve accessiblity
- some additional styles still need to be set on component level (see main navigation submenu) but that's only necessary as long as these components are not from the DS
- uses the accessibility classes / css vars

-  commit [Improve a11y for label color contrast](https://github.com/aiven/klaw/pull/312/commits/da42b16f3398a015419d6acc009c4ba55dac9e76)
-> darker color for labels to match contrast requirements. reduced the font-size to still be distinguishable from other text

- [Improve a11y for login redirect.](https://github.com/aiven/klaw/pull/312/commits/a15a6464f31c0bf6aba4d9dfe80f948d06055447) 

This adds a) a bit of style to the redirect screen and b) accessibility


## This improves:
- accessibility for visual impaired users (that's also e.g. users in a work environment that reduces contrast on screens)
- accessibility for keyboard users, they now can always see where they are navigating
- accessibility for screenreaders (pagination)

## Not solved yet to go not too far from DS
- buttons (primary and in pagination) are not matching color requirements (not enough contrast). 


## Recordings

### Keyboard navigation
(tabbing through to show focus states)


https://user-images.githubusercontent.com/943800/207083741-bbeef9d8-c00d-493e-a02e-0e441eb23b9d.mov

### Screenreader using pagination 
( ⚠️ sound! best "watch" without actually looking at video, matches user experience better)


https://user-images.githubusercontent.com/943800/207084030-f715bf4d-28b8-44dd-b5ee-093a46dfa9ff.mov


### alert for redirect

Videos are having sound & best watched without watching :D so only listening! 

### Without a11y

https://user-images.githubusercontent.com/943800/207275524-565d57f3-2db5-4920-aafe-cff6607bac08.mov


### With a11y 


https://user-images.githubusercontent.com/943800/207275571-d0b95366-913a-4a82-928c-e05b676a6045.mov


I changed the text because the redirect screen is not there too long and dependent on speed of the screenreader, a user may not get all text read, so I started with the most important info.


## Comit message
title: `feat(coral): improve browse topic a11y`
body: 
```
- Improve usability for screenreader for pagination.
   Removes unneccessary handling of tabindex. Adds better tests.
- Fix main nav list semantics
- Introduce and use custom class for a11y improvments 
   for interactive indicators.
- Improve a11y for login redirect by using alertdialog
```