### PR TITLE
refactor(coral):  add links to topic details and coral/topics

### DIFF
--- a/coral/src/app/accessibility.module.css
+++ b/coral/src/app/accessibility.module.css
@@ -11,10 +11,12 @@
  *       or custom theme are covered
 */
 :root {
-  --hover-indicator-primary-80: #e41a4a;
-  --active-indicator-primary-100: #a70045;
-  --focus-indicator-info-70: #0399e3;
-  --text-color-grey-70: #4a4b57;
+  --body-text-color: #4a4b57; /* DS value grey-70*/
+  --text-link-color: #e41a4a; /* DS value primary-80*/
+  --text-link-color-hover: #ff3554; /* DS value primary-70*/
+  --main-navigation-hover: #e41a4a; /* DS value primary-80*/
+  --main-navigation-active: #a70045; /* DS value primary-100*/
+  --interactive-elements-focus: #0399e3; /* DS value info-70*/
 }
 
 /************************************************
@@ -29,14 +31,23 @@ button {
 }
 
 button:focus-visible {
-  outline: 2px solid var(--focus-indicator-info-70) !important;
+  outline: 2px solid var(--interactive-elements-focus) !important;
   outline-offset: 2px !important;
+}
+
+a {
+  color: var(--text-link-color);
+}
+
+a:hover,
+a:focus {
+  color: var(--text-link-color-hover);
 }
 
 a:focus-visible {
   outline-offset: 2px;
   /*represents info-70*/
-  outline-color: var(--focus-indicator-info-70);
+  outline-color: var(--interactive-elements-focus);
   box-shadow: 0 0 3px 0 #ddd;
 }
 
