### PR TITLE
Use LTS NodeJS 18.12.1

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -28,7 +28,7 @@
         <h2.version>2.1.214</h2.version>
         <jasyptencrypt.version>3.0.4</jasyptencrypt.version>
         <netty-all.version>4.1.80.Final</netty-all.version>
-        <node.version>v18.11.0</node.version>
+        <node.version>v18.12.1</node.version>
         <npm.version>8.19.2</npm.version>
         <pnpm.version>7.14.0</pnpm.version>
         <snakeyaml.version>1.33</snakeyaml.version>


### PR DESCRIPTION
About this change - What it does
Current NodeJS version is `18.11.0` which is not LTS.
The first 18.x LTS is `18.12.0` more details are here https://github.com/nodejs/node/blob/main/doc/changelogs/CHANGELOG_V18.md#2022-10-25-version-18120-hydrogen-lts-ruyadorno-and-rafaelgss

Also `18.12.1` is a security release including some security fixes (a list is available at https://github.com/nodejs/node/blob/main/doc/changelogs/CHANGELOG_V18.md#2022-11-03-version-18121-hydrogen-lts-juanarbol)

