### PR TITLE
Remove node,pnpm installation plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ For the versions available, see the [tags on this repository](https://github.com
 ### Manual
 mvn clean install
 
-Note - node, npm and pnpm are installed locally (required for React UI assets) through maven execution plugins.
+Optional step : For new React UI assets, make sure pnpm is pre installed which is required to build coral assets.
 
 Builds two artifacts core/target/klaw-<version>.jar and cluster-api/target/cluster-api-<version>.jar
 

--- a/core/Makefile
+++ b/core/Makefile
@@ -1,8 +1,8 @@
 CORAL_ROOT = ../coral
 CORAL_DIST = $(CORAL_ROOT)/dist
 
-# This is installed as part of Maven
-PNPM = ../core/nodebuild/node/node_modules/.bin/pnpm
+# Make sure pnpm is pre installed
+PNPM = pnpm
 
 $(CORAL_DIST): ../coral/index.html $(shell find $(CORAL_ROOT)/src)
 	cd $(CORAL_ROOT); $(PNPM) install --frozen-lockfile

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -139,28 +139,28 @@
     <build>
         <plugins>
             <!-- Install node and npm for React components -->
-            <plugin>
-                <groupId>com.github.eirslett</groupId>
-                <artifactId>frontend-maven-plugin</artifactId>
-                <version>${front-end-maven-plugin.version}</version>
-                <configuration>
-                    <workingDirectory>nodebuild</workingDirectory>
-                </configuration>
-                <executions>
-                    <execution>
-                        <id>install node and npm</id>
-                        <goals>
-                            <goal>install-node-and-npm</goal>
-                        </goals>
-                        <phase>generate-sources</phase>
-                        <configuration>
-                            <nodeVersion>${node.version}</nodeVersion>
-                            <npmVersion>${npm.version}</npmVersion>
-                        </configuration>
-                    </execution>
-                </executions>
-            </plugin>
-            <!-- Install pnpm. Clean and build React components -->
+<!--            <plugin>-->
+<!--                <groupId>com.github.eirslett</groupId>-->
+<!--                <artifactId>frontend-maven-plugin</artifactId>-->
+<!--                <version>${front-end-maven-plugin.version}</version>-->
+<!--                <configuration>-->
+<!--                    <workingDirectory>nodebuild</workingDirectory>-->
+<!--                </configuration>-->
+<!--                <executions>-->
+<!--                    <execution>-->
+<!--                        <id>install node and npm</id>-->
+<!--                        <goals>-->
+<!--                            <goal>install-node-and-npm</goal>-->
+<!--                        </goals>-->
+<!--                        <phase>generate-sources</phase>-->
+<!--                        <configuration>-->
+<!--                            <nodeVersion>${node.version}</nodeVersion>-->
+<!--                            <npmVersion>${npm.version}</npmVersion>-->
+<!--                        </configuration>-->
+<!--                    </execution>-->
+<!--                </executions>-->
+<!--            </plugin>-->
+
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>exec-maven-plugin</artifactId>
@@ -176,41 +176,41 @@
                             <mainClass>io.aiven.klaw.uglify.UglifyFiles</mainClass>
                         </configuration>
                     </execution>
-                    <!-- Install pnpm for React components -->
-                    <execution>
-                        <id>Install pnpm</id>
-                        <phase>generate-resources</phase>
-                        <goals>
-                            <goal>exec</goal>
-                        </goals>
-                        <configuration>
-                            <basedir>nodebuild/node</basedir>
-                            <executable>bash</executable>
-                            <commandlineArgs>npm install pnpm</commandlineArgs>
-                        </configuration>
-                    </execution>
-                    <execution>
-                        <id>Clean Coral assets before building</id>
-                        <goals>
-                            <goal>exec</goal>
-                        </goals>
-                        <phase>clean</phase>
-                        <configuration>
-                            <executable>make</executable>
-                            <commandlineArgs>clean</commandlineArgs>
-                        </configuration>
-                    </execution>
-                    <execution>
-                        <id>Build and copy Coral assets</id>
-                        <goals>
-                            <goal>exec</goal>
-                        </goals>
-                        <phase>generate-resources</phase>
-                        <configuration>
-                            <executable>make</executable>
-                            <commandlineArgs>src/main/resources/templates/coral/index.html src/main/resources/static/assets/coral</commandlineArgs>
-                        </configuration>
-                    </execution>
+                    <!-- Install pnpm. Clean and build React components -->
+<!--                    <execution>-->
+<!--                        <id>Install pnpm</id>-->
+<!--                        <phase>generate-resources</phase>-->
+<!--                        <goals>-->
+<!--                            <goal>exec</goal>-->
+<!--                        </goals>-->
+<!--                        <configuration>-->
+<!--                            <basedir>nodebuild/node</basedir>-->
+<!--                            <executable>bash</executable>-->
+<!--                            <commandlineArgs>npm install pnpm</commandlineArgs>-->
+<!--                        </configuration>-->
+<!--                    </execution>-->
+<!--                    <execution>-->
+<!--                        <id>Clean Coral assets before building</id>-->
+<!--                        <goals>-->
+<!--                            <goal>exec</goal>-->
+<!--                        </goals>-->
+<!--                        <phase>clean</phase>-->
+<!--                        <configuration>-->
+<!--                            <executable>make</executable>-->
+<!--                            <commandlineArgs>clean</commandlineArgs>-->
+<!--                        </configuration>-->
+<!--                    </execution>-->
+<!--                    <execution>-->
+<!--                        <id>Build and copy Coral assets</id>-->
+<!--                        <goals>-->
+<!--                            <goal>exec</goal>-->
+<!--                        </goals>-->
+<!--                        <phase>generate-resources</phase>-->
+<!--                        <configuration>-->
+<!--                            <executable>make</executable>-->
+<!--                            <commandlineArgs>src/main/resources/templates/coral/index.html src/main/resources/static/assets/coral</commandlineArgs>-->
+<!--                        </configuration>-->
+<!--                    </execution>-->
                 </executions>
             </plugin>
             <plugin>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -189,28 +189,33 @@
 <!--                            <commandlineArgs>npm install pnpm</commandlineArgs>-->
 <!--                        </configuration>-->
 <!--                    </execution>-->
-<!--                    <execution>-->
-<!--                        <id>Clean Coral assets before building</id>-->
-<!--                        <goals>-->
-<!--                            <goal>exec</goal>-->
-<!--                        </goals>-->
-<!--                        <phase>clean</phase>-->
-<!--                        <configuration>-->
-<!--                            <executable>make</executable>-->
-<!--                            <commandlineArgs>clean</commandlineArgs>-->
-<!--                        </configuration>-->
-<!--                    </execution>-->
-<!--                    <execution>-->
-<!--                        <id>Build and copy Coral assets</id>-->
-<!--                        <goals>-->
-<!--                            <goal>exec</goal>-->
-<!--                        </goals>-->
-<!--                        <phase>generate-resources</phase>-->
-<!--                        <configuration>-->
-<!--                            <executable>make</executable>-->
-<!--                            <commandlineArgs>src/main/resources/templates/coral/index.html src/main/resources/static/assets/coral</commandlineArgs>-->
-<!--                        </configuration>-->
-<!--                    </execution>-->
+                    <execution>
+                        <id>Clean Coral assets before building</id>
+                        <goals>
+                            <goal>exec</goal>
+                        </goals>
+                        <phase>clean</phase>
+                        <configuration>
+                            <executable>make</executable>
+                            <commandlineArgs>clean</commandlineArgs>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>Build and copy Coral assets</id>
+                        <goals>
+                            <goal>exec</goal>
+                        </goals>
+                        <phase>generate-resources</phase>
+                        <configuration>
+                            <executable>make</executable>
+                            <commandlineArgs>src/main/resources/templates/coral/index.html src/main/resources/static/assets/coral</commandlineArgs>
+                            <!-- Ignore errors during the execution of this plugin to unblock the user during build process -->
+                            <successCodes>0</successCodes>
+                            <successCodes>1</successCodes>
+                            <!-- Continue to build if pnpm is not installed -->
+                            <successCodes>2</successCodes>
+                        </configuration>
+                    </execution>
                 </executions>
             </plugin>
             <plugin>

--- a/core/src/main/resources/application.properties
+++ b/core/src/main/resources/application.properties
@@ -88,7 +88,10 @@ klaw.saas.plaintext.aclcommand=kafka-acls --authorizer-properties bootstrap.serv
 # comma separated instances of klaw when running in cluster
 klaw.uiapi.servers=https://localhost:9097
 
-# Enable new Klaw user interface
+# Enable new Klaw React based user interface
+# Make sure node, pnpm are installed.
+# If the above are already installed, mvn install will build and copy the coral assets for you.
+# Alternatively you can go through https://github.com/aiven/klaw/blob/main/coral/README.md
 klaw.coral.enabled=false
 
 # Email notification properties


### PR DESCRIPTION
About this change - What it does

during mvn install, node, npm, pnpm are installed and coral assets are copied to the right dir to serve under spring boot application. However the maven plugins are not executed with expected behaviour in different OS like gcp/ubuntu etc. Hence disabling them temporarily.

Resolves: #xxxxx
Why this way

If users would like to view the new interface, they will follow the instructions under coral/readme anyways.

Signed-off-by: muralibasani <muralidhar.basani@aiven.io>