@@ -65,12 +76,12 @@ a:focus-visible {
 
 :root input:focus-visible,
 :root select:focus-visible {
-  outline: 1px solid var(--focus-indicator-info-70) !important;
+  outline: 1px solid var(--interactive-elements-focus) !important;
   outline-offset: 0 !important;
 }
 
 :root button:focus {
-  outline: 2px solid var(--focus-indicator-info-70) !important;
+  outline: 2px solid var(--interactive-elements-focus) !important;
   outline-offset: 0 !important;
 }
 

--- a/coral/src/app/features/browse-topics/components/topic-table/TopicTable.test.tsx
+++ b/coral/src/app/features/browse-topics/components/topic-table/TopicTable.test.tsx
@@ -2,8 +2,9 @@ import { cleanup, screen, render, within } from "@testing-library/react";
 import { createMockTopic } from "src/domain/topic/topic-test-helper";
 import TopicTable from "src/app/features/browse-topics/components/topic-table/TopicTable";
 import { mockIntersectionObserver } from "src/services/test-utils/mock-intersection-observer";
+import { tabThroughForward } from "src/services/test-utils/tabbing";
 
-const mockedTopicNames = ["Name one", "Name two", "Name three", "Name four"];
+const mockedTopicNames = ["Name-one", "Name-two", "Name-three", "Name-four"];
 const mockedTopics = mockedTopicNames.map((name, index) =>
   createMockTopic({ topicName: name, topicId: index })
 );
@@ -43,15 +44,23 @@ describe("TopicTable.tsx", () => {
     });
 
     mockedTopics.forEach((topic) => {
-      it(`renders the topic name ${topic.topicName} as row header`, () => {
+      it(`renders the topic name "${topic.topicName}" as a link to the detail view as row header`, () => {
         const table = screen.getByRole("table", {
           name: "Topics overview, page 1 of 2",
         });
         const rowHeader = within(table).getByRole("rowheader", {
           name: topic.topicName,
         });
+        const link = within(table).getByRole("link", {
+          name: topic.topicName,
+        });
 
         expect(rowHeader).toBeVisible();
+        expect(link).toBeVisible();
+        expect(link).toHaveAttribute(
+          "href",
+          `/topicOverview?topicname=${topic.topicName}`
+        );
       });
 
       it(`renders the team for ${topic.topicName} `, () => {
@@ -96,6 +105,36 @@ describe("TopicTable.tsx", () => {
 
           expect(environment).toBeVisible();
         });
+      });
+    });
+  });
+
+  describe("enables user to keyboard navigate from topic name to topic name", () => {
+    beforeEach(() => {
+      mockIntersectionObserver();
+      render(
+        <TopicTable topics={mockedTopics} activePage={1} totalPages={2} />
+      );
+      const table = screen.getByRole("table", {
+        name: "Topics overview, page 1 of 2",
+      });
+      table.focus();
+    });
+
+    afterEach(cleanup);
+
+    mockedTopics.forEach((topic, index) => {
+      const numbersOfTabs = index + 1;
+      it(`sets focus on "${topic.topicName}" when user tabs ${numbersOfTabs} times`, async () => {
+        const link = screen.getByRole("link", {
+          name: topic.topicName,
+        });
+
+        expect(link).not.toHaveFocus();
+
+        await tabThroughForward(numbersOfTabs);
+
+        expect(link).toHaveFocus();
       });
     });
   });

--- a/coral/src/app/features/browse-topics/components/topic-table/TopicTable.tsx
+++ b/coral/src/app/features/browse-topics/components/topic-table/TopicTable.tsx
@@ -27,8 +27,8 @@ function TopicTable(props: TopicListProps) {
         </Table.Cell>
       </Table.Head>
       <Table.Body>
-        {topics.map((dot) => (
-          <Table.Row key={dot.topicid}>
+        {topics.map((topic) => (
+          <Table.Row key={topic.topicid}>
             {/*Workaround to get right html element with scope*/}
             {/*until DS ready*/}
             <th
@@ -36,13 +36,13 @@ function TopicTable(props: TopicListProps) {
               align={"left"}
               className={classes.topicTableRowHead}
             >
-              <a href={`/topicOverview?topicname=${dot.topicName}`}>
-                {dot.topicName}
+              <a href={`/topicOverview?topicname=${topic.topicName}`}>
+                {topic.topicName}
               </a>
             </th>
             <Table.Cell>
               <Flexbox htmlTag={"ul"} alignItems={"center"} gap={"2"}>
-                {dot.environmentsList.map((env, index) => {
+                {topic.environmentsList.map((env, index) => {
                   return (
                     <li key={index + env}>
                       <Chip text={env} />
@@ -51,7 +51,7 @@ function TopicTable(props: TopicListProps) {
                 })}
               </Flexbox>
             </Table.Cell>
-            <Table.Cell>{dot.teamname}</Table.Cell>
+            <Table.Cell>{topic.teamname}</Table.Cell>
           </Table.Row>
         ))}
       </Table.Body>

--- a/coral/src/app/features/browse-topics/components/topic-table/TopicTable.tsx
+++ b/coral/src/app/features/browse-topics/components/topic-table/TopicTable.tsx
@@ -36,11 +36,12 @@ function TopicTable(props: TopicListProps) {
               align={"left"}
               className={classes.topicTableRowHead}
             >
-              {dot.topicName}
+              <a href={`/topicOverview?topicname=${dot.topicName}`}>
+                {dot.topicName}
+              </a>
             </th>
             <Table.Cell>
               <Flexbox htmlTag={"ul"} alignItems={"center"} gap={"2"}>
-                {/*<ul>*/}
                 {dot.environmentsList.map((env, index) => {
                   return (
                     <li key={index + env}>
@@ -48,7 +49,6 @@ function TopicTable(props: TopicListProps) {
                     </li>
                   );
                 })}
-                {/*</ul>*/}
               </Flexbox>
             </Table.Cell>
             <Table.Cell>{dot.teamname}</Table.Cell>

--- a/coral/src/app/layout/main-navigation/MainNavigation.tsx
+++ b/coral/src/app/layout/main-navigation/MainNavigation.tsx
@@ -33,7 +33,7 @@ function MainNavigation() {
             text={"Topics"}
           >
             <MainNavigationLink
-              href={`/topics`}
+              href={"/coral/topics"}
               linkText={"All Topics"}
               active={true}
             />

--- a/coral/src/app/layout/main-navigation/MainNavigationLink.module.css
+++ b/coral/src/app/layout/main-navigation/MainNavigationLink.module.css
@@ -2,12 +2,18 @@
    defined and active styles is not meeting
    accessibility standards */
 
-.main-navigation-link:hover,
-.main-navigation-link:focus-within {
-  color: var(--hover-indicator-primary-80);
+.main-navigation-link a {
+  color: var(--body-text-color);
 }
 
+.main-navigation-link a:hover,
+.main-navigation-link:focus-within {
+  color: var(--main-navigation-hover);
+}
+
+.main-navigation-link-active a {
+  color: var(--main-navigation-active);
+}
 .main-navigation-link-active {
   background-color: white;
-  color: var(--active-indicator-primary-100);
 }

--- a/coral/src/app/layout/main-navigation/MainNavigationSubmenuList.module.css
+++ b/coral/src/app/layout/main-navigation/MainNavigationSubmenuList.module.css
@@ -4,5 +4,5 @@
 /*temp class until we have a solution for that*/
 .main-navigation-submenu-button:hover,
 .main-navigation-submenu-button:focus-within {
-  color: var(--hover-indicator-primary-80);
+  color: var(--main-navigation-hover);
 }

--- a/coral/src/app/main.module.css
+++ b/coral/src/app/main.module.css
@@ -18,6 +18,6 @@ body {
   /*  to be grey-60 but that does not meet*/
   /*  accessibility standards*/
   /*represents grey-70*/
-  color: var(--text-color-grey-70);
+  color: var(--body-text-color);
   -webkit-text-size-adjust: 100%;
 }


### PR DESCRIPTION
# About this change - What it does
- adds more useful name to css vars
- adds styling for text links
- adds links to detail page for topics in topic table
- updates link in main nav to go to "/coral/topics" which is needed to get the right behaviour in the full app

Resolves: #316 

