### PR TITLE
refactor(coral) Replace @aivenio/design-system by @aivenio/aquarium

### DIFF
--- a/coral/package.json
+++ b/coral/package.json
@@ -33,7 +33,7 @@
     ]
   },
   "dependencies": {
-    "@aivenio/design-system": "^19.0.1",
+    "@aivenio/aquarium": "^1.0.0",
     "@hookform/resolvers": "^2.9.10",
     "@tanstack/react-query": "^4.14.1",
     "react": "^18.2.0",

--- a/coral/pnpm-lock.yaml
+++ b/coral/pnpm-lock.yaml
@@ -1,7 +1,7 @@
 lockfileVersion: 5.4
 
 specifiers:
-  '@aivenio/design-system': ^19.0.1
+  '@aivenio/aquarium': ^1.0.0
   '@hookform/resolvers': ^2.9.10
   '@tanstack/react-query': ^4.14.1
   '@tanstack/react-query-devtools': ^4.14.1
@@ -48,7 +48,7 @@ specifiers:
   zod: ^3.19.1
 
 dependencies:
-  '@aivenio/design-system': 19.0.1_pvnihi4muhoy7kenlmiyxwzuqy
+  '@aivenio/aquarium': 1.0.0_pvnihi4muhoy7kenlmiyxwzuqy
   '@hookform/resolvers': 2.9.10_react-hook-form@7.38.0
   '@tanstack/react-query': 4.14.1_biqbaboplfbrettd7655fr4n2y
   react: 18.2.0
@@ -102,8 +102,8 @@ packages:
     resolution: {integrity: sha512-+u76oB43nOHrF4DDWRLWDCtci7f3QJoEBigemIdIeTi1ODqjx6Tad9NCVnPRwewWlKkVab5PlK8DCtPTyX7S8g==}
     dev: true
 
-  /@aivenio/design-system/19.0.1_pvnihi4muhoy7kenlmiyxwzuqy:
-    resolution: {integrity: sha512-nN4KwqmqCLzYZFqelb28hMcg9D3K6FZgePpJAD8m91tWCa6W6AGjsVVSaU6HwOA4TU79898dAAAX5fqdEpcVPg==}
+  /@aivenio/aquarium/1.0.0_pvnihi4muhoy7kenlmiyxwzuqy:
+    resolution: {integrity: sha512-TwtNi9hsCmYsfk2wqGxY6EYKC/jSF8K/C33LYkoP0/GlAVgZcLuramPwWBH/dGUdcBteHdth/U6pJAHfcXwiGA==}
     peerDependencies:
       lodash: 4.x
       react: 16.x || 17.x
@@ -113,12 +113,14 @@ packages:
       '@iconify/types': 1.1.0
       '@popperjs/core': 2.11.6
       classnames: 2.3.2
-      downshift: 6.1.12_react@18.2.0
+      downshift: 7.0.4_react@18.2.0
       lodash: 4.17.21
       match-sorter: 6.3.1
       react: 18.2.0
+      react-aria: 3.21.0_biqbaboplfbrettd7655fr4n2y
       react-dom: 18.2.0_react@18.2.0
       react-popper: 2.3.0_r6q5zrenym2zg7je7hgi674bti
+      react-stately: 3.19.0_react@18.2.0
     dev: false
 
   /@ampproject/remapping/2.2.0:
@@ -559,6 +561,40 @@ packages:
       - supports-color
     dev: true
 
+  /@formatjs/ecma402-abstract/1.14.3:
+    resolution: {integrity: sha512-SlsbRC/RX+/zg4AApWIFNDdkLtFbkq3LNoZWXZCE/nHVKqoIJyaoQyge/I0Y38vLxowUn9KTtXgusLD91+orbg==}
+    dependencies:
+      '@formatjs/intl-localematcher': 0.2.32
+      tslib: 2.4.0
+    dev: false
+
+  /@formatjs/fast-memoize/1.2.7:
+    resolution: {integrity: sha512-hPeM5LXUUjtCKPybWOUAWpv8lpja8Xz+uKprFPJcg5F2Rd+/bf1E0UUsLRpaAgOReAf5HMRtoIgv/UcyPICrTQ==}
+    dependencies:
+      tslib: 2.4.0
+    dev: false
+
+  /@formatjs/icu-messageformat-parser/2.1.14:
+    resolution: {integrity: sha512-0KqeVOb72losEhUW+59vhZGGd14s1f35uThfEMVKZHKLEObvJdFTiI3ZQwvTMUCzLEMxnS6mtnYPmG4mTvwd3Q==}
+    dependencies:
+      '@formatjs/ecma402-abstract': 1.14.3
+      '@formatjs/icu-skeleton-parser': 1.3.18
+      tslib: 2.4.0
+    dev: false
+
+  /@formatjs/icu-skeleton-parser/1.3.18:
+    resolution: {integrity: sha512-ND1ZkZfmLPcHjAH1sVpkpQxA+QYfOX3py3SjKWMUVGDow18gZ0WPqz3F+pJLYQMpS2LnnQ5zYR2jPVYTbRwMpg==}
+    dependencies:
+      '@formatjs/ecma402-abstract': 1.14.3
+      tslib: 2.4.0
+    dev: false
+
+  /@formatjs/intl-localematcher/0.2.32:
+    resolution: {integrity: sha512-k/MEBstff4sttohyEpXxCmC3MqbUn9VvHGlZ8fauLzkbwXmVrEeyzS+4uhrvAk9DWU9/7otYWxyDox4nT/KVLQ==}
+    dependencies:
+      tslib: 2.4.0
+    dev: false
+
   /@hookform/resolvers/2.9.10_react-hook-form@7.38.0:
     resolution: {integrity: sha512-JIL1DgJIlH9yuxcNGtyhsWX/PgNltz+5Gr6+8SX9fhXc/hPbEIk6wPI82nhgvp3uUb6ZfAM5mqg/x7KR7NAb+A==}
     peerDependencies:
@@ -597,6 +633,31 @@ packages:
 
   /@iconify/types/1.1.0:
     resolution: {integrity: sha512-Jh0llaK2LRXQoYsorIH8maClebsnzTcve+7U3rQUSnC11X4jtPnFuyatqFLvMxZ8MLG8dB4zfHsbPfuvxluONw==}
+    dev: false
+
+  /@internationalized/date/3.0.1:
+    resolution: {integrity: sha512-E/3lASs4mAeJ2Z2ye6ab7eUD0bPUfTeNVTAv6IS+ne9UtMu9Uepb9A1U2Ae0hDr6WAlBuvUtrakaxEdYB9TV6Q==}
+    dependencies:
+      '@babel/runtime': 7.19.4
+    dev: false
+
+  /@internationalized/message/3.0.9:
+    resolution: {integrity: sha512-yHQggKWUuSvj1GznVtie4tcYq+xMrkd/lTKCFHp6gG18KbIliDw+UI7sL9+yJPGuWiR083xuLyyhzqiPbNOEww==}
+    dependencies:
+      '@babel/runtime': 7.19.4
+      intl-messageformat: 10.2.5
+    dev: false
+
+  /@internationalized/number/3.1.1:
+    resolution: {integrity: sha512-dBxCQKIxvsZvW2IBt3KsqrCfaw2nV6o6a8xsloJn/hjW0ayeyhKuiiMtTwW3/WGNPP7ZRyDbtuiUEjMwif1ENQ==}
+    dependencies:
+      '@babel/runtime': 7.19.4
+    dev: false
+
+  /@internationalized/string/3.0.0:
+    resolution: {integrity: sha512-NUSr4u+mNu5BysXFeVWZW4kvjXylPkU/YYqaWzdNuz1eABfehFiZTEYhWAAMzI3U8DTxfqF9PM3zyhk5gcfz6w==}
+    dependencies:
+      '@babel/runtime': 7.19.4
     dev: false
 
   /@istanbuljs/load-nyc-config/1.1.0:
@@ -936,6 +997,1197 @@ packages:
 
   /@popperjs/core/2.11.6:
     resolution: {integrity: sha512-50/17A98tWUfQ176raKiOGXuYpLyyVMkxxG6oylzL3BPOlA6ADGdK7EYunSa4I064xerltq9TGXs8HmOk5E+vw==}
+    dev: false
+
+  /@react-aria/breadcrumbs/3.4.0_react@18.2.0:
+    resolution: {integrity: sha512-zQzDu8yO4DInw14FfuZVkIqsoQ9xJ+nbRjJug1iag+FBJCb598DnBZVpFvZdsOsRKbCtImhHhjK/CcImq1rTpA==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
+    dependencies:
+      '@babel/runtime': 7.19.4
+      '@react-aria/i18n': 3.6.2_react@18.2.0
+      '@react-aria/interactions': 3.13.0_react@18.2.0
+      '@react-aria/link': 3.3.5_react@18.2.0
+      '@react-aria/utils': 3.14.1_react@18.2.0
+      '@react-types/breadcrumbs': 3.4.5_react@18.2.0
+      '@react-types/shared': 3.16.0_react@18.2.0
+      react: 18.2.0
+    dev: false
+
+  /@react-aria/button/3.6.3_react@18.2.0:
+    resolution: {integrity: sha512-t6UHFPFMlAQW0yefjhqwyQya6RYlUtMRtMKZjnRANbK6JskazkkLvu//qULs+vsiM21PLhspKVLcGdS+t2khsA==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
+    dependencies:
+      '@babel/runtime': 7.19.4
+      '@react-aria/focus': 3.10.0_react@18.2.0
+      '@react-aria/interactions': 3.13.0_react@18.2.0
+      '@react-aria/utils': 3.14.1_react@18.2.0
+      '@react-stately/toggle': 3.4.3_react@18.2.0
+      '@react-types/button': 3.7.0_react@18.2.0
+      '@react-types/shared': 3.16.0_react@18.2.0
+      react: 18.2.0
+    dev: false
+
+  /@react-aria/calendar/3.0.4_biqbaboplfbrettd7655fr4n2y:
+    resolution: {integrity: sha512-FE52NSR631YO+ew0k/Qt90C+qV9qJV53uAkFYWXzYE0zeE9/+IM0Jtrb/rdcmUhsx/c4l9tzNPAMdFjKvkawXw==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
+      react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
+    dependencies:
+      '@babel/runtime': 7.19.4
+      '@internationalized/date': 3.0.1
+      '@react-aria/i18n': 3.6.2_react@18.2.0
+      '@react-aria/interactions': 3.13.0_react@18.2.0
+      '@react-aria/live-announcer': 3.1.1
+      '@react-aria/utils': 3.14.1_react@18.2.0
+      '@react-stately/calendar': 3.0.4_react@18.2.0
+      '@react-types/button': 3.7.0_react@18.2.0
+      '@react-types/calendar': 3.0.4_react@18.2.0
+      '@react-types/shared': 3.16.0_react@18.2.0
+      react: 18.2.0
+      react-dom: 18.2.0_react@18.2.0
+    dev: false
+
+  /@react-aria/checkbox/3.7.0_react@18.2.0:
+    resolution: {integrity: sha512-CGVfBcCK3e8YwjPSgIMTQbMxbjTtsDy9xGkw/7iCMVIsHC7MfzO8Ny5qJJbQ2dVkNnSfIgQdtWikYGJN2QjeDw==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
+    dependencies:
+      '@babel/runtime': 7.19.4
+      '@react-aria/label': 3.4.3_react@18.2.0
+      '@react-aria/toggle': 3.4.1_react@18.2.0
+      '@react-aria/utils': 3.14.1_react@18.2.0
+      '@react-stately/checkbox': 3.3.1_react@18.2.0
+      '@react-stately/toggle': 3.4.3_react@18.2.0
+      '@react-types/checkbox': 3.4.1_react@18.2.0
+      '@react-types/shared': 3.16.0_react@18.2.0
+      react: 18.2.0
+    dev: false
+
+  /@react-aria/combobox/3.4.3_biqbaboplfbrettd7655fr4n2y:
+    resolution: {integrity: sha512-MrpxrpJOOIRKMKkFDxTzQFu6y31eL15IsMbTRttO0NsrnQiJl19ojz6MpnhIJjnaC/Wz2EEWqnUawQsJjAVxyQ==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
+      react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
+    dependencies:
+      '@babel/runtime': 7.19.4
+      '@react-aria/i18n': 3.6.2_react@18.2.0
+      '@react-aria/interactions': 3.13.0_react@18.2.0
+      '@react-aria/listbox': 3.7.1_react@18.2.0
+      '@react-aria/live-announcer': 3.1.1
+      '@react-aria/menu': 3.7.0_biqbaboplfbrettd7655fr4n2y
+      '@react-aria/overlays': 3.12.0_biqbaboplfbrettd7655fr4n2y
+      '@react-aria/selection': 3.12.0_react@18.2.0
+      '@react-aria/textfield': 3.8.0_react@18.2.0
+      '@react-aria/utils': 3.14.1_react@18.2.0
+      '@react-stately/collections': 3.5.0_react@18.2.0
+      '@react-stately/combobox': 3.3.0_react@18.2.0
+      '@react-stately/layout': 3.9.0_react@18.2.0
+      '@react-types/button': 3.7.0_react@18.2.0
+      '@react-types/combobox': 3.5.5_react@18.2.0
+      '@react-types/shared': 3.16.0_react@18.2.0
+      react: 18.2.0
+      react-dom: 18.2.0_react@18.2.0
+    dev: false
+
+  /@react-aria/datepicker/3.2.0_biqbaboplfbrettd7655fr4n2y:
+    resolution: {integrity: sha512-qsnAcKeWzmZadXtQPpmTN4TNO10Vq/TXSsf5PF+2MInsJQjEWTN8YFFgTbKVf7ksDwfDRSarTV0f+hZbi5scHA==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
+      react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
+    dependencies:
+      '@babel/runtime': 7.19.4
+      '@internationalized/date': 3.0.1
+      '@internationalized/number': 3.1.1
+      '@internationalized/string': 3.0.0
+      '@react-aria/focus': 3.10.0_react@18.2.0
+      '@react-aria/i18n': 3.6.2_react@18.2.0
+      '@react-aria/interactions': 3.13.0_react@18.2.0
+      '@react-aria/label': 3.4.3_react@18.2.0
+      '@react-aria/spinbutton': 3.2.0_biqbaboplfbrettd7655fr4n2y
+      '@react-aria/utils': 3.14.1_react@18.2.0
+      '@react-stately/datepicker': 3.2.0_react@18.2.0
+      '@react-types/button': 3.7.0_react@18.2.0
+      '@react-types/calendar': 3.0.4_react@18.2.0
+      '@react-types/datepicker': 3.1.3_react@18.2.0
+      '@react-types/dialog': 3.4.5_react@18.2.0
+      '@react-types/shared': 3.16.0_react@18.2.0
+      react: 18.2.0
+      react-dom: 18.2.0_react@18.2.0
+    dev: false
+
+  /@react-aria/dialog/3.4.1_biqbaboplfbrettd7655fr4n2y:
+    resolution: {integrity: sha512-1P6zCn78OP9nv7/1i4QsysOKQ6gxHy9JUyOj0ixrR1jwYI/psCM2MwT9cfPjuj7pGQys6lsu4glSmZ82zARURQ==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
+    dependencies:
+      '@babel/runtime': 7.19.4
+      '@react-aria/focus': 3.10.0_react@18.2.0
+      '@react-aria/overlays': 3.12.0_biqbaboplfbrettd7655fr4n2y
+      '@react-aria/utils': 3.14.1_react@18.2.0
+      '@react-stately/overlays': 3.4.3_react@18.2.0
+      '@react-types/dialog': 3.4.5_react@18.2.0
+      '@react-types/shared': 3.16.0_react@18.2.0
+      react: 18.2.0
+    transitivePeerDependencies:
+      - react-dom
+    dev: false
+
+  /@react-aria/dnd/3.0.0_biqbaboplfbrettd7655fr4n2y:
+    resolution: {integrity: sha512-0sJp1tqqqp4FIN+VBPcImrBy0Tb+qMAIeQ4RmqQCdrwb+T1WDcroyUnYoTRPBatsHBClQMM4z9ETKrudKJqC0w==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
+      react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
+    dependencies:
+      '@babel/runtime': 7.19.4
+      '@internationalized/string': 3.0.0
+      '@react-aria/i18n': 3.6.2_react@18.2.0
+      '@react-aria/interactions': 3.13.0_react@18.2.0
+      '@react-aria/live-announcer': 3.1.1
+      '@react-aria/overlays': 3.12.0_biqbaboplfbrettd7655fr4n2y
+      '@react-aria/utils': 3.14.1_react@18.2.0
+      '@react-aria/visually-hidden': 3.6.0_react@18.2.0
+      '@react-stately/dnd': 3.0.0_react@18.2.0
+      '@react-types/button': 3.7.0_react@18.2.0
+      '@react-types/shared': 3.16.0_react@18.2.0
+      react: 18.2.0
+      react-dom: 18.2.0_react@18.2.0
+    dev: false
+
+  /@react-aria/focus/3.10.0_react@18.2.0:
+    resolution: {integrity: sha512-idI7Etgh6y2BYi3X4d+EuUpzR7gPZ94Lf/0UNnVyMkDM9fzcdz/8DCBt0qKOff24HlaLE1rmREt0+iTR/qRgbA==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
+    dependencies:
+      '@babel/runtime': 7.19.4
+      '@react-aria/interactions': 3.13.0_react@18.2.0
+      '@react-aria/utils': 3.14.1_react@18.2.0
+      '@react-types/shared': 3.16.0_react@18.2.0
+      clsx: 1.2.1
+      react: 18.2.0
+    dev: false
+
+  /@react-aria/grid/3.5.1_biqbaboplfbrettd7655fr4n2y:
+    resolution: {integrity: sha512-eWwhG9wHb6l6poZSvnhoSSCpNy1kG3HxIpcbMaR2/qllbUYgZ4PASyx4N2TT/VqBUsxCSwC/WqcDka11U9d94w==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
+      react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
+    dependencies:
+      '@babel/runtime': 7.19.4
+      '@react-aria/focus': 3.10.0_react@18.2.0
+      '@react-aria/i18n': 3.6.2_react@18.2.0
+      '@react-aria/interactions': 3.13.0_react@18.2.0
+      '@react-aria/live-announcer': 3.1.1
+      '@react-aria/selection': 3.12.0_react@18.2.0
+      '@react-aria/utils': 3.14.1_react@18.2.0
+      '@react-stately/grid': 3.4.1_react@18.2.0
+      '@react-stately/selection': 3.11.1_react@18.2.0
+      '@react-stately/virtualizer': 3.4.0_react@18.2.0
+      '@react-types/checkbox': 3.4.1_react@18.2.0
+      '@react-types/grid': 3.1.5_react@18.2.0
+      '@react-types/shared': 3.16.0_react@18.2.0
+      react: 18.2.0
+      react-dom: 18.2.0_react@18.2.0
+    dev: false
+
+  /@react-aria/gridlist/3.1.1_biqbaboplfbrettd7655fr4n2y:
+    resolution: {integrity: sha512-/2f4RYqPF1Jxz2Zl5uScGh8trS/N+cp3YbihjLX/3q/qwBj6El72lpJCeF6zkGAJQx+bt1Uew5YB0qt9uMYZng==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
+    dependencies:
+      '@babel/runtime': 7.19.4
+      '@react-aria/focus': 3.10.0_react@18.2.0
+      '@react-aria/grid': 3.5.1_biqbaboplfbrettd7655fr4n2y
+      '@react-aria/i18n': 3.6.2_react@18.2.0
+      '@react-aria/interactions': 3.13.0_react@18.2.0
+      '@react-aria/selection': 3.12.0_react@18.2.0
+      '@react-aria/utils': 3.14.1_react@18.2.0
+      '@react-stately/list': 3.6.0_react@18.2.0
+      '@react-types/checkbox': 3.4.1_react@18.2.0
+      '@react-types/shared': 3.16.0_react@18.2.0
+      react: 18.2.0
+    transitivePeerDependencies:
+      - react-dom
+    dev: false
+
+  /@react-aria/i18n/3.6.2_react@18.2.0:
+    resolution: {integrity: sha512-/G22mZQcISX6DcKLBn4j/X53y2SOnFfiD4wOEuY7sIZZDryktd+3I/QHukCnNlf0tKK3PdixQLvWa9Q1RqTSaw==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
+    dependencies:
+      '@babel/runtime': 7.19.4
+      '@internationalized/date': 3.0.1
+      '@internationalized/message': 3.0.9
+      '@internationalized/number': 3.1.1
+      '@internationalized/string': 3.0.0
+      '@react-aria/ssr': 3.4.0_react@18.2.0
+      '@react-aria/utils': 3.14.1_react@18.2.0
+      '@react-types/shared': 3.16.0_react@18.2.0
+      react: 18.2.0
+    dev: false
+
+  /@react-aria/interactions/3.13.0_react@18.2.0:
+    resolution: {integrity: sha512-gbZL+qs+6FPitR/abAramth4lqz/drEzXwzIDF6p6WyajF805mjyAgZin1/3mQygSE5BwJNDU7jMUSGRvgFyTw==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
+    dependencies:
+      '@babel/runtime': 7.19.4
+      '@react-aria/utils': 3.14.1_react@18.2.0
+      '@react-types/shared': 3.16.0_react@18.2.0
+      react: 18.2.0
+    dev: false
+
+  /@react-aria/label/3.4.3_react@18.2.0:
+    resolution: {integrity: sha512-g8NSHQKha6xOpR0cUQ6cmH/HwGJdebEbyy+c1I6VeW6me8lSF47xLnybnA6LBV4x9hJqkST6rfL/oPaBMCEKNA==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
+    dependencies:
+      '@babel/runtime': 7.19.4
+      '@react-aria/utils': 3.14.1_react@18.2.0
+      '@react-types/label': 3.7.1_react@18.2.0
+      '@react-types/shared': 3.16.0_react@18.2.0
+      react: 18.2.0
+    dev: false
+
+  /@react-aria/link/3.3.5_react@18.2.0:
+    resolution: {integrity: sha512-BbyoJ73IAQcQMYWFxhV/zJWYFlx4Edprm6xfBZKMEBrEpUcvBwe/X3QsCQmRXZ8fJodMjQ9SdQPyue1yi8Ksrw==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
+    dependencies:
+      '@babel/runtime': 7.19.4
+      '@react-aria/focus': 3.10.0_react@18.2.0
+      '@react-aria/interactions': 3.13.0_react@18.2.0
+      '@react-aria/utils': 3.14.1_react@18.2.0
+      '@react-types/link': 3.3.5_react@18.2.0
+      '@react-types/shared': 3.16.0_react@18.2.0
+      react: 18.2.0
+    dev: false
+
+  /@react-aria/listbox/3.7.1_react@18.2.0:
+    resolution: {integrity: sha512-vKovd+u8F7jdcogZeDPtm89gn390cR0xpMbOoyPzbACOdST43SYexDXWV4Ww/M2YWkdJxT3jZ576NeifcfO2MA==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
+    dependencies:
+      '@babel/runtime': 7.19.4
+      '@react-aria/focus': 3.10.0_react@18.2.0
+      '@react-aria/interactions': 3.13.0_react@18.2.0
+      '@react-aria/label': 3.4.3_react@18.2.0
+      '@react-aria/selection': 3.12.0_react@18.2.0
+      '@react-aria/utils': 3.14.1_react@18.2.0
+      '@react-stately/collections': 3.5.0_react@18.2.0
+      '@react-stately/list': 3.6.0_react@18.2.0
+      '@react-types/listbox': 3.3.5_react@18.2.0
+      '@react-types/shared': 3.16.0_react@18.2.0
+      react: 18.2.0
+    dev: false
+
+  /@react-aria/live-announcer/3.1.1:
+    resolution: {integrity: sha512-e7b+dRh1SUTla42vzjdbhGYkeLD7E6wIYjYaHW9zZ37rBkSqLHUhTigh3eT3k5NxFlDD/uRxTYuwaFnWQgR+4g==}
+    dependencies:
+      '@babel/runtime': 7.19.4
+    dev: false
+
+  /@react-aria/menu/3.7.0_biqbaboplfbrettd7655fr4n2y:
+    resolution: {integrity: sha512-dCSg67G3vEXOovZyaojZXvcq19MLqual6oTSJC9WhNS/SR0AuNPbwMbD34a/b1Je73ro5bzjIbmQPyt/i3XaCA==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
+      react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
+    dependencies:
+      '@babel/runtime': 7.19.4
+      '@react-aria/i18n': 3.6.2_react@18.2.0
+      '@react-aria/interactions': 3.13.0_react@18.2.0
+      '@react-aria/overlays': 3.12.0_biqbaboplfbrettd7655fr4n2y
+      '@react-aria/selection': 3.12.0_react@18.2.0
+      '@react-aria/utils': 3.14.1_react@18.2.0
+      '@react-stately/collections': 3.5.0_react@18.2.0
+      '@react-stately/menu': 3.4.3_react@18.2.0
+      '@react-stately/tree': 3.4.0_react@18.2.0
+      '@react-types/button': 3.7.0_react@18.2.0
+      '@react-types/menu': 3.7.3_react@18.2.0
+      '@react-types/shared': 3.16.0_react@18.2.0
+      react: 18.2.0
+      react-dom: 18.2.0_react@18.2.0
+    dev: false
+
+  /@react-aria/meter/3.3.3_react@18.2.0:
+    resolution: {integrity: sha512-6pe6Gl5e9yZsDkFsdpQNx9eAqSKIjwcOJ4/mLgTiCVgZWtWYuxprLAPiN7OyCnSYPfLp36wkIrMkk82xfBYb9Q==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
+    dependencies:
+      '@babel/runtime': 7.19.4
+      '@react-aria/progress': 3.3.3_react@18.2.0
+      '@react-types/meter': 3.2.5_react@18.2.0
+      '@react-types/shared': 3.16.0_react@18.2.0
+      react: 18.2.0
+    dev: false
+
+  /@react-aria/numberfield/3.3.3_biqbaboplfbrettd7655fr4n2y:
+    resolution: {integrity: sha512-DxVhoD+RsgN385f2OsOg5J1RYo1yZt0AUfIJdHn7FDWYCxruUVmEhzy1ovDxpXkseK0Gh3IdkfHvOfgiqE+pXg==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
+      react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
+    dependencies:
+      '@babel/runtime': 7.19.4
+      '@react-aria/i18n': 3.6.2_react@18.2.0
+      '@react-aria/interactions': 3.13.0_react@18.2.0
+      '@react-aria/live-announcer': 3.1.1
+      '@react-aria/spinbutton': 3.2.0_biqbaboplfbrettd7655fr4n2y
+      '@react-aria/textfield': 3.8.0_react@18.2.0
+      '@react-aria/utils': 3.14.1_react@18.2.0
+      '@react-stately/numberfield': 3.3.0_react@18.2.0
+      '@react-types/button': 3.7.0_react@18.2.0
+      '@react-types/numberfield': 3.3.5_react@18.2.0
+      '@react-types/shared': 3.16.0_react@18.2.0
+      '@react-types/textfield': 3.6.1_react@18.2.0
+      react: 18.2.0
+      react-dom: 18.2.0_react@18.2.0
+    dev: false
+
+  /@react-aria/overlays/3.12.0_biqbaboplfbrettd7655fr4n2y:
+    resolution: {integrity: sha512-jsGeLTB3W3S5Cf2zDTxh1ODTNkE69miFDOGMB0VLwS1GWDwDvytcTRpBKY9JBrxad+4u0x6evnah7IbJ61qNBA==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
+      react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
+    dependencies:
+      '@babel/runtime': 7.19.4
+      '@react-aria/focus': 3.10.0_react@18.2.0
+      '@react-aria/i18n': 3.6.2_react@18.2.0
+      '@react-aria/interactions': 3.13.0_react@18.2.0
+      '@react-aria/ssr': 3.4.0_react@18.2.0
+      '@react-aria/utils': 3.14.1_react@18.2.0
+      '@react-aria/visually-hidden': 3.6.0_react@18.2.0
+      '@react-stately/overlays': 3.4.3_react@18.2.0
+      '@react-types/button': 3.7.0_react@18.2.0
+      '@react-types/overlays': 3.6.5_react@18.2.0
+      '@react-types/shared': 3.16.0_react@18.2.0
+      react: 18.2.0
+      react-dom: 18.2.0_react@18.2.0
+    dev: false
+
+  /@react-aria/progress/3.3.3_react@18.2.0:
+    resolution: {integrity: sha512-yRE9fBfbjSdyWHWeQ4HqEURAT8foa9drGCJIKnMUx08dEsPAXvdh9tvnAvr1kbJnDlZxVwhlbTyFCwB+E2Mfag==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
+    dependencies:
+      '@babel/runtime': 7.19.4
+      '@react-aria/i18n': 3.6.2_react@18.2.0
+      '@react-aria/label': 3.4.3_react@18.2.0
+      '@react-aria/utils': 3.14.1_react@18.2.0
+      '@react-types/progress': 3.2.5_react@18.2.0
+      '@react-types/shared': 3.16.0_react@18.2.0
+      react: 18.2.0
+    dev: false
+
+  /@react-aria/radio/3.4.1_react@18.2.0:
+    resolution: {integrity: sha512-a1JFxFOiExX1ZRGBE31LW4dgc3VmW2v3upJ5snGQldC83o0XxqNavmOef+fMsIRV0AQA/mcxAJVNQ0n9SfIiUQ==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
+    dependencies:
+      '@babel/runtime': 7.19.4
+      '@react-aria/focus': 3.10.0_react@18.2.0
+      '@react-aria/i18n': 3.6.2_react@18.2.0
+      '@react-aria/interactions': 3.13.0_react@18.2.0
+      '@react-aria/label': 3.4.3_react@18.2.0
+      '@react-aria/utils': 3.14.1_react@18.2.0
+      '@react-stately/radio': 3.6.1_react@18.2.0
+      '@react-types/radio': 3.3.1_react@18.2.0
+      '@react-types/shared': 3.16.0_react@18.2.0
+      react: 18.2.0
+    dev: false
+
+  /@react-aria/searchfield/3.4.3_react@18.2.0:
+    resolution: {integrity: sha512-8WISGEyXWyVKRql4oVc9T5eNx8jTUwDQy0+ZSO5qGXuiZtlyeTJdWMrHN8I4SUdWEoF9c7R0eLhl0Twefnjkiw==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
+    dependencies:
+      '@babel/runtime': 7.19.4
+      '@react-aria/i18n': 3.6.2_react@18.2.0
+      '@react-aria/interactions': 3.13.0_react@18.2.0
+      '@react-aria/textfield': 3.8.0_react@18.2.0
+      '@react-aria/utils': 3.14.1_react@18.2.0
+      '@react-stately/searchfield': 3.3.3_react@18.2.0
+      '@react-types/button': 3.7.0_react@18.2.0
+      '@react-types/searchfield': 3.3.5_react@18.2.0
+      '@react-types/shared': 3.16.0_react@18.2.0
+      react: 18.2.0
+    dev: false
+
+  /@react-aria/select/3.8.3_biqbaboplfbrettd7655fr4n2y:
+    resolution: {integrity: sha512-EkbzbpSEkq0oSmFSeOJskjPzopqmKQ2VxsEaJHL8RebVdJiNxp5kSaBOaH1KxZI9DgrzHQNSRKYJaSJ1pUTfbw==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
+      react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
+    dependencies:
+      '@babel/runtime': 7.19.4
+      '@react-aria/i18n': 3.6.2_react@18.2.0
+      '@react-aria/interactions': 3.13.0_react@18.2.0
+      '@react-aria/label': 3.4.3_react@18.2.0
+      '@react-aria/listbox': 3.7.1_react@18.2.0
+      '@react-aria/menu': 3.7.0_biqbaboplfbrettd7655fr4n2y
+      '@react-aria/selection': 3.12.0_react@18.2.0
+      '@react-aria/utils': 3.14.1_react@18.2.0
+      '@react-aria/visually-hidden': 3.6.0_react@18.2.0
+      '@react-stately/select': 3.3.3_react@18.2.0
+      '@react-types/button': 3.7.0_react@18.2.0
+      '@react-types/select': 3.6.5_react@18.2.0
+      '@react-types/shared': 3.16.0_react@18.2.0
+      react: 18.2.0
+      react-dom: 18.2.0_react@18.2.0
+    dev: false
+
+  /@react-aria/selection/3.12.0_react@18.2.0:
+    resolution: {integrity: sha512-Akzx5Faxw+sOZFXLCOw6OddDNFbP5Kho3EP6bYJfd2pzMkBc8/JemC/YDrtIuy8e9x6Je9HHSZqtKjwiEaXWog==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
+    dependencies:
+      '@babel/runtime': 7.19.4
+      '@react-aria/focus': 3.10.0_react@18.2.0
+      '@react-aria/i18n': 3.6.2_react@18.2.0
+      '@react-aria/interactions': 3.13.0_react@18.2.0
+      '@react-aria/utils': 3.14.1_react@18.2.0
+      '@react-stately/collections': 3.5.0_react@18.2.0
+      '@react-stately/selection': 3.11.1_react@18.2.0
+      '@react-types/shared': 3.16.0_react@18.2.0
+      react: 18.2.0
+    dev: false
+
+  /@react-aria/separator/3.2.5_react@18.2.0:
+    resolution: {integrity: sha512-WJhqvUqMxxs18Qn8kGIdx7NCe/yoHev6w0TCxxcZMf/crJKWdSunv3YpbcQW67loBTRo1093RqhacPtXoRzQvg==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
+    dependencies:
+      '@babel/runtime': 7.19.4
+      '@react-aria/utils': 3.14.1_react@18.2.0
+      '@react-types/shared': 3.16.0_react@18.2.0
+      react: 18.2.0
+    dev: false
+
+  /@react-aria/slider/3.2.3_react@18.2.0:
+    resolution: {integrity: sha512-y2Sx2YExcWcg15Hzhxhqccpylq5xm2RlswnhBxzwY+ms8ZR4MK6UNL64wbCmOBLxhzjgi5mTWSB+OmVCZk5H4A==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
+    dependencies:
+      '@babel/runtime': 7.19.4
+      '@react-aria/focus': 3.10.0_react@18.2.0
+      '@react-aria/i18n': 3.6.2_react@18.2.0
+      '@react-aria/interactions': 3.13.0_react@18.2.0
+      '@react-aria/label': 3.4.3_react@18.2.0
+      '@react-aria/utils': 3.14.1_react@18.2.0
+      '@react-stately/radio': 3.6.1_react@18.2.0
+      '@react-stately/slider': 3.2.3_react@18.2.0
+      '@react-types/radio': 3.3.1_react@18.2.0
+      '@react-types/shared': 3.16.0_react@18.2.0
+      '@react-types/slider': 3.3.1_react@18.2.0
+      react: 18.2.0
+    dev: false
+
+  /@react-aria/spinbutton/3.2.0_biqbaboplfbrettd7655fr4n2y:
+    resolution: {integrity: sha512-6pbfC/uOz1k+D6NL7l/o855yr3hMBaiLdZpKdGu4N/vybnyS5ZcjX9Y1VswBZjYgvZ3Ojp8fSu/buZMU/zAISw==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
+      react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
+    dependencies:
+      '@babel/runtime': 7.19.4
+      '@react-aria/i18n': 3.6.2_react@18.2.0
+      '@react-aria/live-announcer': 3.1.1
+      '@react-aria/utils': 3.14.1_react@18.2.0
+      '@react-types/button': 3.7.0_react@18.2.0
+      '@react-types/shared': 3.16.0_react@18.2.0
+      react: 18.2.0
+      react-dom: 18.2.0_react@18.2.0
+    dev: false
+
+  /@react-aria/ssr/3.4.0_react@18.2.0:
+    resolution: {integrity: sha512-qzuGk14/fUyUAoW/EBwgFcuMkVNXJVGlezTgZ1HovpCZ+p9844E7MUFHE7CuzFzPEIkVeqhBNIoIu+VJJ8YCOA==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
+    dependencies:
+      '@babel/runtime': 7.19.4
+      react: 18.2.0
+    dev: false
+
+  /@react-aria/switch/3.3.0_react@18.2.0:
+    resolution: {integrity: sha512-A/6G9HjZYPvCvaUbrghdCH0rkQfaNbayruQJ+PWGITZbxhYZAUUW7wkxvxLpf3iX2K5+UtNNThxlEMcplEkVrw==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
+    dependencies:
+      '@babel/runtime': 7.19.4
+      '@react-aria/toggle': 3.4.1_react@18.2.0
+      '@react-stately/toggle': 3.4.3_react@18.2.0
+      '@react-types/switch': 3.2.5_react@18.2.0
+      react: 18.2.0
+    dev: false
+
+  /@react-aria/table/3.6.0_biqbaboplfbrettd7655fr4n2y:
+    resolution: {integrity: sha512-hwq+5iwXVSirmi9Lr0v5wDOv7uz7UD+BUNFXP5d9nknrAKzVYDfpuNpz/Bbhpczp9R89VRBcFvcKJ3cWhESYnw==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
+      react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
+    dependencies:
+      '@babel/runtime': 7.19.4
+      '@react-aria/focus': 3.10.0_react@18.2.0
+      '@react-aria/grid': 3.5.1_biqbaboplfbrettd7655fr4n2y
+      '@react-aria/i18n': 3.6.2_react@18.2.0
+      '@react-aria/interactions': 3.13.0_react@18.2.0
+      '@react-aria/live-announcer': 3.1.1
+      '@react-aria/selection': 3.12.0_react@18.2.0
+      '@react-aria/utils': 3.14.1_react@18.2.0
+      '@react-stately/table': 3.6.0_react@18.2.0
+      '@react-stately/virtualizer': 3.4.0_react@18.2.0
+      '@react-types/checkbox': 3.4.1_react@18.2.0
+      '@react-types/grid': 3.1.5_react@18.2.0
+      '@react-types/shared': 3.16.0_react@18.2.0
+      '@react-types/table': 3.3.3_react@18.2.0
+      react: 18.2.0
+      react-dom: 18.2.0_react@18.2.0
+    dev: false
+
+  /@react-aria/tabs/3.3.3_react@18.2.0:
+    resolution: {integrity: sha512-0GeArynZzWQuNXIp1DUexNdfFC0vnTLAhN9cd3ZJDc7jbAvwy5HB363ElYqfTqNgvrtMF1QTJo9tY6KmYWxLeg==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
+    dependencies:
+      '@babel/runtime': 7.19.4
+      '@react-aria/focus': 3.10.0_react@18.2.0
+      '@react-aria/i18n': 3.6.2_react@18.2.0
+      '@react-aria/interactions': 3.13.0_react@18.2.0
+      '@react-aria/selection': 3.12.0_react@18.2.0
+      '@react-aria/utils': 3.14.1_react@18.2.0
+      '@react-stately/list': 3.6.0_react@18.2.0
+      '@react-stately/tabs': 3.2.3_react@18.2.0
+      '@react-types/shared': 3.16.0_react@18.2.0
+      '@react-types/tabs': 3.1.5_react@18.2.0
+      react: 18.2.0
+    dev: false
+
+  /@react-aria/textfield/3.8.0_react@18.2.0:
+    resolution: {integrity: sha512-PRU8q1gK0auDMH1YekJScZ4EZMrLrL3QJEHMNDdp2GDQlVISbPeTRy2On20DXfiG8GlXAtCWj9BiZhK2OE71DQ==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
+    dependencies:
+      '@babel/runtime': 7.19.4
+      '@react-aria/focus': 3.10.0_react@18.2.0
+      '@react-aria/label': 3.4.3_react@18.2.0
+      '@react-aria/utils': 3.14.1_react@18.2.0
+      '@react-types/shared': 3.16.0_react@18.2.0
+      '@react-types/textfield': 3.6.1_react@18.2.0
+      react: 18.2.0
+    dev: false
+
+  /@react-aria/toggle/3.4.1_react@18.2.0:
+    resolution: {integrity: sha512-oVcjqsqvvEXW25vm3F2gxF5Csz8vRNKeF7Kc5pxqLrBohqMausChul+/Zisx5qVB4TL0yO3ygjTGbEvfEYQ1qg==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
+    dependencies:
+      '@babel/runtime': 7.19.4
+      '@react-aria/focus': 3.10.0_react@18.2.0
+      '@react-aria/interactions': 3.13.0_react@18.2.0
+      '@react-aria/utils': 3.14.1_react@18.2.0
+      '@react-stately/toggle': 3.4.3_react@18.2.0
+      '@react-types/checkbox': 3.4.1_react@18.2.0
+      '@react-types/shared': 3.16.0_react@18.2.0
+      '@react-types/switch': 3.2.5_react@18.2.0
+      react: 18.2.0
+    dev: false
+
+  /@react-aria/tooltip/3.3.3_react@18.2.0:
+    resolution: {integrity: sha512-EF58SQ70KEfGJQErsELJh1dk3KUDrBFmCEHo6kD1fVEHCqUgdWLkz+TCfkiP8VgFoj4WoE8zSpl3MpgGOQr/Gg==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
+    dependencies:
+      '@babel/runtime': 7.19.4
+      '@react-aria/focus': 3.10.0_react@18.2.0
+      '@react-aria/interactions': 3.13.0_react@18.2.0
+      '@react-aria/utils': 3.14.1_react@18.2.0
+      '@react-stately/tooltip': 3.2.3_react@18.2.0
+      '@react-types/shared': 3.16.0_react@18.2.0
+      '@react-types/tooltip': 3.2.5_react@18.2.0
+      react: 18.2.0
+    dev: false
+
+  /@react-aria/utils/3.14.1_react@18.2.0:
+    resolution: {integrity: sha512-+ynP0YlxN02MHVEBaeuTrIhBsfBYpfJn36pZm2t7ZEFbafH8DPaMGZ70ffYZXAESkWzRULXL3e79DheWOFI1qA==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
+    dependencies:
+      '@babel/runtime': 7.19.4
+      '@react-aria/ssr': 3.4.0_react@18.2.0
+      '@react-stately/utils': 3.5.1_react@18.2.0
+      '@react-types/shared': 3.16.0_react@18.2.0
+      clsx: 1.2.1
+      react: 18.2.0
+    dev: false
+
+  /@react-aria/visually-hidden/3.6.0_react@18.2.0:
+    resolution: {integrity: sha512-W3Ix5wdlVzh2GY7dytqOAyLCXiHzk3S4jLKSaoiCwPJX9fHE5zMlZwahhDy27V0LXfjmdjBltbwyEZOq4G/Q0w==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
+    dependencies:
+      '@babel/runtime': 7.19.4
+      '@react-aria/interactions': 3.13.0_react@18.2.0
+      '@react-aria/utils': 3.14.1_react@18.2.0
+      '@react-types/shared': 3.16.0_react@18.2.0
+      clsx: 1.2.1
+      react: 18.2.0
+    dev: false
+
+  /@react-stately/calendar/3.0.4_react@18.2.0:
+    resolution: {integrity: sha512-KaytmQVRqEOoKuLDgrm8RzY7ZHJ24IlDirN4dZj1wBHYt7RkAtwgqyTF/eyhS6/VYegmPhu53GcsSk0I3W+xLQ==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
+    dependencies:
+      '@babel/runtime': 7.19.4
+      '@internationalized/date': 3.0.1
+      '@react-stately/utils': 3.5.1_react@18.2.0
+      '@react-types/calendar': 3.0.4_react@18.2.0
+      '@react-types/datepicker': 3.1.3_react@18.2.0
+      '@react-types/shared': 3.16.0_react@18.2.0
+      react: 18.2.0
+    dev: false
+
+  /@react-stately/checkbox/3.3.1_react@18.2.0:
+    resolution: {integrity: sha512-r2hL11GF9r2ztUFEhpiVgiXgE+W99tyL1Kt7rOiTZ8/aMBGWwBxOHAdHeqcWFeBgOztXuJsKiDu82necEG4xhA==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
+    dependencies:
+      '@babel/runtime': 7.19.4
+      '@react-stately/toggle': 3.4.3_react@18.2.0
+      '@react-stately/utils': 3.5.1_react@18.2.0
+      '@react-types/checkbox': 3.4.1_react@18.2.0
+      '@react-types/shared': 3.16.0_react@18.2.0
+      react: 18.2.0
+    dev: false
+
+  /@react-stately/collections/3.5.0_react@18.2.0:
+    resolution: {integrity: sha512-3BAMRjJqrka0IGvyK4m3WslqCeiEfQGx7YsXEIgIgMJoLpk6Fi1Eh4CI8coBnl/wcVLiIRMCIvxubwFRWTgzdg==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
+    dependencies:
+      '@babel/runtime': 7.19.4
+      '@react-types/shared': 3.16.0_react@18.2.0
+      react: 18.2.0
+    dev: false
+
+  /@react-stately/combobox/3.3.0_react@18.2.0:
+    resolution: {integrity: sha512-+9xQW6C4nMcx7M72P4vZdQECa9CqzALTM3HTNAXgdCmfEezhns/m4xGmn4hoN8iw39yYvU8Ffs80rgTFQ+/oFg==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
+    dependencies:
+      '@babel/runtime': 7.19.4
+      '@react-stately/list': 3.6.0_react@18.2.0
+      '@react-stately/menu': 3.4.3_react@18.2.0
+      '@react-stately/select': 3.3.3_react@18.2.0
+      '@react-stately/utils': 3.5.1_react@18.2.0
+      '@react-types/combobox': 3.5.5_react@18.2.0
+      '@react-types/shared': 3.16.0_react@18.2.0
+      react: 18.2.0
+    dev: false
+
+  /@react-stately/data/3.8.0_react@18.2.0:
+    resolution: {integrity: sha512-TR1kjIar2t94SXH5L0BpNfwkEI39p753C1c8DCPwVw7+aamQ03t4j/hcSChN9Bj4A5ycdKylGhJgxYo/vtdCOw==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
+    dependencies:
+      '@babel/runtime': 7.19.4
+      '@react-types/shared': 3.16.0_react@18.2.0
+      react: 18.2.0
+    dev: false
+
+  /@react-stately/datepicker/3.2.0_react@18.2.0:
+    resolution: {integrity: sha512-isFB8jpeiig3vfstWKkaY0cdejG0XT47Q9jZJgsrsEqpMVFBmcvlQQQ3WNqP4yC5c7Mrs3tAscY7WtbPIkDQ4g==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
+    dependencies:
+      '@babel/runtime': 7.19.4
+      '@internationalized/date': 3.0.1
+      '@internationalized/string': 3.0.0
+      '@react-stately/overlays': 3.4.3_react@18.2.0
+      '@react-stately/utils': 3.5.1_react@18.2.0
+      '@react-types/datepicker': 3.1.3_react@18.2.0
+      '@react-types/shared': 3.16.0_react@18.2.0
+      react: 18.2.0
+    dev: false
+
+  /@react-stately/dnd/3.0.0_react@18.2.0:
+    resolution: {integrity: sha512-TI3BqheEm9fUhqrMm6RFY6q8DcWfC5O/LK+IgHpQgOBhL+Vk/EwvGnRice1xyMEQKbAXf04WOFiAjZqfurLshQ==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
+    dependencies:
+      '@babel/runtime': 7.19.4
+      '@react-stately/selection': 3.11.1_react@18.2.0
+      '@react-types/shared': 3.16.0_react@18.2.0
+      react: 18.2.0
+    dev: false
+
+  /@react-stately/grid/3.4.1_react@18.2.0:
+    resolution: {integrity: sha512-IRaqXUQGji87Q+pYYQKJYTuUtgAjoDQaMOlvpvB9HlyK5faXq0H1tJsYAeVYpH0synfzCnr7CN0J6kSTbeL1jA==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
+    dependencies:
+      '@babel/runtime': 7.19.4
+      '@react-stately/selection': 3.11.1_react@18.2.0
+      '@react-types/grid': 3.1.5_react@18.2.0
+      '@react-types/shared': 3.16.0_react@18.2.0
+      react: 18.2.0
+    dev: false
+
+  /@react-stately/layout/3.9.0_react@18.2.0:
+    resolution: {integrity: sha512-uFdK98hIspBV9/RMW/JJaViuWyISdcm5GFplB361JZkhDaYblzomvkoX5Y1dKO5uH/BOjdM2AB5vfCb21oKEhg==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
+    dependencies:
+      '@babel/runtime': 7.19.4
+      '@react-stately/virtualizer': 3.4.0_react@18.2.0
+      '@react-types/grid': 3.1.5_react@18.2.0
+      '@react-types/shared': 3.16.0_react@18.2.0
+      '@react-types/table': 3.3.3_react@18.2.0
+      react: 18.2.0
+    dev: false
+
+  /@react-stately/list/3.6.0_react@18.2.0:
+    resolution: {integrity: sha512-sah2JAiqlSZhg1tQBSv9866LeAJISmosOFsOsVZPfyfAewuCksA+8OHrFtbKmMyzU5MbrmpbR8v2zZH7c1CLdg==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
+    dependencies:
+      '@babel/runtime': 7.19.4
+      '@react-stately/collections': 3.5.0_react@18.2.0
+      '@react-stately/selection': 3.11.1_react@18.2.0
+      '@react-stately/utils': 3.5.1_react@18.2.0
+      '@react-types/shared': 3.16.0_react@18.2.0
+      react: 18.2.0
+    dev: false
+
+  /@react-stately/menu/3.4.3_react@18.2.0:
+    resolution: {integrity: sha512-ZWym6XQSLaC5uFUTZl6+mreEgzc8EUG6ElcnvdXYcH4DWUfswhLxCi3IdnG0lusWEi4NcHbZ2prEUxpT8VKqrg==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
+    dependencies:
+      '@babel/runtime': 7.19.4
+      '@react-stately/overlays': 3.4.3_react@18.2.0
+      '@react-stately/utils': 3.5.1_react@18.2.0
+      '@react-types/menu': 3.7.3_react@18.2.0
+      '@react-types/shared': 3.16.0_react@18.2.0
+      react: 18.2.0
+    dev: false
+
+  /@react-stately/numberfield/3.3.0_react@18.2.0:
+    resolution: {integrity: sha512-UYw8KpLEG7F6U3lHvrqWLdyiWmEeYwvwLlUPErIy+/heoBUW22FRjTIfOANmvVQoeSmd8aGIBWbCVRrbjU6Q5A==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
+    dependencies:
+      '@babel/runtime': 7.19.4
+      '@internationalized/number': 3.1.1
+      '@react-stately/utils': 3.5.1_react@18.2.0
+      '@react-types/numberfield': 3.3.5_react@18.2.0
+      '@react-types/shared': 3.16.0_react@18.2.0
+      react: 18.2.0
+    dev: false
+
+  /@react-stately/overlays/3.4.3_react@18.2.0:
+    resolution: {integrity: sha512-WZCr3J8hj0cplQki1OVBR3MXg2l9V017h15Y2h+TNduWvnKH0yYOE/XfWviAT4KUP0LYoQfCnZ7XMHv+UI+8JA==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
+    dependencies:
+      '@babel/runtime': 7.19.4
+      '@react-stately/utils': 3.5.1_react@18.2.0
+      '@react-types/overlays': 3.6.5_react@18.2.0
+      react: 18.2.0
+    dev: false
+
+  /@react-stately/radio/3.6.1_react@18.2.0:
+    resolution: {integrity: sha512-Hcg2qgvR7ekKMzVKeGby1FgMk3Sw4iDcEY/K1Y6j7UmGjM2HtQOq614tWQSQeGB25pp5I2jAWlparJeX0vY/oA==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
+    dependencies:
+      '@babel/runtime': 7.19.4
+      '@react-stately/utils': 3.5.1_react@18.2.0
+      '@react-types/radio': 3.3.1_react@18.2.0
+      '@react-types/shared': 3.16.0_react@18.2.0
+      react: 18.2.0
+    dev: false
+
+  /@react-stately/searchfield/3.3.3_react@18.2.0:
+    resolution: {integrity: sha512-pQxvFP05gPU2pcm+RuKg5Q8TuYcQ+SpxRwX4i4awwL/wSZTG7VmFkQpOaQK5wU558UXydMnK3QfifmCBV7IN9A==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
+    dependencies:
+      '@babel/runtime': 7.19.4
+      '@react-stately/utils': 3.5.1_react@18.2.0
+      '@react-types/searchfield': 3.3.5_react@18.2.0
+      '@react-types/shared': 3.16.0_react@18.2.0
+      react: 18.2.0
+    dev: false
+
+  /@react-stately/select/3.3.3_react@18.2.0:
+    resolution: {integrity: sha512-HTKKwx5tq21G2r3Q0CVC5v2Amftj1+DvBlFSRIC9ZqWyxeQg//HotX0GpYHzEEyj5hB1GjBklKJ4UVejqNbb0w==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
+    dependencies:
+      '@babel/runtime': 7.19.4
+      '@react-stately/collections': 3.5.0_react@18.2.0
+      '@react-stately/list': 3.6.0_react@18.2.0
+      '@react-stately/menu': 3.4.3_react@18.2.0
+      '@react-stately/selection': 3.11.1_react@18.2.0
+      '@react-stately/utils': 3.5.1_react@18.2.0
+      '@react-types/select': 3.6.5_react@18.2.0
+      '@react-types/shared': 3.16.0_react@18.2.0
+      react: 18.2.0
+    dev: false
+
+  /@react-stately/selection/3.11.1_react@18.2.0:
+    resolution: {integrity: sha512-UHB6/eH5NJ+Q70G+pmnxohHfR3bh0szT+lOlWPj7Mh76WPu9bu07IHKLEob6PSzyJ81h7+Ysk3hdIgS3TewGog==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
+    dependencies:
+      '@babel/runtime': 7.19.4
+      '@react-stately/collections': 3.5.0_react@18.2.0
+      '@react-stately/utils': 3.5.1_react@18.2.0
+      '@react-types/shared': 3.16.0_react@18.2.0
+      react: 18.2.0
+    dev: false
+
+  /@react-stately/slider/3.2.3_react@18.2.0:
+    resolution: {integrity: sha512-l5ezt0+Gq67QO/J5u6YX00mzahRrANSXK/wBx7TVeIxqOAPOG9zc8M8O9Pa5fZB6lYAVpHMbV/aqLSkyy8ImTg==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
+    dependencies:
+      '@babel/runtime': 7.19.4
+      '@react-aria/i18n': 3.6.2_react@18.2.0
+      '@react-aria/utils': 3.14.1_react@18.2.0
+      '@react-stately/utils': 3.5.1_react@18.2.0
+      '@react-types/shared': 3.16.0_react@18.2.0
+      '@react-types/slider': 3.3.1_react@18.2.0
+      react: 18.2.0
+    dev: false
+
+  /@react-stately/table/3.6.0_react@18.2.0:
+    resolution: {integrity: sha512-B6zamfI06j3+kxlMm1mgn+JaQv5CdXgYsMLo96nrU+XRbn2WzAikc2w+XHmfnqlKAcm+PtcDjrshDOCMioP2QA==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
+    dependencies:
+      '@babel/runtime': 7.19.4
+      '@react-stately/collections': 3.5.0_react@18.2.0
+      '@react-stately/grid': 3.4.1_react@18.2.0
+      '@react-stately/selection': 3.11.1_react@18.2.0
+      '@react-types/grid': 3.1.5_react@18.2.0
+      '@react-types/shared': 3.16.0_react@18.2.0
+      '@react-types/table': 3.3.3_react@18.2.0
+      react: 18.2.0
+    dev: false
+
+  /@react-stately/tabs/3.2.3_react@18.2.0:
+    resolution: {integrity: sha512-23GX5iBX1IPY1sD4nq8sTgCfaCt+P2nORYnBWA01+iZoUX/g3BG3+3S2SVL1J7esmcapGnXNapUa2zEbf3aFRg==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
+    dependencies:
+      '@babel/runtime': 7.19.4
+      '@react-stately/list': 3.6.0_react@18.2.0
+      '@react-stately/utils': 3.5.1_react@18.2.0
+      '@react-types/tabs': 3.1.5_react@18.2.0
+      react: 18.2.0
+    dev: false
+
+  /@react-stately/toggle/3.4.3_react@18.2.0:
+    resolution: {integrity: sha512-HsJLMa5d9i6SWyDIahkJExkanXZek86//hirsgSU0IvY7YJx33Wek8UwHE5Vskp39DAOu18QMz2GrAngnUErYQ==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
+    dependencies:
+      '@babel/runtime': 7.19.4
+      '@react-stately/utils': 3.5.1_react@18.2.0
+      '@react-types/checkbox': 3.4.1_react@18.2.0
+      '@react-types/shared': 3.16.0_react@18.2.0
+      react: 18.2.0
+    dev: false
+
+  /@react-stately/tooltip/3.2.3_react@18.2.0:
+    resolution: {integrity: sha512-RWCcqn6iz1IcOXX+TiXBql2kI5hgDlf49DiGZJqSGmNQujX1FVZ1uqn9yHpdh+/TZPZ7JeMvQu3S5lA+x4ehPw==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
+    dependencies:
+      '@babel/runtime': 7.19.4
+      '@react-stately/overlays': 3.4.3_react@18.2.0
+      '@react-stately/utils': 3.5.1_react@18.2.0
+      '@react-types/tooltip': 3.2.5_react@18.2.0
+      react: 18.2.0
+    dev: false
+
+  /@react-stately/tree/3.4.0_react@18.2.0:
+    resolution: {integrity: sha512-MqxSABMzykwI6Wj1B7+jBcCoYc0b05CueRTQDyoL+PfVhnV0SzOH6P84UPD+FHlz8x3RG/2hTTmLr4A8McO2nQ==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
+    dependencies:
+      '@babel/runtime': 7.19.4
+      '@react-stately/collections': 3.5.0_react@18.2.0
+      '@react-stately/selection': 3.11.1_react@18.2.0
+      '@react-stately/utils': 3.5.1_react@18.2.0
+      '@react-types/shared': 3.16.0_react@18.2.0
+      react: 18.2.0
+    dev: false
+
+  /@react-stately/utils/3.5.1_react@18.2.0:
+    resolution: {integrity: sha512-INeQ5Er2Jm+db8Py4upKBtgfzp3UYgwXYmbU/XJn49Xw27ktuimH9e37qP3bgHaReb5L3g8IrGs38tJUpnGPHA==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
+    dependencies:
+      '@babel/runtime': 7.19.4
+      react: 18.2.0
+    dev: false
+
+  /@react-stately/virtualizer/3.4.0_react@18.2.0:
+    resolution: {integrity: sha512-Yy5RKlt6W/1+qjJAVHxPJA0RgpN3KNHcSpnFHdus2OuEvylSXZ2kqwflj97Ao4XfNSpDIs4NQS/eOq+mpZlNqQ==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
+    dependencies:
+      '@babel/runtime': 7.19.4
+      '@react-aria/utils': 3.14.1_react@18.2.0
+      '@react-types/shared': 3.16.0_react@18.2.0
+      react: 18.2.0
+    dev: false
+
+  /@react-types/breadcrumbs/3.4.5_react@18.2.0:
+    resolution: {integrity: sha512-5DXV6qW6Orronu1D9Op903m+lGzPajzJnsW6ygEiv6kjRutY33gIl1ePoQKoBQzNimtFs3uE4YLOw7nLzry1qg==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
+    dependencies:
+      '@react-types/link': 3.3.5_react@18.2.0
+      '@react-types/shared': 3.16.0_react@18.2.0
+      react: 18.2.0
+    dev: false
+
+  /@react-types/button/3.7.0_react@18.2.0:
+    resolution: {integrity: sha512-81BQO3QxSgF9PTXsVozNdNCKxBOB1lpbCWocV99dN1ws9s8uaYw8pmJJZ0LJKLiOsIECQ/3QrhQjmWTDW/qTug==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
+    dependencies:
+      '@react-types/shared': 3.16.0_react@18.2.0
+      react: 18.2.0
+    dev: false
+
+  /@react-types/calendar/3.0.4_react@18.2.0:
+    resolution: {integrity: sha512-0hKaaEil2XbdUESQe9Yg2uLVNvNcFHVzXN6KoQHGBPnpWlkwa24ufKiX27mAWOAoce0nEXlVBG1H9C/kwLMcMw==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
+    dependencies:
+      '@internationalized/date': 3.0.1
+      '@react-types/shared': 3.16.0_react@18.2.0
+      react: 18.2.0
+    dev: false
+
+  /@react-types/checkbox/3.4.1_react@18.2.0:
+    resolution: {integrity: sha512-kDMpy9SntjGQ7x00m5zmW8GENPouOtyiDgiEDKsPXUr2iYqHsNtricqVyG9S9+6hqpzuu8BzTcvZamc/xYjzlg==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
+    dependencies:
+      '@react-types/shared': 3.16.0_react@18.2.0
+      react: 18.2.0
+    dev: false
+
+  /@react-types/combobox/3.5.5_react@18.2.0:
+    resolution: {integrity: sha512-gpDo/NTQFd5IfCZoNnG16N4/JfvwXpZBNc15Kn7bF+NcpSDhDpI26BZN4mvK4lljKCheD4VrEl9/3PtImCg7cA==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
+    dependencies:
+      '@react-types/shared': 3.16.0_react@18.2.0
+      react: 18.2.0
+    dev: false
+
+  /@react-types/datepicker/3.1.3_react@18.2.0:
+    resolution: {integrity: sha512-5ZsCU/quVXMCQd3T9yLYKOviSghBaSx/vqzJDsDGimyFRAxd4n95PRl8SjlGjVf6lR0WSihCbcXB/D+b8/RJIA==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
+    dependencies:
+      '@internationalized/date': 3.0.1
+      '@react-types/overlays': 3.6.5_react@18.2.0
+      '@react-types/shared': 3.16.0_react@18.2.0
+      react: 18.2.0
+    dev: false
+
+  /@react-types/dialog/3.4.5_react@18.2.0:
+    resolution: {integrity: sha512-FkxZAYNRWkZVH5rjlw6qyQ/SpoGcYtNI/JQvn1H/xtZy/OJh2b2ERxGWv5x0RItGSeyATdSwFO1Qnf1Kl2K02A==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
+    dependencies:
+      '@react-types/overlays': 3.6.5_react@18.2.0
+      '@react-types/shared': 3.16.0_react@18.2.0
+      react: 18.2.0
+    dev: false
+
+  /@react-types/grid/3.1.5_react@18.2.0:
+    resolution: {integrity: sha512-KiEywsOJ+wdzLmJerAKEMADdvdItaLfhdo3bFfn1lgNUaKiNDJctDYWlhOYsRePf7MIrzoZuXEFnJj45jfpiOQ==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
+    dependencies:
+      '@react-types/shared': 3.16.0_react@18.2.0
+      react: 18.2.0
+    dev: false
+
+  /@react-types/label/3.7.1_react@18.2.0:
+    resolution: {integrity: sha512-wFpdtjSDBWO4xQQGF57V3PqvVVyE9TPj9ELWLs1yzL09fpXosycuEl5d79RywVlC9aF9dQYUfES09q/DZhRhMQ==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
+    dependencies:
+      '@react-types/shared': 3.16.0_react@18.2.0
+      react: 18.2.0
+    dev: false
+
+  /@react-types/link/3.3.5_react@18.2.0:
+    resolution: {integrity: sha512-wEeYXqzRPwEwU6AakiRfsPrkGxm2l0gjIc992FBmHPz6MWU8eSATTwzeyI668eRzNrQvOBMI7il6lXuxDm1ZLg==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
+    dependencies:
+      '@react-aria/interactions': 3.13.0_react@18.2.0
+      '@react-types/shared': 3.16.0_react@18.2.0
+      react: 18.2.0
+    dev: false
+
+  /@react-types/listbox/3.3.5_react@18.2.0:
+    resolution: {integrity: sha512-7SMRJWUi7ayzQ7SUPCXXwgI/Ua3vg0PPQOZFsmJ4/E8VG/xK82IV7BYSZiNjUQuGpVZJL0VPndt/RwIrQO4S3w==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
+    dependencies:
+      '@react-types/shared': 3.16.0_react@18.2.0
+      react: 18.2.0
+    dev: false
+
+  /@react-types/menu/3.7.3_react@18.2.0:
+    resolution: {integrity: sha512-3Pax24I/FyNKBjKyNR4ePD8eZs35Th57HzJAVjamQg2fHEDRomg9GQ7fdmfGj72Dv3x3JRCoPYqhJ3L5R3kbzg==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
+    dependencies:
+      '@react-types/overlays': 3.6.5_react@18.2.0
+      '@react-types/shared': 3.16.0_react@18.2.0
+      react: 18.2.0
+    dev: false
+
+  /@react-types/meter/3.2.5_react@18.2.0:
+    resolution: {integrity: sha512-pBrHoWRSwrfo3JtCCxoniSEd27Pokt20Fj4ZkJxjjDtLdcHOM4Z1JIKvOlcXMCV35iknrVu4veDHpmXolI+vAw==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
+    dependencies:
+      '@react-types/progress': 3.2.5_react@18.2.0
+      '@react-types/shared': 3.16.0_react@18.2.0
+      react: 18.2.0
+    dev: false
+
+  /@react-types/numberfield/3.3.5_react@18.2.0:
+    resolution: {integrity: sha512-qBhUSkahiIeTW5IvKvyfLtVHgzyqwKfuDIOlJQiBwgrOPR96X8KDDsOib4r5SFv0lhibv0gQ5L5ucXbmwLyQ8A==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
+    dependencies:
+      '@react-types/shared': 3.16.0_react@18.2.0
+      react: 18.2.0
+    dev: false
+
+  /@react-types/overlays/3.6.5_react@18.2.0:
+    resolution: {integrity: sha512-IeWcF+YTucCYYHagNh8fZLH6R4YUONO1VHY57WJyIHwMy0qgEaKSQCwq72VO1fQJ0ySZgOgm31FniOyKkg6+eQ==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
+    dependencies:
+      '@react-types/shared': 3.16.0_react@18.2.0
+      react: 18.2.0
+    dev: false
+
+  /@react-types/progress/3.2.5_react@18.2.0:
+    resolution: {integrity: sha512-pFSqaj6rlSdPqGHVErJ8G3RkIyYigoJ3EVozvhR9bcKkLlhnzJiFgOZl+k5u/ZKJOA+YHivIHJwg+Kl1sG0J6A==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
+    dependencies:
+      '@react-types/shared': 3.16.0_react@18.2.0
+      react: 18.2.0
+    dev: false
+
+  /@react-types/radio/3.3.1_react@18.2.0:
+    resolution: {integrity: sha512-q/x0kMvBsu6mH4bIkp/Jjrm9ff5y/p3UR0V4CmQFI7604gQd2Dt1dZMU/2HV9x70r1JfWRrDeRrVjUHVfFL5Vg==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
+    dependencies:
+      '@react-types/shared': 3.16.0_react@18.2.0
+      react: 18.2.0
+    dev: false
+
+  /@react-types/searchfield/3.3.5_react@18.2.0:
+    resolution: {integrity: sha512-g0kefTbrpqh5Cbv7skvlWfcDnopwTdoe7muHRYkuhMYbGbr8ZeUrCXpWUwVXBq8M24soLSHLuRohaEnKcwpHhw==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
+    dependencies:
+      '@react-types/shared': 3.16.0_react@18.2.0
+      '@react-types/textfield': 3.6.1_react@18.2.0
+      react: 18.2.0
+    dev: false
+
+  /@react-types/select/3.6.5_react@18.2.0:
+    resolution: {integrity: sha512-FDeSA7TYMNnhsbXREnD4dWRSu21T5M4BLy+J/5VgwDpr3IN9pzbvngK8a3jc8Yg2S3igKYLMLYfmcsx+yk7ohA==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
+    dependencies:
+      '@react-types/shared': 3.16.0_react@18.2.0
+      react: 18.2.0
+    dev: false
+
+  /@react-types/shared/3.16.0_react@18.2.0:
+    resolution: {integrity: sha512-IQgU4oAEvMwylEvaTsr2XB1G/mAoMe1JFYLD6G78v++oAR9l8o9MQxZ0YSeANDkqTamb2gKezGoT1RxvSKjVxw==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
+    dependencies:
+      react: 18.2.0
+    dev: false
+
+  /@react-types/slider/3.3.1_react@18.2.0:
+    resolution: {integrity: sha512-CbEa1v1IcUJD7VrFhWyOOlT7VyQ5DHEf/pNMkvICOBLMAwnWxS+tnTiRFgA/EbvV/vp24ydeszHYtMvsyRONRw==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
+    dependencies:
+      '@react-types/shared': 3.16.0_react@18.2.0
+      react: 18.2.0
+    dev: false
+
+  /@react-types/switch/3.2.5_react@18.2.0:
+    resolution: {integrity: sha512-DlUL0Bz79SUTRje/i8m6qn4Ipn+q8QnyIkyJhkoHeH1R0YNude8xZrBPWbj3zfdddAGDFSF1NzP69q0xmNAcTQ==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
+    dependencies:
+      '@react-types/checkbox': 3.4.1_react@18.2.0
+      '@react-types/shared': 3.16.0_react@18.2.0
+      react: 18.2.0
+    dev: false
+
+  /@react-types/table/3.3.3_react@18.2.0:
+    resolution: {integrity: sha512-rdY8PCzdqumVd6EFgN4NCoNRHdU4dVKH2oufr50TrAVPAz2KyoNXaGcDGe0q4RjQeTk+fc0sCvRZZdpMwHRVpQ==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
+    dependencies:
+      '@react-types/grid': 3.1.5_react@18.2.0
+      '@react-types/shared': 3.16.0_react@18.2.0
+      react: 18.2.0
+    dev: false
+
+  /@react-types/tabs/3.1.5_react@18.2.0:
+    resolution: {integrity: sha512-YgWY8IajCDBZmBzR3eii0aW6+SjcAT/dmqDNmfIuVVnDN7sHQ3PFa0nbmByvb0SfjOkJYumt8TJwFUCugohS8A==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
+    dependencies:
+      '@react-types/shared': 3.16.0_react@18.2.0
+      react: 18.2.0
+    dev: false
+
+  /@react-types/textfield/3.6.1_react@18.2.0:
+    resolution: {integrity: sha512-V3EyYw82GVJQbNN0OAWpOLs/UQij+AgUuJpxh8192p/q0B3/9lqepZ9b+Qts2XgMsA+3Db+KgFMWm2IdjaZbpQ==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
+    dependencies:
+      '@react-types/shared': 3.16.0_react@18.2.0
+      react: 18.2.0
+    dev: false
+
+  /@react-types/tooltip/3.2.5_react@18.2.0:
+    resolution: {integrity: sha512-D4lN32JwQuA3JbCgcI26mgCkLHIj1WE8MTzf1McaasPkx7gVaqW+wfPyFwt99/Oo52TLvA/1oin78qePP67PSw==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
+    dependencies:
+      '@react-types/overlays': 3.6.5_react@18.2.0
+      '@react-types/shared': 3.16.0_react@18.2.0
+      react: 18.2.0
     dev: false
 
   /@remix-run/router/1.0.2:
@@ -1889,6 +3141,11 @@ packages:
     engines: {node: '>=0.8'}
     dev: true
 
+  /clsx/1.2.1:
+    resolution: {integrity: sha512-EcR6r5a8bj6pu3ycsa/E/cKVGuTgZJZdsyUYHOksG/UHIiKfjxzRxYJpyVBwYaQeOvghal9fcc4PidlgzugAQg==}
+    engines: {node: '>=6'}
+    dev: false
+
   /co/4.6.0:
     resolution: {integrity: sha512-QVb0dM5HvG+uaxitm8wONl7jltx8dqhfU33DcqtOZcLSVIKSDDLDi7+0LbAKiyI8hD9u42m2YxXSkMGWThaecQ==}
     engines: {iojs: '>= 1.0.0', node: '>= 0.12.0'}
@@ -2126,8 +3383,8 @@ packages:
       webidl-conversions: 7.0.0
     dev: true
 
-  /downshift/6.1.12_react@18.2.0:
-    resolution: {integrity: sha512-7XB/iaSJVS4T8wGFT3WRXmSF1UlBHAA40DshZtkrIscIN+VC+Lh363skLxFTvJwtNgHxAMDGEHT4xsyQFWL+UA==}
+  /downshift/7.0.4_react@18.2.0:
+    resolution: {integrity: sha512-RUDh8vhgFQRfcjL0ovcN95sw+X6njzaNXi2LxIbvVfvxkxju8wwTl021DVeqZOUkf5sZuXg4m4n3Eaf3DoA88g==}
     peerDependencies:
       react: '>=16.12.0'
     dependencies:
@@ -3222,6 +4479,15 @@ packages:
       has: 1.0.3
       side-channel: 1.0.4
     dev: true
+
+  /intl-messageformat/10.2.5:
+    resolution: {integrity: sha512-AievYMN6WLLHwBeCTv4aRKG+w3ZNyZtkObwgsKk3Q7GNTq8zDRvDbJSBQkb2OPeVCcAKcIXvak9FF/bRNavoww==}
+    dependencies:
+      '@formatjs/ecma402-abstract': 1.14.3
+      '@formatjs/fast-memoize': 1.2.7
+      '@formatjs/icu-messageformat-parser': 2.1.14
+      tslib: 2.4.0
+    dev: false
 
   /is-arguments/1.1.1:
     resolution: {integrity: sha512-8Q7EARjzEnKpt/PCD7e1cgUS0a6X8u5tdSiMqXhojOdoV9TsMsiO+9VLC5vAmO8N7/GmXn7yjR8qnA6bVAEzfA==}
@@ -4686,6 +5952,50 @@ packages:
     resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
     dev: true
 
+  /react-aria/3.21.0_biqbaboplfbrettd7655fr4n2y:
+    resolution: {integrity: sha512-gPzUZ+TxY8lDN1j4K90O3SVWBF1k870NuIePjgiymQqmKTMBGvBB6AswxSgbefakQjkgg+GsyQYGhoQMTtpcMA==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
+      react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
+    dependencies:
+      '@react-aria/breadcrumbs': 3.4.0_react@18.2.0
+      '@react-aria/button': 3.6.3_react@18.2.0
+      '@react-aria/calendar': 3.0.4_biqbaboplfbrettd7655fr4n2y
+      '@react-aria/checkbox': 3.7.0_react@18.2.0
+      '@react-aria/combobox': 3.4.3_biqbaboplfbrettd7655fr4n2y
+      '@react-aria/datepicker': 3.2.0_biqbaboplfbrettd7655fr4n2y
+      '@react-aria/dialog': 3.4.1_biqbaboplfbrettd7655fr4n2y
+      '@react-aria/dnd': 3.0.0_biqbaboplfbrettd7655fr4n2y
+      '@react-aria/focus': 3.10.0_react@18.2.0
+      '@react-aria/gridlist': 3.1.1_biqbaboplfbrettd7655fr4n2y
+      '@react-aria/i18n': 3.6.2_react@18.2.0
+      '@react-aria/interactions': 3.13.0_react@18.2.0
+      '@react-aria/label': 3.4.3_react@18.2.0
+      '@react-aria/link': 3.3.5_react@18.2.0
+      '@react-aria/listbox': 3.7.1_react@18.2.0
+      '@react-aria/menu': 3.7.0_biqbaboplfbrettd7655fr4n2y
+      '@react-aria/meter': 3.3.3_react@18.2.0
+      '@react-aria/numberfield': 3.3.3_biqbaboplfbrettd7655fr4n2y
+      '@react-aria/overlays': 3.12.0_biqbaboplfbrettd7655fr4n2y
+      '@react-aria/progress': 3.3.3_react@18.2.0
+      '@react-aria/radio': 3.4.1_react@18.2.0
+      '@react-aria/searchfield': 3.4.3_react@18.2.0
+      '@react-aria/select': 3.8.3_biqbaboplfbrettd7655fr4n2y
+      '@react-aria/selection': 3.12.0_react@18.2.0
+      '@react-aria/separator': 3.2.5_react@18.2.0
+      '@react-aria/slider': 3.2.3_react@18.2.0
+      '@react-aria/ssr': 3.4.0_react@18.2.0
+      '@react-aria/switch': 3.3.0_react@18.2.0
+      '@react-aria/table': 3.6.0_biqbaboplfbrettd7655fr4n2y
+      '@react-aria/tabs': 3.3.3_react@18.2.0
+      '@react-aria/textfield': 3.8.0_react@18.2.0
+      '@react-aria/tooltip': 3.3.3_react@18.2.0
+      '@react-aria/utils': 3.14.1_react@18.2.0
+      '@react-aria/visually-hidden': 3.6.0_react@18.2.0
+      react: 18.2.0
+      react-dom: 18.2.0_react@18.2.0
+    dev: false
+
   /react-dom/18.2.0_react@18.2.0:
     resolution: {integrity: sha512-6IMTriUmvsjHUjNtEDudZfuDQUoWXVxKHhlEGSk81n4YFS+r/Kl99wXiwlVXtPBtJenozv2P+hxDsw9eA7Xo6g==}
     peerDependencies:
@@ -4779,6 +6089,36 @@ packages:
       react: 18.2.0
       react-is: 18.2.0
     dev: true
+
+  /react-stately/3.19.0_react@18.2.0:
+    resolution: {integrity: sha512-jatLPljb5uGxAqMqK3VfVyjYh39itJBcTDPpxQGPLvfiMF6bmxcCtVt7058CSOG+DtWR/fSu+lKB/A0obxWPlg==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
+    dependencies:
+      '@react-stately/calendar': 3.0.4_react@18.2.0
+      '@react-stately/checkbox': 3.3.1_react@18.2.0
+      '@react-stately/collections': 3.5.0_react@18.2.0
+      '@react-stately/combobox': 3.3.0_react@18.2.0
+      '@react-stately/data': 3.8.0_react@18.2.0
+      '@react-stately/datepicker': 3.2.0_react@18.2.0
+      '@react-stately/dnd': 3.0.0_react@18.2.0
+      '@react-stately/list': 3.6.0_react@18.2.0
+      '@react-stately/menu': 3.4.3_react@18.2.0
+      '@react-stately/numberfield': 3.3.0_react@18.2.0
+      '@react-stately/overlays': 3.4.3_react@18.2.0
+      '@react-stately/radio': 3.6.1_react@18.2.0
+      '@react-stately/searchfield': 3.3.3_react@18.2.0
+      '@react-stately/select': 3.3.3_react@18.2.0
+      '@react-stately/selection': 3.11.1_react@18.2.0
+      '@react-stately/slider': 3.2.3_react@18.2.0
+      '@react-stately/table': 3.6.0_react@18.2.0
+      '@react-stately/tabs': 3.2.3_react@18.2.0
+      '@react-stately/toggle': 3.4.3_react@18.2.0
+      '@react-stately/tooltip': 3.2.3_react@18.2.0
+      '@react-stately/tree': 3.4.0_react@18.2.0
+      '@react-types/shared': 3.16.0_react@18.2.0
+      react: 18.2.0
+    dev: false
 
   /react-test-renderer/18.2.0_react@18.2.0:
     resolution: {integrity: sha512-JWD+aQ0lh2gvh4NM3bBM42Kx+XybOxCpgYK7F8ugAlpaTSnWsX+39Z4XkOykGZAHrjwwTZT3x3KxswVWxHPUqA==}

--- a/coral/src/app/components/AuthenticationRequiredBoundary.tsx
+++ b/coral/src/app/components/AuthenticationRequiredBoundary.tsx
@@ -1,4 +1,4 @@
-import { Flexbox, Typography } from "@aivenio/design-system";
+import { Flexbox, Typography } from "@aivenio/aquarium";
 import { Component, ReactElement } from "react";
 import { isUnauthorizedError } from "src/services/api";
 

--- a/coral/src/app/components/Form.test.tsx
+++ b/coral/src/app/components/Form.test.tsx
@@ -1,4 +1,4 @@
-import { Button } from "@aivenio/design-system";
+import { Button } from "@aivenio/aquarium";
 import type { RenderResult } from "@testing-library/react";
 import { cleanup, render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";

--- a/coral/src/app/components/Form.tsx
+++ b/coral/src/app/components/Form.tsx
@@ -3,7 +3,7 @@ import {
   Input as BaseInput,
   InputProps as BaseInputProps,
   Option,
-} from "@aivenio/design-system";
+} from "@aivenio/aquarium";
 import { zodResolver } from "@hookform/resolvers/zod";
 import React, { memo } from "react";
 import {

--- a/coral/src/app/components/Pagination.test.tsx
+++ b/coral/src/app/components/Pagination.test.tsx
@@ -5,10 +5,10 @@ import userEvent from "@testing-library/user-event";
 const mockIconRender = jest.fn();
 // mocks out Icon component to avoid clutter
 // Icon is used purely decoratively
-jest.mock("@aivenio/design-system", () => {
+jest.mock("@aivenio/aquarium", () => {
   return {
     __esModule: true,
-    ...jest.requireActual("@aivenio/design-system"),
+    ...jest.requireActual("@aivenio/aquarium"),
     Icon: () => mockIconRender(),
   };
 });

--- a/coral/src/app/components/Pagination.tsx
+++ b/coral/src/app/components/Pagination.tsx
@@ -1,8 +1,8 @@
-import { Flexbox, GhostButton, Icon } from "@aivenio/design-system";
-import chevronBackward from "@aivenio/design-system/dist/src/icons/chevronBackward";
-import chevronLeft from "@aivenio/design-system/dist/src/icons/chevronLeft";
-import chevronRight from "@aivenio/design-system/dist/src/icons/chevronRight";
-import chevronForward from "@aivenio/design-system/dist/src/icons/chevronForward";
+import { Flexbox, GhostButton, Icon } from "@aivenio/aquarium";
+import chevronBackward from "@aivenio/aquarium/dist/src/icons/chevronBackward";
+import chevronLeft from "@aivenio/aquarium/dist/src/icons/chevronLeft";
+import chevronRight from "@aivenio/aquarium/dist/src/icons/chevronRight";
+import chevronForward from "@aivenio/aquarium/dist/src/icons/chevronForward";
 
 type PaginationProps = {
   activePage: number;

--- a/coral/src/app/components/PreviewBanner.tsx
+++ b/coral/src/app/components/PreviewBanner.tsx
@@ -1,5 +1,5 @@
-import { Box, Flexbox, Icon, Typography } from "@aivenio/design-system";
-import infoSign from "@aivenio/design-system/dist/module/icons/infoSign";
+import { Box, Flexbox, Icon, Typography } from "@aivenio/aquarium";
+import infoSign from "@aivenio/aquarium/dist/module/icons/infoSign";
 
 function Link({
   text,

--- a/coral/src/app/features/browse-topics/BrowseTopics.test.tsx
+++ b/coral/src/app/features/browse-topics/BrowseTopics.test.tsx
@@ -17,10 +17,10 @@ import { mockIntersectionObserver } from "src/services/test-utils/mock-intersect
 import { customRender } from "src/services/test-utils/render-with-wrappers";
 import { tabNavigateTo } from "src/services/test-utils/tabbing";
 
-jest.mock("@aivenio/design-system", () => {
+jest.mock("@aivenio/aquarium", () => {
   return {
     __esModule: true,
-    ...jest.requireActual("@aivenio/design-system"),
+    ...jest.requireActual("@aivenio/aquarium"),
     Icon: jest.fn(),
   };
 });

--- a/coral/src/app/features/browse-topics/BrowseTopics.tsx
+++ b/coral/src/app/features/browse-topics/BrowseTopics.tsx
@@ -3,7 +3,7 @@ import { Pagination } from "src/app/components/Pagination";
 import SelectTeam from "src/app/features/browse-topics/components/select-team/SelectTeam";
 import TopicTable from "src/app/features/browse-topics/components/topic-table/TopicTable";
 import { useState } from "react";
-import { Flexbox, FlexboxItem } from "@aivenio/design-system";
+import { Flexbox, FlexboxItem } from "@aivenio/aquarium";
 import { useSearchParams } from "react-router-dom";
 import SelectEnvironment from "src/app/features/browse-topics/components/select-environment/SelectEnvironment";
 import { SearchTopics } from "src/app/features/browse-topics/components/search/SearchTopics";

--- a/coral/src/app/features/browse-topics/components/search/SearchTopics.tsx
+++ b/coral/src/app/features/browse-topics/components/search/SearchTopics.tsx
@@ -1,6 +1,6 @@
-import { Grid, Icon, InputBase, PrimaryButton } from "@aivenio/design-system";
+import { Grid, Icon, InputBase, PrimaryButton } from "@aivenio/aquarium";
 import { FormEvent, useState } from "react";
-import searchItem from "@aivenio/design-system/dist/module/icons/search";
+import searchItem from "@aivenio/aquarium/dist/module/icons/search";
 
 type SearchTopicsProps = {
   value: string;

--- a/coral/src/app/features/browse-topics/components/select-environment/SelectEnvironment.tsx
+++ b/coral/src/app/features/browse-topics/components/select-environment/SelectEnvironment.tsx
@@ -1,4 +1,4 @@
-import { NativeSelect, Option } from "@aivenio/design-system";
+import { NativeSelect, Option } from "@aivenio/aquarium";
 import { useEffect, useState } from "react";
 import { ALL_ENVIRONMENTS_VALUE, Environment } from "src/domain/environment";
 import { useSearchParams } from "react-router-dom";

--- a/coral/src/app/features/browse-topics/components/select-team/SelectTeam.tsx
+++ b/coral/src/app/features/browse-topics/components/select-team/SelectTeam.tsx
@@ -1,4 +1,4 @@
-import { NativeSelect, Option } from "@aivenio/design-system";
+import { NativeSelect, Option } from "@aivenio/aquarium";
 import { useEffect, useState } from "react";
 import { useGetTeams } from "src/app/features/browse-topics/hooks/teams/useGetTeams";
 import { Team, TEAM_NOT_INITIALIZED } from "src/domain/team";

--- a/coral/src/app/features/browse-topics/components/topic-table/TopicTable.tsx
+++ b/coral/src/app/features/browse-topics/components/topic-table/TopicTable.tsx
@@ -1,4 +1,4 @@
-import { Chip, Flexbox, Table } from "@aivenio/design-system";
+import { Chip, Flexbox, Table } from "@aivenio/aquarium";
 import { Topic } from "src/domain/topic";
 import classes from "src/app/features/browse-topics/components/topic-table/TopicTable.module.css";
 

--- a/coral/src/app/features/login/components/LoginForm.tsx
+++ b/coral/src/app/features/login/components/LoginForm.tsx
@@ -7,7 +7,7 @@ import {
   useForm,
 } from "src/app/components/Form";
 import { FieldErrors } from "react-hook-form";
-import { Flexbox, FlexboxItem } from "@aivenio/design-system";
+import { Flexbox, FlexboxItem } from "@aivenio/aquarium";
 import { useLoginUser } from "src/app/features/login/hooks/useLoginUser";
 import { useEffect } from "react";
 

--- a/coral/src/app/layout/Layout.test.tsx
+++ b/coral/src/app/layout/Layout.test.tsx
@@ -2,10 +2,10 @@ import Layout from "src/app/layout/Layout";
 import { cleanup, screen, render, within } from "@testing-library/react";
 
 // mock out svgs to avoid clutter
-jest.mock("@aivenio/design-system", () => {
+jest.mock("@aivenio/aquarium", () => {
   return {
     __esModule: true,
-    ...jest.requireActual("@aivenio/design-system"),
+    ...jest.requireActual("@aivenio/aquarium"),
     Icon: () => null,
   };
 });

--- a/coral/src/app/layout/Layout.tsx
+++ b/coral/src/app/layout/Layout.tsx
@@ -1,4 +1,4 @@
-import { Box, Flexbox, Grid, GridItem } from "@aivenio/design-system";
+import { Box, Flexbox, Grid, GridItem } from "@aivenio/aquarium";
 import MainNavigation from "src/app/layout/main-navigation/MainNavigation";
 import Header from "src/app/layout/header/Header";
 import SkipLink from "src/app/layout/skip-link/SkipLink";

--- a/coral/src/app/layout/header/Header.test.tsx
+++ b/coral/src/app/layout/header/Header.test.tsx
@@ -6,10 +6,10 @@ import {
 } from "src/services/test-utils/tabbing";
 
 // mock out svgs to avoid clutter
-jest.mock("@aivenio/design-system", () => {
+jest.mock("@aivenio/aquarium", () => {
   return {
     __esModule: true,
-    ...jest.requireActual("@aivenio/design-system"),
+    ...jest.requireActual("@aivenio/aquarium"),
 
     Icon: () => {
       return <div data-testid={"ds-icon"}></div>;

--- a/coral/src/app/layout/header/Header.tsx
+++ b/coral/src/app/layout/header/Header.tsx
@@ -22,7 +22,6 @@ function Header() {
       </a>
       <nav aria-label={"Quick links"}>
         <Flexbox htmlTag={"ul"} colGap={"l2"}>
-          {/*@TODO add correct link*/}
           <li>
             <HeaderMenuLink
               icon={notifications}
@@ -38,7 +37,6 @@ function Header() {
               rel={"noreferrer"}
             />
           </li>
-          {/*@TODO add correct link*/}
           <li>
             <HeaderMenuLink
               icon={user}

--- a/coral/src/app/layout/header/Header.tsx
+++ b/coral/src/app/layout/header/Header.tsx
@@ -1,7 +1,7 @@
-import { Flexbox } from "@aivenio/design-system";
-import questionMark from "@aivenio/design-system/dist/module/icons/questionMark";
-import user from "@aivenio/design-system/dist/module/icons/user";
-import notifications from "@aivenio/design-system/dist/module/icons/notifications";
+import { Flexbox } from "@aivenio/aquarium";
+import questionMark from "@aivenio/aquarium/dist/module/icons/questionMark";
+import user from "@aivenio/aquarium/dist/module/icons/user";
+import notifications from "@aivenio/aquarium/dist/module/icons/notifications";
 import HeaderMenuLink from "src/app/layout/header/HeaderMenuLink";
 import logo from "src/app/layout/header/klaw_logo.png";
 

--- a/coral/src/app/layout/header/HeaderMenuLink.test.tsx
+++ b/coral/src/app/layout/header/HeaderMenuLink.test.tsx
@@ -60,36 +60,40 @@ describe("HeaderMenuLink.tsx", () => {
       const navLink = screen.getByRole("link", {
         name: linkText,
       });
-      const queryForToolTip = () => screen.queryByRole("tooltip");
+      const tooltipBeforeHover = screen.queryByRole("tooltip");
 
-      expect(queryForToolTip()).toBeNull();
+      expect(tooltipBeforeHover).toBeNull();
 
       await userEvent.hover(navLink);
 
-      expect(queryForToolTip()).toBeVisible();
-      expect(queryForToolTip()).toHaveTextContent(linkText);
+      const tooltipAfterHover = screen.getByRole("tooltip");
+
+      expect(tooltipAfterHover).toBeVisible();
+      expect(tooltipAfterHover).toHaveTextContent(linkText);
 
       // Assert the tooltip disappears after hover event stops
       await userEvent.unhover(navLink);
-      expect(queryForToolTip()).toBeNull();
+      expect(tooltipBeforeHover).toBeNull();
     });
 
     it(`triggers the rendering of a Tooltip on tab navigation`, async () => {
       const navLink = screen.getByRole("link", {
         name: linkText,
       });
-      const queryForToolTip = () => screen.queryByRole("tooltip");
+      const tooltipBeforeFocus = screen.queryByRole("tooltip");
 
-      expect(queryForToolTip()).toBeNull();
+      expect(tooltipBeforeFocus).toBeNull();
 
       await tabNavigateTo({ targetElement: navLink });
 
-      expect(queryForToolTip()).toBeVisible();
-      expect(queryForToolTip()).toHaveTextContent(linkText);
+      const tooltipAfterFocus = screen.getByRole("tooltip");
+
+      expect(tooltipAfterFocus).toBeVisible();
+      expect(tooltipAfterFocus).toHaveTextContent(linkText);
 
       // Assert the tooltip disappears after losing focus
       await userEvent.tab();
-      expect(queryForToolTip()).toBeNull();
+      expect(tooltipBeforeFocus).toBeNull();
     });
 
     it(`renders a hidden child with the tooltip text for assistive technology`, async () => {

--- a/coral/src/app/layout/header/HeaderMenuLink.test.tsx
+++ b/coral/src/app/layout/header/HeaderMenuLink.test.tsx
@@ -70,7 +70,7 @@ describe("HeaderMenuLink.tsx", () => {
       expect(queryForToolTip()).toHaveTextContent(linkText);
 
       // Assert the tooltip disappears after hover event stops
-      cleanup();
+      await userEvent.unhover(navLink);
       expect(queryForToolTip()).toBeNull();
     });
 
@@ -88,7 +88,7 @@ describe("HeaderMenuLink.tsx", () => {
       expect(queryForToolTip()).toHaveTextContent(linkText);
 
       // Assert the tooltip disappears after losing focus
-      cleanup();
+      await userEvent.tab();
       expect(queryForToolTip()).toBeNull();
     });
 

--- a/coral/src/app/layout/header/HeaderMenuLink.tsx
+++ b/coral/src/app/layout/header/HeaderMenuLink.tsx
@@ -39,10 +39,16 @@ function HeaderMenuLink(props: HeaderMenuLinkProps) {
         content={linkText}
         placement="right"
         isOpen={isOpen}
+        id={href}
       >
         {/*@TODO add correct link*/}
         {/* aria-hidden="true" is added natively to the Icon component */}
-        <Icon icon={icon} fontSize={"20px"} color={"grey-0"} />
+        <Icon
+          icon={icon}
+          fontSize={"20px"}
+          color={"grey-0"}
+          aria-describedby={href}
+        />
       </Tooltip>
     </a>
   );

--- a/coral/src/app/layout/header/HeaderMenuLink.tsx
+++ b/coral/src/app/layout/header/HeaderMenuLink.tsx
@@ -40,7 +40,6 @@ function HeaderMenuLink(props: HeaderMenuLinkProps) {
         placement="right"
         isOpen={isOpen}
       >
-        {/*@TODO add correct link*/}
         {/* aria-hidden="true" is added natively to the Icon component */}
         <Icon icon={icon} fontSize={"20px"} color={"grey-0"} />
       </Tooltip>

--- a/coral/src/app/layout/header/HeaderMenuLink.tsx
+++ b/coral/src/app/layout/header/HeaderMenuLink.tsx
@@ -1,5 +1,6 @@
-import { Icon, Tooltip } from "@aivenio/design-system";
-import data from "@aivenio/design-system/dist/src/icons/console";
+import { Icon, Tooltip } from "@aivenio/aquarium";
+import data from "@aivenio/aquarium/dist/src/icons/console";
+import { useState } from "react";
 
 type HeaderMenuLinkProps = {
   icon: typeof data;
@@ -9,19 +10,40 @@ type HeaderMenuLinkProps = {
 };
 function HeaderMenuLink(props: HeaderMenuLinkProps) {
   const { icon, linkText, href, rel } = props;
+
+  const [isOpen, setIsOpen] = useState(false);
+  const toggleOpen = () => setIsOpen(!isOpen);
+
   return (
-    <a href={href} rel={rel} style={{ color: "white" }}>
+    <a
+      href={href}
+      rel={rel}
+      // These mouse events are necessary because the Tooltip component does not show the popover on hover with React version >= 18
+      // @TODO: remove when aquarium is compatible with React version >= 18
+      onMouseEnter={toggleOpen}
+      onMouseLeave={toggleOpen}
+      // Allow displaying the tooltip when navigating with keyboard
+      // Because the Tooltip is rendered outside of the main DOM hierarchy, it is ignored by screen readers
+      // So we can display it with keyboard navigation for users who use keyboard navigation, but not a screen reader
+      onFocus={toggleOpen}
+      onBlur={toggleOpen}
+    >
       <span className={"visually-hidden"}>{linkText}</span>
-      <span aria-hidden={"true"}>
-        {/*DS does not fully support React18 now, where children */}
-        {/*is not a default prop for FC*/}
-        {/* eslint-disable-next-line @typescript-eslint/ban-ts-comment */}
-        {/*@ts-ignore*/}
-        <Tooltip content={linkText} placement="right">
-          {/*@TODO add correct link*/}
-          <Icon aria-hidden="true" icon={icon} fontSize={"20px"} />
-        </Tooltip>
-      </span>
+      {/*Aquarium does not fully support React 18 now, where children */}
+      {/*is not a default prop for FC*/}
+      {/* eslint-disable-next-line @typescript-eslint/ban-ts-comment */}
+      {/*@ts-ignore*/}
+      <Tooltip
+        // aria-hidden is currently not forwarded, but it is added for semantics purposes
+        aria-hidden="true"
+        content={linkText}
+        placement="right"
+        isOpen={isOpen}
+      >
+        {/*@TODO add correct link*/}
+        {/* aria-hidden="true" is added natively to the Icon component */}
+        <Icon icon={icon} fontSize={"20px"} color={"grey-0"} />
+      </Tooltip>
     </a>
   );
 }

--- a/coral/src/app/layout/header/HeaderMenuLink.tsx
+++ b/coral/src/app/layout/header/HeaderMenuLink.tsx
@@ -39,16 +39,10 @@ function HeaderMenuLink(props: HeaderMenuLinkProps) {
         content={linkText}
         placement="right"
         isOpen={isOpen}
-        id={href}
       >
         {/*@TODO add correct link*/}
         {/* aria-hidden="true" is added natively to the Icon component */}
-        <Icon
-          icon={icon}
-          fontSize={"20px"}
-          color={"grey-0"}
-          aria-describedby={href}
-        />
+        <Icon icon={icon} fontSize={"20px"} color={"grey-0"} />
       </Tooltip>
     </a>
   );

--- a/coral/src/app/layout/main-navigation/MainNavigation.test.tsx
+++ b/coral/src/app/layout/main-navigation/MainNavigation.test.tsx
@@ -7,10 +7,10 @@ import {
 } from "src/services/test-utils/tabbing";
 
 // mock out svgs to avoid clutter
-jest.mock("@aivenio/design-system", () => {
+jest.mock("@aivenio/aquarium", () => {
   return {
     __esModule: true,
-    ...jest.requireActual("@aivenio/design-system"),
+    ...jest.requireActual("@aivenio/aquarium"),
 
     Icon: () => {
       return <div data-testid={"ds-icon"}></div>;

--- a/coral/src/app/layout/main-navigation/MainNavigation.tsx
+++ b/coral/src/app/layout/main-navigation/MainNavigation.tsx
@@ -1,10 +1,10 @@
-import { Box } from "@aivenio/design-system";
-import database from "@aivenio/design-system/dist/src/icons/database";
-import codeBlock from "@aivenio/design-system/dist/src/icons/codeBlock";
-import layoutGroupBy from "@aivenio/design-system/dist/src/icons/layoutGroupBy";
-import people from "@aivenio/design-system/dist/src/icons/people";
-import list from "@aivenio/design-system/dist/src/icons/list";
-import cog from "@aivenio/design-system/dist/src/icons/cog";
+import { Box } from "@aivenio/aquarium";
+import database from "@aivenio/aquarium/dist/src/icons/database";
+import codeBlock from "@aivenio/aquarium/dist/src/icons/codeBlock";
+import layoutGroupBy from "@aivenio/aquarium/dist/src/icons/layoutGroupBy";
+import people from "@aivenio/aquarium/dist/src/icons/people";
+import list from "@aivenio/aquarium/dist/src/icons/list";
+import cog from "@aivenio/aquarium/dist/src/icons/cog";
 import MainNavigationLink from "src/app/layout/main-navigation/MainNavigationLink";
 import MainNavigationSubmenuList from "src/app/layout/main-navigation/MainNavigationSubmenuList";
 

--- a/coral/src/app/layout/main-navigation/MainNavigationLink.test.tsx
+++ b/coral/src/app/layout/main-navigation/MainNavigationLink.test.tsx
@@ -1,12 +1,12 @@
 import MainNavigationLink from "src/app/layout/main-navigation/MainNavigationLink";
 import { cleanup, screen, render } from "@testing-library/react";
-import data from "@aivenio/design-system/dist/src/icons/console";
+import data from "@aivenio/aquarium/dist/src/icons/console";
 
 // mock out svgs to avoid clutter
-jest.mock("@aivenio/design-system", () => {
+jest.mock("@aivenio/aquarium", () => {
   return {
     __esModule: true,
-    ...jest.requireActual("@aivenio/design-system"),
+    ...jest.requireActual("@aivenio/aquarium"),
 
     Icon: () => {
       return <div data-testid={"ds-icon"}></div>;

--- a/coral/src/app/layout/main-navigation/MainNavigationLink.tsx
+++ b/coral/src/app/layout/main-navigation/MainNavigationLink.tsx
@@ -1,5 +1,5 @@
-import { Box, Flexbox, Icon } from "@aivenio/design-system";
-import data from "@aivenio/design-system/dist/src/icons/console";
+import { Box, Flexbox, Icon } from "@aivenio/aquarium";
+import data from "@aivenio/aquarium/dist/src/icons/console";
 import classes from "src/app/layout/main-navigation/MainNavigationLink.module.css";
 
 type MainNavigationLinkProps = {

--- a/coral/src/app/layout/main-navigation/MainNavigationSubmenuList.test.tsx
+++ b/coral/src/app/layout/main-navigation/MainNavigationSubmenuList.test.tsx
@@ -1,13 +1,13 @@
 import MainNavigationSubmenuList from "src/app/layout/main-navigation/MainNavigationSubmenuList";
 import { cleanup, screen, render, within } from "@testing-library/react";
-import data from "@aivenio/design-system/dist/src/icons/console";
+import data from "@aivenio/aquarium/dist/src/icons/console";
 import userEvent from "@testing-library/user-event";
 
 // mock out svgs to avoid clutter
-jest.mock("@aivenio/design-system", () => {
+jest.mock("@aivenio/aquarium", () => {
   return {
     __esModule: true,
-    ...jest.requireActual("@aivenio/design-system"),
+    ...jest.requireActual("@aivenio/aquarium"),
 
     Icon: () => {
       return <div data-testid={"ds-icon"}></div>;

--- a/coral/src/app/layout/main-navigation/MainNavigationSubmenuList.tsx
+++ b/coral/src/app/layout/main-navigation/MainNavigationSubmenuList.tsx
@@ -1,9 +1,9 @@
-import { Box, Flexbox, Icon } from "@aivenio/design-system";
-import data from "@aivenio/design-system/dist/src/icons/console";
+import { Box, Flexbox, Icon } from "@aivenio/aquarium";
+import data from "@aivenio/aquarium/dist/src/icons/console";
 import classes from "src/app/layout/main-navigation/MainNavigationSubmenuList.module.css";
 import { ReactElement, useState } from "react";
-import caretDown from "@aivenio/design-system/dist/src/icons/caretDown";
-import caretUp from "@aivenio/design-system/dist/src/icons/caretUp";
+import caretDown from "@aivenio/aquarium/dist/src/icons/caretDown";
+import caretUp from "@aivenio/aquarium/dist/src/icons/caretUp";
 import MainNavigationLink from "src/app/layout/main-navigation/MainNavigationLink";
 
 type MainNavigationSubmenuItemProps = {

--- a/coral/src/app/main.tsx
+++ b/coral/src/app/main.tsx
@@ -1,13 +1,14 @@
+import { Context as AquariumContext } from "@aivenio/aquarium";
+import "@aivenio/aquarium/dist/styles.css";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { ReactQueryDevtools } from "@tanstack/react-query-devtools";
 import React from "react";
 import { createRoot } from "react-dom/client";
 import { RouterProvider } from "react-router-dom";
 import router from "src/app/router";
-import "@aivenio/design-system/dist/styles.css";
-import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { ReactQueryDevtools } from "@tanstack/react-query-devtools";
 import { isUnauthorizedError } from "src/services/api";
-import "/src/app/main.module.css";
 import "/src/app/accessibility.module.css";
+import "/src/app/main.module.css";
 
 const DEV_MODE = import.meta.env.DEV;
 
@@ -43,8 +44,10 @@ prepare().then(() => {
   root.render(
     <React.StrictMode>
       <QueryClientProvider client={queryClient}>
-        <RouterProvider router={router} />
-        {DEV_MODE && <ReactQueryDevtools />}
+        <AquariumContext>
+          <RouterProvider router={router} />
+          {DEV_MODE && <ReactQueryDevtools />}
+        </AquariumContext>
       </QueryClientProvider>
     </React.StrictMode>
   );

--- a/coral/src/app/pages/index.tsx
+++ b/coral/src/app/pages/index.tsx
@@ -1,5 +1,5 @@
 import Layout from "src/app/layout/Layout";
-import { PageHeader } from "@aivenio/design-system";
+import { PageHeader } from "@aivenio/aquarium";
 
 const HomePage = () => {
   return (

--- a/coral/src/app/pages/topics/index.tsx
+++ b/coral/src/app/pages/topics/index.tsx
@@ -1,5 +1,5 @@
-import { PageHeader } from "@aivenio/design-system";
-import add from "@aivenio/design-system/dist/src/icons/add";
+import { PageHeader } from "@aivenio/aquarium";
+import add from "@aivenio/aquarium/dist/src/icons/add";
 import AuthenticationRequiredBoundary from "src/app/components/AuthenticationRequiredBoundary";
 import PreviewBanner from "src/app/components/PreviewBanner";
 import BrowseTopics from "src/app/features/browse-topics/BrowseTopics";

--- a/coral/vite.config.ts
+++ b/coral/vite.config.ts
@@ -113,7 +113,7 @@ export default defineConfig(({ mode }) => {
     plugins: [react()],
     define: {
       // Vite does not use process.env (see https://vitejs.dev/guide/env-and-mode.html).
-      // If a library depends on process.env (like "@aivenio/design-system").
+      // If a library depends on process.env (like "@aivenio/aquarium").
       // ⛔ Note: there are stackoverflow answers / github issues that recommend e.g
       // ⛔ 'process.env': process.env or
       // ⛔ 'process.env': { ...process.env}


### PR DESCRIPTION
# About this change - What it does

The design system has been published on NPM (https://www.npmjs.com/package/@aivenio/aquarium). This PR migrates the dependency `@aivenio/design-system` to be `@aivenio/aquarium`

Mostly seamless,  excepting the case of `Tooltip`: it does not trigger on hover when the React version is >= 18. A follow-up with the DS team is needed. 

Other issues arose with the `Tooltip` component, mostly revolving around the fact that it is no longer rendered inline in the DOM, but appended to `body`.  The following changes were applied to `HeaderMenuLink` (the only component currently using `Tooltip`):
- control the open state of `Tooltip` through `isOpen` prop and local state.
- remove `<span aria-hidden={"true"}>` wrapping `Tooltip` , as screen readers now seem to exclude the `Tooltip` even without it.
- add `aria-hidden="true"` to `Tooltip` as an added security, even if the attribute seems to not be forwarded to the DOM element. A follow-up with the DS team will be made
- add a11y functionality to display the tooltip on tab navigation, for users navigating with keyboard, but who are not visually impaired (and therefore were not at information parity with mouse users)
- refactor the tests to reflect the new state of `HeaderMenuLink`

https://user-images.githubusercontent.com/20607294/207612546-2a73733a-4077-437d-b990-b552a5a60e16.mov



https://user-images.githubusercontent.com/20607294/207612466-5b8209a9-a04a-4b3b-96ef-71e4618ec135.mov



