### PR TITLE
refactor: add prettier formatting for openapi.yaml

### DIFF
--- a/coral/.husky/pre-commit
+++ b/coral/.husky/pre-commit
@@ -2,6 +2,7 @@
 . "$(dirname "$0")/_/husky.sh"
 
 FRONTEND_ROOT="coral"
+OPENAPI_SPECS='openapi.yaml'
 GIT_ROOT=$(git rev-parse --show-toplevel)
 STAGED_FILES=$(git diff --staged --name-only)
 
@@ -11,3 +12,11 @@ then
     pnpm --prefix="$GIT_ROOT"/"$FRONTEND_ROOT" tsc
     pnpm --prefix="$GIT_ROOT"/"$FRONTEND_ROOT" test --bail
 fi
+
+if echo "$STAGED_FILES" | grep "$OPENAPI_SPECS";
+then
+    pnpm --prefix="$GIT_ROOT"/"$FRONTEND_ROOT" lint-staged --config="$GIT_ROOT"/"$FRONTEND_ROOT"/package.json --cwd="$GIT_ROOT"
+fi
+
+
+

--- a/coral/package.json
+++ b/coral/package.json
@@ -30,6 +30,9 @@
     ],
     "**/*.css": [
       "prettier --check"
+    ],
+    "*.yaml": [
+      "prettier --check"
     ]
   },
   "dependencies": {


### PR DESCRIPTION
Signed-off-by: Mathieu Anderson <mathieu.anderson@aiven.io>

# About this change - What it does

- Add `husky` script to run `lint-staged` on `openapi.yaml
- Add a `*.yaml` rule to `lint-staged` config to run `prettier --check` on these files.

Will bail out of commit if file is not formatted according to `prettier` rules:
<img width="679" alt="Screenshot 2022-12-21 at 14 56 46" src="https://user-images.githubusercontent.com/20607294/208922938-2a7ce370-3c19-43c6-9355-a71c94b87bd8.png">


# Why this way

We want to keep our formatting consistent, and `prettier` can handle `yaml` files, so we should leverage it to ensure consistency.
