### PR TITLE
fix(coral): Fix husky lint-staged issues

### DIFF
--- a/coral/.husky/pre-commit
+++ b/coral/.husky/pre-commit
@@ -6,17 +6,9 @@ OPENAPI_SPECS='openapi.yaml'
 GIT_ROOT=$(git rev-parse --show-toplevel)
 STAGED_FILES=$(git diff --staged --name-only)
 
-if echo "$STAGED_FILES" | grep -q "$FRONTEND_ROOT";
+if echo "$STAGED_FILES" | grep -q -e "$FRONTEND_ROOT" -e "$OPENAPI_SPECS";
 then
     pnpm --prefix="$GIT_ROOT"/"$FRONTEND_ROOT" lint-staged
     pnpm --prefix="$GIT_ROOT"/"$FRONTEND_ROOT" tsc
     pnpm --prefix="$GIT_ROOT"/"$FRONTEND_ROOT" test --bail
 fi
-
-if echo "$STAGED_FILES" | grep "$OPENAPI_SPECS";
-then
-    pnpm --prefix="$GIT_ROOT"/"$FRONTEND_ROOT" lint-staged --config="$GIT_ROOT"/"$FRONTEND_ROOT"/package.json --cwd="$GIT_ROOT"
-fi
-
-
-

--- a/coral/package.json
+++ b/coral/package.json
@@ -31,7 +31,7 @@
     "**/*.css": [
       "prettier --check"
     ],
-    "*.yaml": [
+    "../openapi.yaml": [
       "prettier --check"
     ]
   },


### PR DESCRIPTION
# About this change - What it does

When committing changes to both `openapi.yaml` and some files in `src`, I noticed two problems with the way the `husky` scripts were set up to allow us to run `lint-staged` on `openapi.yaml`:
- one wasteful problem: it makes `lint-staged` run twice on all the patterns defined in `package.json`
- one blocking problem: if one commits `openapi.yaml` changes along with changes in `src` (`ts*` or `css`), an `eslint` check fail, as it cannot resolve the imported modules' paths. This failure happens in the `lint-staged` ran in case there are changes to `openapi.yaml`. I suspect that the fact that we change the working directory with `--cwd="$GIT_ROOT"` in this case results in this behaviour.
<img width="1197" alt="Screenshot 2022-12-30 at 15 28 36" src="https://user-images.githubusercontent.com/20607294/210080996-e9e9f7e1-9dc7-4680-bb6d-492b6d8e4c51.png">

This PR removes the additional conditional run of `lint-staged`, and adds the proper pattern for one single run of `lint-staged` to run on all the files we want to check. 

# Why this way

Addresses the two issues outlined above, and remove complexity.

Caveat: it will run the `husky` checks on `src` even when only `openapi.yaml` has changed.
