### PR TITLE
Retrieve authorizations/attributes from AD token

### DIFF
--- a/cluster-api/src/main/java/io/aiven/klaw/clusterapi/services/ApacheKafkaAclService.java
+++ b/cluster-api/src/main/java/io/aiven/klaw/clusterapi/services/ApacheKafkaAclService.java
@@ -29,7 +29,6 @@ import org.apache.kafka.common.resource.PatternType;
 import org.apache.kafka.common.resource.ResourcePattern;
 import org.apache.kafka.common.resource.ResourcePatternFilter;
 import org.apache.kafka.common.resource.ResourceType;
-import org.springframework.core.env.Environment;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -38,18 +37,10 @@ public class ApacheKafkaAclService {
 
   private static final long TIME_OUT_SECS_FOR_ACLS = 5;
 
-  private Environment env;
-
-  private ClusterApiUtils clusterApiUtils;
+  private final ClusterApiUtils clusterApiUtils;
 
   public ApacheKafkaAclService(ClusterApiUtils clusterApiUtils) {
     this.clusterApiUtils = clusterApiUtils;
-  }
-
-  public ApacheKafkaAclService() {}
-
-  public ApacheKafkaAclService(Environment env) {
-    this.env = env;
   }
 
   public synchronized Set<Map<String, String>> loadAcls(

--- a/core/src/main/java/io/aiven/klaw/controller/ResourceClientController.java
+++ b/core/src/main/java/io/aiven/klaw/controller/ResourceClientController.java
@@ -30,8 +30,8 @@ public class ResourceClientController {
   @Value("${resourceserver.api.url:testResourceUrl}")
   private String resourceUrl;
 
-  @Value("${spring.security.oauth2.client.provider.klaw.user-info-uri:testResourceUrl}")
-  private String userInfoUri;
+  @Value("${klaw.ad.username.attribute:preferred_username}")
+  private String preferredUsernameAttribute;
 
   private static final String authorizationRequestBaseUri = "oauth2/authorize-client";
   Map<String, String> oauth2AuthenticationUrls = new HashMap<>();
@@ -67,7 +67,7 @@ public class ResourceClientController {
       OAuth2AuthorizedClient client =
           authorizedClientService.loadAuthorizedClient(
               authentication.getAuthorizedClientRegistrationId(),
-              (String) defaultOAuth2User.getAttributes().get("preferred_username"));
+              (String) defaultOAuth2User.getAttributes().get(preferredUsernameAttribute));
       if (client == null) {
         return ("redirect:oauthLogin");
       }

--- a/core/src/main/java/io/aiven/klaw/error/KlawErrorMessages.java
+++ b/core/src/main/java/io/aiven/klaw/error/KlawErrorMessages.java
@@ -1,0 +1,25 @@
+package io.aiven.klaw.error;
+
+public class KlawErrorMessages {
+
+  public static final String ACTIVE_DIRECTORY_ERR_CODE_101 = "AD101";
+  public static final String ACTIVE_DIRECTORY_ERR_CODE_102 = "AD102";
+  public static final String ACTIVE_DIRECTORY_ERR_CODE_103 = "AD103";
+  public static final String ACTIVE_DIRECTORY_ERR_CODE_104 = "AD104";
+
+  public static final String AD_ERROR_101_NO_MATCHING_ROLE =
+      "No matching role is configured. Please make sure only one matching role"
+          + " from Klaw is configured in AD. Denying login !!";
+
+  public static final String AD_ERROR_102_NO_MATCHING_TEAM =
+      "No matching team is configured. Please make sure only one matching team"
+          + " from Klaw is configured in AD. Denying login !!";
+
+  public static final String AD_ERROR_103_MULTIPLE_MATCHING_ROLE =
+      "Multiple matching roles are configured. Please make sure only one matching role"
+          + " from Klaw is configured in AD. Denying login !!";
+
+  public static final String AD_ERROR_104_MULTIPLE_MATCHING_TEAM =
+      "Multiple matching teams are configured. Please make sure only one matching team"
+          + " from Klaw is configured in AD. Denying login !!";
+}

--- a/core/src/main/java/io/aiven/klaw/helpers/HandleDbRequests.java
+++ b/core/src/main/java/io/aiven/klaw/helpers/HandleDbRequests.java
@@ -148,6 +148,8 @@ public interface HandleDbRequests {
 
   List<RegisterUserInfo> selectAllRegisterUsersInfo();
 
+  List<RegisterUserInfo> selectAllStagingRegisterUsersInfo(String userId);
+
   UserInfo getUsersInfo(String username);
 
   RegisterUserInfo getRegisterUsersInfo(String username);

--- a/core/src/main/java/io/aiven/klaw/helpers/KwConstants.java
+++ b/core/src/main/java/io/aiven/klaw/helpers/KwConstants.java
@@ -64,6 +64,22 @@ public class KwConstants {
   public static final String MAIL_PASSWORDRESET_CONTENT =
       "Dear User, \\nYou have requested for reset password on your Klaw account. \\n\\nUser name : %s \\nYour new Password : %s ";
 
+  public static final String AD_ERROR_101_NO_MATCHING_ROLE =
+      "No matching role is configured. Please make sure only one matching role"
+          + " from Klaw is configured in AD. Denying login !!";
+
+  public static final String AD_ERROR_102_NO_MATCHING_TEAM =
+      "No matching team is configured. Please make sure only one matching team"
+          + " from Klaw is configured in AD. Denying login !!";
+
+  public static final String AD_ERROR_103_MULTIPLE_MATCHING_ROLE =
+      "Multiple matching roles are configured. Please make sure only one matching role"
+          + " from Klaw is configured in AD. Denying login !!";
+
+  public static final String AD_ERROR_104_MULTIPLE_MATCHING_TEAM =
+      "Multiple matching teams are configured. Please make sure only one matching team"
+          + " from Klaw is configured in AD. Denying login !!";
+
   public static final String REPORTS_LOCATION = "/tmp/";
   public static final String MAIL_NOTIFICATIONS_ENABLE = "true";
   public static final String GETSCHEMAS_ENABLE = "false";

--- a/core/src/main/java/io/aiven/klaw/helpers/KwConstants.java
+++ b/core/src/main/java/io/aiven/klaw/helpers/KwConstants.java
@@ -64,22 +64,6 @@ public class KwConstants {
   public static final String MAIL_PASSWORDRESET_CONTENT =
       "Dear User, \\nYou have requested for reset password on your Klaw account. \\n\\nUser name : %s \\nYour new Password : %s ";
 
-  public static final String AD_ERROR_101_NO_MATCHING_ROLE =
-      "No matching role is configured. Please make sure only one matching role"
-          + " from Klaw is configured in AD. Denying login !!";
-
-  public static final String AD_ERROR_102_NO_MATCHING_TEAM =
-      "No matching team is configured. Please make sure only one matching team"
-          + " from Klaw is configured in AD. Denying login !!";
-
-  public static final String AD_ERROR_103_MULTIPLE_MATCHING_ROLE =
-      "Multiple matching roles are configured. Please make sure only one matching role"
-          + " from Klaw is configured in AD. Denying login !!";
-
-  public static final String AD_ERROR_104_MULTIPLE_MATCHING_TEAM =
-      "Multiple matching teams are configured. Please make sure only one matching team"
-          + " from Klaw is configured in AD. Denying login !!";
-
   public static final String REPORTS_LOCATION = "/tmp/";
   public static final String MAIL_NOTIFICATIONS_ENABLE = "true";
   public static final String GETSCHEMAS_ENABLE = "false";

--- a/core/src/main/java/io/aiven/klaw/helpers/db/rdbms/HandleDbRequestsJdbc.java
+++ b/core/src/main/java/io/aiven/klaw/helpers/db/rdbms/HandleDbRequestsJdbc.java
@@ -310,6 +310,11 @@ public class HandleDbRequestsJdbc implements HandleDbRequests {
     return jdbcSelectHelper.selectAllRegisterUsersInfo();
   }
 
+  @Override
+  public List<RegisterUserInfo> selectAllStagingRegisterUsersInfo(String userName) {
+    return jdbcSelectHelper.selectAllStagingRegisterUsersInfo(userName);
+  }
+
   public UserInfo getUsersInfo(String username) {
     return jdbcSelectHelper.selectUserInfo(username);
   }

--- a/core/src/main/java/io/aiven/klaw/helpers/db/rdbms/SelectDataJdbc.java
+++ b/core/src/main/java/io/aiven/klaw/helpers/db/rdbms/SelectDataJdbc.java
@@ -679,6 +679,10 @@ public class SelectDataJdbc {
     return registerInfoRepo.findAllByStatus("PENDING");
   }
 
+  public List<RegisterUserInfo> selectAllStagingRegisterUsersInfo(String userId) {
+    return registerInfoRepo.findAllByUsernameAndStatus(userId, "STAGING");
+  }
+
   public RegisterUserInfo selectRegisterUsersInfo(String username) {
     Optional<RegisterUserInfo> registerUserRec = registerInfoRepo.findById(username);
     return registerUserRec.orElse(null);

--- a/core/src/main/java/io/aiven/klaw/model/RegisterUserInfoModel.java
+++ b/core/src/main/java/io/aiven/klaw/model/RegisterUserInfoModel.java
@@ -24,6 +24,8 @@ public class RegisterUserInfoModel implements Serializable {
 
   private String team;
 
+  private Integer teamId;
+
   private String role;
 
   @Size(min = 5, max = 50, message = "Name must be above 4 characters")

--- a/core/src/main/java/io/aiven/klaw/service/ClusterApiService.java
+++ b/core/src/main/java/io/aiven/klaw/service/ClusterApiService.java
@@ -790,7 +790,7 @@ public class ClusterApiService {
     return store;
   }
 
-  private HttpHeaders createHeaders(String username) {
+  private HttpHeaders createHeaders(String username) throws KlawException {
     HttpHeaders httpHeaders = new HttpHeaders();
     String authHeader = "Bearer " + generateToken(username);
     httpHeaders.set("Authorization", authHeader);
@@ -798,7 +798,14 @@ public class ClusterApiService {
     return httpHeaders;
   }
 
-  private String generateToken(String username) {
+  private String generateToken(String username) throws KlawException {
+    if (clusterApiAccessBase64Secret.isBlank()) {
+      String errorTxt =
+          "CONFIGURE CLUSTER API SECRET FOR CLUSTER OPERATIONS. klaw.clusterapi.access.base64.secret";
+      log.error(errorTxt);
+      throw new KlawException(errorTxt);
+    }
+
     Key hmacKey =
         new SecretKeySpec(
             Base64.decodeBase64(clusterApiAccessBase64Secret),
@@ -815,7 +822,7 @@ public class ClusterApiService {
         .compact();
   }
 
-  private HttpEntity<String> getHttpEntity() {
+  private HttpEntity<String> getHttpEntity() throws KlawException {
     HttpHeaders headers = createHeaders(clusterApiUser);
     headers.setContentType(MediaType.APPLICATION_JSON);
 

--- a/core/src/main/java/io/aiven/klaw/service/MailUtils.java
+++ b/core/src/main/java/io/aiven/klaw/service/MailUtils.java
@@ -2,6 +2,7 @@ package io.aiven.klaw.service;
 
 import io.aiven.klaw.config.ManageDatabase;
 import io.aiven.klaw.dao.RegisterUserInfo;
+import io.aiven.klaw.dao.Team;
 import io.aiven.klaw.helpers.HandleDbRequests;
 import io.aiven.klaw.helpers.KwConstants;
 import io.aiven.klaw.helpers.UtilMethods;
@@ -27,7 +28,7 @@ public class MailUtils {
   @Value("${klaw.admin.mailid}")
   private String kwSaasAdminMailId;
 
-  @Value("${spring.security.oauth2.client.provider.klaw.user-name-attribute:preferred_username}")
+  @Value("${klaw.ad.username.attribute:preferred_username}")
   private String preferredUsername;
 
   private static final String SUPERUSER_MAILID_KEY = "klaw.superuser.mailid";
@@ -334,7 +335,7 @@ public class MailUtils {
         () -> {
           String emailId;
 
-          String emailIdTeam;
+          String emailIdTeam = null;
           try {
             if (registrationRequest) {
               emailId = otherMailId;
@@ -343,10 +344,10 @@ public class MailUtils {
             }
 
             try {
-              emailIdTeam = dbHandle.selectAllTeamsOfUsers(username, tenantId).get(0).getTeammail();
+              List<Team> allTeams = dbHandle.selectAllTeamsOfUsers(username, tenantId);
+              if (!allTeams.isEmpty()) emailIdTeam = allTeams.get(0).getTeammail();
             } catch (Exception e) {
-              log.error("Exception:", e);
-              emailIdTeam = null;
+              log.error("Exception :", e);
             }
 
             if (emailId != null) {

--- a/core/src/main/java/io/aiven/klaw/service/UiControllerLoginService.java
+++ b/core/src/main/java/io/aiven/klaw/service/UiControllerLoginService.java
@@ -16,6 +16,7 @@ import io.aiven.klaw.helpers.KwConstants;
 import io.aiven.klaw.model.RegisterUserInfoModel;
 import io.aiven.klaw.model.enums.ApiResultStatus;
 import io.aiven.klaw.model.enums.NewUserStatus;
+import java.io.IOException;
 import java.sql.Timestamp;
 import java.util.Collection;
 import java.util.Objects;
@@ -143,7 +144,9 @@ public class UiControllerLoginService {
   }
 
   public String checkAnonymousLogin(
-      String uri, OAuth2AuthenticationToken auth2AuthenticationToken) {
+      String uri,
+      OAuth2AuthenticationToken auth2AuthenticationToken,
+      HttpServletResponse response) {
     try {
       DefaultOAuth2User defaultOAuth2User =
           (DefaultOAuth2User) SecurityContextHolder.getContext().getAuthentication().getPrincipal();
@@ -177,6 +180,12 @@ public class UiControllerLoginService {
       }
     } catch (Exception e) {
       log.error("Exception:", e);
+      try {
+        // Display error to the user based on error code
+        response.sendRedirect("login?errorCode=AD101");
+      } catch (IOException ex) {
+        log.error("Ignore error from response redirect !");
+      }
       return oauthLoginPage;
     }
   }
@@ -282,7 +291,7 @@ public class UiControllerLoginService {
         return uri;
       } else {
         if (authentication instanceof OAuth2AuthenticationToken) {
-          return checkAnonymousLogin(uri, (OAuth2AuthenticationToken) authentication);
+          return checkAnonymousLogin(uri, (OAuth2AuthenticationToken) authentication, response);
         } else {
           return oauthLoginPage;
         }

--- a/core/src/main/java/io/aiven/klaw/service/UiControllerLoginService.java
+++ b/core/src/main/java/io/aiven/klaw/service/UiControllerLoginService.java
@@ -1,5 +1,6 @@
 package io.aiven.klaw.service;
 
+import static io.aiven.klaw.error.KlawErrorMessages.*;
 import static io.aiven.klaw.helpers.KwConstants.*;
 import static io.aiven.klaw.model.enums.AuthenticationType.ACTIVE_DIRECTORY;
 import static io.aiven.klaw.model.enums.AuthenticationType.DATABASE;
@@ -268,19 +269,19 @@ public class UiControllerLoginService {
     Boolean validClaim = Boolean.TRUE;
     if (claimMatched == 0) {
       if (claimType.equals("roles")) {
-        errorCode = "AD101";
+        errorCode = ACTIVE_DIRECTORY_ERR_CODE_101;
         log.error(AD_ERROR_101_NO_MATCHING_ROLE + "{}", userName);
       } else {
-        errorCode = "AD102";
+        errorCode = ACTIVE_DIRECTORY_ERR_CODE_102;
         log.error(AD_ERROR_102_NO_MATCHING_TEAM + "{}", userName);
       }
       validClaim = Boolean.FALSE;
     } else if (claimMatched > 1) {
       if (claimType.equals("roles")) {
-        errorCode = "AD103";
+        errorCode = ACTIVE_DIRECTORY_ERR_CODE_103;
         log.error(AD_ERROR_103_MULTIPLE_MATCHING_ROLE + "{}", userName);
       } else {
-        errorCode = "AD104";
+        errorCode = ACTIVE_DIRECTORY_ERR_CODE_104;
         log.error(AD_ERROR_104_MULTIPLE_MATCHING_TEAM + "{}", userName);
       }
       validClaim = Boolean.FALSE;

--- a/core/src/main/java/io/aiven/klaw/service/UtilControllerService.java
+++ b/core/src/main/java/io/aiven/klaw/service/UtilControllerService.java
@@ -1,5 +1,9 @@
 package io.aiven.klaw.service;
 
+import static io.aiven.klaw.helpers.KwConstants.AD_ERROR_101_NO_MATCHING_ROLE;
+import static io.aiven.klaw.helpers.KwConstants.AD_ERROR_102_NO_MATCHING_TEAM;
+import static io.aiven.klaw.helpers.KwConstants.AD_ERROR_103_MULTIPLE_MATCHING_ROLE;
+import static io.aiven.klaw.helpers.KwConstants.AD_ERROR_104_MULTIPLE_MATCHING_TEAM;
 import static io.aiven.klaw.model.enums.AuthenticationType.ACTIVE_DIRECTORY;
 import static io.aiven.klaw.model.enums.RolesType.SUPERADMIN;
 
@@ -598,6 +602,12 @@ public class UtilControllerService {
 
     resultBasicInfo.put("ssoServerUrlAzure", ssoServerLoginUrlAzure);
     resultBasicInfo.put("ssoServerUrlGoogle", ssoServerLoginUrlGoogle);
+
+    // error codes of active directory authorization errors
+    resultBasicInfo.put("AD101", AD_ERROR_101_NO_MATCHING_ROLE);
+    resultBasicInfo.put("AD102", AD_ERROR_102_NO_MATCHING_TEAM);
+    resultBasicInfo.put("AD103", AD_ERROR_103_MULTIPLE_MATCHING_ROLE);
+    resultBasicInfo.put("AD104", AD_ERROR_104_MULTIPLE_MATCHING_TEAM);
 
     return resultBasicInfo;
   }

--- a/core/src/main/java/io/aiven/klaw/service/UtilControllerService.java
+++ b/core/src/main/java/io/aiven/klaw/service/UtilControllerService.java
@@ -1,9 +1,6 @@
 package io.aiven.klaw.service;
 
-import static io.aiven.klaw.helpers.KwConstants.AD_ERROR_101_NO_MATCHING_ROLE;
-import static io.aiven.klaw.helpers.KwConstants.AD_ERROR_102_NO_MATCHING_TEAM;
-import static io.aiven.klaw.helpers.KwConstants.AD_ERROR_103_MULTIPLE_MATCHING_ROLE;
-import static io.aiven.klaw.helpers.KwConstants.AD_ERROR_104_MULTIPLE_MATCHING_TEAM;
+import static io.aiven.klaw.error.KlawErrorMessages.*;
 import static io.aiven.klaw.model.enums.AuthenticationType.ACTIVE_DIRECTORY;
 import static io.aiven.klaw.model.enums.RolesType.SUPERADMIN;
 
@@ -604,10 +601,10 @@ public class UtilControllerService {
     resultBasicInfo.put("ssoServerUrlGoogle", ssoServerLoginUrlGoogle);
 
     // error codes of active directory authorization errors
-    resultBasicInfo.put("AD101", AD_ERROR_101_NO_MATCHING_ROLE);
-    resultBasicInfo.put("AD102", AD_ERROR_102_NO_MATCHING_TEAM);
-    resultBasicInfo.put("AD103", AD_ERROR_103_MULTIPLE_MATCHING_ROLE);
-    resultBasicInfo.put("AD104", AD_ERROR_104_MULTIPLE_MATCHING_TEAM);
+    resultBasicInfo.put(ACTIVE_DIRECTORY_ERR_CODE_101, AD_ERROR_101_NO_MATCHING_ROLE);
+    resultBasicInfo.put(ACTIVE_DIRECTORY_ERR_CODE_102, AD_ERROR_102_NO_MATCHING_TEAM);
+    resultBasicInfo.put(ACTIVE_DIRECTORY_ERR_CODE_103, AD_ERROR_103_MULTIPLE_MATCHING_ROLE);
+    resultBasicInfo.put(ACTIVE_DIRECTORY_ERR_CODE_104, AD_ERROR_104_MULTIPLE_MATCHING_TEAM);
 
     return resultBasicInfo;
   }

--- a/core/src/main/resources/application.properties
+++ b/core/src/main/resources/application.properties
@@ -44,7 +44,11 @@ klaw.login.authentication.type=db
 #spring.ad.filter=
 
 # Enable user Authorization/roles from AD/SSO, instead of database.
-# klaw.login.authentication.type should be set to ad fo this value to be true
+# klaw.login.authentication.type should be set to ad for this value to be true
+# Role : If enabled, during authentication, role will be picked up from authentication token/authorities ex : ROLE_USER.
+# and looks for matching role in Klaw. Make sure only one matching role exists. If nothing exists, user is denied login.
+# Team : If enabled, during authentication, team will be picked up from authentication token/attributes of team.
+# If nothing exists, user is denied login.
 klaw.enable.authorization.ad=false
 
 # sso config
@@ -165,6 +169,13 @@ spring.jpa.properties.hibernate.naming.physical-strategy=org.hibernate.boot.mode
 # Azure, Google OAuth2 login url
 klaw.sso.server.loginurl.azure=/oauth2/authorization/azure
 klaw.sso.server.loginurl.google=/oauth2/authorization/google
+
+# Default attributes to extract for AD authentication
+klaw.ad.username.attribute=preferred_username
+klaw.ad.email.attribute=email
+klaw.ad.name.attribute=name
+klaw.ad.roles.attribute=roles
+klaw.ad.teams.attribute=teams
 
 # other spring config
 spring.cache.type=NONE

--- a/core/src/main/resources/static/js/loginSaas.js
+++ b/core/src/main/resources/static/js/loginSaas.js
@@ -18,28 +18,27 @@ app.controller("loginSaasCtrl", function($scope, $http, $location, $window) {
     $scope.alert = "";
 
         $scope.validateErrors = function(){
-            var sPageURL = window.location.search.substring(1);
-            var sURLVariables = sPageURL.split('&');
-            for (var i = 0; i < sURLVariables.length; i++)
+            const sPageURL = window.location.search.substring(1);
+            const sURLVariables = sPageURL.split('&');
+            for (let i = 0; i < sURLVariables.length; i++)
             {
-                var sParameterName = sURLVariables[i].split('=');
+                const sParameterName = sURLVariables[i].split('=');
                 if (sParameterName[0] === "errorCode")
                 {
-                    if(sParameterName[1] === "AD101"){
-                        $scope.alert = "Please make sure a matching role/team from Klaw is configured in AD Authorities/Attributes. Denying login !!";
-                    }
+                    $scope.alert = $scope.dashboardDetails[sParameterName[1]];
                 }
             }
         }
 
         $scope.getBasicInfo = function() {
-            $scope.validateErrors();
+
             $http({
                        method: "GET",
                        url: "getBasicInfo",
                        headers : { 'Content-Type' : 'application/json' }
                    }).success(function(output) {
                        $scope.dashboardDetails = output;
+                       $scope.validateErrors();
                    }).error(
                        function(error)
                        {

--- a/core/src/main/resources/static/js/loginSaas.js
+++ b/core/src/main/resources/static/js/loginSaas.js
@@ -15,8 +15,25 @@ app.controller("loginSaasCtrl", function($scope, $http, $location, $window) {
 	// getting a "text/plain" response which is not able to be
 	// parsed. 
 	$http.defaults.headers.common['Accept'] = 'application/json';
+    $scope.alert = "";
+
+        $scope.validateErrors = function(){
+            var sPageURL = window.location.search.substring(1);
+            var sURLVariables = sPageURL.split('&');
+            for (var i = 0; i < sURLVariables.length; i++)
+            {
+                var sParameterName = sURLVariables[i].split('=');
+                if (sParameterName[0] === "errorCode")
+                {
+                    if(sParameterName[1] === "AD101"){
+                        $scope.alert = "Please make sure a matching role/team from Klaw is configured in AD Authorities/Attributes. Denying login !!";
+                    }
+                }
+            }
+        }
 
         $scope.getBasicInfo = function() {
+            $scope.validateErrors();
             $http({
                        method: "GET",
                        url: "getBasicInfo",

--- a/core/src/main/resources/static/js/requestAcls.js
+++ b/core/src/main/resources/static/js/requestAcls.js
@@ -187,8 +187,10 @@ app.controller("requestAclsCtrl", function($scope, $http, $location, $window) {
                         params: {'envSelected' : envName, 'envType' : 'kafka' },
                     }).success(function(output) {
                         $scope.aivenCluster = output.aivenCluster;
-                        if($scope.aivenCluster === 'false')
+                        if($scope.aivenCluster === 'false'){
                             $scope.acl_ip_ssl = 'IP';
+                            $scope.selectedAclType="IP_ADDRESS";
+                        }
                         else{
                             $scope.acl_ip_ssl = 'SSL';
                             $scope.selectedAclType="PRINCIPAL";

--- a/core/src/main/resources/swagger_spec.json
+++ b/core/src/main/resources/swagger_spec.json
@@ -4015,6 +4015,10 @@
         "team" : {
           "type" : "string"
         },
+        "teamId" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
         "role" : {
           "type" : "string"
         },

--- a/core/src/main/resources/templates/modifyUser.html
+++ b/core/src/main/resources/templates/modifyUser.html
@@ -524,6 +524,15 @@
 												</select>
 											</div>
 										</div>
+
+										<div class="col-md-6" ng-if="dashboardDetails.adAuthRoleEnabled=='true'">
+											<div class="form-group">
+												<label>Select a Role</label>
+												<select disabled class="form-control custom-select" ng-model="userDetails.role" ng-options="roleid as roleid for roleid in rolelist">
+
+												</select>
+											</div>
+										</div>
 										<!--/span-->
 									</div>
 

--- a/core/src/main/resources/templates/modifyUser.html
+++ b/core/src/main/resources/templates/modifyUser.html
@@ -516,19 +516,10 @@
 											</div>
 										</div>
 										<!--/span-->
-										<div class="col-md-6" ng-if="dashboardDetails.adAuthRoleEnabled=='false'">
+										<div class="col-md-6">
 											<div class="form-group">
 												<label>Select a Role</label>
 												<select class="form-control custom-select" ng-model="userDetails.role" ng-options="roleid as roleid for roleid in rolelist">
-
-												</select>
-											</div>
-										</div>
-
-										<div class="col-md-6" ng-if="dashboardDetails.adAuthRoleEnabled=='true'">
-											<div class="form-group">
-												<label>Select a Role</label>
-												<select disabled class="form-control custom-select" ng-model="userDetails.role" ng-options="roleid as roleid for roleid in rolelist">
 
 												</select>
 											</div>

--- a/core/src/main/resources/templates/oauthLogin.html
+++ b/core/src/main/resources/templates/oauthLogin.html
@@ -126,6 +126,13 @@
                         </div>
                     </div>
                 </div>
+                <div ng-show="alert != ''">
+                    <div  class="col-lg-12 col-md-6 col-xlg-2 col-xs-12" >
+                        <div class="ribbon-wrapper card">
+                            <p class="text-danger">{{ alert }}</p>
+                        </div>
+                    </div>
+                </div>
             </div>
         </div>
     </section>

--- a/core/src/main/resources/templates/showUsers.html
+++ b/core/src/main/resources/templates/showUsers.html
@@ -466,7 +466,7 @@
 										<th>Username</th>
 										<th width="20%">Name</th>
 										<th>Team</th>
-										<th ng-if="dashboardDetails.adAuthRoleEnabled=='false'">Role</th>
+										<th>Role</th>
 										<th>EmailId</th>
 										<th width="10%" ng-show="dashboardDetails.addUser=='Authorized'">Edit</th>
 										<th width="10%" ng-show="dashboardDetails.addUser=='Authorized'">Delete</th>
@@ -477,7 +477,7 @@
 										<td>{{ userDetails.username }}</td>
 										<td>{{ userDetails.fullname }}</td>
 										<td><a href="teams">{{ userDetails.team }}</a></td>
-										<td ng-if="dashboardDetails.adAuthRoleEnabled=='false'"><span class="badge badge-info">{{ userDetails.role }}</span></td>
+										<td><span class="badge badge-info">{{ userDetails.role }}</span></td>
 
 										<td>{{ userDetails.mailid }}</td>
 										<td ng-show="dashboardDetails.addUser=='Authorized'">

--- a/core/src/test/java/io/aiven/klaw/ActiveDirectoryAuthorizationIT.java
+++ b/core/src/test/java/io/aiven/klaw/ActiveDirectoryAuthorizationIT.java
@@ -1,0 +1,115 @@
+package io.aiven.klaw;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.security.oauth2.core.oidc.endpoint.OidcParameterNames.ID_TOKEN;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.oidcLogin;
+
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.oauth2.core.oidc.OidcIdToken;
+import org.springframework.security.oauth2.core.oidc.user.DefaultOidcUser;
+import org.springframework.security.oauth2.core.oidc.user.OidcUser;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+
+@SpringBootTest(
+    webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
+    classes = UiapiApplication.class)
+// Config file with property klaw.login.authentication.type set to 'ad' and klaw.enable.sso set to
+// true. klaw.enable.authorization.ad=true means role and team are retrieved from AD token
+@TestPropertySource(locations = "classpath:test-application-rdbms-ad-authorization.properties")
+@AutoConfigureMockMvc
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+@DirtiesContext
+public class ActiveDirectoryAuthorizationIT {
+
+  @Autowired private MockMvc mvc;
+
+  // Register a user with a no role and no team in AD authorities/attributes - deny signup with
+  // error
+  @Test
+  @Order(1)
+  public void adRegisterUserWithNoRoleAndNoTeamSignupDeny() {
+    String errorCode = "AD101";
+    try {
+      MockHttpServletResponse response =
+          mvc.perform(
+                  MockMvcRequestBuilders.get("/")
+                      .with(
+                          oidcLogin()
+                              .oidcUser(
+                                  getOidcUser(
+                                      "newuser", "NONE"))) // oidc register with no role and team
+                      // authorities
+                      .contentType(MediaType.APPLICATION_JSON)
+                      .accept(MediaType.APPLICATION_JSON))
+              .andReturn()
+              .getResponse();
+      assertThat(response.getRedirectedUrl()).contains("login?errorCode=" + errorCode); //
+      // dashboard details
+    } catch (Exception e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  // Register a user with a valid role and no team in AD authorities/attributes - deny signup with
+  // error
+  @Test
+  @Order(1)
+  public void adRegisterUserWithValidRoleAndNoTeamSignupDeny() {
+    String errorCode = "AD102";
+    try {
+      MockHttpServletResponse response =
+          mvc.perform(
+                  MockMvcRequestBuilders.get("/")
+                      .with(
+                          oidcLogin()
+                              .oidcUser(
+                                  getOidcUser(
+                                      "newuser",
+                                      "VALID"))) // oidc register with valid role and no team
+                      // authorities
+                      .contentType(MediaType.APPLICATION_JSON)
+                      .accept(MediaType.APPLICATION_JSON))
+              .andReturn()
+              .getResponse();
+      assertThat(response.getRedirectedUrl()).contains("login?errorCode=" + errorCode); //
+      // dashboard details
+    } catch (Exception e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  private OidcUser getOidcUser(String username, String authorityType) {
+    Map<String, Object> claims = new HashMap<>();
+    claims.put("groups", "ROLE_USER");
+    claims.put("sub", 123);
+    claims.put("preferred_username", username); // existing user with default installation
+    OidcIdToken idToken =
+        new OidcIdToken(ID_TOKEN, Instant.now(), Instant.now().plusSeconds(60), claims);
+    Collection<GrantedAuthority> authorities = getAuthorities(authorityType);
+    return new DefaultOidcUser(authorities, idToken);
+  }
+
+  private static Collection<GrantedAuthority> getAuthorities(String authorityType) {
+    Collection<GrantedAuthority> authorities = new ArrayList<>();
+    if (authorityType.equals("VALID")) authorities.add(new SimpleGrantedAuthority("ROLE_USER"));
+    return authorities;
+  }
+}

--- a/core/src/test/java/io/aiven/klaw/ActiveDirectoryAuthorizationIT.java
+++ b/core/src/test/java/io/aiven/klaw/ActiveDirectoryAuthorizationIT.java
@@ -1,16 +1,18 @@
 package io.aiven.klaw;
 
+import static io.aiven.klaw.helpers.KwConstants.INFRATEAM;
+import static io.aiven.klaw.helpers.KwConstants.STAGINGTEAM;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.springframework.security.oauth2.core.oidc.endpoint.OidcParameterNames.ID_TOKEN;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.oidcLogin;
 
+import com.nimbusds.jose.shaded.json.JSONArray;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
 import org.junit.jupiter.api.MethodOrderer;
-import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestMethodOrder;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -44,7 +46,6 @@ public class ActiveDirectoryAuthorizationIT {
   // Register a user with a no role and no team in AD authorities/attributes - deny signup with
   // error
   @Test
-  @Order(1)
   public void adRegisterUserWithNoRoleAndNoTeamSignupDeny() {
     String errorCode = "AD101";
     try {
@@ -55,14 +56,12 @@ public class ActiveDirectoryAuthorizationIT {
                           oidcLogin()
                               .oidcUser(
                                   getOidcUser(
-                                      "newuser", "NONE"))) // oidc register with no role and team
-                      // authorities
+                                      "NONE", "NONE"))) // oidc register with no role and team
                       .contentType(MediaType.APPLICATION_JSON)
                       .accept(MediaType.APPLICATION_JSON))
               .andReturn()
               .getResponse();
-      assertThat(response.getRedirectedUrl()).contains("login?errorCode=" + errorCode); //
-      // dashboard details
+      assertThat(response.getRedirectedUrl()).contains("login?errorCode=" + errorCode);
     } catch (Exception e) {
       throw new RuntimeException(e);
     }
@@ -71,7 +70,6 @@ public class ActiveDirectoryAuthorizationIT {
   // Register a user with a valid role and no team in AD authorities/attributes - deny signup with
   // error
   @Test
-  @Order(1)
   public void adRegisterUserWithValidRoleAndNoTeamSignupDeny() {
     String errorCode = "AD102";
     try {
@@ -82,9 +80,8 @@ public class ActiveDirectoryAuthorizationIT {
                           oidcLogin()
                               .oidcUser(
                                   getOidcUser(
-                                      "newuser",
-                                      "VALID"))) // oidc register with valid role and no team
-                      // authorities
+                                      "VALID",
+                                      "NONE"))) // oidc register with valid role and no team
                       .contentType(MediaType.APPLICATION_JSON)
                       .accept(MediaType.APPLICATION_JSON))
               .andReturn()
@@ -96,11 +93,99 @@ public class ActiveDirectoryAuthorizationIT {
     }
   }
 
-  private OidcUser getOidcUser(String username, String authorityType) {
+  // Register a user with valid multiple roles and no team in AD authorities/attributes - deny
+  // signup with error
+  @Test
+  public void adRegisterUserWithMultipleRolesAndNoTeamSignupDeny() {
+    String errorCode = "AD103";
+    try {
+      MockHttpServletResponse response =
+          mvc.perform(
+                  MockMvcRequestBuilders.get("/")
+                      .with(
+                          oidcLogin()
+                              .oidcUser(
+                                  getOidcUser(
+                                      "MULTIPLE",
+                                      "NONE"))) // oidc register with multiple valid roles and no
+                      // team
+                      .contentType(MediaType.APPLICATION_JSON)
+                      .accept(MediaType.APPLICATION_JSON))
+              .andReturn()
+              .getResponse();
+      assertThat(response.getRedirectedUrl()).contains("login?errorCode=" + errorCode);
+    } catch (Exception e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  // Register a user with a valid role and multiple valid teams in AD authorities/attributes - deny
+  // signup with error
+  @Test
+  public void adRegisterUserWithValidRoleAndValidTeamSignupDeny() {
+    String errorCode = "AD104";
+    try {
+      MockHttpServletResponse response =
+          mvc.perform(
+                  MockMvcRequestBuilders.get("/")
+                      .with(
+                          oidcLogin()
+                              .oidcUser(
+                                  getOidcUser(
+                                      "VALID",
+                                      "MULTIPLE"))) // oidc register with one valid role and
+                      // multiple valid team
+                      .contentType(MediaType.APPLICATION_JSON)
+                      .accept(MediaType.APPLICATION_JSON))
+              .andReturn()
+              .getResponse();
+      assertThat(response.getRedirectedUrl()).contains("login?errorCode=" + errorCode);
+    } catch (Exception e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  // Register a user with a valid role and no team in AD authorities/attributes - deny signup with
+  // error
+  @Test
+  public void adRegisterUserWithValidRoleAndValidTeamSignupAccept() {
+    try {
+      MockHttpServletResponse response =
+          mvc.perform(
+                  MockMvcRequestBuilders.get("/")
+                      .with(
+                          oidcLogin()
+                              .oidcUser(
+                                  getOidcUser(
+                                      "VALID",
+                                      "VALID"))) // oidc register with one valid role and one valid
+                      // team authorities
+                      .contentType(MediaType.APPLICATION_JSON)
+                      .accept(MediaType.APPLICATION_JSON))
+              .andReturn()
+              .getResponse();
+      assertThat(response.getRedirectedUrl())
+          .contains("register?userRegistrationId="); // redirecting to registration page
+    } catch (Exception e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  private OidcUser getOidcUser(String authorityType, String teams) {
     Map<String, Object> claims = new HashMap<>();
     claims.put("groups", "ROLE_USER");
     claims.put("sub", 123);
-    claims.put("preferred_username", username); // existing user with default installation
+    claims.put("preferred_username", "newuser"); // new user who doesn't exist
+    if (teams.equals("VALID")) { // add one valid team
+      JSONArray jsonArray = new JSONArray();
+      jsonArray.add(INFRATEAM);
+      claims.put("teams", jsonArray);
+    } else if (teams.equals("MULTIPLE")) { // add multiple valid teams
+      JSONArray jsonArray = new JSONArray();
+      jsonArray.add(INFRATEAM);
+      jsonArray.add(STAGINGTEAM);
+      claims.put("teams", jsonArray);
+    }
     OidcIdToken idToken =
         new OidcIdToken(ID_TOKEN, Instant.now(), Instant.now().plusSeconds(60), claims);
     Collection<GrantedAuthority> authorities = getAuthorities(authorityType);
@@ -109,7 +194,12 @@ public class ActiveDirectoryAuthorizationIT {
 
   private static Collection<GrantedAuthority> getAuthorities(String authorityType) {
     Collection<GrantedAuthority> authorities = new ArrayList<>();
-    if (authorityType.equals("VALID")) authorities.add(new SimpleGrantedAuthority("ROLE_USER"));
+    if (authorityType.equals("VALID")) { // add one valid role
+      authorities.add(new SimpleGrantedAuthority("ROLE_USER"));
+    } else if (authorityType.equals("MULTIPLE")) { // add multiple valid roles
+      authorities.add(new SimpleGrantedAuthority("ROLE_USER"));
+      authorities.add(new SimpleGrantedAuthority("ROLE_SUPERADMIN"));
+    }
     return authorities;
   }
 }

--- a/core/src/test/resources/test-application-rdbms-ad-authorization.properties
+++ b/core/src/test/resources/test-application-rdbms-ad-authorization.properties
@@ -1,0 +1,161 @@
+server.port=9097
+
+#server.servlet.context-path=/klaw
+
+# SSL Properties
+#server.ssl.key-store=./client.keystore.jks
+#server.ssl.trust-store=./client.truststore.jks
+#server.ssl.key-store-password=klaw
+#server.ssl.key-password=klaw
+#server.ssl.trust-store-password=klaw
+#server.ssl.key-store-type=JKS
+
+# klaw.db.storetype should be "rdbms"
+klaw.db.storetype=rdbms
+
+# klaw application is either "saas" or "onpremise"
+klaw.installation.type=onpremise
+
+# Possible values "db" or "ad" or "azuread". If SSO config or Active directory is enabled below, this value should be "ad"
+klaw.login.authentication.type=ad
+
+# Database settings
+spring.liquibase.enabled=true
+spring.liquibase.change-log=classpath:db/changelog/changelog.yaml
+
+klaw.version=1.2.0
+
+# Spring JPA properties mysql
+# Spring JPA properties filedb
+spring.datasource.url=jdbc:h2:mem:testdb;DB_CLOSE_DELAY=-1
+spring.datasource.driver.class=org.h2.Driver
+spring.datasource.username=kafkauser
+spring.datasource.password=klaw
+spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.H2Dialect
+##enabling the H2 console
+spring.h2.console.enabled=false
+
+# Generic JPA props
+spring.datasource.hikari.connectionTimeout=30000
+spring.datasource.hikari.idleTimeout=600000
+spring.datasource.hikari.maxPoolSize=50
+spring.jpa.hibernate.show_sql=false
+spring.jpa.hibernate.generate-ddl=false
+spring.jpa.hibernate.ddl-auto=create-drop
+spring.jpa.hibernate.jdbc.lob.non_contextual_creation=true
+spring.jpa.properties.hibernate.naming.physical-strategy=org.hibernate.boot.model.naming.PhysicalNamingStrategyStandardImpl
+spring.jpa.hibernate.naming-strategy=org.hibernate.cfg.ImprovedNamingStrategy
+
+# Email notification properties
+klaw.mail.notifications.enable=false
+spring.mail.properties.mail.transport.protocol=smtp
+spring.mail.host=smtp.gmail.com
+spring.mail.port=587
+spring.mail.username=
+spring.mail.password=
+spring.mail.properties.mail.smtp.auth=true
+spring.mail.properties.mail.smtp.starttls.enable=true
+spring.mail.properties.mail.debug=false
+spring.mail.noreplymailid=testmailid
+spring.mail.frommailid=testmailid
+
+# ActiveDirectory properties
+#spring.ad.domain=
+#spring.ad.url=
+#spring.ad.rootDn=
+#spring.ad.filter=
+
+klaw.aad.server.loginurl=/oauth2/authorization/azure
+spring.cloud.azure.active-directory.enabled=true
+# Specifies your Active Directory ID:
+spring.cloud.azure.active-directory.profile.tenant-id=azure-tenant-id
+# Specifies your App Registration's Application ID:
+spring.cloud.azure.active-directory.credential.client-id=azure-app-client-id
+# Specifies your App Registration's secret key:
+spring.cloud.azure.active-directory.credential.client-secret=client-secret
+
+# Enable user Authorization/roles from AD/SSO, instead of database.
+# klaw.login.authentication.type should be set to ad fo this value to be true
+klaw.enable.authorization.ad=true
+
+# sso config
+klaw.enable.sso=true
+
+klaw.sso.server.loginurl=/oauth2/authorization/azure
+klaw.sso.client.registration.id=klaw
+#Based on above registration id, create the keys below. spring.security.oauth2.client.registration.[registrationid]...
+spring.security.oauth2.client.registration.klaw.client-id=ssoClient-1
+spring.security.oauth2.client.registration.klaw.client-secret=ssoClientSecret-1
+spring.security.oauth2.client.registration.klaw.scope=read,write
+spring.security.oauth2.client.registration.klaw.redirect-uri=https://localhost:9097/login/oauth2/code/klaw
+spring.security.oauth2.client.registration.klaw.authorization-grant-type=authorization_code
+spring.security.oauth2.client.registration.klaw.client-name=klaw
+spring.security.oauth2.client.provider.klaw.authorization-uri=http://localhost:8083/auth/realms/klaw/protocol/openid-connect/auth
+spring.security.oauth2.client.provider.klaw.token-uri=http://localhost:8083/auth/realms/klaw/protocol/openid-connect/token
+spring.security.oauth2.client.provider.klaw.user-info-uri=http://localhost:8083/auth/realms/klaw/protocol/openid-connect/userinfo
+spring.security.oauth2.client.provider.klaw.user-name-attribute=preferred_username
+
+# other spring config
+spring.cache.type=NONE
+spring.thymeleaf.cache=false
+
+# application shutdown properties
+management.endpoints.web.exposure.include=*
+management.endpoint.shutdown.enabled=true
+endpoints.shutdown.enabled=true
+
+#jasypt encryption pwd secret key
+klaw.jasypt.encryptor.secretkey=kw2021secretkey
+
+#reload cluster status in milli secs - default 30 mins
+klaw.reloadclusterstatus.interval=1800000
+
+# ClusterApi access
+klaw.clusterapi.access.username=kwclusterapiuser
+
+# Monitoring
+klaw.monitoring.metrics.enable=false
+klaw.monitoring.metrics.collectinterval.ms=60000
+
+# custom banner
+spring.banner.location=classpath:banner.txt
+
+#kw prize list
+klaw.prizelist.pertenant=1 month (8 $),2 months (15 $),3 months (20 $),6 months (42 $),1 year (75 $),2 years (150 $),3 years (225 $),5 years (350 $) 
+
+klaw.admin.mailid=adminmailid
+klaw.superadmin.default.username=superadmin
+klaw.superadmin.default.password=kwsuperadmin123$$
+
+#kw saas admin
+klaw.saas.ssl.aclcommand=kafka-acls --authorizer-properties bootstrap.server=host:port --add --allow-principal User:"CN=abc..." --operation All  --cluster Cluster:kafka-cluster --topic "*"
+klaw.saas.ssl.pubkey=./certs/Klaw_PublicKey.zip
+klaw.saas.ssl.clientcerts.location=./clientcerts
+klaw.saas.ssl.clusterapi.truststore=./client.truststore.jks
+klaw.saas.ssl.clusterapi.truststore.pwd=klaw
+klaw.saas.plaintext.aclcommand=kafka-acls --authorizer-properties bootstrap.server=host:port --add --allow-principal User:'*' --operation All --allow-host hostname_ip --cluster Cluster:kafka-cluster --topic "*"
+
+klaw.uiapi.servers=https://localhost:9097
+
+#google recaptcha settings
+google.recaptcha.sitekey=sitekey
+google.recaptcha.verification.endpoint=https://www.google.com/recaptcha/api/siteverify
+google.recaptcha.secret=secret
+
+
+# Enable response compression
+server.compression.enabled=true
+
+# The comma-separated list of mime types that should be compressed
+server.compression.mime-types=text/html,text/xml,text/plain,text/css,text/javascript,application/javascript,application/json
+
+# Compress the response only if the response size is at least 1KB
+server.compression.min-response-size=1024
+
+#maximum tenants can be created
+klaw.max.tenants=200
+
+# log file settings
+#logging.level.root=debug
+logging.level.org.hibernate.SQL=off
+logging.file.name=./../logs/kw-uiapi.log


### PR DESCRIPTION
About this change - What it does

When a user is being registered for the first time being a member of AD, his/her roles/teams are being retrieved from the authentication token.

Property : klaw.enable.authorization.ad setting to true will enable this functionality of retrieving role and team attributes.
If this is enabled, and no matching role and team are configured, user is denied registering, and is forced to configure the same in AD and then try login again.

- fixes bug of aclservice constructor

Resolves: #274 
Resolves: #388 
Why this way
A Super user does not have to manually change the role and team of the user, and it is automatically picked up from AD.
