### PR TITLE
Remove teamname from schemareq

### DIFF
--- a/core/src/main/java/io/aiven/klaw/controller/SchemaRegstryController.java
+++ b/core/src/main/java/io/aiven/klaw/controller/SchemaRegstryController.java
@@ -76,7 +76,9 @@ public class SchemaRegstryController {
         HttpStatus.OK);
   }
 
-  @PostMapping(value = "/uploadSchema")
+  @PostMapping(
+      value = "/uploadSchema",
+      produces = {MediaType.APPLICATION_JSON_VALUE})
   public ResponseEntity<ApiResponse> uploadSchema(
       @Valid @RequestBody SchemaRequestModel addSchemaRequest) throws KlawException {
     return new ResponseEntity<>(

--- a/core/src/main/resources/static/js/requestAvroSchemaUpload.js
+++ b/core/src/main/resources/static/js/requestAvroSchemaUpload.js
@@ -181,7 +181,6 @@ app.controller("requestSchemaCtrl", function($scope, $http, $location, $window) 
 
             serviceInput['environment'] = $scope.addSchema.envName;
             serviceInput['topicname'] = $scope.addSchema.topicname;
-            serviceInput['teamname'] = $scope.teamname;
             serviceInput['appname'] = "App";
             serviceInput['remarks'] = $scope.addSchema.remarks;
             serviceInput['schemafull'] = $scope.addSchema.schemafull;

--- a/core/src/main/resources/swagger_spec.json
+++ b/core/src/main/resources/swagger_spec.json
@@ -3207,6 +3207,7 @@
     "/uploadSchema" : {
       "post" : {
         "operationId" : "uploadSchema",
+        "produces" : [ "application/json" ],
         "parameters" : [ {
           "in" : "body",
           "name" : "body",

--- a/core/src/test/java/io/aiven/klaw/UtilMethods.java
+++ b/core/src/test/java/io/aiven/klaw/UtilMethods.java
@@ -367,7 +367,6 @@ public class UtilMethods {
     List<SchemaRequestModel> schemaList = new ArrayList<>();
     SchemaRequestModel schemaRequest = new SchemaRequestModel();
     schemaRequest.setEnvironment("1");
-    schemaRequest.setTeamname("Seahorses");
     schemaRequest.setUsername("kwusera");
     schemaRequest.setSchemafull("schemafdsfsd");
     schemaRequest.setTeamId(1001);


### PR DESCRIPTION
About this change - What it does

teamname field in SchemaRequest is not required, as when the user submits a new schema request, teamId is retrieved from user who submits it. So it's redundant. field is removed in PR.

Resolves: #xxxxx
Why this way

Field is redundant, and hence removed.

Signed-off-by: muralibasani <muralidhar.basani@aiven.io>