### PR TITLE
feat(coral) Add MultiInput component, remove superfluous register

### DIFF
--- a/coral/src/app/components/Form.tsx
+++ b/coral/src/app/components/Form.tsx
@@ -4,6 +4,8 @@ import {
   InputProps as BaseInputProps,
   Textarea as BaseTextarea,
   TextareaProps as BaseTextareaProps,
+  MultiInput as BaseMultiInput,
+  MultiInputProps as BaseMultiInputProps,
   NativeSelect as BaseNativeSelect,
   NativeSelectProps as BaseNativeSelectProps,
   RadioButton as BaseRadioButton,
@@ -239,6 +241,51 @@ function _SubmitButton<T extends FieldValues>({
     <PrimaryButton {...props} type="submit" disabled={!isDirty || !isValid} />
   );
 }
+
+//
+// <MultiInput>
+//
+function _MultiInput<T extends FieldValues>({
+  name,
+  formContext: form,
+  ...props
+}: BaseMultiInputProps<T> & FormInputProps<T> & FormRegisterProps<T>) {
+  return (
+    <_Controller
+      name={name}
+      control={form.control}
+      render={({ field: { value, name }, fieldState: { error } }) => {
+        return (
+          <BaseMultiInput
+            {...props}
+            name={name}
+            value={value}
+            onChange={(value) => {
+              // eslint-disable-next-line @typescript-eslint/no-explicit-any
+              form.setValue(name, value as any, {
+                shouldValidate: true,
+                shouldDirty: true,
+              });
+            }}
+            error={error?.message}
+          />
+        );
+      }}
+    />
+  );
+}
+
+const MultiInputMemo = memo(_MultiInput) as typeof _MultiInput;
+
+// eslint-disable-next-line import/exports-last,import/group-exports
+export const MultiInput = <T extends FieldValues>(
+  props: FormInputProps<T> & BaseMultiInputProps<T>
+): React.ReactElement<FormInputProps<T> & BaseMultiInputProps<T>> => {
+  const ctx = useFormContext<T>();
+  return <MultiInputMemo formContext={ctx} {...props} />;
+};
+
+MultiInput.Skeleton = BaseMultiInput.Skeleton;
 
 //
 // <NativeSelect>

--- a/coral/src/app/components/Form.tsx
+++ b/coral/src/app/components/Form.tsx
@@ -377,7 +377,6 @@ function _RadioButtonGroup<T extends FieldValues>({
         return (
           <BaseRadioButtonGroup
             {...props}
-            {...form.register(name)}
             name={name}
             value={value}
             onChange={(value) => {


### PR DESCRIPTION
# About this change - What it does

- Add `MultiInput` component to `Form`
- Remove superfluous `register` of controlled inputs (wrapped in `Controller`) -> this was giving us props conflicts and console warnings, and was actually a no-op (registering a field is used when using the uncontrolled approach)
