### PR TITLE
Bug fix for topic search, support for multiple SR, connect clusters

### DIFF
--- a/cluster-api/src/main/java/io/aiven/klaw/clusterapi/config/SslContextConfig.java
+++ b/cluster-api/src/main/java/io/aiven/klaw/clusterapi/config/SslContextConfig.java
@@ -7,13 +7,13 @@ import java.nio.file.Files;
 import java.security.*;
 import java.security.cert.CertificateException;
 import java.security.cert.X509Certificate;
-import javax.annotation.PostConstruct;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.http.conn.ssl.NoopHostnameVerifier;
 import org.apache.http.conn.ssl.SSLConnectionSocketFactory;
 import org.apache.http.conn.ssl.TrustStrategy;
 import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.HttpClients;
+import org.springframework.beans.factory.InitializingBean;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.client.HttpComponentsClientHttpRequestFactory;
@@ -21,9 +21,9 @@ import org.springframework.util.ResourceUtils;
 
 @Configuration
 @Slf4j
-public class SslContextConfig {
+public class SslContextConfig implements InitializingBean {
 
-  public static HttpComponentsClientHttpRequestFactory requestFactory;
+  private HttpComponentsClientHttpRequestFactory requestFactory;
 
   @Value("${server.ssl.trust-store:null}")
   private String trustStore;
@@ -40,8 +40,11 @@ public class SslContextConfig {
   @Value("${server.ssl.key-store-type:JKS}")
   private String keyStoreType;
 
-  @PostConstruct
-  public void setKwSSLContext() throws Exception {
+  public HttpComponentsClientHttpRequestFactory getClientHttpRequestFactory() {
+    return requestFactory;
+  }
+
+  private void setKwSSLContext() throws Exception {
     if (keyStore != null && !keyStore.equals("null")) {
       TrustStrategy acceptingTrustStrategy = (X509Certificate[] chain, String authType) -> true;
       javax.net.ssl.SSLContext sslContext;
@@ -80,5 +83,10 @@ public class SslContextConfig {
       store.load(inputStream, secret.toCharArray());
     }
     return store;
+  }
+
+  @Override
+  public void afterPropertiesSet() throws Exception {
+    setKwSSLContext();
   }
 }

--- a/cluster-api/src/main/java/io/aiven/klaw/clusterapi/controller/ClusterApiController.java
+++ b/cluster-api/src/main/java/io/aiven/klaw/clusterapi/controller/ClusterApiController.java
@@ -1,13 +1,13 @@
 package io.aiven.klaw.clusterapi.controller;
 
-import io.aiven.klaw.clusterapi.models.AclType;
-import io.aiven.klaw.clusterapi.models.AclsNativeType;
 import io.aiven.klaw.clusterapi.models.ApiResponse;
 import io.aiven.klaw.clusterapi.models.ClusterAclRequest;
 import io.aiven.klaw.clusterapi.models.ClusterSchemaRequest;
-import io.aiven.klaw.clusterapi.models.ClusterStatus;
 import io.aiven.klaw.clusterapi.models.ClusterTopicRequest;
-import io.aiven.klaw.clusterapi.models.KafkaSupportedProtocol;
+import io.aiven.klaw.clusterapi.models.enums.AclType;
+import io.aiven.klaw.clusterapi.models.enums.AclsNativeType;
+import io.aiven.klaw.clusterapi.models.enums.ClusterStatus;
+import io.aiven.klaw.clusterapi.models.enums.KafkaSupportedProtocol;
 import io.aiven.klaw.clusterapi.services.AivenApiService;
 import io.aiven.klaw.clusterapi.services.ApacheKafkaAclService;
 import io.aiven.klaw.clusterapi.services.ApacheKafkaTopicService;
@@ -106,16 +106,16 @@ public class ClusterApiController {
   }
 
   @RequestMapping(
-      value = "/getSchema/{bootstrapServers}/{protocol}/{clusterName}/{topicName}",
+      value = "/getSchema/{bootstrapServers}/{protocol}/{clusterIdentification}/{topicName}",
       method = RequestMethod.GET,
       produces = {MediaType.APPLICATION_JSON_VALUE})
   public ResponseEntity<Map<Integer, Map<String, Object>>> getSchema(
       @PathVariable String bootstrapServers,
       @Valid @PathVariable KafkaSupportedProtocol protocol,
       @PathVariable String topicName,
-      @PathVariable String clusterName) {
+      @PathVariable String clusterIdentification) {
     Map<Integer, Map<String, Object>> schema =
-        schemaService.getSchema(bootstrapServers, protocol, topicName);
+        schemaService.getSchema(bootstrapServers, protocol, clusterIdentification, topicName);
     return new ResponseEntity<>(schema, HttpStatus.OK);
   }
 

--- a/cluster-api/src/main/java/io/aiven/klaw/clusterapi/controller/KafkaConnectController.java
+++ b/cluster-api/src/main/java/io/aiven/klaw/clusterapi/controller/KafkaConnectController.java
@@ -2,7 +2,7 @@ package io.aiven.klaw.clusterapi.controller;
 
 import io.aiven.klaw.clusterapi.models.ApiResponse;
 import io.aiven.klaw.clusterapi.models.ClusterConnectorRequest;
-import io.aiven.klaw.clusterapi.models.KafkaSupportedProtocol;
+import io.aiven.klaw.clusterapi.models.enums.KafkaSupportedProtocol;
 import io.aiven.klaw.clusterapi.services.KafkaConnectService;
 import java.util.*;
 import javax.validation.Valid;
@@ -21,25 +21,31 @@ public class KafkaConnectController {
   @Autowired KafkaConnectService kafkaConnectService;
 
   @RequestMapping(
-      value = "/getAllConnectors/{kafkaConnectHost}/{protocol}",
+      value = "/getAllConnectors/{kafkaConnectHost}/{protocol}/{clusterIdentification}",
       method = RequestMethod.GET,
       produces = {MediaType.APPLICATION_JSON_VALUE})
   public ResponseEntity<List<String>> getAllConnectors(
-      @PathVariable String kafkaConnectHost, @Valid @PathVariable KafkaSupportedProtocol protocol) {
+      @PathVariable String kafkaConnectHost,
+      @Valid @PathVariable KafkaSupportedProtocol protocol,
+      @PathVariable String clusterIdentification) {
     return new ResponseEntity<>(
-        kafkaConnectService.getConnectors(kafkaConnectHost, protocol), HttpStatus.OK);
+        kafkaConnectService.getConnectors(kafkaConnectHost, protocol, clusterIdentification),
+        HttpStatus.OK);
   }
 
   @RequestMapping(
-      value = "/getConnectorDetails/{connectorName}/{kafkaConnectHost}/{protocol}",
+      value =
+          "/getConnectorDetails/{connectorName}/{kafkaConnectHost}/{protocol}/{clusterIdentification}",
       method = RequestMethod.GET,
       produces = {MediaType.APPLICATION_JSON_VALUE})
   public ResponseEntity<Map<String, Object>> getConnectorDetails(
       @PathVariable String connectorName,
       @PathVariable String kafkaConnectHost,
-      @Valid @PathVariable KafkaSupportedProtocol protocol) {
+      @Valid @PathVariable KafkaSupportedProtocol protocol,
+      @PathVariable String clusterIdentification) {
     return new ResponseEntity<>(
-        kafkaConnectService.getConnectorDetails(connectorName, kafkaConnectHost, protocol),
+        kafkaConnectService.getConnectorDetails(
+            connectorName, kafkaConnectHost, protocol, clusterIdentification),
         HttpStatus.OK);
   }
 

--- a/cluster-api/src/main/java/io/aiven/klaw/clusterapi/models/ClusterAclRequest.java
+++ b/cluster-api/src/main/java/io/aiven/klaw/clusterapi/models/ClusterAclRequest.java
@@ -1,12 +1,18 @@
 package io.aiven.klaw.clusterapi.models;
 
+import io.aiven.klaw.clusterapi.models.enums.KafkaSupportedProtocol;
+import io.aiven.klaw.clusterapi.models.enums.RequestOperationType;
 import java.io.Serializable;
 import javax.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Builder
 @Getter
+@AllArgsConstructor
+@NoArgsConstructor
 public class ClusterAclRequest implements Serializable {
 
   @NotNull private String aclNativeType;

--- a/cluster-api/src/main/java/io/aiven/klaw/clusterapi/models/ClusterConnectorRequest.java
+++ b/cluster-api/src/main/java/io/aiven/klaw/clusterapi/models/ClusterConnectorRequest.java
@@ -1,12 +1,17 @@
 package io.aiven.klaw.clusterapi.models;
 
+import io.aiven.klaw.clusterapi.models.enums.KafkaSupportedProtocol;
 import java.io.Serializable;
 import javax.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Builder
 @Getter
+@AllArgsConstructor
+@NoArgsConstructor
 public class ClusterConnectorRequest implements Serializable {
 
   @NotNull private String env;
@@ -16,4 +21,6 @@ public class ClusterConnectorRequest implements Serializable {
   @NotNull private String connectorConfig;
 
   @NotNull private String connectorName;
+
+  @NotNull private String clusterIdentification;
 }

--- a/cluster-api/src/main/java/io/aiven/klaw/clusterapi/models/ClusterSchemaRequest.java
+++ b/cluster-api/src/main/java/io/aiven/klaw/clusterapi/models/ClusterSchemaRequest.java
@@ -1,11 +1,16 @@
 package io.aiven.klaw.clusterapi.models;
 
+import io.aiven.klaw.clusterapi.models.enums.KafkaSupportedProtocol;
 import java.io.Serializable;
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Builder
 @Getter
+@AllArgsConstructor
+@NoArgsConstructor
 public class ClusterSchemaRequest implements Serializable {
 
   private String env;
@@ -15,4 +20,6 @@ public class ClusterSchemaRequest implements Serializable {
   private String topicName;
 
   private String fullSchema;
+
+  private String clusterIdentification;
 }

--- a/cluster-api/src/main/java/io/aiven/klaw/clusterapi/models/ClusterTopicRequest.java
+++ b/cluster-api/src/main/java/io/aiven/klaw/clusterapi/models/ClusterTopicRequest.java
@@ -1,12 +1,17 @@
 package io.aiven.klaw.clusterapi.models;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import io.aiven.klaw.clusterapi.models.enums.KafkaSupportedProtocol;
 import java.util.Map;
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Builder
 @Getter
+@AllArgsConstructor
+@NoArgsConstructor
 public class ClusterTopicRequest {
   @JsonProperty private String env;
 

--- a/cluster-api/src/main/java/io/aiven/klaw/clusterapi/models/enums/AclAttributes.java
+++ b/cluster-api/src/main/java/io/aiven/klaw/clusterapi/models/enums/AclAttributes.java
@@ -1,0 +1,13 @@
+package io.aiven.klaw.clusterapi.models.enums;
+
+public enum AclAttributes {
+  TOPIC("topic"),
+  PERMISSION("permission"),
+  USERNAME("username");
+
+  public final String value;
+
+  AclAttributes(String value) {
+    this.value = value;
+  }
+}

--- a/cluster-api/src/main/java/io/aiven/klaw/clusterapi/models/enums/AclIPPrincipleType.java
+++ b/cluster-api/src/main/java/io/aiven/klaw/clusterapi/models/enums/AclIPPrincipleType.java
@@ -1,4 +1,4 @@
-package io.aiven.klaw.clusterapi.models;
+package io.aiven.klaw.clusterapi.models.enums;
 
 public enum AclIPPrincipleType {
   IP_ADDRESS,

--- a/cluster-api/src/main/java/io/aiven/klaw/clusterapi/models/enums/AclPatternType.java
+++ b/cluster-api/src/main/java/io/aiven/klaw/clusterapi/models/enums/AclPatternType.java
@@ -1,4 +1,4 @@
-package io.aiven.klaw.clusterapi.models;
+package io.aiven.klaw.clusterapi.models.enums;
 
 public enum AclPatternType {
   PREFIXED("PREFIXED"),

--- a/cluster-api/src/main/java/io/aiven/klaw/clusterapi/models/enums/AclType.java
+++ b/cluster-api/src/main/java/io/aiven/klaw/clusterapi/models/enums/AclType.java
@@ -1,4 +1,4 @@
-package io.aiven.klaw.clusterapi.models;
+package io.aiven.klaw.clusterapi.models.enums;
 
 public enum AclType {
   PRODUCER("Producer"),

--- a/cluster-api/src/main/java/io/aiven/klaw/clusterapi/models/enums/AclsNativeType.java
+++ b/cluster-api/src/main/java/io/aiven/klaw/clusterapi/models/enums/AclsNativeType.java
@@ -1,4 +1,4 @@
-package io.aiven.klaw.clusterapi.models;
+package io.aiven.klaw.clusterapi.models.enums;
 
 public enum AclsNativeType {
   NATIVE,

--- a/cluster-api/src/main/java/io/aiven/klaw/clusterapi/models/enums/ApiResultStatus.java
+++ b/cluster-api/src/main/java/io/aiven/klaw/clusterapi/models/enums/ApiResultStatus.java
@@ -1,4 +1,4 @@
-package io.aiven.klaw.clusterapi.models;
+package io.aiven.klaw.clusterapi.models.enums;
 
 public enum ApiResultStatus {
   SUCCESS("success"),

--- a/cluster-api/src/main/java/io/aiven/klaw/clusterapi/models/enums/ClusterStatus.java
+++ b/cluster-api/src/main/java/io/aiven/klaw/clusterapi/models/enums/ClusterStatus.java
@@ -1,4 +1,4 @@
-package io.aiven.klaw.clusterapi.models;
+package io.aiven.klaw.clusterapi.models.enums;
 
 public enum ClusterStatus {
   OFFLINE("OFFLINE"),

--- a/cluster-api/src/main/java/io/aiven/klaw/clusterapi/models/enums/KafkaClustersType.java
+++ b/cluster-api/src/main/java/io/aiven/klaw/clusterapi/models/enums/KafkaClustersType.java
@@ -1,4 +1,4 @@
-package io.aiven.klaw.clusterapi.models;
+package io.aiven.klaw.clusterapi.models.enums;
 
 public enum KafkaClustersType {
   KAFKA("kafka"),

--- a/cluster-api/src/main/java/io/aiven/klaw/clusterapi/models/enums/KafkaSupportedProtocol.java
+++ b/cluster-api/src/main/java/io/aiven/klaw/clusterapi/models/enums/KafkaSupportedProtocol.java
@@ -1,4 +1,4 @@
-package io.aiven.klaw.clusterapi.models;
+package io.aiven.klaw.clusterapi.models.enums;
 
 public enum KafkaSupportedProtocol {
   PLAINTEXT("PLAINTEXT"),

--- a/cluster-api/src/main/java/io/aiven/klaw/clusterapi/models/enums/RequestOperationType.java
+++ b/cluster-api/src/main/java/io/aiven/klaw/clusterapi/models/enums/RequestOperationType.java
@@ -1,4 +1,4 @@
-package io.aiven.klaw.clusterapi.models;
+package io.aiven.klaw.clusterapi.models.enums;
 
 public enum RequestOperationType {
   CREATE("Create"),

--- a/cluster-api/src/main/java/io/aiven/klaw/clusterapi/services/AivenApiService.java
+++ b/cluster-api/src/main/java/io/aiven/klaw/clusterapi/services/AivenApiService.java
@@ -3,8 +3,9 @@ package io.aiven.klaw.clusterapi.services;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.aiven.klaw.clusterapi.models.AivenAclResponse;
 import io.aiven.klaw.clusterapi.models.AivenAclStruct;
-import io.aiven.klaw.clusterapi.models.ApiResultStatus;
 import io.aiven.klaw.clusterapi.models.ClusterAclRequest;
+import io.aiven.klaw.clusterapi.models.enums.AclAttributes;
+import io.aiven.klaw.clusterapi.models.enums.ApiResultStatus;
 import java.util.*;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
@@ -38,16 +39,16 @@ public class AivenApiService {
     String projectName = clusterAclRequest.getProjectName();
     String serviceName = clusterAclRequest.getServiceName();
 
-    LinkedHashMap<String, String> permissionsMap = new LinkedHashMap<>();
-    permissionsMap.put("topic", clusterAclRequest.getTopicName());
-    permissionsMap.put("permission", clusterAclRequest.getPermission());
-    permissionsMap.put("username", clusterAclRequest.getUsername());
+    Map<String, String> permissionsMap = new HashMap<>();
+    permissionsMap.put(AclAttributes.TOPIC.value, clusterAclRequest.getTopicName());
+    permissionsMap.put(AclAttributes.PERMISSION.value, clusterAclRequest.getPermission());
+    permissionsMap.put(AclAttributes.USERNAME.value, clusterAclRequest.getUsername());
 
     String uri =
         addAclsApiEndpoint.replace("projectName", projectName).replace("serviceName", serviceName);
 
     HttpHeaders headers = getHttpHeaders();
-    HttpEntity<LinkedHashMap<String, String>> request = new HttpEntity<>(permissionsMap, headers);
+    HttpEntity<Map<String, String>> request = new HttpEntity<>(permissionsMap, headers);
 
     try {
       ResponseEntity<String> response = restTemplate.postForEntity(uri, request, String.class);

--- a/cluster-api/src/main/java/io/aiven/klaw/clusterapi/services/ApacheKafkaAclService.java
+++ b/cluster-api/src/main/java/io/aiven/klaw/clusterapi/services/ApacheKafkaAclService.java
@@ -1,11 +1,11 @@
 package io.aiven.klaw.clusterapi.services;
 
-import io.aiven.klaw.clusterapi.models.AclIPPrincipleType;
-import io.aiven.klaw.clusterapi.models.AclPatternType;
-import io.aiven.klaw.clusterapi.models.ApiResultStatus;
 import io.aiven.klaw.clusterapi.models.ClusterAclRequest;
-import io.aiven.klaw.clusterapi.models.KafkaSupportedProtocol;
-import io.aiven.klaw.clusterapi.models.RequestOperationType;
+import io.aiven.klaw.clusterapi.models.enums.AclIPPrincipleType;
+import io.aiven.klaw.clusterapi.models.enums.AclPatternType;
+import io.aiven.klaw.clusterapi.models.enums.ApiResultStatus;
+import io.aiven.klaw.clusterapi.models.enums.KafkaSupportedProtocol;
+import io.aiven.klaw.clusterapi.models.enums.RequestOperationType;
 import io.aiven.klaw.clusterapi.utils.ClusterApiUtils;
 import java.util.ArrayList;
 import java.util.HashMap;

--- a/cluster-api/src/main/java/io/aiven/klaw/clusterapi/services/ApacheKafkaTopicService.java
+++ b/cluster-api/src/main/java/io/aiven/klaw/clusterapi/services/ApacheKafkaTopicService.java
@@ -1,9 +1,9 @@
 package io.aiven.klaw.clusterapi.services;
 
 import io.aiven.klaw.clusterapi.models.ApiResponse;
-import io.aiven.klaw.clusterapi.models.ApiResultStatus;
 import io.aiven.klaw.clusterapi.models.ClusterTopicRequest;
-import io.aiven.klaw.clusterapi.models.KafkaSupportedProtocol;
+import io.aiven.klaw.clusterapi.models.enums.ApiResultStatus;
+import io.aiven.klaw.clusterapi.models.enums.KafkaSupportedProtocol;
 import io.aiven.klaw.clusterapi.utils.ClusterApiUtils;
 import java.util.ArrayList;
 import java.util.Collections;

--- a/cluster-api/src/main/java/io/aiven/klaw/clusterapi/services/KafkaConnectService.java
+++ b/cluster-api/src/main/java/io/aiven/klaw/clusterapi/services/KafkaConnectService.java
@@ -1,11 +1,11 @@
 package io.aiven.klaw.clusterapi.services;
 
 import io.aiven.klaw.clusterapi.models.ApiResponse;
-import io.aiven.klaw.clusterapi.models.ApiResultStatus;
 import io.aiven.klaw.clusterapi.models.ClusterConnectorRequest;
-import io.aiven.klaw.clusterapi.models.ClusterStatus;
-import io.aiven.klaw.clusterapi.models.KafkaClustersType;
-import io.aiven.klaw.clusterapi.models.KafkaSupportedProtocol;
+import io.aiven.klaw.clusterapi.models.enums.ApiResultStatus;
+import io.aiven.klaw.clusterapi.models.enums.ClusterStatus;
+import io.aiven.klaw.clusterapi.models.enums.KafkaClustersType;
+import io.aiven.klaw.clusterapi.models.enums.KafkaSupportedProtocol;
 import io.aiven.klaw.clusterapi.utils.ClusterApiUtils;
 import java.util.*;
 import lombok.extern.slf4j.Slf4j;
@@ -41,7 +41,10 @@ public class KafkaConnectService {
             + clusterConnectorRequest.getConnectorName();
     Pair<String, RestTemplate> reqDetails =
         clusterApiUtils.getRequestDetails(
-            suffixUrl, clusterConnectorRequest.getProtocol(), KafkaClustersType.KAFKA_CONNECT);
+            suffixUrl,
+            clusterConnectorRequest.getProtocol(),
+            KafkaClustersType.KAFKA_CONNECT,
+            clusterConnectorRequest.getClusterIdentification());
 
     try {
       reqDetails.getRight().delete(reqDetails.getLeft(), String.class);
@@ -66,7 +69,10 @@ public class KafkaConnectService {
             + "/config";
     Pair<String, RestTemplate> reqDetails =
         clusterApiUtils.getRequestDetails(
-            suffixUrl, clusterConnectorRequest.getProtocol(), KafkaClustersType.KAFKA_CONNECT);
+            suffixUrl,
+            clusterConnectorRequest.getProtocol(),
+            KafkaClustersType.KAFKA_CONNECT,
+            clusterConnectorRequest.getClusterIdentification());
 
     HttpHeaders headers = new HttpHeaders();
     headers.set("Content-Type", "application/json");
@@ -94,7 +100,10 @@ public class KafkaConnectService {
     String suffixUrl = clusterConnectorRequest.getEnv() + "/connectors";
     Pair<String, RestTemplate> reqDetails =
         clusterApiUtils.getRequestDetails(
-            suffixUrl, clusterConnectorRequest.getProtocol(), KafkaClustersType.KAFKA_CONNECT);
+            suffixUrl,
+            clusterConnectorRequest.getProtocol(),
+            KafkaClustersType.KAFKA_CONNECT,
+            clusterConnectorRequest.getClusterIdentification());
 
     HttpHeaders headers = new HttpHeaders();
     headers.set("Content-Type", "application/json");
@@ -116,7 +125,8 @@ public class KafkaConnectService {
     }
   }
 
-  public List<String> getConnectors(String environmentVal, KafkaSupportedProtocol protocol) {
+  public List<String> getConnectors(
+      String environmentVal, KafkaSupportedProtocol protocol, String clusterIdentification) {
     try {
       log.info("Into getConnectors {} {}", environmentVal, protocol);
       if (environmentVal == null) {
@@ -125,7 +135,8 @@ public class KafkaConnectService {
 
       String suffixUrl = environmentVal + "/connectors";
       Pair<String, RestTemplate> reqDetails =
-          clusterApiUtils.getRequestDetails(suffixUrl, protocol, KafkaClustersType.KAFKA_CONNECT);
+          clusterApiUtils.getRequestDetails(
+              suffixUrl, protocol, KafkaClustersType.KAFKA_CONNECT, clusterIdentification);
 
       Map<String, String> params = new HashMap<>();
       ResponseEntity<List<String>> responseList =
@@ -141,7 +152,10 @@ public class KafkaConnectService {
   }
 
   public Map<String, Object> getConnectorDetails(
-      String connector, String environmentVal, KafkaSupportedProtocol protocol) {
+      String connector,
+      String environmentVal,
+      KafkaSupportedProtocol protocol,
+      String clusterIdentification) {
     try {
       log.info("Into getConnectorDetails {} {}", environmentVal, protocol);
       if (environmentVal == null) {
@@ -150,7 +164,8 @@ public class KafkaConnectService {
 
       String suffixUrl = environmentVal + "/connectors" + "/" + connector;
       Pair<String, RestTemplate> reqDetails =
-          clusterApiUtils.getRequestDetails(suffixUrl, protocol, KafkaClustersType.KAFKA_CONNECT);
+          clusterApiUtils.getRequestDetails(
+              suffixUrl, protocol, KafkaClustersType.KAFKA_CONNECT, clusterIdentification);
 
       Map<String, String> params = new HashMap<>();
 
@@ -173,10 +188,11 @@ public class KafkaConnectService {
   }
 
   protected ClusterStatus getKafkaConnectStatus(
-      String environment, KafkaSupportedProtocol protocol) {
+      String environment, KafkaSupportedProtocol protocol, String clusterIdentification) {
     String suffixUrl = environment + "/connectors";
     Pair<String, RestTemplate> reqDetails =
-        clusterApiUtils.getRequestDetails(suffixUrl, protocol, KafkaClustersType.KAFKA_CONNECT);
+        clusterApiUtils.getRequestDetails(
+            suffixUrl, protocol, KafkaClustersType.KAFKA_CONNECT, clusterIdentification);
     Map<String, String> params = new HashMap<>();
 
     try {

--- a/cluster-api/src/main/java/io/aiven/klaw/clusterapi/services/MonitoringService.java
+++ b/cluster-api/src/main/java/io/aiven/klaw/clusterapi/services/MonitoringService.java
@@ -1,6 +1,6 @@
 package io.aiven.klaw.clusterapi.services;
 
-import io.aiven.klaw.clusterapi.models.KafkaSupportedProtocol;
+import io.aiven.klaw.clusterapi.models.enums.KafkaSupportedProtocol;
 import io.aiven.klaw.clusterapi.utils.ClusterApiUtils;
 import java.util.*;
 import lombok.extern.slf4j.Slf4j;

--- a/cluster-api/src/main/java/io/aiven/klaw/clusterapi/services/SchemaService.java
+++ b/cluster-api/src/main/java/io/aiven/klaw/clusterapi/services/SchemaService.java
@@ -2,9 +2,9 @@ package io.aiven.klaw.clusterapi.services;
 
 import io.aiven.klaw.clusterapi.models.ApiResponse;
 import io.aiven.klaw.clusterapi.models.ClusterSchemaRequest;
-import io.aiven.klaw.clusterapi.models.ClusterStatus;
-import io.aiven.klaw.clusterapi.models.KafkaClustersType;
-import io.aiven.klaw.clusterapi.models.KafkaSupportedProtocol;
+import io.aiven.klaw.clusterapi.models.enums.ClusterStatus;
+import io.aiven.klaw.clusterapi.models.enums.KafkaClustersType;
+import io.aiven.klaw.clusterapi.models.enums.KafkaSupportedProtocol;
 import io.aiven.klaw.clusterapi.utils.ClusterApiUtils;
 import java.util.*;
 import lombok.extern.slf4j.Slf4j;
@@ -56,7 +56,10 @@ public class SchemaService {
               + "-value/versions";
       Pair<String, RestTemplate> reqDetails =
           clusterApiUtils.getRequestDetails(
-              suffixUrl, clusterSchemaRequest.getProtocol(), KafkaClustersType.SCHEMA_REGISTRY);
+              suffixUrl,
+              clusterSchemaRequest.getProtocol(),
+              KafkaClustersType.SCHEMA_REGISTRY,
+              clusterSchemaRequest.getClusterIdentification());
 
       Map<String, String> params = new HashMap<>();
       params.put("schema", clusterSchemaRequest.getFullSchema());
@@ -83,15 +86,20 @@ public class SchemaService {
   }
 
   public Map<Integer, Map<String, Object>> getSchema(
-      String environmentVal, KafkaSupportedProtocol protocol, String topicName) {
+      String environmentVal,
+      KafkaSupportedProtocol protocol,
+      String clusterIdentification,
+      String topicName) {
     try {
       log.info("Into getSchema request {} {} {}", topicName, environmentVal, protocol);
       if (environmentVal == null) {
         return null;
       }
 
-      List<Integer> versionsList = getSchemaVersions(environmentVal, topicName, protocol);
-      String schemaCompatibility = getSchemaCompatibility(environmentVal, topicName, protocol);
+      List<Integer> versionsList =
+          getSchemaVersions(environmentVal, topicName, protocol, clusterIdentification);
+      String schemaCompatibility =
+          getSchemaCompatibility(environmentVal, topicName, protocol, clusterIdentification);
       Map<Integer, Map<String, Object>> allSchemaObjects = new TreeMap<>();
 
       if (versionsList != null) {
@@ -100,7 +108,7 @@ public class SchemaService {
               environmentVal + "/subjects/" + topicName + "-value/versions/" + schemaVersion;
           Pair<String, RestTemplate> reqDetails =
               clusterApiUtils.getRequestDetails(
-                  suffixUrl, protocol, KafkaClustersType.SCHEMA_REGISTRY);
+                  suffixUrl, protocol, KafkaClustersType.SCHEMA_REGISTRY, clusterIdentification);
 
           Map<String, String> params = new HashMap<>();
 
@@ -126,7 +134,10 @@ public class SchemaService {
   }
 
   private List<Integer> getSchemaVersions(
-      String environmentVal, String topicName, KafkaSupportedProtocol protocol) {
+      String environmentVal,
+      String topicName,
+      KafkaSupportedProtocol protocol,
+      String clusterIdentification) {
     try {
       log.info("Into getSchema versions {} {}", topicName, environmentVal);
       if (environmentVal == null) {
@@ -135,7 +146,8 @@ public class SchemaService {
 
       String suffixUrl = environmentVal + "/subjects/" + topicName + "-value/versions";
       Pair<String, RestTemplate> reqDetails =
-          clusterApiUtils.getRequestDetails(suffixUrl, protocol, KafkaClustersType.SCHEMA_REGISTRY);
+          clusterApiUtils.getRequestDetails(
+              suffixUrl, protocol, KafkaClustersType.SCHEMA_REGISTRY, clusterIdentification);
 
       Map<String, String> params = new HashMap<>();
 
@@ -153,7 +165,10 @@ public class SchemaService {
   }
 
   private String getSchemaCompatibility(
-      String environmentVal, String topicName, KafkaSupportedProtocol protocol) {
+      String environmentVal,
+      String topicName,
+      KafkaSupportedProtocol protocol,
+      String clusterIdentification) {
     try {
       log.info("Into getSchema compatibility {} {}", topicName, environmentVal);
       if (environmentVal == null) {
@@ -162,7 +177,8 @@ public class SchemaService {
 
       String suffixUrl = environmentVal + "/config/" + topicName + "-value";
       Pair<String, RestTemplate> reqDetails =
-          clusterApiUtils.getRequestDetails(suffixUrl, protocol, KafkaClustersType.SCHEMA_REGISTRY);
+          clusterApiUtils.getRequestDetails(
+              suffixUrl, protocol, KafkaClustersType.SCHEMA_REGISTRY, clusterIdentification);
 
       Map<String, String> params = new HashMap<>();
 
@@ -184,7 +200,11 @@ public class SchemaService {
   }
 
   private boolean setSchemaCompatibility(
-      String environmentVal, String topicName, boolean isForce, KafkaSupportedProtocol protocol) {
+      String environmentVal,
+      String topicName,
+      boolean isForce,
+      KafkaSupportedProtocol protocol,
+      String clusterIdentification) {
     try {
       log.info("Into setSchema compatibility {} {}", topicName, environmentVal);
       if (environmentVal == null) {
@@ -193,7 +213,8 @@ public class SchemaService {
 
       String suffixUrl = environmentVal + "/config/" + topicName + "-value";
       Pair<String, RestTemplate> reqDetails =
-          clusterApiUtils.getRequestDetails(suffixUrl, protocol, KafkaClustersType.SCHEMA_REGISTRY);
+          clusterApiUtils.getRequestDetails(
+              suffixUrl, protocol, KafkaClustersType.SCHEMA_REGISTRY, clusterIdentification);
 
       Map<String, String> params = new HashMap<>();
       if (isForce) {
@@ -212,11 +233,12 @@ public class SchemaService {
   }
 
   protected ClusterStatus getSchemaRegistryStatus(
-      String environmentVal, KafkaSupportedProtocol protocol) {
+      String environmentVal, KafkaSupportedProtocol protocol, String clusterIdentification) {
 
     String suffixUrl = environmentVal + "/subjects";
     Pair<String, RestTemplate> reqDetails =
-        clusterApiUtils.getRequestDetails(suffixUrl, protocol, KafkaClustersType.SCHEMA_REGISTRY);
+        clusterApiUtils.getRequestDetails(
+            suffixUrl, protocol, KafkaClustersType.SCHEMA_REGISTRY, clusterIdentification);
 
     Map<String, String> params = new HashMap<>();
 

--- a/cluster-api/src/main/java/io/aiven/klaw/clusterapi/services/UtilComponentsService.java
+++ b/cluster-api/src/main/java/io/aiven/klaw/clusterapi/services/UtilComponentsService.java
@@ -1,7 +1,7 @@
 package io.aiven.klaw.clusterapi.services;
 
-import io.aiven.klaw.clusterapi.models.ClusterStatus;
-import io.aiven.klaw.clusterapi.models.KafkaSupportedProtocol;
+import io.aiven.klaw.clusterapi.models.enums.ClusterStatus;
+import io.aiven.klaw.clusterapi.models.enums.KafkaSupportedProtocol;
 import io.aiven.klaw.clusterapi.utils.ClusterApiUtils;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.kafka.clients.admin.*;
@@ -46,15 +46,19 @@ public class UtilComponentsService {
   //    }
 
   public ClusterStatus getStatus(
-      String environment, KafkaSupportedProtocol protocol, String clusterName, String clusterType) {
+      String environment,
+      KafkaSupportedProtocol protocol,
+      String clusterIdentification,
+      String clusterType) {
     log.info("getStatus {} {}", environment, protocol);
     switch (clusterType) {
       case "kafka":
-        return getStatusKafka(environment, protocol, clusterName);
+        return getStatusKafka(environment, protocol, clusterIdentification);
       case "schemaregistry":
-        return schemaService.getSchemaRegistryStatus(environment, protocol);
+        return schemaService.getSchemaRegistryStatus(environment, protocol, clusterIdentification);
       case "kafkaconnect":
-        return kafkaConnectService.getKafkaConnectStatus(environment, protocol);
+        return kafkaConnectService.getKafkaConnectStatus(
+            environment, protocol, clusterIdentification);
       default:
         return ClusterStatus.OFFLINE;
     }

--- a/cluster-api/src/main/java/io/aiven/klaw/clusterapi/utils/AdminClientProperties.java
+++ b/cluster-api/src/main/java/io/aiven/klaw/clusterapi/utils/AdminClientProperties.java
@@ -15,7 +15,7 @@ import org.springframework.stereotype.Component;
  */
 @Getter
 @Component
-class AdminClientProperties {
+public class AdminClientProperties {
 
   @Value("${klaw.request.timeout.ms:15000}")
   private String requestTimeOutMs;
@@ -25,10 +25,4 @@ class AdminClientProperties {
 
   @Value("${klaw.retry.backoff.ms:15000}")
   private String retryBackOffMsConfig;
-
-  @Value("${klaw.aiven.kafkaconnect.credentials:credentials}")
-  private String connectCredentials;
-
-  @Value("${klaw.aiven.karapace.credentials}")
-  private String schemaRegistryCredentials;
 }

--- a/cluster-api/src/main/resources/application.properties
+++ b/cluster-api/src/main/resources/application.properties
@@ -1,6 +1,5 @@
-server.port=9343
+# Uncomment the below SSL/Https Properties to secure this Cluster Api application
 
-# SSL/Https Properties
 #server.ssl.key-store=client.keystore.p12
 #server.ssl.trust-store=client.truststore.jks
 #server.ssl.key-store-password=klaw1234
@@ -8,31 +7,48 @@ server.port=9343
 #server.ssl.trust-store-password=klaw1234
 #server.ssl.key-store-type=pkcs12
 
-# SSL properties to connect to Kafka clusters
+# Uncomment the below SSL properties to connect to Kafka clusters over SSL.
+# Each of the below block can be repeated for a cluster with unique cluster identification id
 
-klawssl.kafkassl.keystore.location=client.keystore.p12
-klawssl.kafkassl.keystore.pwd=klaw1234
-klawssl.kafkassl.key.pwd=klaw1234
-klawssl.kafkassl.truststore.location=client.truststore.jks
-klawssl.kafkassl.truststore.pwd=klaw1234
-klawssl.kafkassl.keystore.type=pkcs12
-klawssl.kafkassl.truststore.type=JKS
+#clusterid.kafkassl.keystore.location=client.keystore.p12
+#clusterid.kafkassl.keystore.pwd=klaw1234
+#clusterid.kafkassl.key.pwd=klaw1234
+#clusterid.kafkassl.truststore.location=client.truststore.jks
+#clusterid.kafkassl.truststore.pwd=klaw1234
+#clusterid.kafkassl.keystore.type=pkcs12
+#clusterid.kafkassl.truststore.type=JKS
 
-# SASL properties to connect to Kafka clusters
-#acc1.kafkasasl.jaasconfig.plain=org.apache.kafka.common.security.plain.PlainLoginModule required username='kwuser' password='kwuser-secret';
-#acc1.kafkasasl.jaasconfig.scram=org.apache.kafka.common.security.scram.ScramLoginModule required username='kwuser' password='kwuser-secret';
-#acc1.kafkasasl.saslmechanism.gssapi.servicename=kafka
-#acc1.kafkasasl.jaasconfig.gssapi=com.sun.security.auth.module.Krb5LoginModule required useKeyTab=true storeKey=true keyTab="/location/kafka_client.keytab" principal="kafkaclient1@EXAMPLE.COM";
+# Uncomment the below SASL properties to connect to Kafka clusters over SASL
+# Each of the below block can be repeated for a cluster with unique cluster identification id
 
-kafkasasl.saslmechanism.plain=PLAIN
-kafkasasl.saslmechanism.gssapi=GSSAPI
-kafkasasl.saslmechanism.scram.256=SCRAM-SHA-256
-kafkasasl.saslmechanism.scram.512=SCRAM-SHA-512
+#clusterid.kafkasasl.jaasconfig.plain=org.apache.kafka.common.security.plain.PlainLoginModule required username='kwuser' password='kwuser-secret';
+#clusterid.kafkasasl.jaasconfig.scram=org.apache.kafka.common.security.scram.ScramLoginModule required username='kwuser' password='kwuser-secret';
+#clusterid.kafkasasl.saslmechanism.gssapi.servicename=kafka
+#clusterid.kafkasasl.jaasconfig.gssapi=com.sun.security.auth.module.Krb5LoginModule required useKeyTab=true storeKey=true keyTab="/location/kafka_client.keytab" principal="kafkaclient1@EXAMPLE.COM";
 
-# User for accessing Cluster api
-klaw.clusterapi.access.username=kwclusterapiuser
-# Provide a base 64 encoded string below. The same secret should be configured in Klaw Api. Change to a new one. Ex : dGhpcyBpcyBhIHNlY3JldCB0byBhY2Nlc3MgY2x1c3RlcmFwaQ==
+# Uncomment the below Schema Registry/karapace HTTPS credentials (Ex : username:password) to connect to SchemaRegistry/Karapace server
+# Each of the below block can be repeated for a cluster with unique cluster identification id
+#clusterid.klaw.schemaregistry.credentials=
+
+# Uncomment the below Kafka Connect HTTPS credentials (Ex : username:password) to connect to a Kafka connect server
+# Each of the below block can be repeated for a cluster with unique cluster identification id
+#clusterid.klaw.kafkaconnect.credentials=
+
+# Uncomment the below to establish connectivity between core and cluster apis.
+# Provide a base 64 encoded string. The same secret should be configured in Klaw Api. Please change to a new one.
+# Ex : dGhpcyBpcyBhIHNlY3JldCB0byBhY2Nlc3MgY2x1c3RlcmFwaQ==
 klaw.clusterapi.access.base64.secret=
+
+# Uncomment the below to establish connectivity between Aiven console and Cluster api
+# Provide the access token for https requests
+# (Currently applicable on Aiven calls only)
+klaw.clusters.accesstoken=
+
+# --------------------- Please do not modify the below defaults unless required ---------------------
+server.port=9343
+
+# User for accessing Cluster api by Core Api
+klaw.clusterapi.access.username=kwclusterapiuser
 
 # this property is required to avoid default password printing to console.
 spring.security.user.password=avoid_default_pwd_logging
@@ -45,24 +61,22 @@ klaw.retries.config=10
 klaw.retry.backoff.ms=5000
 klaw.request.timeout.ms=15000
 
+# default Kafka SASL properties
+kafkasasl.saslmechanism.plain=PLAIN
+kafkasasl.saslmechanism.gssapi=GSSAPI
+kafkasasl.saslmechanism.scram.256=SCRAM-SHA-256
+kafkasasl.saslmechanism.scram.512=SCRAM-SHA-512
+
 # swagger documentation path parser
 spring.mvc.pathmatch.matching-strategy = ANT_PATH_MATCHER
 
 spring.banner.location=classpath:banner.txt
+# log file settings
+logging.file.name=./../logs/kw-clusterapi.log
+spring.mvc.log-resolved-exception=true
+logging.level.root=info
 
-# custom acls api endpoints
+# Custom Acls - Api Endpoints (Currently applicable on Aiven calls)
 klaw.clusters.listacls.api=https://api.aiven.io/v1/project/projectName/service/serviceName/acl
 klaw.clusters.addacls.api=https://api.aiven.io/v1/project/projectName/service/serviceName/acl
 klaw.clusters.deleteacls.api=https://api.aiven.io/v1/project/projectName/service/serviceName/acl/aclId
-
-# access token for https requests
-klaw.clusters.accesstoken=
-
-#aiven schema security
-klaw.aiven.karapace.credentials=
-klaw.aiven.kafkaconnect.credentials=
-
-# log file settings
-logging.level.root=info
-logging.file.name=./../logs/kw-clusterapi.log
-spring.mvc.log-resolved-exception=true

--- a/cluster-api/src/test/java/io/aiven/klaw/clusterapi/AuthenticationIntegrationTest.java
+++ b/cluster-api/src/test/java/io/aiven/klaw/clusterapi/AuthenticationIntegrationTest.java
@@ -1,11 +1,11 @@
 package io.aiven.klaw.clusterapi;
 
-import static io.aiven.klaw.clusterapi.models.ClusterStatus.ONLINE;
+import static io.aiven.klaw.clusterapi.models.enums.ClusterStatus.ONLINE;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import io.aiven.klaw.clusterapi.models.ClusterStatus;
+import io.aiven.klaw.clusterapi.models.enums.ClusterStatus;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.SignatureAlgorithm;
 import java.security.Key;

--- a/cluster-api/src/test/java/io/aiven/klaw/clusterapi/UtilMethods.java
+++ b/cluster-api/src/test/java/io/aiven/klaw/clusterapi/UtilMethods.java
@@ -1,12 +1,12 @@
 package io.aiven.klaw.clusterapi;
 
-import io.aiven.klaw.clusterapi.models.AclIPPrincipleType;
-import io.aiven.klaw.clusterapi.models.AclsNativeType;
 import io.aiven.klaw.clusterapi.models.ClusterAclRequest;
 import io.aiven.klaw.clusterapi.models.ClusterSchemaRequest;
 import io.aiven.klaw.clusterapi.models.ClusterTopicRequest;
-import io.aiven.klaw.clusterapi.models.KafkaSupportedProtocol;
-import io.aiven.klaw.clusterapi.models.RequestOperationType;
+import io.aiven.klaw.clusterapi.models.enums.AclIPPrincipleType;
+import io.aiven.klaw.clusterapi.models.enums.AclsNativeType;
+import io.aiven.klaw.clusterapi.models.enums.KafkaSupportedProtocol;
+import io.aiven.klaw.clusterapi.models.enums.RequestOperationType;
 import java.util.*;
 import org.apache.kafka.common.acl.AccessControlEntry;
 import org.apache.kafka.common.acl.AclBinding;
@@ -113,6 +113,7 @@ public class UtilMethods {
         .fullSchema("{type:string}")
         .protocol(KafkaSupportedProtocol.PLAINTEXT)
         .topicName("testtopic")
+        .clusterIdentification("CLID1")
         .build();
   }
 

--- a/cluster-api/src/test/java/io/aiven/klaw/clusterapi/controller/ClusterApiControllerTest.java
+++ b/cluster-api/src/test/java/io/aiven/klaw/clusterapi/controller/ClusterApiControllerTest.java
@@ -10,16 +10,15 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.aiven.klaw.clusterapi.UtilMethods;
-import io.aiven.klaw.clusterapi.config.JwtRequestFilter;
-import io.aiven.klaw.clusterapi.models.AclType;
-import io.aiven.klaw.clusterapi.models.AclsNativeType;
 import io.aiven.klaw.clusterapi.models.ApiResponse;
-import io.aiven.klaw.clusterapi.models.ApiResultStatus;
 import io.aiven.klaw.clusterapi.models.ClusterAclRequest;
 import io.aiven.klaw.clusterapi.models.ClusterSchemaRequest;
-import io.aiven.klaw.clusterapi.models.ClusterStatus;
 import io.aiven.klaw.clusterapi.models.ClusterTopicRequest;
-import io.aiven.klaw.clusterapi.models.KafkaSupportedProtocol;
+import io.aiven.klaw.clusterapi.models.enums.AclType;
+import io.aiven.klaw.clusterapi.models.enums.AclsNativeType;
+import io.aiven.klaw.clusterapi.models.enums.ApiResultStatus;
+import io.aiven.klaw.clusterapi.models.enums.ClusterStatus;
+import io.aiven.klaw.clusterapi.models.enums.KafkaSupportedProtocol;
 import io.aiven.klaw.clusterapi.services.AivenApiService;
 import io.aiven.klaw.clusterapi.services.ApacheKafkaAclService;
 import io.aiven.klaw.clusterapi.services.ApacheKafkaTopicService;
@@ -29,16 +28,15 @@ import io.aiven.klaw.clusterapi.services.UtilComponentsService;
 import java.nio.charset.StandardCharsets;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
-import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 
-@WebMvcTest(controllers = ClusterApiController.class)
-@AutoConfigureMockMvc(addFilters = false)
+@ExtendWith(SpringExtension.class)
 public class ClusterApiControllerTest {
 
   @MockBean private UtilComponentsService utilComponentsService;
@@ -47,15 +45,23 @@ public class ClusterApiControllerTest {
   @MockBean private SchemaService schemaService;
   @MockBean private MonitoringService monitoringService;
   @MockBean private AivenApiService aivenApiService;
-  @MockBean private JwtRequestFilter jwtRequestFilter;
 
-  @Autowired private MockMvc mvc;
+  private MockMvc mvc;
 
   private UtilMethods utilMethods;
 
   @BeforeEach
   public void setUp() throws Exception {
     utilMethods = new UtilMethods();
+    ClusterApiController clusterApiController =
+        new ClusterApiController(
+            utilComponentsService,
+            apacheKafkaAclService,
+            apacheKafkaTopicService,
+            schemaService,
+            monitoringService,
+            aivenApiService);
+    mvc = MockMvcBuilders.standaloneSetup(clusterApiController).dispatchOptions(true).build();
   }
 
   @Test

--- a/cluster-api/src/test/java/io/aiven/klaw/clusterapi/controller/KafkaConnectControllerTest.java
+++ b/cluster-api/src/test/java/io/aiven/klaw/clusterapi/controller/KafkaConnectControllerTest.java
@@ -1,0 +1,186 @@
+package io.aiven.klaw.clusterapi.controller;
+
+import static org.hamcrest.Matchers.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.aiven.klaw.clusterapi.models.ApiResponse;
+import io.aiven.klaw.clusterapi.models.ClusterConnectorRequest;
+import io.aiven.klaw.clusterapi.models.enums.ApiResultStatus;
+import io.aiven.klaw.clusterapi.models.enums.KafkaSupportedProtocol;
+import io.aiven.klaw.clusterapi.services.KafkaConnectService;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+@ExtendWith(SpringExtension.class)
+public class KafkaConnectControllerTest {
+  private MockMvc mvc;
+
+  @MockBean KafkaConnectService kafkaConnectService;
+
+  @BeforeEach
+  public void setUp() {
+    KafkaConnectController connectController = new KafkaConnectController();
+    mvc = MockMvcBuilders.standaloneSetup(connectController).dispatchOptions(true).build();
+    ReflectionTestUtils.setField(connectController, "kafkaConnectService", kafkaConnectService);
+  }
+
+  @Test
+  public void getAllConnectorsTest() throws Exception {
+    String getUrl = "/topics/getAllConnectors/localhost/" + KafkaSupportedProtocol.SSL + "/CLID1";
+    List<String> connectors = new ArrayList<>(List.of("conn1", "conn2"));
+    when(kafkaConnectService.getConnectors(anyString(), any(), anyString())).thenReturn(connectors);
+
+    mvc.perform(get(getUrl))
+        .andExpect(status().isOk())
+        .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+        .andExpect(jsonPath("$", hasSize(2)))
+        .andExpect(content().string(containsString("conn1")))
+        .andExpect(content().string(containsString("conn2")));
+  }
+
+  @Test
+  public void getAllConnectorsInvalidProtocolTest() throws Exception {
+    String getUrl = "/topics/getAllConnectors/localhost/" + "INVALIDPROTOCOL" + "/CLID1";
+    List<String> connectors = new ArrayList<>(List.of("conn1", "conn2"));
+    when(kafkaConnectService.getConnectors(anyString(), any(), anyString())).thenReturn(connectors);
+
+    mvc.perform(get(getUrl)).andExpect(status().is4xxClientError());
+  }
+
+  @Test
+  public void getAllConnectorsClusterCallFailureTest() throws Exception {
+    String getUrl = "/topics/getAllConnectors/localhost/" + KafkaSupportedProtocol.SSL + "/CLID1";
+
+    mvc.perform(get(getUrl)).andExpect(status().isOk()).andExpect(jsonPath("$", hasSize(0)));
+    ;
+  }
+
+  @Test
+  public void getConnectorDetailsTest() throws Exception {
+    String getUrl =
+        "/topics/getConnectorDetails/connectorName/kafkaConnectHost/ "
+            + KafkaSupportedProtocol.SSL
+            + "/CLID1";
+    Map<String, Object> connDetails = new HashMap<>();
+    connDetails.put("tasks.max", "4");
+    when(kafkaConnectService.getConnectorDetails(anyString(), anyString(), any(), anyString()))
+        .thenReturn(connDetails);
+
+    mvc.perform(get(getUrl))
+        .andExpect(status().isOk())
+        .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+        .andExpect(jsonPath("$", hasKey("tasks.max")));
+  }
+
+  @Test
+  public void getConnectorDetailsInvalidProtocolTest() throws Exception {
+    String getUrl =
+        "/topics/getConnectorDetails/connectorName/kafkaConnectHost/ "
+            + "INVALIDPROTOCOL"
+            + "/CLID1";
+    Map<String, Object> connDetails = new HashMap<>();
+    connDetails.put("tasks.max", "4");
+    when(kafkaConnectService.getConnectorDetails(anyString(), anyString(), any(), anyString()))
+        .thenReturn(connDetails);
+
+    mvc.perform(get(getUrl)).andExpect(status().is4xxClientError());
+  }
+
+  @Test
+  public void getConnectorDetailsClusterCallFailureTest() throws Exception {
+    String getUrl =
+        "/topics/getConnectorDetails/connectorName/kafkaConnectHost/ "
+            + KafkaSupportedProtocol.SSL
+            + "/CLID1";
+
+    mvc.perform(get(getUrl)).andExpect(status().isOk()).andExpect(jsonPath("$", aMapWithSize(0)));
+    ;
+  }
+
+  @Test
+  public void postConnectorTest() throws Exception {
+    String postUrl = "/topics/postConnector";
+    ApiResponse apiResponse = ApiResponse.builder().result(ApiResultStatus.SUCCESS.value).build();
+    ClusterConnectorRequest clusterConnectorRequest = getClusterConnectorRequest();
+    String jsonReq = new ObjectMapper().writer().writeValueAsString(clusterConnectorRequest);
+    when(kafkaConnectService.postNewConnector(any())).thenReturn(apiResponse);
+
+    mvc.perform(post(postUrl).content(jsonReq).contentType(MediaType.APPLICATION_JSON))
+        .andExpect(status().isOk())
+        .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+        .andExpect(content().string(containsString(ApiResultStatus.SUCCESS.value)));
+  }
+
+  @Test
+  public void postConnectorClusterFailureTest() throws Exception {
+    String postUrl = "/topics/postConnector";
+    ApiResponse apiResponse = ApiResponse.builder().result(ApiResultStatus.FAILURE.value).build();
+    ClusterConnectorRequest clusterConnectorRequest = getClusterConnectorRequest();
+    String jsonReq = new ObjectMapper().writer().writeValueAsString(clusterConnectorRequest);
+    when(kafkaConnectService.postNewConnector(any())).thenReturn(apiResponse);
+
+    mvc.perform(post(postUrl).content(jsonReq).contentType(MediaType.APPLICATION_JSON))
+        .andExpect(status().isOk())
+        .andExpect(content().string(containsString(ApiResultStatus.FAILURE.value)));
+  }
+
+  @Test
+  public void updateConnector() throws Exception {
+    String postUrl = "/topics/updateConnector";
+    Map<String, String> resultMap = new HashMap<>();
+    resultMap.put("result", ApiResultStatus.SUCCESS.value);
+    ClusterConnectorRequest clusterConnectorRequest = getClusterConnectorRequest();
+    String jsonReq = new ObjectMapper().writer().writeValueAsString(clusterConnectorRequest);
+    when(kafkaConnectService.updateConnector(any())).thenReturn(resultMap);
+
+    mvc.perform(post(postUrl).content(jsonReq).contentType(MediaType.APPLICATION_JSON))
+        .andExpect(status().isOk())
+        .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+        .andExpect(jsonPath("$", hasKey("result")));
+  }
+
+  @Test
+  public void deleteConnector() throws Exception {
+    String postUrl = "/topics/deleteConnector";
+    Map<String, String> resultMap = new HashMap<>();
+    resultMap.put("result", ApiResultStatus.SUCCESS.value);
+    ClusterConnectorRequest clusterConnectorRequest = getClusterConnectorRequest();
+    String jsonReq = new ObjectMapper().writer().writeValueAsString(clusterConnectorRequest);
+    when(kafkaConnectService.deleteConnector(any())).thenReturn(resultMap);
+
+    mvc.perform(post(postUrl).content(jsonReq).contentType(MediaType.APPLICATION_JSON))
+        .andExpect(status().isOk())
+        .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+        .andExpect(jsonPath("$", hasKey("result")))
+        .andExpect(jsonPath("$", hasValue(ApiResultStatus.SUCCESS.value)));
+  }
+
+  private static ClusterConnectorRequest getClusterConnectorRequest() {
+    return ClusterConnectorRequest.builder()
+        .clusterIdentification("CLID1")
+        .connectorConfig("{connectorname:test}")
+        .connectorName("test")
+        .env("localhost:843")
+        .protocol(KafkaSupportedProtocol.SSL)
+        .build();
+  }
+}

--- a/cluster-api/src/test/java/io/aiven/klaw/clusterapi/services/ClusterApiUtilsTest.java
+++ b/cluster-api/src/test/java/io/aiven/klaw/clusterapi/services/ClusterApiUtilsTest.java
@@ -1,0 +1,151 @@
+package io.aiven.klaw.clusterapi.services;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+
+import io.aiven.klaw.clusterapi.config.SslContextConfig;
+import io.aiven.klaw.clusterapi.models.enums.KafkaClustersType;
+import io.aiven.klaw.clusterapi.models.enums.KafkaSupportedProtocol;
+import io.aiven.klaw.clusterapi.utils.AdminClientProperties;
+import io.aiven.klaw.clusterapi.utils.ClusterApiUtils;
+import org.apache.commons.lang3.tuple.Pair;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.core.env.Environment;
+import org.springframework.http.client.HttpComponentsClientHttpRequestFactory;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.web.client.RestTemplate;
+
+@ExtendWith(MockitoExtension.class)
+public class ClusterApiUtilsTest {
+
+  @Mock Environment env;
+  @Mock private AdminClientProperties adminClientProperties;
+  private ClusterApiUtils clusterApiUtils;
+
+  @Mock private HttpComponentsClientHttpRequestFactory httpComponentsClientHttpRequestFactory;
+
+  @Mock SslContextConfig sslContextConfig;
+
+  @BeforeEach
+  public void setUp() {
+    clusterApiUtils = new ClusterApiUtils(env, adminClientProperties);
+    ReflectionTestUtils.setField(clusterApiUtils, "sslContextConfig", sslContextConfig);
+  }
+
+  @Test
+  public void getSchemaRegistryRequestDetailsSSL() {
+    String clusterIdentification = "CLID1";
+    String credentials = "username:password";
+    String suffixUrl = "localhost:8081/subjects";
+    String key =
+        clusterIdentification.toLowerCase() + ClusterApiUtils.KAFKA_SR_CREDENTIALS_PROPERTY_SFX;
+    when(env.getProperty(eq(key))).thenReturn(credentials);
+    when(sslContextConfig.getClientHttpRequestFactory())
+        .thenReturn(httpComponentsClientHttpRequestFactory);
+    Pair<String, RestTemplate> templatePair =
+        clusterApiUtils.getRequestDetails(
+            suffixUrl,
+            KafkaSupportedProtocol.SSL,
+            KafkaClustersType.SCHEMA_REGISTRY,
+            clusterIdentification);
+
+    assertThat(templatePair.getLeft())
+        .isEqualTo(ClusterApiUtils.HTTPS_PREFIX + credentials + "@" + suffixUrl);
+  }
+
+  @Test
+  public void getSchemaRegistryRequestDetailsSSLClIdNotConfigured() {
+    String clusterIdentification = "CLID1";
+    String suffixUrl = "localhost:8081/subjects";
+    String key =
+        clusterIdentification.toLowerCase() + ClusterApiUtils.KAFKA_SR_CREDENTIALS_PROPERTY_SFX;
+    when(env.getProperty(eq(key))).thenReturn(null);
+    when(sslContextConfig.getClientHttpRequestFactory())
+        .thenReturn(httpComponentsClientHttpRequestFactory);
+    Pair<String, RestTemplate> templatePair =
+        clusterApiUtils.getRequestDetails(
+            suffixUrl,
+            KafkaSupportedProtocol.SSL,
+            KafkaClustersType.SCHEMA_REGISTRY,
+            clusterIdentification);
+
+    assertThat(templatePair.getLeft()).isEqualTo(ClusterApiUtils.HTTPS_PREFIX + suffixUrl);
+    assertThat(templatePair.getRight().getRequestFactory())
+        .isEqualTo(httpComponentsClientHttpRequestFactory);
+  }
+
+  @Test
+  public void getSchemaRegistryRequestDetailsPlain() {
+    String clusterIdentification = "CLID1";
+    String suffixUrl = "localhost:8081/subjects";
+    Pair<String, RestTemplate> templatePair =
+        clusterApiUtils.getRequestDetails(
+            suffixUrl,
+            KafkaSupportedProtocol.PLAINTEXT,
+            KafkaClustersType.SCHEMA_REGISTRY,
+            clusterIdentification);
+
+    assertThat(templatePair.getLeft()).isEqualTo(ClusterApiUtils.HTTP_PREFIX + suffixUrl);
+  }
+
+  @Test
+  public void getConnectRequestDetailsSSL() {
+    String clusterIdentification = "CLID1";
+    String credentials = "username:password";
+    String suffixUrl = "localhost:8081/subjects";
+    String key =
+        clusterIdentification.toLowerCase()
+            + ClusterApiUtils.KAFKA_CONNECT_CREDENTIALS_PROPERTY_SFX;
+    when(env.getProperty(eq(key))).thenReturn(credentials);
+    when(sslContextConfig.getClientHttpRequestFactory())
+        .thenReturn(httpComponentsClientHttpRequestFactory);
+    Pair<String, RestTemplate> templatePair =
+        clusterApiUtils.getRequestDetails(
+            suffixUrl,
+            KafkaSupportedProtocol.SSL,
+            KafkaClustersType.KAFKA_CONNECT,
+            clusterIdentification);
+
+    assertThat(templatePair.getLeft())
+        .isEqualTo(ClusterApiUtils.HTTPS_PREFIX + credentials + "@" + suffixUrl);
+  }
+
+  @Test
+  public void getConnectRequestDetailsSSLClIdNotConfigured() {
+    String clusterIdentification = "CLID1";
+    String suffixUrl = "localhost:8081/subjects";
+    String key =
+        clusterIdentification.toLowerCase()
+            + ClusterApiUtils.KAFKA_CONNECT_CREDENTIALS_PROPERTY_SFX;
+    when(env.getProperty(eq(key))).thenReturn(null);
+    when(sslContextConfig.getClientHttpRequestFactory())
+        .thenReturn(httpComponentsClientHttpRequestFactory);
+    Pair<String, RestTemplate> templatePair =
+        clusterApiUtils.getRequestDetails(
+            suffixUrl,
+            KafkaSupportedProtocol.SSL,
+            KafkaClustersType.KAFKA_CONNECT,
+            clusterIdentification);
+
+    assertThat(templatePair.getLeft()).isEqualTo(ClusterApiUtils.HTTPS_PREFIX + suffixUrl);
+  }
+
+  @Test
+  public void getConnectRequestDetailsPlain() {
+    String clusterIdentification = "CLID1";
+    String suffixUrl = "localhost:8081/subjects";
+    Pair<String, RestTemplate> templatePair =
+        clusterApiUtils.getRequestDetails(
+            suffixUrl,
+            KafkaSupportedProtocol.PLAINTEXT,
+            KafkaClustersType.KAFKA_CONNECT,
+            clusterIdentification);
+
+    assertThat(templatePair.getLeft()).isEqualTo(ClusterApiUtils.HTTP_PREFIX + suffixUrl);
+  }
+}

--- a/cluster-api/src/test/java/io/aiven/klaw/clusterapi/services/KafkaConnectServiceTest.java
+++ b/cluster-api/src/test/java/io/aiven/klaw/clusterapi/services/KafkaConnectServiceTest.java
@@ -2,6 +2,7 @@ package io.aiven.klaw.clusterapi.services;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.client.match.MockRestRequestMatchers.requestTo;
@@ -9,8 +10,8 @@ import static org.springframework.test.web.client.response.MockRestResponseCreat
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import io.aiven.klaw.clusterapi.models.KafkaClustersType;
-import io.aiven.klaw.clusterapi.models.KafkaSupportedProtocol;
+import io.aiven.klaw.clusterapi.models.enums.KafkaClustersType;
+import io.aiven.klaw.clusterapi.models.enums.KafkaSupportedProtocol;
 import io.aiven.klaw.clusterapi.utils.ClusterApiUtils;
 import java.util.Collections;
 import org.apache.commons.lang3.tuple.Pair;
@@ -44,7 +45,8 @@ class KafkaConnectServiceTest {
   // TODO need to add proper return value
   @Test
   public void getConnectors_returnList() throws JsonProcessingException {
-    when(getAdminClient.getRequestDetails(any(), eq(KafkaSupportedProtocol.PLAINTEXT), any()))
+    when(getAdminClient.getRequestDetails(
+            any(), eq(KafkaSupportedProtocol.PLAINTEXT), any(), anyString()))
         .thenReturn(Pair.of("/env/connectors", restTemplate));
     this.mockRestServiceServer
         .expect(requestTo("/env/connectors"))
@@ -53,7 +55,7 @@ class KafkaConnectServiceTest {
                 objectMapper.writeValueAsString(Lists.list("conn1", "conn2")),
                 MediaType.APPLICATION_JSON));
 
-    assertThat(kafkaConnectService.getConnectors("env", KafkaSupportedProtocol.PLAINTEXT))
+    assertThat(kafkaConnectService.getConnectors("env", KafkaSupportedProtocol.PLAINTEXT, "CLID1"))
         .isNotEmpty();
   }
 
@@ -61,7 +63,10 @@ class KafkaConnectServiceTest {
   @Test
   public void getConnectorDetails_returnMap() throws JsonProcessingException {
     when(getAdminClient.getRequestDetails(
-            any(), eq(KafkaSupportedProtocol.PLAINTEXT), eq(KafkaClustersType.KAFKA_CONNECT)))
+            any(),
+            eq(KafkaSupportedProtocol.PLAINTEXT),
+            eq(KafkaClustersType.KAFKA_CONNECT),
+            anyString()))
         .thenReturn(Pair.of("/env/connectors/conn1", restTemplate));
     this.mockRestServiceServer
         .expect(requestTo("/env/connectors/conn1"))
@@ -72,7 +77,7 @@ class KafkaConnectServiceTest {
 
     assertThat(
             kafkaConnectService.getConnectorDetails(
-                "conn1", "env", KafkaSupportedProtocol.PLAINTEXT))
+                "conn1", "env", KafkaSupportedProtocol.PLAINTEXT, "CLID1"))
         .isNotEmpty();
   }
 }

--- a/cluster-api/src/test/java/io/aiven/klaw/clusterapi/services/SchemaServiceTest.java
+++ b/cluster-api/src/test/java/io/aiven/klaw/clusterapi/services/SchemaServiceTest.java
@@ -2,6 +2,7 @@ package io.aiven.klaw.clusterapi.services;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.client.match.MockRestRequestMatchers.requestTo;
@@ -9,8 +10,8 @@ import static org.springframework.test.web.client.response.MockRestResponseCreat
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import io.aiven.klaw.clusterapi.models.KafkaClustersType;
-import io.aiven.klaw.clusterapi.models.KafkaSupportedProtocol;
+import io.aiven.klaw.clusterapi.models.enums.KafkaClustersType;
+import io.aiven.klaw.clusterapi.models.enums.KafkaSupportedProtocol;
 import io.aiven.klaw.clusterapi.utils.ClusterApiUtils;
 import java.util.Collections;
 import org.apache.commons.lang3.tuple.Pair;
@@ -49,7 +50,8 @@ class SchemaServiceTest {
     when(getAdminClient.getRequestDetails(
             eq(getSchemaVersionsUrl),
             eq(KafkaSupportedProtocol.PLAINTEXT),
-            eq(KafkaClustersType.SCHEMA_REGISTRY)))
+            eq(KafkaClustersType.SCHEMA_REGISTRY),
+            anyString()))
         .thenReturn(Pair.of(getSchemaVersionsUrl, restTemplate));
     this.mockRestServiceServer
         .expect(requestTo("/" + getSchemaVersionsUrl))
@@ -62,7 +64,8 @@ class SchemaServiceTest {
     when(getAdminClient.getRequestDetails(
             eq(getSchemaCompatibilityUrl),
             eq(KafkaSupportedProtocol.PLAINTEXT),
-            eq(KafkaClustersType.SCHEMA_REGISTRY)))
+            eq(KafkaClustersType.SCHEMA_REGISTRY),
+            anyString()))
         .thenReturn(Pair.of(getSchemaCompatibilityUrl, restTemplate));
     this.mockRestServiceServer
         .expect(requestTo("/" + getSchemaCompatibilityUrl))
@@ -77,11 +80,12 @@ class SchemaServiceTest {
     when(getAdminClient.getRequestDetails(
             eq(getSchemaUrl),
             eq(KafkaSupportedProtocol.PLAINTEXT),
-            eq(KafkaClustersType.SCHEMA_REGISTRY)))
+            eq(KafkaClustersType.SCHEMA_REGISTRY),
+            anyString()))
         .thenReturn(Pair.of(getSchemaUrl, restTemplate));
 
     when(getAdminClient.getRequestDetails(
-            eq(getSchemaUrl), eq(KafkaSupportedProtocol.PLAINTEXT), any()))
+            eq(getSchemaUrl), eq(KafkaSupportedProtocol.PLAINTEXT), any(), anyString()))
         .thenReturn(Pair.of(getSchemaUrl, restTemplate));
     this.mockRestServiceServer
         .expect(requestTo("/" + getSchemaUrl))
@@ -90,7 +94,7 @@ class SchemaServiceTest {
                 objectMapper.writeValueAsString(Collections.singletonMap("foo", "bar")),
                 MediaType.APPLICATION_JSON));
 
-    assertThat(schemaService.getSchema("env", KafkaSupportedProtocol.PLAINTEXT, "topic"))
+    assertThat(schemaService.getSchema("env", KafkaSupportedProtocol.PLAINTEXT, "CLID1", "topic"))
         .isNotEmpty();
   }
 }

--- a/cluster-api/src/test/java/io/aiven/klaw/clusterapi/services/UtilComponentsServiceTest.java
+++ b/cluster-api/src/test/java/io/aiven/klaw/clusterapi/services/UtilComponentsServiceTest.java
@@ -6,14 +6,14 @@ import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.when;
 
 import io.aiven.klaw.clusterapi.UtilMethods;
-import io.aiven.klaw.clusterapi.models.AclType;
 import io.aiven.klaw.clusterapi.models.ApiResponse;
-import io.aiven.klaw.clusterapi.models.ApiResultStatus;
 import io.aiven.klaw.clusterapi.models.ClusterAclRequest;
 import io.aiven.klaw.clusterapi.models.ClusterSchemaRequest;
-import io.aiven.klaw.clusterapi.models.ClusterStatus;
 import io.aiven.klaw.clusterapi.models.ClusterTopicRequest;
-import io.aiven.klaw.clusterapi.models.KafkaSupportedProtocol;
+import io.aiven.klaw.clusterapi.models.enums.AclType;
+import io.aiven.klaw.clusterapi.models.enums.ApiResultStatus;
+import io.aiven.klaw.clusterapi.models.enums.ClusterStatus;
+import io.aiven.klaw.clusterapi.models.enums.KafkaSupportedProtocol;
 import io.aiven.klaw.clusterapi.utils.ClusterApiUtils;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -362,7 +362,7 @@ public class UtilComponentsServiceTest {
     ClusterSchemaRequest clusterSchemaRequest = utilMethods.getSchema();
     ApiResponse apiResponse = ApiResponse.builder().result("Schema created id : 101").build();
     ResponseEntity<ApiResponse> response = new ResponseEntity<>(apiResponse, HttpStatus.OK);
-    when(getAdminClient.getRequestDetails(any(), any(), any()))
+    when(getAdminClient.getRequestDetails(any(), any(), any(), anyString()))
         .thenReturn(Pair.of("", restTemplate));
     when(restTemplate.postForEntity(anyString(), any(), eq(String.class)))
         .thenReturn(new ResponseEntity<>("Schema created id : 101", HttpStatus.OK));
@@ -374,7 +374,7 @@ public class UtilComponentsServiceTest {
   @Test
   public void postSchema2() {
     ClusterSchemaRequest clusterSchemaRequest = utilMethods.getSchema();
-    when(getAdminClient.getRequestDetails(any(), any(), any()))
+    when(getAdminClient.getRequestDetails(any(), any(), any(), anyString()))
         .thenReturn(Pair.of("", restTemplate));
     when(restTemplate.postForEntity(anyString(), any(), eq(String.class)))
         .thenReturn(

--- a/cluster-api/src/test/java/io/aiven/klaw/clusterapi/utils/GetAdminClientTest.java
+++ b/cluster-api/src/test/java/io/aiven/klaw/clusterapi/utils/GetAdminClientTest.java
@@ -5,9 +5,10 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.when;
 
-import io.aiven.klaw.clusterapi.models.KafkaSupportedProtocol;
+import io.aiven.klaw.clusterapi.models.enums.KafkaSupportedProtocol;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
 import org.apache.kafka.clients.admin.AdminClient;
@@ -21,6 +22,7 @@ import org.mockito.Mock;
 import org.mockito.MockedStatic;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.core.env.Environment;
+import org.springframework.web.client.RestTemplate;
 
 @ExtendWith(MockitoExtension.class)
 public class GetAdminClientTest {
@@ -35,11 +37,14 @@ public class GetAdminClientTest {
   @Mock private ListTopicsResult listTopicsResult;
   @Mock private KafkaFuture<Set<String>> kafkaFuture;
   @Mock private HashMap<String, AdminClient> adminClientsMap;
+
+  @Mock private Map<String, RestTemplate> restTemplateMap;
   @Mock private AdminClientProperties adminClientProperties;
 
   @BeforeEach
-  public void setUp() throws Exception {
-    getAdminClient = new ClusterApiUtils(env, adminClientProperties, adminClientsMap);
+  public void setUp() {
+    getAdminClient =
+        new ClusterApiUtils(env, adminClientProperties, adminClientsMap, restTemplateMap);
     when(adminClientProperties.getRetriesConfig()).thenReturn("3");
     when(adminClientProperties.getRequestTimeOutMs()).thenReturn("15000");
     when(adminClientProperties.getRetryBackOffMsConfig()).thenReturn("15000");

--- a/cluster-api/src/test/resources/application.properties
+++ b/cluster-api/src/test/resources/application.properties
@@ -1,24 +1,45 @@
-server.port=9343
+# SSL/Https Properties to secure Cluster Api application
+
+#server.ssl.key-store=classpath:certs/keystore.p12
+#server.ssl.trust-store=classpath:certs/truststore.jks
+#server.ssl.key-store-password=klaw1234
+#server.ssl.key-password=klaw1234
+#server.ssl.trust-store-password=klaw1234
+#server.ssl.key-store-type=pkcs12
 
 # SSL properties to connect to Kafka clusters
 
-klawssl.kafkassl.keystore.location=client.keystore.p12
-klawssl.kafkassl.keystore.pwd=pwd
-klawssl.kafkassl.key.pwd=pwd
-klawssl.kafkassl.truststore.location=client.truststore.jks
-klawssl.kafkassl.truststore.pwd=pwd
-klawssl.kafkassl.keystore.type=pkcs12
-klawssl.kafkassl.truststore.type=JKS
+#dev1.kafkassl.keystore.location=classpath:certs/keystore.p12
+#dev1.kafkassl.keystore.pwd=klaw1234
+#dev1.kafkassl.key.pwd=klaw1234
+#dev1.kafkassl.truststore.location=classpath:certs/truststore.jks
+#dev1.kafkassl.truststore.pwd=klaw1234
+#dev1.kafkassl.keystore.type=pkcs12
 
-kafkasasl.saslmechanism.plain=PLAIN
-kafkasasl.saslmechanism.gssapi=GSSAPI
-kafkasasl.saslmechanism.scram.256=SCRAM-SHA-256
-kafkasasl.saslmechanism.scram.512=SCRAM-SHA-512
+# SASL properties to connect to Kafka clusters
+#clusterid.kafkasasl.jaasconfig.plain=org.apache.kafka.common.security.plain.PlainLoginModule required username='kwuser' password='kwuser-secret';
+#clusterid.kafkasasl.jaasconfig.scram=org.apache.kafka.common.security.scram.ScramLoginModule required username='kwuser' password='kwuser-secret';
+#clusterid.kafkasasl.saslmechanism.gssapi.servicename=kafka
+#clusterid.kafkasasl.jaasconfig.gssapi=com.sun.security.auth.module.Krb5LoginModule required useKeyTab=true storeKey=true keyTab="/location/kafka_client.keytab" principal="kafkaclient1@EXAMPLE.COM";
 
-# User for accessing Cluster api
-klaw.clusterapi.access.username=kwclusterapiuser
-# Provide a base 64 encoded string below. The same secret should be configured in Klaw Api. Change to a new one. Ex : dGhpcyBpcyBhIHNlY3JldCB0byBhY2Nlc3MgY2x1c3RlcmFwaQ==
+# Schema Registry/karapace HTTPS credentials (Ex : username:password)
+srdev1.klaw.schemaregistry.credentials=uname:password
+
+# Kafka Connect HTTPS credentials (Ex : username:password)
+devcon1.klaw.kafkaconnect.credentials=uname:password
+
+# Provide a base 64 encoded string below. The same secret should be configured in Klaw Api. Change to a new one.
+# Ex : dGhpcyBpcyBhIHNlY3JldCB0byBhY2Nlc3MgY2x1c3RlcmFwaQ==
 klaw.clusterapi.access.base64.secret=dGhpcyBpcyBhIHNlY3JldCB0byBhY2Nlc3MgY2x1c3RlcmFwaQ==
+
+# access token for https requests (Currently applicable on Aiven calls)
+klaw.clusters.accesstoken=
+
+# --------------------- Please do not modify the below defaults unless required ---------------------
+server.port=9343
+
+# User for accessing Cluster api by Core Api
+klaw.clusterapi.access.username=kwclusterapiuser
 
 # this property is required to avoid default password printing to console.
 spring.security.user.password=avoid_default_pwd_logging
@@ -31,21 +52,22 @@ klaw.retries.config=10
 klaw.retry.backoff.ms=5000
 klaw.request.timeout.ms=15000
 
+# default Kafka SASL properties
+kafkasasl.saslmechanism.plain=PLAIN
+kafkasasl.saslmechanism.gssapi=GSSAPI
+kafkasasl.saslmechanism.scram.256=SCRAM-SHA-256
+kafkasasl.saslmechanism.scram.512=SCRAM-SHA-512
+
+# swagger documentation path parser
+spring.mvc.pathmatch.matching-strategy = ANT_PATH_MATCHER
+
 spring.banner.location=classpath:banner.txt
-
-# aiven acls config
-klaw.aiven.listacls.api=https://api.aiven.io/v1/project/projectName/service/serviceName/acl
-klaw.aiven.addacls.api=https://api.aiven.io/v1/project/projectName/service/serviceName/acl
-klaw.aiven.deleteacls.api=https://api.aiven.io/v1/project/projectName/service/serviceName/acl/aclId
-klaw.aiven.accesstoken=accesstoken
-
-# access token for https requests
-klaw.clusters.accesstoken=
-
-#aiven schema security
-klaw.aiven.karapace.credentials=
-klaw.aiven.kafkaconnect.credentials=
-
 # log file settings
-#logging.level.root=info
 logging.file.name=./../logs/kw-clusterapi.log
+spring.mvc.log-resolved-exception=true
+logging.level.root=info
+
+# Custom Acls - Api Endpoints (Currently applicable on Aiven calls)
+klaw.clusters.listacls.api=https://api.aiven.io/v1/project/projectName/service/serviceName/acl
+klaw.clusters.addacls.api=https://api.aiven.io/v1/project/projectName/service/serviceName/acl
+klaw.clusters.deleteacls.api=https://api.aiven.io/v1/project/projectName/service/serviceName/acl/aclId

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -174,7 +174,7 @@
                         <goals>
                             <goal>install-node-and-npm</goal>
                         </goals>
-                        <phase>generate-resources</phase>
+                        <phase>generate-sources</phase>
                         <configuration>
                             <nodeVersion>${node.version}</nodeVersion>
                             <npmVersion>${npm.version}</npmVersion>
@@ -191,7 +191,7 @@
                     <!-- Install pnpm for React components -->
                     <execution>
                         <id>Install pnpm</id>
-                        <phase>compile</phase>
+                        <phase>generate-resources</phase>
                         <goals>
                             <goal>exec</goal>
                         </goals>
@@ -217,7 +217,7 @@
                         <goals>
                             <goal>exec</goal>
                         </goals>
-                        <phase>compile</phase>
+                        <phase>generate-resources</phase>
                         <configuration>
                             <executable>make</executable>
                             <commandlineArgs>src/main/resources/templates/coral/index.html src/main/resources/static/assets/coral</commandlineArgs>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -213,7 +213,7 @@
                         </configuration>
                     </execution>
                     <execution>
-                        <id>Compile and copy Coral assets</id>
+                        <id>Build and copy Coral assets</id>
                         <goals>
                             <goal>exec</goal>
                         </goals>

--- a/core/src/main/java/io/aiven/klaw/config/ManageDatabase.java
+++ b/core/src/main/java/io/aiven/klaw/config/ManageDatabase.java
@@ -100,9 +100,6 @@ public class ManageDatabase implements ApplicationContextAware, InitializingBean
 
   @Autowired private DefaultDataService defaultDataService;
 
-  @Value("${klaw.org.name}")
-  private String orgName;
-
   @Value("${klaw.login.authentication.type}")
   private String authenticationType;
 
@@ -115,7 +112,7 @@ public class ManageDatabase implements ApplicationContextAware, InitializingBean
   @Value("${klaw.superadmin.default.password}")
   private String superAdminDefaultPwd;
 
-  @Value("${klaw.version:1.0.0}")
+  @Value("${klaw.version}")
   private String kwVersion;
 
   @Value("${klaw.jasypt.encryptor.secretkey}")

--- a/core/src/main/java/io/aiven/klaw/model/cluster/ClusterConnectorRequest.java
+++ b/core/src/main/java/io/aiven/klaw/model/cluster/ClusterConnectorRequest.java
@@ -15,4 +15,6 @@ public class ClusterConnectorRequest implements Serializable {
   @JsonProperty private String connectorConfig;
 
   @JsonProperty private String connectorName;
+
+  @JsonProperty private String clusterIdentification;
 }

--- a/core/src/main/java/io/aiven/klaw/model/cluster/ClusterSchemaRequest.java
+++ b/core/src/main/java/io/aiven/klaw/model/cluster/ClusterSchemaRequest.java
@@ -15,4 +15,6 @@ public class ClusterSchemaRequest implements Serializable {
   @JsonProperty private String topicName;
 
   @JsonProperty private String fullSchema;
+
+  @JsonProperty private String clusterIdentification;
 }

--- a/core/src/main/java/io/aiven/klaw/service/KafkaConnectControllerService.java
+++ b/core/src/main/java/io/aiven/klaw/service/KafkaConnectControllerService.java
@@ -579,6 +579,7 @@ public class KafkaConnectControllerService {
                 connectorRequest.getConnectortype(),
                 connectorRequest.getConnectorConfig(),
                 kafkaConnectHost,
+                kwClusters.getClusterName() + kwClusters.getClusterId(),
                 tenantId);
       } else {
         updateTopicReqStatus =
@@ -588,6 +589,7 @@ public class KafkaConnectControllerService {
                 connectorRequest.getConnectortype(),
                 jsonConnectorConfig,
                 kafkaConnectHost,
+                kwClusters.getClusterName() + kwClusters.getClusterId(),
                 tenantId);
       }
       if (Objects.equals(updateTopicReqStatus, ApiResultStatus.SUCCESS.value)) {

--- a/core/src/main/java/io/aiven/klaw/service/KafkaConnectSyncControllerService.java
+++ b/core/src/main/java/io/aiven/klaw/service/KafkaConnectSyncControllerService.java
@@ -54,7 +54,11 @@ public class KafkaConnectSyncControllerService {
 
     Map<String, Object> res =
         clusterApiService.getConnectorDetails(
-            connectorName, kwClusters.getBootstrapServers(), kwClusters.getProtocol(), tenantId);
+            connectorName,
+            kwClusters.getBootstrapServers(),
+            kwClusters.getProtocol(),
+            kwClusters.getClusterName() + kwClusters.getClusterId(),
+            tenantId);
 
     try {
       String schemaOfObj = OBJECT_MAPPER.writerWithDefaultPrettyPrinter().writeValueAsString(res);
@@ -217,7 +221,7 @@ public class KafkaConnectSyncControllerService {
       return ApiResponse.builder()
           .result(
               "Failure. Please sync up the team of the following connector(s) first in"
-                  + " main Sync cluster (klaw.syncdata.cluster)"
+                  + " main Sync cluster"
                   + " :"
                   + syncCluster
                   + ". \n Topics : "
@@ -229,7 +233,7 @@ public class KafkaConnectSyncControllerService {
       return ApiResponse.builder()
           .result(
               "Failure. The following connectors are being synchronized with"
-                  + " a different team, when compared to main Sync cluster (klaw.syncdata.cluster)"
+                  + " a different team, when compared to main Sync cluster"
                   + " :"
                   + syncCluster
                   + ". \n Topics : "
@@ -260,7 +264,11 @@ public class KafkaConnectSyncControllerService {
     Object configMap =
         clusterApiService
             .getConnectorDetails(
-                connectorName, kwClusters.getBootstrapServers(), kwClusters.getProtocol(), tenantId)
+                connectorName,
+                kwClusters.getBootstrapServers(),
+                kwClusters.getProtocol(),
+                kwClusters.getClusterName() + kwClusters.getClusterId(),
+                tenantId)
             .get("config");
     return WRITER_WITH_DEFAULT_PRETTY_PRINTER.writeValueAsString(configMap);
   }
@@ -325,13 +333,18 @@ public class KafkaConnectSyncControllerService {
 
     // get from cluster
     List<KafkaConnectorModel> kafkaConnectorModelClusterList = new ArrayList<>();
-    String bootstrapHost =
+    KwClusters kwClusters =
         manageDatabase
             .getClusters(KafkaClustersType.KAFKA_CONNECT, tenantId)
-            .get(envSelected.getClusterId())
-            .getBootstrapServers();
+            .get(envSelected.getClusterId());
+    String bootstrapHost = kwClusters.getBootstrapServers();
     try {
-      List<String> allConnectors = clusterApiService.getAllKafkaConnectors(bootstrapHost, tenantId);
+      List<String> allConnectors =
+          clusterApiService.getAllKafkaConnectors(
+              bootstrapHost,
+              kwClusters.getProtocol().getName(),
+              kwClusters.getClusterName() + kwClusters.getClusterId(),
+              tenantId);
 
       if (connectorNameSearch != null && connectorNameSearch.length() > 0) {
         final String topicSearchFilter = connectorNameSearch;

--- a/core/src/main/java/io/aiven/klaw/service/TopicControllerService.java
+++ b/core/src/main/java/io/aiven/klaw/service/TopicControllerService.java
@@ -960,7 +960,9 @@ public class TopicControllerService {
       final String topicSearchFilter = topicNameSearch;
       topicFilteredList =
           topicsFromSOT.stream()
-              .filter(topic -> topic.getTopicname().contains(topicSearchFilter))
+              .filter(
+                  topic ->
+                      topic.getTopicname().toLowerCase().contains(topicSearchFilter.toLowerCase()))
               .collect(Collectors.toList());
 
       // searching documentation
@@ -969,7 +971,10 @@ public class TopicControllerService {
               .filter(
                   topic ->
                       (topic.getDocumentation() != null
-                          && topic.getDocumentation().contains(topicSearchFilter)))
+                          && topic
+                              .getDocumentation()
+                              .toLowerCase()
+                              .contains(topicSearchFilter.toLowerCase())))
               .collect(Collectors.toList());
 
       topicFilteredList.addAll(searchDocList);

--- a/core/src/main/java/io/aiven/klaw/service/TopicOverviewService.java
+++ b/core/src/main/java/io/aiven/klaw/service/TopicOverviewService.java
@@ -174,7 +174,7 @@ public class TopicOverviewService {
               clusterApiService.getAvroSchema(
                   kwClusters.getBootstrapServers(),
                   kwClusters.getProtocol(),
-                  kwClusters.getClusterName(),
+                  kwClusters.getClusterName() + kwClusters.getClusterId(),
                   topicNameSearch,
                   tenantId);
 

--- a/core/src/main/java/io/aiven/klaw/service/TopicSyncControllerService.java
+++ b/core/src/main/java/io/aiven/klaw/service/TopicSyncControllerService.java
@@ -1098,7 +1098,7 @@ public class TopicSyncControllerService {
       return ApiResponse.builder()
           .result(
               "Failure. Please sync up the team of the following topic(s) first in"
-                  + " main Sync cluster (klaw.syncdata.cluster)"
+                  + " main Sync cluster"
                   + " :"
                   + syncCluster
                   + ". \n Topics : "
@@ -1110,7 +1110,7 @@ public class TopicSyncControllerService {
       return ApiResponse.builder()
           .result(
               "Failure. The following topics are being synchronized with"
-                  + " a different team, when compared to main Sync cluster (klaw.syncdata.cluster)"
+                  + " a different team, when compared to main Sync cluster"
                   + " :"
                   + syncCluster
                   + ". \n Topics : "

--- a/core/src/main/java/io/aiven/klaw/service/UtilControllerService.java
+++ b/core/src/main/java/io/aiven/klaw/service/UtilControllerService.java
@@ -42,7 +42,7 @@ public class UtilControllerService {
 
   @Autowired private CommonUtilsService commonUtilsService;
 
-  @Value("${klaw.version:1.0.1}")
+  @Value("${klaw.version}")
   private String klawVersion;
 
   @Value("${klaw.login.authentication.type}")

--- a/core/src/main/resources/application.properties
+++ b/core/src/main/resources/application.properties
@@ -1,8 +1,5 @@
-server.port=9097
+# Uncomment the below SSL/Https Properties to secure this Cluster Api application
 
-#server.servlet.context-path=/klaw
-
-# SSL Properties
 #server.ssl.key-store=client.keystore.p12
 #server.ssl.trust-store=client.truststore.jks
 #server.ssl.key-store-password=klaw1234
@@ -10,33 +7,8 @@ server.port=9097
 #server.ssl.trust-store-password=klaw1234
 #server.ssl.key-store-type=pkcs12
 
-# klaw.db.storetype should be "rdbms"
-klaw.db.storetype=rdbms
+#Uncomment the below to configure Spring JPA properties to connect Klaw to MySql Rdbms
 
-# klaw application is either "saas" or "onpremise"
-klaw.installation.type=onpremise
-
-# Possible values "db" or "ad". If SSO config or Active directory is enabled below, this value should be "ad"
-klaw.login.authentication.type=db
-
-# Database settings
-spring.liquibase.enabled=true
-spring.liquibase.change-log=classpath:db/changelog/changelog.yaml
-
-# default cluster to synchronize data
-klaw.syncdata.cluster=DEV
-
-# order of envs
-klaw.envs.order=DEV,TST,ACC,PRD
-
-#request topics in below envs. Promote topics will be in higher envs
-klaw.request.topics.envs=DEV,TST
-
-# Org info
-klaw.org.name=MyOrganization
-klaw.version=1.2.0
-
-# Spring JPA properties mysql
 #spring.datasource.url=jdbc:mysql://localhost:3306/kafkametadbpro?autoReconnect=true&useUnicode=true&useJDBCCompliantTimezoneShift=true&useLegacyDatetimeCode=false&serverTimezone=UTC&cachePrepStmts=true&useServerPrepStmts=true&rewriteBatchedStatements=true&verifyServerCertificate=false&useSSL=false&requireSSL=false&allowPublicKeyRetrieval=true
 #spring.datasource.username=kafkauser
 #spring.datasource.password=kafkauser123
@@ -44,7 +16,8 @@ klaw.version=1.2.0
 #spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.MySQLDialect
 #spring.datasource.platform=mysql
 
-# Spring JPA properties postgresql
+#Uncomment the below to configure Spring JPA properties to connect Klaw to Postgres Rdbms
+
 #spring.datasource.url=jdbc:postgresql://localhost:5432/klaw?cachePrepStmts=true&useServerPrepStmts=true&rewriteBatchedStatements=true
 #spring.datasource.username=kafkauser
 #spring.datasource.password=klaw
@@ -52,7 +25,8 @@ klaw.version=1.2.0
 #spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.PostgreSQL92Dialect
 #spring.datasource.platform=postgres
 
-# Spring JPA properties filedb
+#To configure Spring JPA properties to connect Klaw to internal file database
+
 spring.datasource.url=jdbc:h2:file:./klawprodb;DB_CLOSE_ON_EXIT=FALSE;DB_CLOSE_DELAY=-1;MODE=MySQL;CASE_INSENSITIVE_IDENTIFIERS=TRUE;
 spring.datasource.driver.class=org.h2.Driver
 spring.datasource.username=kafkauser
@@ -60,30 +34,10 @@ spring.datasource.password=klaw
 spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.H2Dialect
 spring.h2.console.enabled=true
 
-# Generic JPA props
-spring.datasource.hikari.connectionTimeout=30000
-spring.datasource.hikari.idleTimeout=600000
-spring.datasource.hikari.maxPoolSize=50
-spring.jpa.hibernate.show_sql=false
-spring.jpa.hibernate.generate-ddl=false
-spring.jpa.hibernate.ddl-auto=update
-spring.jpa.hibernate.jdbc.lob.non_contextual_creation=true
-spring.jpa.properties.hibernate.naming.physical-strategy=org.hibernate.boot.model.naming.PhysicalNamingStrategyStandardImpl
+# Possible values "db" or "ad". If SSO config or Active directory is enabled below, this value should be "ad"
+klaw.login.authentication.type=db
 
-# Email notification properties
-klaw.mail.notifications.enable=true
-spring.mail.properties.mail.transport.protocol=smtp
-spring.mail.host=smtphost
-spring.mail.port=587
-spring.mail.username=mailid
-spring.mail.password=mailpwd
-spring.mail.properties.mail.smtp.auth=true
-spring.mail.properties.mail.smtp.starttls.enable=true
-spring.mail.properties.mail.debug=false
-spring.mail.noreplymailid=noreplyid
-spring.mail.frommailid=fromailid
-
-# ActiveDirectory properties. Users can login with their active directory credentials
+# Uncomment the below ActiveDirectory properties for Users to login with their active directory credentials.
 #spring.ad.domain=
 #spring.ad.url=
 #spring.ad.rootDn=
@@ -97,7 +51,9 @@ klaw.enable.authorization.ad=false
 klaw.enable.sso=false
 klaw.sso.server.loginurl=/oauth2/authorization/azure
 
+# Uncomment the below to configure OAuth2 client for authentication
 #Based on above registration id, create the keys below. spring.security.oauth2.client.registration.[registrationid]...
+
 #spring.security.oauth2.client.registration.klaw.client-id=ssoClient-1
 #spring.security.oauth2.client.registration.klaw.client-secret=ssoClientSecret-1
 #spring.security.oauth2.client.registration.klaw.scope=read,write
@@ -109,7 +65,7 @@ klaw.sso.server.loginurl=/oauth2/authorization/azure
 #spring.security.oauth2.client.provider.klaw.user-info-uri=http://localhost:8083/auth/realms/klaw/protocol/openid-connect/userinfo
 #spring.security.oauth2.client.provider.klaw.user-name-attribute=preferred_username
 
-# Azure AD-SSO configuration for authentication
+# Azure AD-SSO configuration for Klaw Authentication
 # Enable related features.
 spring.cloud.azure.active-directory.enabled=true
 # Specifies your Active Directory ID:
@@ -120,55 +76,68 @@ spring.cloud.azure.active-directory.credential.client-id=clientid
 spring.cloud.azure.active-directory.credential.client-secret=client-secret
 # grants & scopes
 
-# other spring config
-spring.cache.type=NONE
-spring.thymeleaf.cache=false
-
-# application shutdown and health properties
-management.endpoints.web.exposure.include=health,info,metrics
-management.endpoints.web.exposure.exclude=
-management.health.ldap.enabled=false
-management.endpoint.shutdown.enabled=false
-
-#jasypt encryption pwd secret key
-klaw.jasypt.encryptor.secretkey=kw2021secretkey
-
-# ClusterApi access
-klaw.clusterapi.access.username=kwclusterapiuser
+# Uncomment the below to establish connectivity between core and cluster apis.
+# Provide a base 64 encoded string. The same secret should be configured in Klaw Cluster Api.
 klaw.clusterapi.access.base64.secret=
-
-# Monitoring
-klaw.monitoring.metrics.enable=false
-klaw.monitoring.metrics.collectinterval.ms=60000
-
-# custom banner
-spring.banner.location=classpath:banner.txt
-
-#kw prize list
-klaw.prizelist.pertenant=1 month (8 $),2 months (15 $),3 months (20 $),6 months (42 $),1 year (75 $),2 years (150 $),3 years (225 $),5 years (350 $) 
-
-klaw.admin.mailid=superuser@maild
 
 # In case of AD or Azure AD, configure an existing user from AD in the below config for username. Ex : superadmin@domain.
 # Leave it blank if this user is not required
 klaw.superadmin.default.username=superadmin
 klaw.superadmin.default.password=kwsuperadmin123$$
 
-#kw saas admin
+# Klaw Saas Admin
 klaw.saas.ssl.aclcommand=kafka-acls --authorizer-properties bootstrap.server=host:port --add --allow-principal User:"CN=abc..." --operation All  --cluster Cluster:kafka-cluster --topic "*"
-klaw.saas.ssl.pubkey=C:/location/Klaw_PublicKey.zip
-klaw.saas.ssl.clientcerts.location=C:/location/clientcerts
-klaw.saas.ssl.clusterapi.truststore=C:/location/client.truststore.jks
+klaw.saas.ssl.pubkey=/location/Klaw_PublicKey.zip
+klaw.saas.ssl.clientcerts.location=/location/clientcerts
+klaw.saas.ssl.clusterapi.truststore=/location/client.truststore.jks
 klaw.saas.ssl.clusterapi.truststore.pwd=klaw
 klaw.saas.plaintext.aclcommand=kafka-acls --authorizer-properties bootstrap.server=host:port --add --allow-principal User:'*' --operation All --allow-host hostname_ip --cluster Cluster:kafka-cluster --topic "*"
 
+# comma separated instances of klaw when running in cluster
 klaw.uiapi.servers=https://localhost:9097
+
+# Enable new Klaw user interface
+klaw.coral.enabled=false
+
+# Email notification properties
+klaw.admin.mailid=superuser@maild
+klaw.mail.notifications.enable=true
+spring.mail.properties.mail.transport.protocol=smtp
+spring.mail.host=smtphost
+spring.mail.port=587
+spring.mail.username=mailid
+spring.mail.password=mailpwd
+spring.mail.properties.mail.smtp.auth=true
+spring.mail.properties.mail.smtp.starttls.enable=true
+spring.mail.properties.mail.debug=false
+spring.mail.noreplymailid=noreplyid
+spring.mail.frommailid=fromailid
 
 #google recaptcha settings
 klaw.recaptcha.validate=false
 google.recaptcha.sitekey=
 google.recaptcha.verification.endpoint=https://www.google.com/recaptcha/api/siteverify
 google.recaptcha.secret=
+
+# --------------------- Please do not modify the below defaults unless required ---------------------
+server.port=9097
+#server.servlet.context-path=/klaw
+
+# klaw.db.storetype should be "rdbms"
+klaw.db.storetype=rdbms
+
+# klaw application is either "saas" or "onpremise"
+klaw.installation.type=onpremise
+
+# current version of klaw
+klaw.version=1.2.0
+
+# Database settings
+spring.liquibase.enabled=true
+spring.liquibase.change-log=classpath:db/changelog/changelog.yaml
+
+#kw prize list
+klaw.prizelist.pertenant=<to be removed> 
 
 # Enable response compression
 server.compression.enabled=true
@@ -182,11 +151,41 @@ server.compression.min-response-size=1024
 #maximum tenants can be created
 klaw.max.tenants=200
 
-# Enable new Klaw user interface
-klaw.coral.enabled=false
+# ClusterApi access
+klaw.clusterapi.access.username=kwclusterapiuser
+
+# Monitoring
+klaw.monitoring.metrics.enable=false
+klaw.monitoring.metrics.collectinterval.ms=60000
+
+# custom banner
+spring.banner.location=classpath:banner.txt
+
+#jasypt encryption pwd secret key
+klaw.jasypt.encryptor.secretkey=kw2021secretkey
+
+# Generic JPA props
+spring.datasource.hikari.connectionTimeout=30000
+spring.datasource.hikari.idleTimeout=600000
+spring.datasource.hikari.maxPoolSize=50
+spring.jpa.hibernate.show_sql=false
+spring.jpa.hibernate.generate-ddl=false
+spring.jpa.hibernate.ddl-auto=update
+spring.jpa.hibernate.jdbc.lob.non_contextual_creation=true
+spring.jpa.properties.hibernate.naming.physical-strategy=org.hibernate.boot.model.naming.PhysicalNamingStrategyStandardImpl
+
+# other spring config
+spring.cache.type=NONE
+spring.thymeleaf.cache=false
+
+# application shutdown and health properties
+management.endpoints.web.exposure.include=health,info,metrics
+management.endpoints.web.exposure.exclude=
+management.health.ldap.enabled=false
+management.endpoint.shutdown.enabled=false
 
 # log file settings
-#logging.level.root=debug
+logging.level.root=info
 logging.level.org.hibernate.SQL=off
 logging.file.name=./../logs/kw-uiapi.log
 spring.mvc.log-resolved-exception=true

--- a/core/src/main/resources/templates/error.html
+++ b/core/src/main/resources/templates/error.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html>
+<body>
+<h1>Something went wrong! </h1>
+<h2>If you are accessing new Coral interface, please go through
+    <a target="_blank" href="https://github.com/aiven/klaw/blob/main/coral/README.md">Read Me</a>
+</h2>
+
+<a href="/">Go Home</a>
+</body>
+</html>

--- a/core/src/test/java/io/aiven/klaw/EnvsClustersTenantsControllerIT.java
+++ b/core/src/test/java/io/aiven/klaw/EnvsClustersTenantsControllerIT.java
@@ -160,10 +160,10 @@ public class EnvsClustersTenantsControllerIT {
     List clusterModels = OBJECT_MAPPER.readValue(response, List.class);
     assertThat(clusterModels).hasSize(1);
 
-    Map<String, Integer> linkedHashMap = (Map<String, Integer>) clusterModels.get(0);
+    Map<String, Integer> hashMap = (Map<String, Integer>) clusterModels.get(0);
 
     KwClustersModel kwClustersModel = mockMethods.getClusterModel("DEV_CLUSTER");
-    kwClustersModel.setClusterId(linkedHashMap.get("clusterId"));
+    kwClustersModel.setClusterId(hashMap.get("clusterId"));
     kwClustersModel.setBootstrapServers("localhost:9093");
     String jsonReq = OBJECT_MAPPER.writer().writeValueAsString(kwClustersModel);
     response =
@@ -238,13 +238,13 @@ public class EnvsClustersTenantsControllerIT {
     List clusterModels = OBJECT_MAPPER.readValue(response, List.class);
     assertThat(clusterModels).hasSize(2);
 
-    Map<String, Integer> linkedHashMap = (Map) clusterModels.get(0);
+    Map<String, Integer> hashMap = (Map) clusterModels.get(0);
 
     response =
         mvc.perform(
                 MockMvcRequestBuilders.post("/deleteCluster")
                     .with(user(superAdmin).password(superAdminPwd))
-                    .param("clusterId", "" + linkedHashMap.get("clusterId"))
+                    .param("clusterId", "" + hashMap.get("clusterId"))
                     .content(jsonReq)
                     .contentType(MediaType.APPLICATION_JSON)
                     .accept(MediaType.APPLICATION_JSON))

--- a/core/src/test/java/io/aiven/klaw/TopicAclControllerIT.java
+++ b/core/src/test/java/io/aiven/klaw/TopicAclControllerIT.java
@@ -33,7 +33,6 @@ import io.aiven.klaw.model.enums.RequestOperationType;
 import io.aiven.klaw.service.ClusterApiService;
 import java.util.ArrayList;
 import java.util.HashMap;
-import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import org.junit.jupiter.api.BeforeAll;
@@ -565,7 +564,7 @@ public class TopicAclControllerIT {
 
     List response = OBJECT_MAPPER.readValue(res, List.class);
     Object obj = response.get(0);
-    LinkedHashMap<String, Integer> hMap = (LinkedHashMap) obj;
+    Map<String, Integer> hMap = (HashMap) obj;
 
     ApiResponse apiResponse = ApiResponse.builder().result(ApiResultStatus.SUCCESS.value).build();
     when(clusterApiService.approveAclRequests(any(), anyInt()))
@@ -627,7 +626,7 @@ public class TopicAclControllerIT {
 
     List response = OBJECT_MAPPER.readValue(res, List.class);
     Object obj = response.get(0);
-    LinkedHashMap<String, Integer> hMap = (LinkedHashMap) obj;
+    Map<String, Integer> hMap = (HashMap) obj;
     Integer reqNo = hMap.get("req_no");
 
     String resNew =
@@ -664,7 +663,7 @@ public class TopicAclControllerIT {
 
     List<AclRequests> response = OBJECT_MAPPER.readValue(res, List.class);
     Object obj = response.get(0);
-    LinkedHashMap<String, Integer> hMap = (LinkedHashMap) obj;
+    Map<String, Integer> hMap = (HashMap) obj;
 
     String responseNew =
         mvc.perform(

--- a/core/src/test/resources/test-application-rdbms-ad.properties
+++ b/core/src/test/resources/test-application-rdbms-ad.properties
@@ -23,9 +23,7 @@ klaw.login.authentication.type=ad
 spring.liquibase.enabled=true
 spring.liquibase.change-log=classpath:db/changelog/changelog.yaml
 
-# licensing info
-klaw.org.name=Our Organization
-klaw.version=1.1.0
+klaw.version=1.2.0
 
 # Spring JPA properties mysql
 # Spring JPA properties filedb

--- a/core/src/test/resources/test-application-rdbms.properties
+++ b/core/src/test/resources/test-application-rdbms.properties
@@ -23,9 +23,7 @@ klaw.login.authentication.type=db
 spring.liquibase.enabled=true
 spring.liquibase.change-log=classpath:db/changelog/changelog.yaml
 
-# licensing info
-klaw.org.name=Our Organization
-klaw.version=1.1.0
+klaw.version=1.2.0
 
 # Spring JPA properties mysql
 # Spring JPA properties filedb

--- a/core/src/test/resources/test-application-rdbms1.properties
+++ b/core/src/test/resources/test-application-rdbms1.properties
@@ -23,9 +23,7 @@ klaw.login.authentication.type=db
 spring.liquibase.enabled=true
 spring.liquibase.change-log=classpath:db/changelog/changelog.yaml
 
-# licensing info
-klaw.org.name=Our Organization
-klaw.version=1.1.0
+klaw.version=1.2.0
 
 # Spring JPA properties mysql
 # Spring JPA properties filedb


### PR DESCRIPTION
About this change - What it does

fixes a bug on browse topics page for search (making search case insensitive)
LinkedHashMap is replaced with HashMap (as it was not really required in such cases)
few unused properties have been removed
Support for multiple SSL schemaregistry/karapace cluster connections
support for multiple SSL kafka connect cluster connections
Resolves: https://github.com/aiven/klaw/issues/300
Resolves https://github.com/aiven/klaw/issues/289
Resolves https://github.com/aiven/klaw/issues/173

Why this way
To support multiple cluster configurations on SR and connect, needed to implement similar mechanism of kafka clusters

Signed-off-by: muralibasani <muralidhar.basani@aiven.io>