### PR TITLE
Union exec maven plugin executions

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -143,23 +143,6 @@
 
     <build>
         <plugins>
-            <plugin>
-                <groupId>org.codehaus.mojo</groupId>
-                <artifactId>exec-maven-plugin</artifactId>
-                <version>${exec-maven-plugin.version}</version>
-                <executions>
-                    <execution>
-                        <id>uglifyjs-files</id>
-                        <goals>
-                            <goal>java</goal>
-                        </goals>
-                        <phase>test</phase>
-                        <configuration>
-                            <mainClass>io.aiven.klaw.uglify.UglifyFiles</mainClass>
-                        </configuration>
-                    </execution>
-                </executions>
-            </plugin>
             <!-- Install node and npm for React components -->
             <plugin>
                 <groupId>com.github.eirslett</groupId>
@@ -188,6 +171,16 @@
                 <artifactId>exec-maven-plugin</artifactId>
                 <version>${exec-maven-plugin.version}</version>
                 <executions>
+                    <execution>
+                        <id>uglifyjs-files</id>
+                        <goals>
+                            <goal>java</goal>
+                        </goals>
+                        <phase>test</phase>
+                        <configuration>
+                            <mainClass>io.aiven.klaw.uglify.UglifyFiles</mainClass>
+                        </configuration>
+                    </execution>
                     <!-- Install pnpm for React components -->
                     <execution>
                         <id>Install pnpm</id>


### PR DESCRIPTION
About this change - What it does
Currently maven complains like
```
[WARNING] 
[WARNING] Some problems were encountered while building the effective model for io.aiven:klaw:jar:1.2.0
[WARNING] 'build.plugins.plugin.(groupId:artifactId)' must be unique but found duplicate declaration of plugin org.codehaus.mojo:exec-maven-plugin @ line 186, column 21
[WARNING] 
[WARNING] It is highly recommended to fix these problems because they threaten the stability of your build.
[WARNING] 
[WARNING] For this reason, future Maven versions might no longer support building such malformed projects.
[WARNING] 

```
The reason is that `exec-maven-plugin` declared several times.
It should be declared once and union all the execution
