### PR TITLE
coral(feat): Add component to handle NativeSelect with complex options

### DIFF
--- a/coral/src/app/components/ComplexNativeSelect.test.tsx
+++ b/coral/src/app/components/ComplexNativeSelect.test.tsx
@@ -1,7 +1,6 @@
 import { cleanup, render, within, screen } from "@testing-library/react";
 import { ComplexNativeSelect } from "src/app/components/ComplexNativeSelect";
 import userEvent from "@testing-library/user-event";
-import { waitFor } from "@testing-library/react/pure";
 
 type TestOption = {
   id: string;

--- a/coral/src/app/components/ComplexNativeSelect.test.tsx
+++ b/coral/src/app/components/ComplexNativeSelect.test.tsx
@@ -1,0 +1,257 @@
+import { cleanup, render, within, screen } from "@testing-library/react";
+import { ComplexNativeSelect } from "src/app/components/ComplexNativeSelect";
+import userEvent from "@testing-library/user-event";
+
+const testOptions = [
+  {
+    id: "1",
+    name: "First option",
+  },
+  {
+    id: "2",
+    name: "Second option",
+  },
+  {
+    id: "3",
+    name: "Third option",
+  },
+];
+
+const labelText = "Best option";
+const placeholder = "Please select";
+
+describe("ComplexNativeSelect.tsx", () => {
+  describe("renders a select element with required properties", () => {
+    const onBlurMock = jest.fn();
+    const optionToStringMock = jest.fn((option) => option.name);
+    const getValueMock = jest.fn((option) => option.id);
+
+    const requiredProps = {
+      options: testOptions,
+      onBlur: onBlurMock,
+      optionToString: optionToStringMock,
+      getValue: getValueMock,
+      placeholder: placeholder,
+      labelText: labelText,
+    };
+
+    beforeAll(() => {
+      render(<ComplexNativeSelect {...requiredProps} />);
+    });
+
+    afterAll(cleanup);
+
+    it("shows a select element", () => {
+      const select = screen.getByRole("combobox", { name: labelText });
+
+      expect(select).toBeEnabled();
+    });
+
+    it("shows a given placeholder text as displayed value", () => {
+      const select = screen.getByRole("combobox", { name: labelText });
+
+      expect(select).toHaveDisplayValue(placeholder);
+    });
+
+    it("renders a list of given options including a disabled placeholder options", () => {
+      const select = screen.getByRole("combobox", { name: labelText });
+      const options = within(select).getAllByRole("option");
+
+      expect(options).toHaveLength(testOptions.length + 1);
+    });
+
+    it("sets the option related to the placeholder as selected, but disabled", () => {
+      const select = screen.getByRole("combobox", { name: labelText });
+      const selectedOption = within(select).getByRole("option", {
+        name: placeholder,
+      });
+
+      expect(selectedOption).toHaveAttribute("selected");
+      expect(selectedOption).toBeDisabled();
+    });
+
+    testOptions.forEach((option) => {
+      it(`shows the option "${option.name}"`, () => {
+        const select = screen.getByRole("combobox", { name: labelText });
+        const currOption = within(select).getByRole("option", {
+          name: option.name,
+        });
+
+        expect(currOption).not.toHaveAttribute("selected");
+        expect(currOption).toHaveValue(option.id);
+        expect(currOption).toBeEnabled();
+      });
+    });
+  });
+
+  describe("renders a disabled select based on prop", () => {
+    const onBlurMock = jest.fn();
+    const optionToStringMock = jest.fn((option) => option.name);
+    const getValueMock = jest.fn((option) => option.id);
+
+    const requiredProps = {
+      options: testOptions,
+      onBlur: onBlurMock,
+      optionToString: optionToStringMock,
+      getValue: getValueMock,
+      placeholder: placeholder,
+      labelText: labelText,
+    };
+
+    beforeEach(() => {
+      render(<ComplexNativeSelect {...requiredProps} disabled={true} />);
+    });
+
+    afterEach(cleanup);
+
+    it("shows a disabled select element", () => {
+      const select = screen.getByRole("combobox", { name: labelText });
+
+      expect(select).toBeDisabled();
+    });
+
+    testOptions.forEach((option) => {
+      it(`shows the option "${option.name}" as disabled`, () => {
+        const select = screen.getByRole("combobox", { name: labelText });
+        const currOption = within(select).getByRole("option", {
+          name: option.name,
+        });
+
+        expect(currOption).not.toHaveAttribute("selected");
+        expect(currOption).toHaveValue(option.id);
+        expect(currOption).toBeDisabled();
+      });
+    });
+
+    it("prevents user from interacting with the select", async () => {
+      const select = screen.getByRole("combobox", { name: labelText });
+      const option = within(select).getByRole("option", {
+        name: testOptions[0].name,
+      });
+
+      await userEvent.selectOptions(select, option);
+
+      expect(select).toHaveDisplayValue(placeholder);
+      expect(option).not.toHaveAttribute("selected");
+    });
+  });
+
+  describe("renders a required select based on prop", () => {
+    const onBlurMock = jest.fn();
+    const optionToStringMock = jest.fn((option) => option.name);
+    const getValueMock = jest.fn((option) => option.id);
+
+    const requiredProps = {
+      options: testOptions,
+      onBlur: onBlurMock,
+      optionToString: optionToStringMock,
+      getValue: getValueMock,
+      placeholder: placeholder,
+      labelText: labelText,
+    };
+
+    beforeEach(() => {
+      render(<ComplexNativeSelect {...requiredProps} required={true} />);
+    });
+
+    afterEach(cleanup);
+
+    it("shows a required select element", () => {
+      const select = screen.getByRole("combobox", {
+        name: new RegExp(`${labelText}`, "i"),
+      });
+
+      expect(select).toBeRequired();
+    });
+  });
+
+  describe("renders an invalid select and shows an error message dependent on prop", () => {
+    const onBlurMock = jest.fn();
+    const optionToStringMock = jest.fn((option) => option.name);
+    const getValueMock = jest.fn((option) => option.id);
+
+    const errorMessage = "Oh no this is an error";
+
+    const requiredProps = {
+      options: testOptions,
+      onBlur: onBlurMock,
+      optionToString: optionToStringMock,
+      getValue: getValueMock,
+      placeholder: placeholder,
+      labelText: labelText,
+    };
+
+    beforeEach(() => {
+      render(<ComplexNativeSelect {...requiredProps} error={errorMessage} />);
+    });
+
+    afterEach(cleanup);
+
+    it("shows an invalid select element", () => {
+      const select = screen.getByRole("combobox", {
+        name: new RegExp(`${labelText}`, "i"),
+      });
+
+      expect(select).toBeInvalid();
+    });
+
+    it("shows a given error message", () => {
+      const errorMessage = screen.getByText("Oh no this is an error");
+
+      expect(errorMessage).toBeVisible();
+    });
+  });
+
+  describe("renders a given option as default value", () => {
+    const onBlurMock = jest.fn();
+    const optionToStringMock = jest.fn((option) => option.name);
+    const getValueMock = jest.fn((option) => option.id);
+
+    const selectedOption = testOptions[0];
+
+    const requiredProps = {
+      options: testOptions,
+      onBlur: onBlurMock,
+      optionToString: optionToStringMock,
+      getValue: getValueMock,
+      placeholder: placeholder,
+      labelText: labelText,
+    };
+
+    beforeEach(() => {
+      render(
+        <ComplexNativeSelect
+          {...requiredProps}
+          defaultValue={selectedOption.id}
+        />
+      );
+    });
+
+    afterEach(cleanup);
+
+    it("shows the name of the option as active value of the select", () => {
+      const select = screen.getByRole("combobox", { name: labelText });
+
+      expect(select).toHaveDisplayValue(selectedOption.name);
+    });
+
+    it("shows option related to the given option value as selected one", () => {
+      const select = screen.getByRole("combobox", { name: labelText });
+      const option = within(select).getByRole("option", {
+        name: selectedOption.name,
+      });
+
+      expect(option).toHaveValue(selectedOption.id);
+      expect(option).toHaveAttribute("selected");
+    });
+
+    it("does not render the disabled placeholder option", () => {
+      const select = screen.getByRole("combobox", { name: labelText });
+      const placeholderOption = within(select).queryByRole("option", {
+        name: placeholder,
+      });
+
+      expect(placeholderOption).not.toBeInTheDocument();
+    });
+  });
+});

--- a/coral/src/app/components/ComplexNativeSelect.test.tsx
+++ b/coral/src/app/components/ComplexNativeSelect.test.tsx
@@ -212,16 +212,6 @@ describe("ComplexNativeSelect.tsx", () => {
       expect(onBlurMock).toHaveBeenCalledWith(testOptions[0]);
     });
 
-    //TODO check why this is not working
-    xit("enables user to select an option with keyboard", async () => {
-      const select = screen.getByRole("combobox", { name: labelText });
-      select.focus();
-      await userEvent.keyboard("{ArrowDown}{ArrowDown}{Enter}");
-      await userEvent.tab();
-
-      expect(onBlurMock).toHaveBeenCalledWith(testOptions[0]);
-    });
-
     it("does not set an value and call onBlur if user didn't select an option", async () => {
       const select = screen.getByRole("combobox", { name: labelText });
       await userEvent.tab();

--- a/coral/src/app/components/ComplexNativeSelect.tsx
+++ b/coral/src/app/components/ComplexNativeSelect.tsx
@@ -1,0 +1,73 @@
+import { NativeSelect } from "@aivenio/aquarium";
+import { ChangeEvent } from "react";
+
+type ComplexNativeSelectProps<T> = {
+  options: Array<T>;
+  onBlur: (option: T | undefined) => void;
+  optionToString: (opt: T) => string;
+  getValue: (opt: T) => string;
+  placeholder: string;
+  labelText: string;
+  disabled?: boolean;
+  defaultValue?: string;
+  required?: boolean;
+  error?: string;
+};
+
+function ComplexNativeSelect<T>(props: ComplexNativeSelectProps<T>) {
+  const {
+    options,
+    onBlur,
+    disabled = false,
+    required = false,
+    defaultValue,
+    labelText,
+    optionToString,
+    placeholder,
+    getValue,
+    error,
+  } = props;
+
+  // the placeholder behavior will be covered by DS NativeSelect
+  // soon, this is a temp solution
+  const placeholderValue = "055d87f2-8cd4-11ed-a1eb-0242ac120002";
+  function setNewOption({ target: { value } }: ChangeEvent<HTMLSelectElement>) {
+    if (value === placeholderValue) {
+      onBlur(undefined);
+    } else {
+      const newOption = options.find((option) => getValue(option) === value);
+      if (newOption) {
+        onBlur(newOption);
+      }
+    }
+  }
+
+  return (
+    <NativeSelect
+      onBlur={setNewOption}
+      disabled={disabled}
+      labelText={labelText}
+      required={required}
+      defaultValue={defaultValue || placeholderValue}
+      valid={error ? false : undefined}
+      helperText={error}
+    >
+      {!defaultValue && (
+        <option key={placeholderValue} value={placeholderValue} disabled={true}>
+          {placeholder}
+        </option>
+      )}
+      {options.map((option) => {
+        const value = getValue(option);
+        return (
+          <option key={value} value={value}>
+            {optionToString(option)}
+          </option>
+        );
+      })}
+    </NativeSelect>
+  );
+}
+
+export { ComplexNativeSelect };
+export type { ComplexNativeSelectProps };

--- a/coral/src/app/components/ComplexNativeSelect.tsx
+++ b/coral/src/app/components/ComplexNativeSelect.tsx
@@ -2,19 +2,16 @@ import { NativeSelect, NativeSelectProps } from "@aivenio/aquarium";
 import { omit } from "lodash";
 import { ChangeEvent, useState } from "react";
 
-type ComplexNativeSelectProps<ComplexNativeSelectOptionType> =
-  NativeSelectProps & {
-    options: Array<ComplexNativeSelectOptionType>;
-    identifierValue: keyof ComplexNativeSelectOptionType;
-    identifierName: keyof ComplexNativeSelectOptionType;
-    onBlur: (option: ComplexNativeSelectOptionType | undefined) => void;
-    placeholder: string;
-    activeOption?: ComplexNativeSelectOptionType;
-  };
+type ComplexNativeSelectProps<T> = NativeSelectProps & {
+  options: Array<T>;
+  identifierValue: keyof T;
+  identifierName: keyof T;
+  onBlur: (option: T | undefined) => void;
+  placeholder: string;
+  activeOption?: T;
+};
 
-function ComplexNativeSelect<ComplexNativeSelectOptionType>(
-  props: ComplexNativeSelectProps<ComplexNativeSelectOptionType>
-) {
+function ComplexNativeSelect<T>(props: ComplexNativeSelectProps<T>) {
   const {
     options,
     onBlur,
@@ -24,16 +21,16 @@ function ComplexNativeSelect<ComplexNativeSelectOptionType>(
     activeOption,
   } = props;
 
-  const [activeValue, setActiveValue] = useState<
-    ComplexNativeSelectOptionType | undefined
-  >(activeOption || undefined);
+  const [activeValue, setActiveValue] = useState<T | undefined>(
+    activeOption || undefined
+  );
 
-  function getValue(option: ComplexNativeSelectOptionType): string {
-    return String((option as ComplexNativeSelectOptionType)[identifierValue]);
+  function getValue(option: T): string {
+    return String((option as T)[identifierValue]);
   }
 
-  function getName(option: ComplexNativeSelectOptionType): string {
-    return String((option as ComplexNativeSelectOptionType)[identifierName]);
+  function getName(option: T): string {
+    return String((option as T)[identifierName]);
   }
 
   // the placeholder behavior will be covered by DS NativeSelect

--- a/coral/src/app/components/Form.tsx
+++ b/coral/src/app/components/Form.tsx
@@ -11,6 +11,7 @@ import {
   RadioButtonGroup as BaseRadioButtonGroup,
   RadioButtonGroupProps as BaseRadioButtonGroupProps,
   Option,
+  OptionType,
 } from "@aivenio/aquarium";
 import { zodResolver } from "@hookform/resolvers/zod";
 import React, { memo } from "react";
@@ -31,6 +32,10 @@ import {
 import type { FormState } from "react-hook-form";
 import { ZodSchema } from "zod";
 import get from "lodash/get";
+import {
+  ComplexNativeSelect as BaseComplexNativeSelect,
+  ComplexNativeSelectProps as BaseComplexNativeSelectProps,
+} from "src/app/components/ComplexNativeSelect";
 
 type FormInputProps<T extends FieldValues = FieldValues> = {
   name: FieldPath<T>;
@@ -380,3 +385,64 @@ function parseFieldErrorMessage<T extends FieldValues>(
   }
   return undefined;
 }
+
+// <ComplexNativeSelect>
+//
+function _ComplexNativeSelect<
+  T extends FieldValues,
+  FieldValue extends string | OptionType
+>({
+  name,
+  formContext: form,
+  disabled,
+  ...props
+}: Omit<BaseComplexNativeSelectProps<FieldValue>, "value" | "onBlur"> &
+  FormInputProps<T> &
+  FormRegisterProps<T>) {
+  return (
+    <_Controller
+      name={name}
+      control={form.control}
+      render={({ field: { name }, fieldState: { error } }) => {
+        const { isSubmitting } = form.formState;
+
+        return (
+          <BaseComplexNativeSelect
+            {...props}
+            name={name}
+            disabled={disabled || isSubmitting}
+            onBlur={(option) => {
+              // eslint-disable-next-line @typescript-eslint/no-explicit-any
+              form.setValue(name, option as any, {
+                shouldValidate: true,
+                shouldDirty: true,
+              });
+            }}
+            helperText={error?.message}
+            valid={error ? false : undefined}
+          />
+        );
+      }}
+    />
+  );
+}
+
+const ComplexNativeSelectMemo = memo(
+  _ComplexNativeSelect,
+  () => false
+) as typeof _ComplexNativeSelect;
+
+// eslint-disable-next-line import/exports-last,import/group-exports
+export const ComplexNativeSelect = <
+  T extends FieldValues,
+  FieldValue extends string | OptionType
+>(
+  props: FormInputProps<T> &
+    Omit<BaseComplexNativeSelectProps<FieldValue>, "value" | "onBlur">
+): React.ReactElement<
+  FormInputProps<T> &
+    Omit<BaseComplexNativeSelectProps<FieldValue>, "value" | "onBlur">
+> => {
+  const ctx = useFormContext<T>();
+  return <ComplexNativeSelectMemo formContext={ctx} {...props} />;
+};


### PR DESCRIPTION
## About this change - What it does

- Adds a component `ComplexNativeSelect` that implements a `NativeSelect` that can handle Array of Objects as options instead of only strings
- Adds `ComplexNativeSelect` in `Form`

Resolves: #396 


