### PR TITLE
feature(coral) Add NotFound page, use as fallback in router

### DIFF
--- a/coral/src/app/pages/not-found/index.test.tsx
+++ b/coral/src/app/pages/not-found/index.test.tsx
@@ -1,0 +1,26 @@
+import { render, screen } from "@testing-library/react/pure";
+import NotFound from "src/app/pages/not-found";
+
+describe("NotFound", () => {
+  describe("renders a Not Found page with correct text", () => {
+    beforeAll(() => {
+      render(<NotFound />);
+    });
+
+    it("renders a headline", async () => {
+      const headline = screen.getByRole("heading", {
+        name: "Page not found",
+      });
+
+      expect(headline).toBeVisible();
+    });
+
+    it("renders a description", async () => {
+      const description = screen.getByText(
+        "If it should have been found, we are working on building it!"
+      );
+
+      expect(description).toBeVisible();
+    });
+  });
+});

--- a/coral/src/app/pages/not-found/index.test.tsx
+++ b/coral/src/app/pages/not-found/index.test.tsx
@@ -1,5 +1,6 @@
 import { render, screen } from "@testing-library/react/pure";
 import NotFound from "src/app/pages/not-found";
+import { tabNavigateTo } from "src/services/test-utils/tabbing";
 
 describe("NotFound", () => {
   describe("renders a Not Found page with correct text", () => {
@@ -21,6 +22,25 @@ describe("NotFound", () => {
       );
 
       expect(description).toBeVisible();
+    });
+
+    it("renders a link to old interface index page", async () => {
+      const link = screen.getByRole("link", {
+        name: "Go back to old interface",
+      });
+
+      expect(link).toBeVisible();
+      expect(link).toHaveAttribute("href", "/index");
+    });
+
+    it("should allow navigating to link with keyboard", async () => {
+      const link = screen.getByRole("link", {
+        name: "Go back to old interface",
+      });
+
+      await tabNavigateTo({ targetElement: link });
+
+      expect(link).toHaveFocus();
     });
   });
 });

--- a/coral/src/app/pages/not-found/index.test.tsx
+++ b/coral/src/app/pages/not-found/index.test.tsx
@@ -18,7 +18,7 @@ describe("NotFound", () => {
 
     it("renders a description", async () => {
       const description = screen.getByText(
-        "If it should have been found, we are working on building it!"
+        "Sorry, the page you are looking for does not exist."
       );
 
       expect(description).toBeVisible();
@@ -26,7 +26,7 @@ describe("NotFound", () => {
 
     it("renders a link to old interface index page", async () => {
       const link = screen.getByRole("link", {
-        name: "Go back to old interface",
+        name: "Return to the old interface.",
       });
 
       expect(link).toBeVisible();
@@ -35,7 +35,7 @@ describe("NotFound", () => {
 
     it("should allow navigating to link with keyboard", async () => {
       const link = screen.getByRole("link", {
-        name: "Go back to old interface",
+        name: "Return to the old interface.",
       });
 
       await tabNavigateTo({ targetElement: link });

--- a/coral/src/app/pages/not-found/index.tsx
+++ b/coral/src/app/pages/not-found/index.tsx
@@ -1,4 +1,4 @@
-import { Typography } from "@aivenio/aquarium";
+import { Box, Typography } from "@aivenio/aquarium";
 import AuthenticationRequiredBoundary from "src/app/components/AuthenticationRequiredBoundary";
 import Layout from "src/app/layout/Layout";
 
@@ -6,13 +6,19 @@ const NotFound = () => {
   return (
     <AuthenticationRequiredBoundary>
       <Layout>
-        <Typography.Heading color={"secondary-100"}>
-          Page not found
-        </Typography.Heading>
+        <Box role="main" display={"flex"} flexDirection={"column"} gap={"5"}>
+          <Typography.Heading color={"secondary-100"}>
+            Page not found
+          </Typography.Heading>
 
-        <Typography.LargeText>
-          If it should have been found, we are working on building it!
-        </Typography.LargeText>
+          <Typography.LargeText>
+            If it should have been found, we are working on building it!
+          </Typography.LargeText>
+
+          <Typography.MediumText>
+            <a href={"/index"}>Go back to old interface</a>
+          </Typography.MediumText>
+        </Box>
       </Layout>
     </AuthenticationRequiredBoundary>
   );

--- a/coral/src/app/pages/not-found/index.tsx
+++ b/coral/src/app/pages/not-found/index.tsx
@@ -1,0 +1,21 @@
+import { Typography } from "@aivenio/aquarium";
+import AuthenticationRequiredBoundary from "src/app/components/AuthenticationRequiredBoundary";
+import Layout from "src/app/layout/Layout";
+
+const NotFound = () => {
+  return (
+    <AuthenticationRequiredBoundary>
+      <Layout>
+        <Typography.Heading color={"secondary-100"}>
+          Page not found
+        </Typography.Heading>
+
+        <Typography.LargeText>
+          If it should have been found, we are working on building it!
+        </Typography.LargeText>
+      </Layout>
+    </AuthenticationRequiredBoundary>
+  );
+};
+
+export default NotFound;

--- a/coral/src/app/pages/not-found/index.tsx
+++ b/coral/src/app/pages/not-found/index.tsx
@@ -12,11 +12,11 @@ const NotFound = () => {
           </Typography.Heading>
 
           <Typography.LargeText>
-            If it should have been found, we are working on building it!
+            Sorry, the page you are looking for does not exist.
           </Typography.LargeText>
 
           <Typography.MediumText>
-            <a href={"/index"}>Go back to old interface</a>
+            <a href={"/index"}>Return to the old interface.</a>
           </Typography.MediumText>
         </Box>
       </Layout>

--- a/coral/src/app/router.tsx
+++ b/coral/src/app/router.tsx
@@ -1,4 +1,5 @@
-import { createBrowserRouter, Navigate, RouteObject } from "react-router-dom";
+import { createBrowserRouter, RouteObject } from "react-router-dom";
+import NotFound from "src/app/pages/not-found";
 import Topics from "src/app/pages/topics";
 import { getRouterBasename } from "src/config";
 
@@ -14,7 +15,7 @@ const routes: Array<RouteObject> = [
   },
   {
     path: "*",
-    element: <Navigate to="/topics" />,
+    element: <NotFound />,
   },
 ];
 


### PR DESCRIPTION
# About this change - What it does

- adds `NotFound` page
- use it as component of the `*` fallback route
<img width="1508" alt="Screenshot 2022-12-20 at 15 48 41" src="https://user-images.githubusercontent.com/20607294/208694691-96777eab-3f0a-4e19-b02b-feddc55ece54.png">


# Why this way

This was implemented for two reasons:
- we did not have a 404 page, so we redirected everything to `/topics`
- we want to provide a simple way to hide unfinished work from users, and not adding a route to `router` is a simple way to do this for new pages.
- the 404 page also has a link to the index page of the old interface
