### PR TITLE
feat(coral) - Add ACL `domain` entities

### DIFF
--- a/coral/src/domain/acl/acl-api.ts
+++ b/coral/src/domain/acl/acl-api.ts
@@ -3,14 +3,17 @@ import {
   CreateAclRequestTopicTypeConsumer,
 } from "src/domain/acl/acl-types";
 import api from "src/services/api";
-import { KlawApiResponse } from "types/utils";
+import { KlawApiRequest, KlawApiResponse } from "types/utils";
 
-const postAclRequest = (
+const createAclRequest = (
   aclParams:
     | CreateAclRequestTopicTypeProducer
     | CreateAclRequestTopicTypeConsumer
 ): Promise<KlawApiResponse<"createAclRequest">> => {
-  return api.post("/createAcl", aclParams);
+  return api.post<
+    KlawApiResponse<"createAclRequest">,
+    KlawApiRequest<"createAclRequest">
+  >("/createAcl", aclParams);
 };
 
-export { postAclRequest };
+export { createAclRequest };

--- a/coral/src/domain/acl/acl-api.ts
+++ b/coral/src/domain/acl/acl-api.ts
@@ -1,0 +1,16 @@
+import {
+  CreateAclRequestTopicTypeProducer,
+  CreateAclRequestTopicTypeConsumer,
+} from "src/domain/acl/acl-types";
+import api from "src/services/api";
+import { KlawApiResponse } from "types/utils";
+
+const postAclRequest = (
+  aclParams:
+    | CreateAclRequestTopicTypeProducer
+    | CreateAclRequestTopicTypeConsumer
+): Promise<KlawApiResponse<"createAclRequest">> => {
+  return api.post("/createAcl", aclParams);
+};
+
+export { postAclRequest };

--- a/coral/src/domain/acl/acl-mutations.ts
+++ b/coral/src/domain/acl/acl-mutations.ts
@@ -1,17 +1,17 @@
-import { postAclRequest } from "src/domain/acl/acl-api";
+import { createAclRequest } from "src/domain/acl/acl-api";
 import {
   CreateAclRequestTopicTypeProducer,
   CreateAclRequestTopicTypeConsumer,
 } from "src/domain/acl/acl-types";
 
-const createAclRequest = (
+const createAclRequestMutation = (
   aclParams:
     | CreateAclRequestTopicTypeProducer
     | CreateAclRequestTopicTypeConsumer
 ) => {
   return {
-    mutationFn: () => postAclRequest(aclParams),
+    mutationFn: () => createAclRequest(aclParams),
   };
 };
 
-export { createAclRequest };
+export { createAclRequestMutation };

--- a/coral/src/domain/acl/acl-queries.ts
+++ b/coral/src/domain/acl/acl-queries.ts
@@ -1,0 +1,17 @@
+import { postAclRequest } from "src/domain/acl/acl-api";
+import {
+  CreateAclRequestTopicTypeProducer,
+  CreateAclRequestTopicTypeConsumer,
+} from "src/domain/acl/acl-types";
+
+const createAclRequest = (
+  aclParams:
+    | CreateAclRequestTopicTypeProducer
+    | CreateAclRequestTopicTypeConsumer
+) => {
+  return {
+    mutationFn: () => postAclRequest(aclParams),
+  };
+};
+
+export { createAclRequest };

--- a/coral/src/domain/acl/acl-types.ts
+++ b/coral/src/domain/acl/acl-types.ts
@@ -1,0 +1,42 @@
+import { KlawApiModel } from "types/utils";
+
+// Several types are dependent on topictype when it is "Consumer":
+// - aclPatternType can only be "LITERAL"
+// - consumergroup is required
+// - transactionalId becomes available
+// So we define two types depending on the topictype
+
+type CreateAclRequestTopicTypeProducer = Pick<
+  KlawApiModel<"AclRequest">,
+  | "remarks"
+  | "aclPatternType"
+  | "topicname"
+  | "environment"
+  | "teamname"
+  | "aclIpPrincipleType"
+  | "consumergroup"
+  | "acl_ssl"
+  | "acl_ip"
+> & { topictype: "Producer" };
+
+type CreateAclRequestTopicTypeConsumer = Pick<
+  KlawApiModel<"AclRequest">,
+  | "remarks"
+  | "aclPatternType"
+  | "topicname"
+  | "environment"
+  | "teamname"
+  | "aclIpPrincipleType"
+  | "acl_ssl"
+  | "acl_ip"
+  | "transactionalId"
+> & {
+  topictype: "Consumer";
+  aclPatternType: "LITERAL";
+  consumergroup: string;
+};
+
+export type {
+  CreateAclRequestTopicTypeProducer,
+  CreateAclRequestTopicTypeConsumer,
+};

--- a/coral/src/domain/acl/acl-types.ts
+++ b/coral/src/domain/acl/acl-types.ts
@@ -4,12 +4,16 @@ import { KlawApiRequest } from "types/utils";
 // - aclPatternType can only be "LITERAL"
 // - consumergroup is required
 // - transactionalId becomes available
-// So we define two types depending on the topictype
+// So we define three types:
+// - BaseCreateAclRequest has all the properties for a create ACL request
+// - CreateAclRequestTopicTypeProducer makes the relevant property mandatory
+// - CreateAclRequestTopicTypeConsumer adds transactionalId and make relevant properties mandatory
 
-type CreateAclRequestTopicTypeProducer = Pick<
+type BaseCreateAclRequest = Pick<
   KlawApiRequest<"createAclRequest">,
   | "remarks"
   | "aclPatternType"
+  | "topictype"
   | "topicname"
   | "environment"
   | "teamname"
@@ -17,20 +21,14 @@ type CreateAclRequestTopicTypeProducer = Pick<
   | "consumergroup"
   | "acl_ssl"
   | "acl_ip"
-> & { topictype: "Producer" };
+>;
 
-type CreateAclRequestTopicTypeConsumer = Pick<
-  KlawApiRequest<"createAclRequest">,
-  | "remarks"
-  | "aclPatternType"
-  | "topicname"
-  | "environment"
-  | "teamname"
-  | "aclIpPrincipleType"
-  | "acl_ssl"
-  | "acl_ip"
-  | "transactionalId"
-> & {
+type CreateAclRequestTopicTypeProducer = BaseCreateAclRequest & {
+  topictype: "Producer";
+};
+
+type CreateAclRequestTopicTypeConsumer = BaseCreateAclRequest & {
+  transactionalId?: string;
   topictype: "Consumer";
   aclPatternType: "LITERAL";
   consumergroup: string;

--- a/coral/src/domain/acl/acl-types.ts
+++ b/coral/src/domain/acl/acl-types.ts
@@ -1,4 +1,4 @@
-import { KlawApiModel } from "types/utils";
+import { KlawApiRequest } from "types/utils";
 
 // Several types are dependent on topictype when it is "Consumer":
 // - aclPatternType can only be "LITERAL"
@@ -7,7 +7,7 @@ import { KlawApiModel } from "types/utils";
 // So we define two types depending on the topictype
 
 type CreateAclRequestTopicTypeProducer = Pick<
-  KlawApiModel<"AclRequest">,
+  KlawApiRequest<"createAclRequest">,
   | "remarks"
   | "aclPatternType"
   | "topicname"
@@ -20,7 +20,7 @@ type CreateAclRequestTopicTypeProducer = Pick<
 > & { topictype: "Producer" };
 
 type CreateAclRequestTopicTypeConsumer = Pick<
-  KlawApiModel<"AclRequest">,
+  KlawApiRequest<"createAclRequest">,
   | "remarks"
   | "aclPatternType"
   | "topicname"

--- a/coral/src/domain/acl/index.ts
+++ b/coral/src/domain/acl/index.ts
@@ -1,0 +1,11 @@
+import { createAclRequest } from "src/domain/acl/acl-queries";
+import {
+  CreateAclRequestTopicTypeProducer,
+  CreateAclRequestTopicTypeConsumer,
+} from "src/domain/acl/acl-types";
+
+export { createAclRequest };
+export type {
+  CreateAclRequestTopicTypeProducer,
+  CreateAclRequestTopicTypeConsumer,
+};

--- a/coral/src/domain/acl/index.ts
+++ b/coral/src/domain/acl/index.ts
@@ -1,10 +1,10 @@
-import { createAclRequest } from "src/domain/acl/acl-queries";
+import { createAclRequestMutation } from "src/domain/acl/acl-mutations";
 import {
   CreateAclRequestTopicTypeProducer,
   CreateAclRequestTopicTypeConsumer,
 } from "src/domain/acl/acl-types";
 
-export { createAclRequest };
+export { createAclRequestMutation };
 export type {
   CreateAclRequestTopicTypeProducer,
   CreateAclRequestTopicTypeConsumer,

--- a/coral/src/domain/environment/environment-api.ts
+++ b/coral/src/domain/environment/environment-api.ts
@@ -21,7 +21,7 @@ const getClusterInfo = async ({
 }): Promise<ClusterInfo> => {
   const params = new URLSearchParams({ envSelected, envType });
   return api.get<KlawApiResponse<"environmentGetClusterInfo">>(
-    `/getClusterInfoFromEnv?${new URLSearchParams(params)}`
+    `/getClusterInfoFromEnv?${params}`
   );
 };
 

--- a/coral/src/domain/environment/environment-api.ts
+++ b/coral/src/domain/environment/environment-api.ts
@@ -1,5 +1,8 @@
 import { transformEnvironmentApiResponse } from "src/domain/environment/environment-transformer";
-import { Environment } from "src/domain/environment/environment-types";
+import {
+  ClusterInfo,
+  Environment,
+} from "src/domain/environment/environment-types";
 import api from "src/services/api";
 import { KlawApiResponse } from "types/utils";
 
@@ -9,4 +12,17 @@ const getEnvironments = async (): Promise<Environment[]> => {
     .then(transformEnvironmentApiResponse);
 };
 
-export { getEnvironments };
+const getClusterInfo = async ({
+  envSelected,
+  envType,
+}: {
+  envSelected: string;
+  envType: string;
+}): Promise<ClusterInfo> => {
+  const params = new URLSearchParams({ envSelected, envType });
+  return api.get<KlawApiResponse<"environmentGetClusterInfo">>(
+    `/getClusterInfoFromEnv?${new URLSearchParams(params)}`
+  );
+};
+
+export { getEnvironments, getClusterInfo };

--- a/coral/src/domain/environment/environment-queries.ts
+++ b/coral/src/domain/environment/environment-queries.ts
@@ -1,0 +1,17 @@
+import { getClusterInfo } from "src/domain/environment/environment-api";
+
+const clusterInfoFromEnvironment = ({
+  envSelected,
+  envType,
+}: {
+  envSelected: string;
+  envType: string;
+}) => {
+  return {
+    queryKey: ["clusterInfoFromEnvironment", envSelected, envType],
+    queryFn: () => getClusterInfo({ envSelected, envType }),
+    keepPreviousData: true,
+  };
+};
+
+export { clusterInfoFromEnvironment };

--- a/coral/src/domain/environment/environment-types.ts
+++ b/coral/src/domain/environment/environment-types.ts
@@ -1,10 +1,13 @@
+import { KlawApiModel } from "types/utils";
+
 type Environment = {
   name: string;
   id: string;
 };
+type ClusterInfo = KlawApiModel<"EnvironmentGetClusterInfoResponse">;
 
 const ALL_ENVIRONMENTS_VALUE = "ALL";
 const ENVIRONMENT_NOT_INITIALIZED = "d3a914ff-cff6-42d4-988e-b0425128e770";
 
-export type { Environment };
+export type { Environment, ClusterInfo };
 export { ALL_ENVIRONMENTS_VALUE, ENVIRONMENT_NOT_INITIALIZED };

--- a/coral/src/domain/environment/index.ts
+++ b/coral/src/domain/environment/index.ts
@@ -1,9 +1,16 @@
 import { getEnvironments } from "src/domain/environment/environment-api";
 import { mockGetEnvironments } from "src/domain/environment/environment-api.msw";
+import { clusterInfoFromEnvironment } from "src/domain/environment/environment-queries";
 import {
   ALL_ENVIRONMENTS_VALUE,
+  ClusterInfo,
   Environment,
 } from "src/domain/environment/environment-types";
 
-export { getEnvironments, mockGetEnvironments, ALL_ENVIRONMENTS_VALUE };
-export type { Environment };
+export {
+  getEnvironments,
+  mockGetEnvironments,
+  ALL_ENVIRONMENTS_VALUE,
+  clusterInfoFromEnvironment,
+};
+export type { Environment, ClusterInfo };

--- a/coral/src/domain/topic/index.ts
+++ b/coral/src/domain/topic/index.ts
@@ -1,5 +1,9 @@
-import { getTopicNames, getTopics } from "src/domain/topic/topic-api";
-import { Topic, TopicNames } from "src/domain/topic/topic-types";
+import {
+  getTopicNames,
+  getTopics,
+  getTopicTeam,
+} from "src/domain/topic/topic-api";
+import { Topic, TopicNames, TopicTeam } from "src/domain/topic/topic-types";
 
-export type { Topic, TopicNames };
-export { getTopics, getTopicNames };
+export type { Topic, TopicNames, TopicTeam };
+export { getTopics, getTopicNames, getTopicTeam };

--- a/coral/src/domain/topic/index.ts
+++ b/coral/src/domain/topic/index.ts
@@ -1,5 +1,5 @@
-import { Topic } from "src/domain/topic/topic-types";
-import { getTopics } from "src/domain/topic/topic-api";
+import { getTopicNames, getTopics } from "src/domain/topic/topic-api";
+import { Topic, TopicNames } from "src/domain/topic/topic-types";
 
-export type { Topic };
-export { getTopics };
+export type { Topic, TopicNames };
+export { getTopics, getTopicNames };

--- a/coral/src/domain/topic/topic-api.ts
+++ b/coral/src/domain/topic/topic-api.ts
@@ -37,29 +37,31 @@ const getTopics = async ({
     .then(transformTopicApiResponse);
 };
 
-const getTopicNames = async ({
-  onlyMyTeamTopics,
-}: Partial<{
+type GetTopicNamesArgs = Partial<{
   onlyMyTeamTopics: boolean;
-}> = {}) => {
+}>;
+
+const getTopicNames = async ({ onlyMyTeamTopics }: GetTopicNamesArgs = {}) => {
   const isMyTeamTopics = onlyMyTeamTopics ?? false;
   const params = { isMyTeamTopics: isMyTeamTopics.toString() };
 
-  return await api.get<KlawApiResponse<"topicsGetOnly">>(
+  return api.get<KlawApiResponse<"topicsGetOnly">>(
     `/getTopicsOnly?${new URLSearchParams(params)}`
   );
 };
 
+interface GetTopicTeamArgs {
+  topicName: string;
+  patternType?: "LITERAL" | "PREFIXED";
+}
+
 const getTopicTeam = async ({
   topicName,
   patternType = "LITERAL",
-}: {
-  topicName: string;
-  patternType?: "LITERAL" | "PREFIXED";
-}) => {
+}: GetTopicTeamArgs) => {
   const params = { topicName, patternType };
 
-  return await api.get<KlawApiResponse<"topicGetTeam">>(
+  return api.get<KlawApiResponse<"topicGetTeam">>(
     `/getTopicTeam?${new URLSearchParams(params)}`
   );
 };

--- a/coral/src/domain/topic/topic-api.ts
+++ b/coral/src/domain/topic/topic-api.ts
@@ -50,4 +50,18 @@ const getTopicNames = async ({
   );
 };
 
-export { getTopics, getTopicNames };
+const getTopicTeam = async ({
+  topicName,
+  patternType = "LITERAL",
+}: {
+  topicName: string;
+  patternType?: "LITERAL" | "PREFIXED";
+}) => {
+  const params = { topicName, patternType };
+
+  return await api.get<KlawApiResponse<"topicGetTeam">>(
+    `/getTopicTeam?${new URLSearchParams(params)}`
+  );
+};
+
+export { getTopics, getTopicNames, getTopicTeam };

--- a/coral/src/domain/topic/topic-api.ts
+++ b/coral/src/domain/topic/topic-api.ts
@@ -1,9 +1,9 @@
-import api from "src/services/api";
-import { TopicApiResponse } from "src/domain/topic/topic-types";
-import { transformTopicApiResponse } from "src/domain/topic/topic-transformer";
 import { ALL_ENVIRONMENTS_VALUE } from "src/domain/environment";
 import { Team } from "src/domain/team";
 import { ALL_TEAMS_VALUE } from "src/domain/team/team-types";
+import { transformTopicApiResponse } from "src/domain/topic/topic-transformer";
+import { TopicApiResponse } from "src/domain/topic/topic-types";
+import api from "src/services/api";
 import { KlawApiResponse } from "types/utils";
 
 const getTopics = async ({
@@ -37,4 +37,17 @@ const getTopics = async ({
     .then(transformTopicApiResponse);
 };
 
-export { getTopics };
+const getTopicNames = async ({
+  onlyMyTeamTopics,
+}: Partial<{
+  onlyMyTeamTopics: boolean;
+}> = {}) => {
+  const isMyTeamTopics = onlyMyTeamTopics ?? false;
+  const params = { isMyTeamTopics: isMyTeamTopics.toString() };
+
+  return await api.get<KlawApiResponse<"topicsGetOnly">>(
+    `/getTopicsOnly?${new URLSearchParams(params)}`
+  );
+};
+
+export { getTopics, getTopicNames };

--- a/coral/src/domain/topic/topic-queries.ts
+++ b/coral/src/domain/topic/topic-queries.ts
@@ -1,6 +1,10 @@
 import { ENVIRONMENT_NOT_INITIALIZED } from "src/domain/environment/environment-types";
 import { Team, TEAM_NOT_INITIALIZED } from "src/domain/team";
-import { getTopicNames, getTopics } from "src/domain/topic/topic-api";
+import {
+  getTopicNames,
+  getTopics,
+  getTopicTeam,
+} from "src/domain/topic/topic-api";
 
 const topicsQuery = ({
   currentPage,
@@ -38,4 +42,18 @@ const topicNamesQuery = ({
   };
 };
 
-export { topicsQuery, topicNamesQuery };
+const topicTeamQuery = ({
+  topicName,
+  patternType = "LITERAL",
+}: {
+  topicName: string;
+  patternType?: "LITERAL" | "PREFIXED";
+}) => {
+  return {
+    queryKey: ["topicTeam", topicName, patternType],
+    queryFn: () => getTopicTeam({ topicName, patternType }),
+    keepPreviousData: true,
+  };
+};
+
+export { topicsQuery, topicNamesQuery, topicTeamQuery };

--- a/coral/src/domain/topic/topic-queries.ts
+++ b/coral/src/domain/topic/topic-queries.ts
@@ -1,8 +1,8 @@
-import { getTopics } from "src/domain/topic/topic-api";
-import { Team, TEAM_NOT_INITIALIZED } from "src/domain/team";
 import { ENVIRONMENT_NOT_INITIALIZED } from "src/domain/environment/environment-types";
+import { Team, TEAM_NOT_INITIALIZED } from "src/domain/team";
+import { getTopicNames, getTopics } from "src/domain/topic/topic-api";
 
-export const topicsQuery = ({
+const topicsQuery = ({
   currentPage,
   environment,
   teamName,
@@ -23,3 +23,19 @@ export const topicsQuery = ({
       environment !== ENVIRONMENT_NOT_INITIALIZED,
   };
 };
+
+const topicNamesQuery = ({
+  onlyMyTeamTopics,
+}: Partial<{
+  onlyMyTeamTopics: boolean;
+}> = {}) => {
+  const isMyTeamTopics = onlyMyTeamTopics ?? false;
+
+  return {
+    queryKey: ["topicNames", isMyTeamTopics],
+    queryFn: () => getTopicNames({ onlyMyTeamTopics }),
+    keepPreviousData: true,
+  };
+};
+
+export { topicsQuery, topicNamesQuery };

--- a/coral/src/domain/topic/topic-types.ts
+++ b/coral/src/domain/topic/topic-types.ts
@@ -10,5 +10,6 @@ type TopicApiResponse = Paginated<Topic[]>;
 
 type Topic = KlawApiModel<"TopicInfo">;
 type TopicNames = KlawApiModel<"TopicsGetOnlyResponse">;
+type TopicTeam = KlawApiModel<"TopicGetTeamResponse">;
 
-export type { Topic, TopicNames, TopicApiResponse };
+export type { Topic, TopicNames, TopicTeam, TopicApiResponse };

--- a/coral/src/domain/topic/topic-types.ts
+++ b/coral/src/domain/topic/topic-types.ts
@@ -9,5 +9,6 @@ type Paginated<T> = {
 type TopicApiResponse = Paginated<Topic[]>;
 
 type Topic = KlawApiModel<"TopicInfo">;
+type TopicNames = KlawApiModel<"TopicsGetOnlyResponse">;
 
-export type { Topic, TopicApiResponse };
+export type { Topic, TopicNames, TopicApiResponse };

--- a/coral/types/api.d.ts
+++ b/coral/types/api.d.ts
@@ -433,10 +433,7 @@ export type components = {
      *   "aivenCluster": "false"
      * }
      */
-    EnvironmentGetClusterInfoResponse: {
-      /** @enum {string} */
-      clusterName: "true" | "false";
-    };
+    EnvironmentGetClusterInfoResponse: { [key: string]: "true" | "false" };
     /** TopicCreateRequest */
     topicCreateRequest: {
       /**

--- a/coral/types/api.d.ts
+++ b/coral/types/api.d.ts
@@ -811,7 +811,7 @@ export type operations = {
         /** The environment for which to get the cluster info */
         envSelected: string;
         /** The type of  environment for which to get the cluster info */
-        envType: string;
+        envType: unknown;
       };
     };
     responses: {

--- a/coral/types/api.d.ts
+++ b/coral/types/api.d.ts
@@ -12,6 +12,12 @@ export type paths = {
   "/getTopics": {
     get: operations["topicsGet"];
   };
+  "/getTopicsOnly": {
+    get: operations["topicsGetOnly"];
+  };
+  "/getTopicTeam": {
+    get: operations["topicGetTeam"];
+  };
   "/createTopics": {
     post: operations["topicCreate"];
   };
@@ -26,6 +32,12 @@ export type paths = {
   };
   "/getEnvsBaseClusterFilteredForTeam": {
     get: operations["getEnvsBaseClusterFilteredForTeam"];
+  };
+  "/getClusterInfoFromEnv": {
+    get: operations["environmentGetClusterInfo"];
+  };
+  "/createAcl": {
+    post: operations["createAclRequest"];
   };
 };
 
@@ -149,6 +161,21 @@ export type components = {
       tokenType: "JWT";
     };
     TopicsGetResponse: components["schemas"]["TopicInfo"][][];
+    /**
+     * @example [
+     *   "myTopic",
+     *   "otherTopic"
+     * ]
+     */
+    TopicsGetOnlyResponse: string[];
+    /**
+     * @example {
+     *   "team": "Team A"
+     * }
+     */
+    TopicGetTeamResponse: {
+      team: string;
+    };
     TopicInfo: {
       /**
        * Topic identifier
@@ -401,6 +428,15 @@ export type components = {
      * }
      */
     topicAdvancedConfigGetResponse: { [key: string]: string };
+    /**
+     * @example {
+     *   "aivenCluster": "false"
+     * }
+     */
+    EnvironmentGetClusterInfoResponse: {
+      /** @enum {string} */
+      clusterName: "true" | "false";
+    };
     /** TopicCreateRequest */
     topicCreateRequest: {
       /**
@@ -511,6 +547,131 @@ export type components = {
        */
       currentPage?: string;
     };
+    AclRequest: {
+      /**
+       * @description A comment on the request for the approver.
+       * @example Hello, thank you.
+       */
+      remarks?: string;
+      /**
+       * @description This is mandatory if topictype is consumer
+       * @example Group-one
+       */
+      consumergroup?: string;
+      /**
+       * @example [
+       *   "35.239.43.144",
+       *   "35.239.43.145"
+       * ]
+       */
+      acl_ip?: string[];
+      /**
+       * @example [
+       *   "username",
+       *   "username-two"
+       * ]
+       */
+      acl_ssl?: string[];
+      /**
+       * @description If topictype is consumer, this field can only be LITERAL. If topictype is producer, this field can be LITERAL or PREFIXED
+       * @example LITERAL
+       * @enum {string}
+       */
+      aclPatternType: "LITERAL" | "PREFIXED";
+      /**
+       * @description Only available if aclPatternType is LITERAL
+       * @example id-123
+       */
+      transactionalId?: string;
+      /**
+       * Format: int32
+       * @example 100
+       */
+      req_no?: number;
+      /**
+       * @description Only topics available in chosen environment are allowed
+       * @example myTopic
+       */
+      topicname: string;
+      /**
+       * @description ID of environment
+       * @example 1
+       */
+      environment: string;
+      /**
+       * @description Name of environment
+       * @example DEV
+       */
+      environmentName?: string;
+      /** @example Ospo */
+      teamname: string;
+      /**
+       * Format: int32
+       * @example 1
+       */
+      teamId?: number;
+      /**
+       * Format: int32
+       * @example 1
+       */
+      requestingteam?: number;
+      /** @example App */
+      appname?: string;
+      /**
+       * @example Producer
+       * @enum {string}
+       */
+      topictype: "Producer" | "Consumer";
+      /** @example User */
+      username?: string;
+      /**
+       * Format: date-time
+       * @example 2018-03-20T09:12:28Z
+       */
+      requesttime?: string;
+      /** @example 10-11-2020 10:45:30 */
+      requesttimestring?: string;
+      /**
+       * @example created
+       * @enum {string}
+       */
+      aclstatus?: "created" | "approved" | "denied" | "deleted";
+      approver?: string;
+      /**
+       * Format: date-time
+       * @example 2018-03-20T09:12:28Z
+       */
+      approvingtime?: string;
+      /**
+       * @example Producer
+       * @enum {string}
+       */
+      aclType?: "Producer" | "Consumer";
+      /**
+       * @example PRINCIPAL
+       * @enum {string}
+       */
+      aclIpPrincipleType: "IP_ADDRESS" | "PRINCIPAL" | "USERNAME";
+      /**
+       * @description Other possible values GROUP, CLUSTER
+       * @example TOPIC
+       */
+      aclResourceType?: string;
+      /** @example 1 */
+      currentPage?: string;
+      otherParams?: string;
+      /** @example 10 */
+      totalNoPages?: string;
+      /**
+       * @example [
+       *   "1",
+       *   "2"
+       * ]
+       */
+      allPageNos?: string[];
+      /** @example DevRel */
+      approvingTeamDetails?: string;
+    };
   };
 };
 
@@ -554,6 +715,40 @@ export type operations = {
       200: {
         content: {
           "application/json": components["schemas"]["TopicsGetResponse"];
+        };
+      };
+    };
+  };
+  topicsGetOnly: {
+    parameters: {
+      query: {
+        /** Set to true to only get the topic names for topics belonging to the team of the current user */
+        isMyTeamTopics?: components["schemas"]["TopicsGetOnlyResponse"];
+      };
+    };
+    responses: {
+      /** OK */
+      200: {
+        content: {
+          "application/json": string[];
+        };
+      };
+    };
+  };
+  topicGetTeam: {
+    parameters: {
+      query: {
+        /** The name of the topic */
+        topicName: string;
+        /** The pattern type of the topic */
+        patternType?: "LITERAL" | "PREFIXED";
+      };
+    };
+    responses: {
+      /** OK */
+      200: {
+        content: {
+          "application/json": components["schemas"]["TopicGetTeamResponse"];
         };
       };
     };
@@ -613,6 +808,39 @@ export type operations = {
       };
     };
   };
+  environmentGetClusterInfo: {
+    parameters: {
+      query: {
+        /** The environment for which to get the cluster info */
+        envSelected: string;
+        /** The type of  environment for which to get the cluster info */
+        envType: string;
+      };
+    };
+    responses: {
+      /** OK */
+      200: {
+        content: {
+          "application/json": components["schemas"]["EnvironmentGetClusterInfoResponse"];
+        };
+      };
+    };
+  };
+  createAclRequest: {
+    responses: {
+      /** OK */
+      200: {
+        content: {
+          "application/json": components["schemas"]["GenericApiResponse"];
+        };
+      };
+    };
+    requestBody: {
+      content: {
+        "application/json": components["schemas"]["AclRequest"];
+      };
+    };
+  };
 };
 
 export type external = {};
@@ -620,9 +848,13 @@ export type external = {};
 export enum ApiPaths {
   userAuthentication = "/user/authenticate",
   topicsGet = "/getTopics",
+  topicsGetOnly = "/getTopicsOnly",
+  topicGetTeam = "/getTopicTeam",
   topicCreate = "/createTopics",
   topicAdvancedConfigGet = "/getAdvancedTopicConfigs",
   teamNamesGet = "/getAllTeamsSUOnly",
   environmentsGet = "/getEnvs",
   getEnvsBaseClusterFilteredForTeam = "/getEnvsBaseClusterFilteredForTeam",
+  environmentGetClusterInfo = "/getClusterInfoFromEnv",
+  createAclRequest = "/createAcl",
 }

--- a/coral/types/utils.d.ts
+++ b/coral/types/utils.d.ts
@@ -4,5 +4,7 @@ type KlawApiResponse<OperationId extends keyof operations> =
   operations[OperationId]["responses"][200]["content"]["application/json"];
 type KlawApiModel<Schema extends keyof components["schemas"]> =
   components["schemas"][Schema];
+type KlawApiRequest<OperationId extends keyof operations> =
+  operations[OperationId]["requestBody"]["content"]["application/json"];
 
-export type { KlawApiResponse, KlawApiModel };
+export type { KlawApiResponse, KlawApiModel, KlawApiRequest };

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -698,11 +698,9 @@ components:
         type: string
     EnvironmentGetClusterInfoResponse:
       type: object
-      properties:
-        clusterName:
-          type: string
-          enum: ["true", "false"]
-      required: [clusterName]
+      additionalProperties:
+        type: string
+        enum: ["true", "false"]
       example: { "aivenCluster": "false" }
     topicCreateRequest:
       title: TopicCreateRequest

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -252,8 +252,10 @@ paths:
           required: true
           description: The type of  environment for which to get the cluster info
           schema:
-            type: string
-            example: "kafka"
+            type:
+              type: string
+              enum: ["kafka", "kafkaconnect", "schema"]
+              example: "kafka"
       responses:
         "200":
           description: OK


### PR DESCRIPTION
# About this change - What it does

Add the entities in `domain` related to the endpoints documented in https://github.com/aiven/klaw/pull/381

Resolves: #362

# Notes

- also fixes small issues in the `openapi.yaml` specs for the ACL endpoints ([30d7bdd](https://github.com/aiven/klaw/pull/382/commits/30d7bdd87377c69f48ae3508201bfd9491eb296e), [6217cf7](https://github.com/aiven/klaw/pull/382/commits/6217cf756613781bea3ced72ccd82bb504ed14c4))
- introduces a new generic type util for API requests [ec144ad](https://github.com/aiven/klaw/pull/382/commits/ec144ad4328d9a5233e69c57b2842282f5e98210)
