### PR TITLE
Issue 332 Synchronise Topics

### DIFF
--- a/cluster-api/src/test/java/io/aiven/klaw/clusterapi/ClusterApiControllerIT.java
+++ b/cluster-api/src/test/java/io/aiven/klaw/clusterapi/ClusterApiControllerIT.java
@@ -30,6 +30,7 @@ import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.ExecutionException;
 import javax.crypto.spec.SecretKeySpec;
+import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.codec.binary.Base64;
 import org.apache.kafka.common.KafkaFuture;
 import org.apache.kafka.common.acl.AccessControlEntryFilter;
@@ -67,6 +68,7 @@ import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
 @DirtiesContext
 @EmbeddedKafka
+@Slf4j
 public class ClusterApiControllerIT {
 
   public static final String KWCLUSTERAPIUSER = "kwclusterapiuser";
@@ -142,7 +144,7 @@ public class ClusterApiControllerIT {
             Set<String> topicsSet = adminClient.listTopics().names().get();
             assertThat(topicsSet).contains(topicName);
           } catch (InterruptedException | ExecutionException e) {
-            e.printStackTrace();
+            log.error("Error : ", e);
           }
         });
   }
@@ -395,7 +397,7 @@ public class ClusterApiControllerIT {
             Set<String> topicsSet = adminClient.listTopics().names().get();
             assertThat(topicsSet).contains(topicName);
           } catch (InterruptedException | ExecutionException e) {
-            e.printStackTrace();
+            log.error("Error : ", e);
           }
         });
   }

--- a/core/src/test/java/io/aiven/klaw/service/TopicSyncControllerServiceTest.java
+++ b/core/src/test/java/io/aiven/klaw/service/TopicSyncControllerServiceTest.java
@@ -1,38 +1,32 @@
 package io.aiven.klaw.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyInt;
-import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.Mockito.when;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
 
 import io.aiven.klaw.UtilMethods;
 import io.aiven.klaw.config.ManageDatabase;
-import io.aiven.klaw.dao.Env;
-import io.aiven.klaw.dao.KwClusters;
-import io.aiven.klaw.dao.Team;
-import io.aiven.klaw.dao.UserInfo;
+import io.aiven.klaw.dao.*;
 import io.aiven.klaw.error.KlawException;
 import io.aiven.klaw.helpers.db.rdbms.HandleDbRequestsJdbc;
-import io.aiven.klaw.model.ApiResponse;
-import io.aiven.klaw.model.KafkaSupportedProtocol;
-import io.aiven.klaw.model.KwTenantConfigModel;
-import io.aiven.klaw.model.SyncTopicUpdates;
+import io.aiven.klaw.model.*;
 import io.aiven.klaw.model.enums.ApiResultStatus;
 import io.aiven.klaw.model.enums.KafkaClustersType;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.MethodOrderer;
 import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestMethodOrder;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
 import org.mockito.Mock;
 import org.mockito.Mockito;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContext;
 import org.springframework.security.core.context.SecurityContextHolder;
