### PR TITLE
refactor(coral): do not re-export API types from domains

### DIFF
--- a/coral/docs/mock-api-for-development.md
+++ b/coral/docs/mock-api-for-development.md
@@ -14,7 +14,7 @@ The API call looks like this:
 
 const getTeams = () => {
  return api
-   .get<TeamNamesGetResponse>("/getAllTeamsSUOnly")
+   .get<KlawApiResponse<"teamNamesGet">>("/getAllTeamsSUOnly")
    .then(transformTeamNamesGetResponse);
 };
 

--- a/coral/src/app/features/topics/browse/components/select-environment/SelectEnvironment.test.tsx
+++ b/coral/src/app/features/topics/browse/components/select-environment/SelectEnvironment.test.tsx
@@ -2,7 +2,6 @@ import { cleanup, screen, waitFor } from "@testing-library/react";
 import {
   ALL_ENVIRONMENTS_VALUE,
   Environment,
-  EnvironmentDTO,
   mockGetEnvironments,
 } from "src/domain/environment";
 import SelectEnvironment from "src/app/features/topics/browse/components/select-environment/SelectEnvironment";
@@ -53,7 +52,7 @@ describe("SelectEnvironment.tsx", () => {
     });
 
     it("renders a list of options for environments plus a option for `All environments`", () => {
-      mockedEnvironmentResponse.forEach((environment: EnvironmentDTO) => {
+      mockedEnvironmentResponse.forEach((environment) => {
         const option = screen.getByRole("option", {
           name: environment.name,
         });

--- a/coral/src/domain/environment/environment-api.msw.ts
+++ b/coral/src/domain/environment/environment-api.msw.ts
@@ -2,7 +2,7 @@ import { MswInstance } from "src/services/api-mocks/types";
 import { rest } from "msw";
 import { createMockEnvironmentDTO } from "src/domain/environment/environment-test-helper";
 import { getHTTPBaseAPIUrl } from "src/config";
-import { EnvironmentsGetResponse } from "src/domain/environment/environment-types";
+import { KlawApiResponse } from "types/utils";
 
 function mockGetEnvironments({
   mswInstance,
@@ -11,7 +11,7 @@ function mockGetEnvironments({
   mswInstance: MswInstance;
   response: {
     status?: number;
-    data: EnvironmentsGetResponse | { message: string };
+    data: KlawApiResponse<"environmentsGet"> | { message: string };
   };
 }) {
   const url = `${getHTTPBaseAPIUrl()}/getEnvs`;

--- a/coral/src/domain/environment/environment-api.ts
+++ b/coral/src/domain/environment/environment-api.ts
@@ -1,13 +1,11 @@
 import { transformEnvironmentApiResponse } from "src/domain/environment/environment-transformer";
-import {
-  Environment,
-  EnvironmentsGetResponse,
-} from "src/domain/environment/environment-types";
+import { Environment } from "src/domain/environment/environment-types";
 import api from "src/services/api";
+import { KlawApiResponse } from "types/utils";
 
 const getEnvironments = async (): Promise<Environment[]> => {
   return api
-    .get<EnvironmentsGetResponse>("/getEnvs")
+    .get<KlawApiResponse<"environmentsGet">>("/getEnvs")
     .then(transformEnvironmentApiResponse);
 };
 

--- a/coral/src/domain/environment/environment-test-helper.ts
+++ b/coral/src/domain/environment/environment-test-helper.ts
@@ -1,6 +1,6 @@
-import { EnvironmentDTO } from "src/domain/environment/environment-types";
+import { KlawApiModel } from "types/utils";
 
-const defaultEnvironmentDTO: EnvironmentDTO = {
+const defaultEnvironmentDTO: KlawApiModel<"Environment"> = {
   id: "1",
   name: "DEV",
   type: "kafka",
@@ -23,8 +23,8 @@ const defaultEnvironmentDTO: EnvironmentDTO = {
 };
 
 function createMockEnvironmentDTO(
-  environment: Partial<EnvironmentDTO>
-): EnvironmentDTO {
+  environment: Partial<KlawApiModel<"Environment">>
+): KlawApiModel<"Environment"> {
   return { ...defaultEnvironmentDTO, ...environment };
 }
 

--- a/coral/src/domain/environment/environment-transformer.ts
+++ b/coral/src/domain/environment/environment-transformer.ts
@@ -1,11 +1,9 @@
 import pick from "lodash/pick";
-import {
-  Environment,
-  EnvironmentsGetResponse,
-} from "src/domain/environment/environment-types";
+import { Environment } from "src/domain/environment/environment-types";
+import { KlawApiResponse } from "types/utils";
 
 function transformEnvironmentApiResponse(
-  apiResponse: EnvironmentsGetResponse
+  apiResponse: KlawApiResponse<"environmentsGet">
 ): Environment[] {
   return apiResponse.map((environment) => pick(environment, ["name", "id"]));
 }

--- a/coral/src/domain/environment/environment-types.ts
+++ b/coral/src/domain/environment/environment-types.ts
@@ -1,8 +1,7 @@
-import { components, operations } from "types/api.d";
+import type { KlawApiResponse, KlawApiModel } from "types/utils";
 
-type EnvironmentsGetResponse =
-  operations["environmentsGet"]["responses"]["200"]["content"]["application/json"];
-type EnvironmentDTO = components["schemas"]["Environment"];
+type EnvironmentsGetResponse = KlawApiResponse<"environmentsGet">;
+type EnvironmentDTO = KlawApiModel<"Environment">;
 
 type Environment = {
   name: string;

--- a/coral/src/domain/environment/environment-types.ts
+++ b/coral/src/domain/environment/environment-types.ts
@@ -1,8 +1,3 @@
-import type { KlawApiResponse, KlawApiModel } from "types/utils";
-
-type EnvironmentsGetResponse = KlawApiResponse<"environmentsGet">;
-type EnvironmentDTO = KlawApiModel<"Environment">;
-
 type Environment = {
   name: string;
   id: string;
@@ -11,5 +6,5 @@ type Environment = {
 const ALL_ENVIRONMENTS_VALUE = "ALL";
 const ENVIRONMENT_NOT_INITIALIZED = "d3a914ff-cff6-42d4-988e-b0425128e770";
 
-export type { Environment, EnvironmentDTO, EnvironmentsGetResponse };
+export type { Environment };
 export { ALL_ENVIRONMENTS_VALUE, ENVIRONMENT_NOT_INITIALIZED };

--- a/coral/src/domain/environment/index.ts
+++ b/coral/src/domain/environment/index.ts
@@ -3,8 +3,7 @@ import { mockGetEnvironments } from "src/domain/environment/environment-api.msw"
 import {
   ALL_ENVIRONMENTS_VALUE,
   Environment,
-  EnvironmentDTO,
 } from "src/domain/environment/environment-types";
 
 export { getEnvironments, mockGetEnvironments, ALL_ENVIRONMENTS_VALUE };
-export type { Environment, EnvironmentDTO };
+export type { Environment };

--- a/coral/src/domain/team/team-api.msw.ts
+++ b/coral/src/domain/team/team-api.msw.ts
@@ -1,7 +1,7 @@
 import { rest } from "msw";
 import { getHTTPBaseAPIUrl } from "src/config";
 import { MswInstance } from "src/services/api-mocks/types";
-import { TeamNamesGetResponse } from "src/domain/team/team-types";
+import { KlawApiResponse } from "types/utils";
 
 function mockGetTeams({
   mswInstance,
@@ -10,7 +10,7 @@ function mockGetTeams({
   mswInstance: MswInstance;
   response: {
     status?: number;
-    data: TeamNamesGetResponse | { message: string };
+    data: KlawApiResponse<"teamNamesGet"> | { message: string };
   };
 }) {
   const url = `${getHTTPBaseAPIUrl()}/getAllTeamsSUOnly`;

--- a/coral/src/domain/team/team-api.ts
+++ b/coral/src/domain/team/team-api.ts
@@ -1,10 +1,10 @@
 import api from "src/services/api";
-import { TeamNamesGetResponse } from "src/domain/team/team-types";
 import { transformTeamNamesGetResponse } from "src/domain/team/team-transformer";
+import { KlawApiResponse } from "types/utils";
 
 const getTeams = () => {
   return api
-    .get<TeamNamesGetResponse>("/getAllTeamsSUOnly")
+    .get<KlawApiResponse<"teamNamesGet">>("/getAllTeamsSUOnly")
     .then(transformTeamNamesGetResponse);
 };
 

--- a/coral/src/domain/team/team-transformer.ts
+++ b/coral/src/domain/team/team-transformer.ts
@@ -1,6 +1,9 @@
-import { Team, TeamNamesGetResponse } from "src/domain/team/team-types";
+import { Team } from "src/domain/team/team-types";
+import { KlawApiResponse } from "types/utils";
 
-function transformTeamNamesGetResponse(response: TeamNamesGetResponse): Team[] {
+function transformTeamNamesGetResponse(
+  response: KlawApiResponse<"teamNamesGet">
+): Team[] {
   return response.filter((name) => name !== "All teams");
 }
 

--- a/coral/src/domain/team/team-types.ts
+++ b/coral/src/domain/team/team-types.ts
@@ -1,4 +1,4 @@
-import { components } from "types/api.d";
+import type { KlawApiResponse } from "types/utils";
 // "teamName" is a optional parameter for the getTopics api,
 // but we still need an identifier in frontend
 // to be able to set "All teams" as a visible option
@@ -9,7 +9,7 @@ const TEAM_NOT_INITIALIZED = "931bd061-fb50-4b92-ae49-b1e8004324d3";
 
 type Team = string | typeof ALL_TEAMS_VALUE;
 
-type TeamNamesGetResponse = components["schemas"]["TeamNamesGetResponse"];
+type TeamNamesGetResponse = KlawApiResponse<"teamNamesGet">;
 
 export type { Team, TeamNamesGetResponse };
 export { ALL_TEAMS_VALUE, TEAM_NOT_INITIALIZED };

--- a/coral/src/domain/team/team-types.ts
+++ b/coral/src/domain/team/team-types.ts
@@ -1,4 +1,3 @@
-import type { KlawApiResponse } from "types/utils";
 // "teamName" is a optional parameter for the getTopics api,
 // but we still need an identifier in frontend
 // to be able to set "All teams" as a visible option
@@ -9,7 +8,5 @@ const TEAM_NOT_INITIALIZED = "931bd061-fb50-4b92-ae49-b1e8004324d3";
 
 type Team = string | typeof ALL_TEAMS_VALUE;
 
-type TeamNamesGetResponse = KlawApiResponse<"teamNamesGet">;
-
-export type { Team, TeamNamesGetResponse };
+export type { Team };
 export { ALL_TEAMS_VALUE, TEAM_NOT_INITIALIZED };

--- a/coral/src/domain/topic/topic-api.msw.ts
+++ b/coral/src/domain/topic/topic-api.msw.ts
@@ -1,6 +1,5 @@
 import { rest } from "msw";
 import { MswInstance } from "src/services/api-mocks/types";
-import { TopicDTOApiResponse } from "src/domain/topic/topic-types";
 import { transformTopicApiResponse } from "src/domain/topic/topic-transformer";
 import {
   createMockTopic,
@@ -9,6 +8,7 @@ import {
 import { getHTTPBaseAPIUrl } from "src/config";
 
 import { isObject } from "lodash";
+import { KlawApiResponse } from "types/utils";
 // @TODO
 // create visible mocked responses and easy responses for different scenarios to use in tests
 // use json files from real api for mocked responses for web worker (more realistic(
@@ -20,7 +20,7 @@ function mockTopicGetRequest({
   mswInstance: MswInstance;
   response?: {
     status?: number;
-    data: TopicDTOApiResponse | { message: string };
+    data: KlawApiResponse<"topicsGet"> | { message: string };
   };
 }) {
   const base = getHTTPBaseAPIUrl();
@@ -62,12 +62,12 @@ function mockTopicGetRequest({
   );
 }
 
-const mockedResponseSinglePage: TopicDTOApiResponse =
+const mockedResponseSinglePage: KlawApiResponse<"topicsGet"> =
   createMockTopicApiResponse({
     entries: 10,
   });
 
-const mockedResponseMultiplePage: TopicDTOApiResponse =
+const mockedResponseMultiplePage: KlawApiResponse<"topicsGet"> =
   createMockTopicApiResponse({
     entries: 2,
     totalPages: 4,
@@ -78,7 +78,7 @@ const mockedResponseMultiplePageTransformed = transformTopicApiResponse(
   mockedResponseMultiplePage
 );
 
-const mockedResponseTopicEnv: TopicDTOApiResponse = [
+const mockedResponseTopicEnv: KlawApiResponse<"topicsGet"> = [
   [
     createMockTopic({
       topicName: "Topic 1",

--- a/coral/src/domain/topic/topic-api.ts
+++ b/coral/src/domain/topic/topic-api.ts
@@ -1,12 +1,10 @@
 import api from "src/services/api";
-import {
-  TopicApiResponse,
-  TopicDTOApiResponse,
-} from "src/domain/topic/topic-types";
+import { TopicApiResponse } from "src/domain/topic/topic-types";
 import { transformTopicApiResponse } from "src/domain/topic/topic-transformer";
 import { ALL_ENVIRONMENTS_VALUE } from "src/domain/environment";
 import { Team } from "src/domain/team";
 import { ALL_TEAMS_VALUE } from "src/domain/team/team-types";
+import { KlawApiResponse } from "types/utils";
 
 const getTopics = async ({
   currentPage = 1,
@@ -33,7 +31,9 @@ const getTopics = async ({
   };
 
   return api
-    .get<TopicDTOApiResponse>(`/getTopics?${new URLSearchParams(params)}`)
+    .get<KlawApiResponse<"topicsGet">>(
+      `/getTopics?${new URLSearchParams(params)}`
+    )
     .then(transformTopicApiResponse);
 };
 

--- a/coral/src/domain/topic/topic-test-helper.ts
+++ b/coral/src/domain/topic/topic-test-helper.ts
@@ -1,4 +1,5 @@
-import { Topic, TopicDTOApiResponse } from "src/domain/topic/topic-types";
+import { Topic } from "src/domain/topic/topic-types";
+import { KlawApiResponse } from "types/utils";
 
 // currently this file is used in code (topcis-api.msw.ts)
 // so "expect" is not defined there
@@ -66,8 +67,8 @@ function createMockTopicApiResponse({
   entries: 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10;
   totalPages?: number;
   currentPage?: number;
-}): TopicDTOApiResponse {
-  const response: TopicDTOApiResponse = [[]];
+}): KlawApiResponse<"topicsGet"> {
+  const response: KlawApiResponse<"topicsGet"> = [[]];
 
   const totalPageNumber = currentPage > totalPages ? currentPage : totalPages;
   if (entries >= 4 && entries <= 6) {

--- a/coral/src/domain/topic/topic-transformer.test.ts
+++ b/coral/src/domain/topic/topic-transformer.test.ts
@@ -1,20 +1,17 @@
 import { transformTopicApiResponse } from "src/domain/topic/topic-transformer";
-import {
-  Topic,
-  TopicApiResponse,
-  TopicDTOApiResponse,
-} from "src/domain/topic/topic-types";
+import { Topic, TopicApiResponse } from "src/domain/topic/topic-types";
 import {
   baseTestObjectMockedTopic,
   createMockTopicApiResponse,
 } from "src/domain/topic/topic-test-helper";
+import { KlawApiResponse } from "types/utils";
 
 describe("topic-transformer.ts", () => {
   describe("'transformTopicApiResponse' transforms API response into list of topics", () => {
     const mockedTopic: Topic = baseTestObjectMockedTopic();
 
     it("transforms a response with two entries", () => {
-      const apiResponse: TopicDTOApiResponse = createMockTopicApiResponse({
+      const apiResponse = createMockTopicApiResponse({
         entries: 2,
       });
 
@@ -28,7 +25,7 @@ describe("topic-transformer.ts", () => {
     });
 
     it("transforms a response with four entries", () => {
-      const apiResponse: TopicDTOApiResponse = createMockTopicApiResponse({
+      const apiResponse = createMockTopicApiResponse({
         entries: 4,
       });
       const result: TopicApiResponse = {
@@ -41,7 +38,7 @@ describe("topic-transformer.ts", () => {
     });
 
     it("transforms a response with no entries", () => {
-      const apiResponse: TopicDTOApiResponse = [];
+      const apiResponse: KlawApiResponse<"topicsGet"> = [];
       const result: TopicApiResponse = {
         totalPages: 0,
         currentPage: 0,

--- a/coral/src/domain/topic/topic-transformer.ts
+++ b/coral/src/domain/topic/topic-transformer.ts
@@ -1,11 +1,9 @@
-import {
-  TopicApiResponse,
-  TopicDTOApiResponse,
-} from "src/domain/topic/topic-types";
+import { TopicApiResponse } from "src/domain/topic/topic-types";
+import { KlawApiResponse } from "types/utils";
 
 // @TODO check zod for this!
 function transformTopicApiResponse(
-  apiResponse: TopicDTOApiResponse
+  apiResponse: KlawApiResponse<"topicsGet">
 ): TopicApiResponse {
   if (apiResponse.length === 0) {
     return {

--- a/coral/src/domain/topic/topic-types.ts
+++ b/coral/src/domain/topic/topic-types.ts
@@ -1,14 +1,13 @@
-import type { KlawApiResponse, KlawApiModel } from "types/utils";
+import type { KlawApiModel } from "types/utils";
 
-type TopicDTO = KlawApiModel<"TopicInfo">;
-
-type TopicApiResponse = {
+type Paginated<T> = {
   totalPages: number;
   currentPage: number;
-  entries: Topic[];
+  entries: T;
 };
 
-type Topic = TopicDTO;
-type TopicDTOApiResponse = KlawApiResponse<"topicsGet">;
+type TopicApiResponse = Paginated<Topic[]>;
 
-export type { TopicDTO, TopicApiResponse, Topic, TopicDTOApiResponse };
+type Topic = KlawApiModel<"TopicInfo">;
+
+export type { Topic, TopicApiResponse };

--- a/coral/src/domain/topic/topic-types.ts
+++ b/coral/src/domain/topic/topic-types.ts
@@ -1,6 +1,6 @@
-import { components } from "types/api";
+import type { KlawApiResponse, KlawApiModel } from "types/utils";
 
-type TopicDTO = components["schemas"]["TopicInfo"];
+type TopicDTO = KlawApiModel<"TopicInfo">;
 
 type TopicApiResponse = {
   totalPages: number;
@@ -9,6 +9,6 @@ type TopicApiResponse = {
 };
 
 type Topic = TopicDTO;
-type TopicDTOApiResponse = components["schemas"]["TopicsGetResponse"];
+type TopicDTOApiResponse = KlawApiResponse<"topicsGet">;
 
 export type { TopicDTO, TopicApiResponse, Topic, TopicDTOApiResponse };

--- a/coral/types/utils.d.ts
+++ b/coral/types/utils.d.ts
@@ -1,0 +1,8 @@
+import type { operations, components } from "types/api.d";
+
+type KlawApiResponse<OperationId extends keyof operations> =
+  operations[OperationId]["responses"][200]["content"]["application/json"];
+type KlawApiModel<Schema extends keyof components["schemas"]> =
+  components["schemas"][Schema];
+
+export type { KlawApiResponse, KlawApiModel };


### PR DESCRIPTION
After this only the application types will be exported from `domain`. In order to make the API types more developer friendly, this PR also introduces the following utility types:  `KlawApiResponse` and `KlawApiModel`.