### PR TITLE
fix(coral): Fix environmentGetClusterInfoResponse schema

### DIFF
--- a/coral/types/api.d.ts
+++ b/coral/types/api.d.ts
@@ -439,7 +439,10 @@ export type components = {
      *   "aivenCluster": "false"
      * }
      */
-    environmentGetClusterInfoResponse: { [key: string]: "true" | "false" };
+    environmentGetClusterInfoResponse: {
+      /** @enum {string} */
+      aivenCluster: "true" | "false";
+    };
     /** TopicCreateRequest */
     topicCreateRequest: {
       /**

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -3,7 +3,7 @@ info:
   title: Klaw - OpenAPI
   version: 1.0.0
   description: >
-    This specification is still a work in progress and is not yet implemented in any API. The purpose of this 
+    This specification is still a work in progress and is not yet implemented in any API. The purpose of this
     specification is to facilitate developers discussions.
   contact:
     email: info@klaw-project.io
@@ -736,9 +736,11 @@ components:
         type: string
     environmentGetClusterInfoResponse:
       type: object
-      additionalProperties:
-        type: string
-        enum: ["true", "false"]
+      required: ["aivenCluster"]
+      properties:
+        aivenCluster:
+          type: string
+          enum: ["true", "false"]
       example: { "aivenCluster": "false" }
     topicCreateRequest:
       title: TopicCreateRequest


### PR DESCRIPTION
# About this change - What it does

`environmentGetClusterInfoResponse` can only have `aivenCluster` as property, as it is an exception implemented specifically for Aiven clusters. If `"true"`, then `aclIpPrincipleType` in an ACL request can only be `PRINCIPAL`.