@@ -44,6 +38,10 @@ import org.springframework.test.util.ReflectionTestUtils;
 @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
 public class TopicSyncControllerServiceTest {
 
+  public static final String SELECTED_TOPICS = "SELECTED_TOPICS";
+  public static final String ALL_TOPICS = "ALL_TOPICS";
+  public static final int TENANT_ID = 1;
+  public static final String USERNAME = "kwusera";
   @Mock private ClusterApiService clusterApiService;
 
   @Mock private UserDetails userDetails;
@@ -72,13 +70,17 @@ public class TopicSyncControllerServiceTest {
 
   private UtilMethods utilMethods;
 
+  private Env env = new Env();
+  private Env test = new Env();
+  @Captor ArgumentCaptor<TopicRequest> topicRequestCaptor;
+
+  @Captor ArgumentCaptor<TopicRequest> updateTopicRequestCaptor;
+
   @BeforeEach
   public void setUp() throws Exception {
     this.topicSyncControllerService = new TopicSyncControllerService();
     utilMethods = new UtilMethods();
-    Env env = new Env();
-    env.setId("1");
-    env.setName("DEV");
+    EnvironmentSetUp();
 
     ReflectionTestUtils.setField(topicSyncControllerService, "manageDatabase", manageDatabase);
     ReflectionTestUtils.setField(topicSyncControllerService, "mailService", mailService);
@@ -95,6 +97,15 @@ public class TopicSyncControllerServiceTest {
     loginMock();
   }
 
+  private void EnvironmentSetUp() {
+    env.setId("1");
+    env.setName("DEV");
+
+    test.setId("2");
+    test.setName("TST");
+    when(manageDatabase.getKafkaEnvList(anyInt())).thenReturn(List.of(env, test));
+  }
+
   private void loginMock() {
     Authentication authentication = Mockito.mock(Authentication.class);
     SecurityContext securityContext = Mockito.mock(SecurityContext.class);
@@ -107,12 +118,17 @@ public class TopicSyncControllerServiceTest {
   @Order(1)
   public void updateSyncTopicsSuccess() throws KlawException {
     stubUserInfo();
+    // mock DB
     when(manageDatabase.getTenantConfig()).thenReturn(tenantConfig);
+
     when(tenantConfig.get(anyInt())).thenReturn(tenantConfigModel);
     when(tenantConfigModel.getBaseSyncEnvironment()).thenReturn("1");
+    // Mock Common Utils
     when(commonUtilsService.isNotAuthorizedUser(any(), any())).thenReturn(false);
     when(commonUtilsService.getEnvsFromUserId(anyString()))
         .thenReturn(new HashSet<>(Collections.singletonList("1")));
+
+    //    Mock DB Requests
     when(handleDbRequests.addToSynctopics(any())).thenReturn(ApiResultStatus.SUCCESS.value);
 
     ApiResponse result =
@@ -177,6 +193,190 @@ public class TopicSyncControllerServiceTest {
     assertThat(topicRequests).hasSize(2);
   }
 
+  @Test
+  @Order(5)
+  public void approveTopicRequestAllTopicsWhereOneTopicIsAlreadyCreated() throws KlawException {
+    // mock
+    stubUserInfo();
+    MockMultipleTopics();
+    mockGetTopicsFromEnv();
+    when(clusterApiService.approveTopicRequests(
+            any(), anyString(), anyInt(), anyString(), anyString(), any(), eq(TENANT_ID)))
+        .thenReturn(createAPIResponse(HttpStatus.OK, ApiResultStatus.SUCCESS.value))
+            .thenReturn(createAPIResponse(HttpStatus.OK, "org.apache.kafka.common.errors.TopicExistsException: Topic 'testtopic' already exists."));
+
+    // execute
+    ApiResponse retval =
+        topicSyncControllerService.updateSyncBackTopics(
+            createSyncBackTopic(ALL_TOPICS, new String[0]));
+
+    // verfiy only 1 topic Request is sent to the manage database as the other already exists.
+    verify(handleDbRequests).requestForTopic(topicRequestCaptor.capture());
+    verify(handleDbRequests).updateTopicRequest(updateTopicRequestCaptor.capture(), eq(USERNAME));
+
+    List<TopicRequest> req = topicRequestCaptor.getAllValues();
+    List<TopicRequest> update = updateTopicRequestCaptor.getAllValues();
+    // we have two topics but one already exists so only one should be added to the database.
+    assertEquals(1, req.size());
+    assertEquals(1, update.size());
+    // we expect all request to also be updated to approved
+    assertEquals(req.size(), update.size());
+
+    verifyCaptureContents(req, update, 0, 1, "UnitTest-01");
+
+    // This should pass when clusterApi is updated
+         assertNotEquals("Error :Could not approve topic request. Please contact Administrator.",retval.getResult());
+     assertEquals("success",retval.getResult());
+  }
+
+  @Test
+  @Order(6)
+  public void approveTopicRequestAllTopicsCreateAll() throws KlawException {
+
+    stubUserInfo();
+    MockMultipleTopics();
+    mockGetTopicsFromEnv();
+    when(clusterApiService.approveTopicRequests(
+            any(), anyString(), anyInt(), anyString(), anyString(), any(), eq(TENANT_ID)))
+        .thenReturn(createAPIResponse(HttpStatus.OK, ApiResultStatus.SUCCESS.value));
+
+    // execute
+    ApiResponse retval =
+        topicSyncControllerService.updateSyncBackTopics(
+            createSyncBackTopic(ALL_TOPICS, new String[0]));
+
+    // verfiy exactly 2 topics Requests are sent to the manage database
+    verify(handleDbRequests, times(2)).requestForTopic(topicRequestCaptor.capture());
+    verify(handleDbRequests, times(2))
+        .updateTopicRequest(updateTopicRequestCaptor.capture(), eq(USERNAME));
+
+    List<TopicRequest> req = topicRequestCaptor.getAllValues();
+    List<TopicRequest> update = updateTopicRequestCaptor.getAllValues();
+    // we have two new topics both should be added to the database.
+    assertEquals(2, req.size());
+    assertEquals(2, update.size());
+    // we expect all request to also be updated to approved
+    verifyCaptureContents(req, update, 0, 1, "UnitTest-01");
+
+    verifyCaptureContents(req, update, 1, 2, "UnitTest-02");
+    assertNotEquals(
+        "Error :Could not approve topic request. Please contact Administrator.",
+        retval.getResult());
+    assertEquals("success", retval.getResult());
+  }
+
+  @Test
+  @Order(7)
+  public void approveTopicRequestSelectedWhereOneTopicIsAlreadyCreated() throws KlawException {
+    stubUserInfo();
+    MockMultipleTopics();
+    mockSelectedOnlyTopics(1, "UnitTest-01", env.getId());
+
+    mockSelectedOnlyTopics(2, "UnitTest-02", test.getId());
+    when(clusterApiService.approveTopicRequests(
+            any(), anyString(), anyInt(), anyString(), anyString(), any(), eq(TENANT_ID)))
+        .thenReturn(createAPIResponse(HttpStatus.OK, ApiResultStatus.SUCCESS.value))
+            .thenReturn(createAPIResponse(HttpStatus.OK, "org.apache.kafka.common.errors.TopicExistsException: Topic 'testtopic' already exists."));
+
+    ApiResponse retval =
+        topicSyncControllerService.updateSyncBackTopics(
+            createSyncBackTopic(SELECTED_TOPICS, new String[] {"1", "2"}));
+
+    // verfiy only 1 topic Request is sent to the manage database
+    verify(handleDbRequests).requestForTopic(topicRequestCaptor.capture());
+    verify(handleDbRequests).updateTopicRequest(updateTopicRequestCaptor.capture(), eq(USERNAME));
+
+    List<TopicRequest> req = topicRequestCaptor.getAllValues();
+    List<TopicRequest> update = updateTopicRequestCaptor.getAllValues();
+    // we have two topics but one already exists so only one should be added to the database.
+    assertEquals(1, req.size());
+    assertEquals(1, update.size());
+    // we expect all request to also be updated to approved
+    assertEquals(req.size(), update.size());
+
+    verifyCaptureContents(req, update, 0, 1, "UnitTest-01");
+
+        assertNotEquals(
+                "Error :Could not approve topic request. Please contact Administrator.",
+                retval.getResult());
+        assertEquals("success", retval.getResult());
+  }
+
+  @Test
+  @Order(8)
+  public void approveTopicRequestSelectedCreateAll() throws KlawException {
+
+    stubUserInfo();
+    MockMultipleTopics();
+    mockSelectedOnlyTopics(1, "UnitTest-01", env.getId());
+
+    mockSelectedOnlyTopics(2, "UnitTest-02", test.getId());
+    when(clusterApiService.approveTopicRequests(
+            any(), anyString(), anyInt(), anyString(), anyString(), any(), eq(TENANT_ID)))
+        .thenReturn(createAPIResponse(HttpStatus.OK, ApiResultStatus.SUCCESS.value));
+
+    ApiResponse retval =
+        topicSyncControllerService.updateSyncBackTopics(
+            createSyncBackTopic(SELECTED_TOPICS, new String[] {"1", "2"}));
+
+    // verfiy only 1 topic Request is sent to the manage database
+    verify(handleDbRequests, times(2)).requestForTopic(topicRequestCaptor.capture());
+    verify(handleDbRequests, times(2))
+        .updateTopicRequest(updateTopicRequestCaptor.capture(), eq(USERNAME));
+
+    List<TopicRequest> req = topicRequestCaptor.getAllValues();
+    List<TopicRequest> update = updateTopicRequestCaptor.getAllValues();
+    // we have two new topics both should be added to the database.
+    assertEquals(2, req.size());
+    assertEquals(2, update.size());
+    // we expect all request to also be updated to approved
+    assertEquals(req.size(), update.size());
+
+    verifyCaptureContents(req, update, 0, 1, "UnitTest-01");
+    verifyCaptureContents(req, update, 1, 2, "UnitTest-02");
+    assertNotEquals(
+        "Error :Could not approve topic request. Please contact Administrator.",
+        retval.getResult());
+    assertEquals("success", retval.getResult());
+  }
+
+  @Test
+  @Order(9)
+  public void approveTopicRequestSelectedUnexpectedExceptionFromClusterApi() throws KlawException {
+    stubUserInfo();
+    MockMultipleTopics();
+    mockSelectedOnlyTopics(1, "UnitTest-01", env.getId());
+
+    mockSelectedOnlyTopics(2, "UnitTest-02", test.getId());
+    when(clusterApiService.approveTopicRequests(
+            any(), anyString(), anyInt(), anyString(), anyString(), any(), eq(TENANT_ID)))
+            .thenReturn(createAPIResponse(HttpStatus.OK, ApiResultStatus.SUCCESS.value))
+            .thenThrow(
+                    new KlawException("Could not approve topic request. Please contact Administrator."));
+
+    ApiResponse retval =
+            topicSyncControllerService.updateSyncBackTopics(
+                    createSyncBackTopic(SELECTED_TOPICS, new String[] {"1", "2"}));
+
+    // verfiy only 1 topic Request is sent to the manage database
+    verify(handleDbRequests).requestForTopic(topicRequestCaptor.capture());
+    verify(handleDbRequests).updateTopicRequest(updateTopicRequestCaptor.capture(), eq(USERNAME));
+
+    List<TopicRequest> req = topicRequestCaptor.getAllValues();
+    List<TopicRequest> update = updateTopicRequestCaptor.getAllValues();
+    // we have two topics but one already exists so only one should be added to the database.
+    assertEquals(1, req.size());
+    assertEquals(1, update.size());
+    // we expect all request to also be updated to approved
+    assertEquals(req.size(), update.size());
+
+    verifyCaptureContents(req, update, 0, 1, "UnitTest-01");
+
+    assertEquals(
+            "Error :Could not approve topic request. Please contact Administrator.",
+            retval.getResult());
+  }
+
   private List<Team> getAvailableTeams() {
 
     Team team1 = new Team();
@@ -199,6 +399,80 @@ public class TopicSyncControllerServiceTest {
   private void stubUserInfo() {
     when(handleDbRequests.getUsersInfo(anyString())).thenReturn(userInfo);
     when(userInfo.getTeamId()).thenReturn(101);
-    when(mailService.getUserName(any())).thenReturn("kwusera");
+    when(mailService.getUserName(any())).thenReturn(USERNAME);
+    when(commonUtilsService.getTenantId(eq(USERNAME))).thenReturn(TENANT_ID);
+  }
+
+  private SyncBackTopics createSyncBackTopic(String TypeOfSync, String[] topics) {
+    SyncBackTopics syncBackTopics = new SyncBackTopics();
+    syncBackTopics.setSourceEnv("1");
+    syncBackTopics.setTargetEnv("2");
+    syncBackTopics.setTypeOfSync(TypeOfSync);
+    syncBackTopics.setTopicIds(topics);
+    return syncBackTopics;
+  }
+
+  private Topic createTopic(Integer topicId, String topicName, String EnvId) {
+
+    Topic topic = new Topic();
+    topic.setTeamId(topicId);
+    topic.setTopicname(topicName);
+    topic.setEnvironment(EnvId);
+    topic.setNoOfPartitions(2);
+    topic.setNoOfReplcias("1");
+    topic.setTeamId(TENANT_ID);
+    return topic;
+  }
+
+  private ResponseEntity<ApiResponse> createAPIResponse(
+      HttpStatus status, String resultStatus) {
+    return ResponseEntity.status(status)
+        .body(ApiResponse.builder().status(status).result(resultStatus).build());
+  }
+
+  private void MockMultipleTopics() {
+
+    when(handleDbRequests.requestForTopic(any()))
+        .thenReturn(
+            new HashMap<String, String>() {
+              {
+                put("result", "success");
+                put("topicId", "1");
+              }
+            })
+        .thenReturn(
+            new HashMap<String, String>() {
+              {
+                put("result", "success");
+                put("topicId", "2");
+              }
+            });
+    when(commonUtilsService.getFilteredTopicsForTenant(any()))
+        .thenReturn(List.of(createTopic(Integer.valueOf(1), "UnitTest-01", env.getId())))
+        .thenReturn(List.of(createTopic(Integer.valueOf(2), "UnitTest-02", env.getId())));
+  }
+
+  private void mockGetTopicsFromEnv() {
+    when(handleDbRequests.getTopicsFromEnv(env.getId(), TENANT_ID))
+        .thenReturn(
+            List.of(
+                createTopic(Integer.valueOf(1), "UnitTest-01", env.getId()),
+                createTopic(Integer.valueOf(2), "UnitTest-02", test.getId())));
+  }
+
+  private void mockSelectedOnlyTopics(int topicId, String topicName, String envId) {
+    when(handleDbRequests.getTopicFromId(eq(topicId), eq(TENANT_ID)))
+        .thenReturn(Optional.of(createTopic(Integer.valueOf(topicId), topicName, envId)));
+  }
+
+  private void verifyCaptureContents(
+      List<TopicRequest> req, List<TopicRequest> update, int entry, int topicId, String topicName) {
+    assertEquals(req.size(), update.size());
+    assertEquals(req.get(entry).getTopicid(), update.get(entry).getTopicid());
+    // Check it is the expected topic.
+    TopicRequest topicReq = req.get(entry);
+    assertEquals(test.getId(), topicReq.getEnvironment());
+    assertEquals(topicId, topicReq.getTopicid());
+    assertEquals(topicName, topicReq.getTopicname());
   }
 }

--- a/core/src/test/java/io/aiven/klaw/service/TopicSyncControllerServiceTest.java
+++ b/core/src/test/java/io/aiven/klaw/service/TopicSyncControllerServiceTest.java
@@ -118,17 +118,12 @@ public class TopicSyncControllerServiceTest {
   @Order(1)
   public void updateSyncTopicsSuccess() throws KlawException {
     stubUserInfo();
-    // mock DB
     when(manageDatabase.getTenantConfig()).thenReturn(tenantConfig);
-
     when(tenantConfig.get(anyInt())).thenReturn(tenantConfigModel);
     when(tenantConfigModel.getBaseSyncEnvironment()).thenReturn("1");
-    // Mock Common Utils
     when(commonUtilsService.isNotAuthorizedUser(any(), any())).thenReturn(false);
     when(commonUtilsService.getEnvsFromUserId(anyString()))
         .thenReturn(new HashSet<>(Collections.singletonList("1")));
-
-    //    Mock DB Requests
     when(handleDbRequests.addToSynctopics(any())).thenReturn(ApiResultStatus.SUCCESS.value);
 
     ApiResponse result =
@@ -203,7 +198,10 @@ public class TopicSyncControllerServiceTest {
     when(clusterApiService.approveTopicRequests(
             any(), anyString(), anyInt(), anyString(), anyString(), any(), eq(TENANT_ID)))
         .thenReturn(createAPIResponse(HttpStatus.OK, ApiResultStatus.SUCCESS.value))
-            .thenReturn(createAPIResponse(HttpStatus.OK, "org.apache.kafka.common.errors.TopicExistsException: Topic 'testtopic' already exists."));
+        .thenReturn(
+            createAPIResponse(
+                HttpStatus.OK,
+                "org.apache.kafka.common.errors.TopicExistsException: Topic 'testtopic' already exists."));
 
     // execute
     ApiResponse retval =
@@ -225,8 +223,10 @@ public class TopicSyncControllerServiceTest {
     verifyCaptureContents(req, update, 0, 1, "UnitTest-01");
 
     // This should pass when clusterApi is updated
-         assertNotEquals("Error :Could not approve topic request. Please contact Administrator.",retval.getResult());
-     assertEquals("success",retval.getResult());
+    assertNotEquals(
+        "Error :Could not approve topic request. Please contact Administrator.",
+        retval.getResult());
+    assertEquals("success", retval.getResult());
   }
 
   @Test
@@ -276,7 +276,10 @@ public class TopicSyncControllerServiceTest {
     when(clusterApiService.approveTopicRequests(
             any(), anyString(), anyInt(), anyString(), anyString(), any(), eq(TENANT_ID)))
         .thenReturn(createAPIResponse(HttpStatus.OK, ApiResultStatus.SUCCESS.value))
-            .thenReturn(createAPIResponse(HttpStatus.OK, "org.apache.kafka.common.errors.TopicExistsException: Topic 'testtopic' already exists."));
+        .thenReturn(
+            createAPIResponse(
+                HttpStatus.OK,
+                "org.apache.kafka.common.errors.TopicExistsException: Topic 'testtopic' already exists."));
 
     ApiResponse retval =
         topicSyncControllerService.updateSyncBackTopics(
@@ -296,10 +299,10 @@ public class TopicSyncControllerServiceTest {
 
     verifyCaptureContents(req, update, 0, 1, "UnitTest-01");
 
-        assertNotEquals(
-                "Error :Could not approve topic request. Please contact Administrator.",
-                retval.getResult());
-        assertEquals("success", retval.getResult());
+    assertNotEquals(
+        "Error :Could not approve topic request. Please contact Administrator.",
+        retval.getResult());
+    assertEquals("success", retval.getResult());
   }
 
   @Test
@@ -350,13 +353,13 @@ public class TopicSyncControllerServiceTest {
     mockSelectedOnlyTopics(2, "UnitTest-02", test.getId());
     when(clusterApiService.approveTopicRequests(
             any(), anyString(), anyInt(), anyString(), anyString(), any(), eq(TENANT_ID)))
-            .thenReturn(createAPIResponse(HttpStatus.OK, ApiResultStatus.SUCCESS.value))
-            .thenThrow(
-                    new KlawException("Could not approve topic request. Please contact Administrator."));
+        .thenReturn(createAPIResponse(HttpStatus.OK, ApiResultStatus.SUCCESS.value))
+        .thenThrow(
+            new KlawException("Could not approve topic request. Please contact Administrator."));
 
     ApiResponse retval =
-            topicSyncControllerService.updateSyncBackTopics(
-                    createSyncBackTopic(SELECTED_TOPICS, new String[] {"1", "2"}));
+        topicSyncControllerService.updateSyncBackTopics(
+            createSyncBackTopic(SELECTED_TOPICS, new String[] {"1", "2"}));
 
     // verfiy only 1 topic Request is sent to the manage database
     verify(handleDbRequests).requestForTopic(topicRequestCaptor.capture());
@@ -373,8 +376,8 @@ public class TopicSyncControllerServiceTest {
     verifyCaptureContents(req, update, 0, 1, "UnitTest-01");
 
     assertEquals(
-            "Error :Could not approve topic request. Please contact Administrator.",
-            retval.getResult());
+        "Error :Could not approve topic request. Please contact Administrator.",
+        retval.getResult());
   }
 
   private List<Team> getAvailableTeams() {
@@ -424,8 +427,7 @@ public class TopicSyncControllerServiceTest {
     return topic;
   }
 
-  private ResponseEntity<ApiResponse> createAPIResponse(
-      HttpStatus status, String resultStatus) {
+  private ResponseEntity<ApiResponse> createAPIResponse(HttpStatus status, String resultStatus) {
     return ResponseEntity.status(status)
         .body(ApiResponse.builder().status(status).result(resultStatus).build());
   }


### PR DESCRIPTION
About this change - What it does
- Adds unit tests to Klaw-core to ensure that the issue 332 does not re-occur.
- Reformats api response from create topic when topic already exists.
- Integration test that verifies the return message is in the expected returned format for calling APIs.


Resolves: #332 
Why this way
This is a small change that returns the expected API response and includes unit tests to prevent the issue-332 from being re-introduced.