### PR TITLE
🪸 Add types for "Request new schema" operations

### DIFF
--- a/coral/src/domain/schema-request/index.ts
+++ b/coral/src/domain/schema-request/index.ts
@@ -1,0 +1,8 @@
+import { SchemaRequest } from "src/domain/schema-request/schema-request-types";
+import {
+  createSchemaRequest,
+  getSchemaRegistryEnvironments,
+} from "src/domain/schema-request/schema-request-api";
+
+export type { SchemaRequest };
+export { getSchemaRegistryEnvironments, createSchemaRequest };

--- a/coral/src/domain/schema-request/schema-request-api.ts
+++ b/coral/src/domain/schema-request/schema-request-api.ts
@@ -1,0 +1,26 @@
+import { KlawApiRequest, KlawApiResponse } from "types/utils";
+import api from "src/services/api";
+
+const getSchemaRegistryEnvironments = (): Promise<
+  KlawApiResponse<"schemaRegEnvsGet">
+> => {
+  return api.get<KlawApiResponse<"schemaRegEnvsGet">>("/getSchemaRegEnvs");
+};
+
+const createSchemaRequest = (
+  params: KlawApiRequest<"schemaUpload">
+): Promise<KlawApiResponse<"schemaUpload">> => {
+  const schemaUploadParams = {
+    ...params,
+    // schemaversion and appname
+    // should be hard coded at the moment
+    schemaversion: "1.0",
+    appname: "App",
+  };
+  return api.post<
+    KlawApiResponse<"schemaUpload">,
+    KlawApiRequest<"schemaUpload">
+  >("/uploadSchema", schemaUploadParams);
+};
+
+export { createSchemaRequest, getSchemaRegistryEnvironments };

--- a/coral/src/domain/schema-request/schema-request-types.ts
+++ b/coral/src/domain/schema-request/schema-request-types.ts
@@ -1,0 +1,5 @@
+import { KlawApiModel } from "types/utils";
+
+type SchemaRequest = KlawApiModel<"SchemaRequest">;
+
+export type { SchemaRequest };

--- a/coral/types/api.d.ts
+++ b/coral/types/api.d.ts
@@ -166,6 +166,12 @@ export type components = {
        */
       tokenType: "JWT";
     };
+    /**
+     * Type of request related to topic
+     * @example Update
+     * @enum {string}
+     */
+    TopicRequestTypes: "Create" | "Update" | "Delete" | "Claim";
     TopicsGetResponse: components["schemas"]["TopicInfo"][][];
     /**
      * @example [
@@ -444,6 +450,12 @@ export type components = {
       /** @enum {string} */
       aivenCluster: "true" | "false";
     };
+    /**
+     * Status of a request
+     * @example created
+     * @enum {string}
+     */
+    RequestStatus: "created" | "deleted" | "declined" | "approved";
     /** TopicCreateRequest */
     topicCreateRequest: {
       /**
@@ -505,8 +517,7 @@ export type components = {
       requesttime?: string;
       /** Request time string */
       requesttimestring?: string;
-      /** Topic status */
-      topicstatus?: string;
+      topicstatus?: components["schemas"]["RequestStatus"];
       /**
        * Approver
        * @example jon.snow@klaw-project.io
@@ -769,16 +780,8 @@ export type components = {
        * @example 28-Dec-2022 14:54:57
        */
       requesttimestring?: string;
-      /**
-       * Topic status
-       * @example created
-       */
-      topicstatus?: string;
-      /**
-       * Type of request
-       * @example Create
-       */
-      requesttype?: string;
+      topicstatus?: components["schemas"]["RequestStatus"];
+      requesttype?: components["schemas"]["TopicRequestTypes"];
       /**
        * Remarks
        * @description SchemaRequest specific comment
@@ -968,7 +971,7 @@ export type operations = {
       /** OK */
       200: {
         content: {
-          "application/json": components["schemas"]["EnvironmentGetClusterInfoResponse"];
+          "application/json": components["schemas"]["environmentGetClusterInfoResponse"];
         };
       };
     };
@@ -984,7 +987,7 @@ export type operations = {
     };
     requestBody: {
       content: {
-        "application/json": components["schemas"]["AclRequest"];
+        "application/json": components["schemas"]["aclRequest"];
       };
     };
   };
@@ -1003,7 +1006,7 @@ export type operations = {
       /** OK */
       200: {
         content: {
-          "*/*": components["schemas"]["GenericApiResponse"];
+          "application/json": components["schemas"]["GenericApiResponse"];
         };
       };
     };

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -264,7 +264,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/EnvironmentGetClusterInfoResponse"
+                $ref: "#/components/schemas/environmentGetClusterInfoResponse"
   /createAcl:
     post:
       tags:
@@ -274,7 +274,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/AclRequest"
+              $ref: "#/components/schemas/aclRequest"
         required: true
       responses:
         "200":
@@ -314,7 +314,7 @@ paths:
         "200":
           description: OK
           content:
-            "*/*":
+            application/json:
               schema:
                 $ref: "#/components/schemas/GenericApiResponse"
 components:
@@ -447,6 +447,15 @@ components:
           example: JWT
           type: string
           enum: [JWT]
+    TopicRequestTypes:
+      title: Type of request related to topic
+      type: string
+      enum:
+        - Create
+        - Update
+        - Delete
+        - Claim
+      example: Update
     TopicsGetResponse:
       type: array
       items:
@@ -743,6 +752,15 @@ components:
           type: string
           enum: ["true", "false"]
       example: { "aivenCluster": "false" }
+    RequestStatus:
+      type: string
+      title: Status of a request
+      enum:
+        - created
+        - deleted
+        - declined
+        - approved
+      example: created
     topicCreateRequest:
       title: TopicCreateRequest
       type: object
@@ -828,8 +846,7 @@ components:
           title: Request time string
           type: string
         topicstatus:
-          title: Topic status
-          type: string
+          $ref: "#/components/schemas/RequestStatus"
         approver:
           title: Approver
           type: string
@@ -1068,13 +1085,9 @@ components:
           type: string
           example: "28-Dec-2022 14:54:57"
         topicstatus:
-          title: Topic status
-          type: string
-          example: "created"
+          $ref: "#/components/schemas/RequestStatus"
         requesttype:
-          title: Type of request
-          type: string
-          example: "Create"
+          $ref: "#/components/schemas/TopicRequestTypes"
         remarks:
           title: Remarks
           description: SchemaRequest specific comment


### PR DESCRIPTION
# About this change - What it does

- fixed upper-case typos
- adds global enums for  `RequestStatus` and `TopicRequestTypes`
- updates open API desc for `schemaUpload` based on new swagger_spec
- adds types for requesting a new schema in `/domain`
- adds API calls for creating a new schema and getting the schema registry envs

Resolves: #368 


