### PR TITLE
🪸 Add component to upload files 

### DIFF
--- a/coral/src/app/accessibility.module.css
+++ b/coral/src/app/accessibility.module.css
@@ -85,7 +85,7 @@ a:focus-visible {
   outline-offset: 0 !important;
 }
 
-:root label span {
+:root label span:not([class*="error"]) {
   /*represents grey-70 */
   color: #4a4b57 !important;
   /*represents body-small*/

--- a/coral/src/app/components/FileInput.module.css
+++ b/coral/src/app/components/FileInput.module.css
@@ -1,22 +1,22 @@
 /*z-index and positions are needed to */
 /*get the right focus behavior for*/
 
-.fake-button {
+.fakeButton {
   position: relative;
   z-index: 2;
   cursor: pointer;
 }
 
-.file-input-wrapper {
+.fileInputWrapper {
   position: relative;
   z-index: 1;
 }
 
-.file-input-wrapper:focus-within {
+.fileInputWrapper:focus-within {
   outline: 2px solid var(--interactive-elements-focus) !important;
 }
 
-.file-input {
+.fileInput {
   /*the width is an arbitrary value*/
   /*it has to be small enough to hide*/
   /*the input field behind the fake-button*/

--- a/coral/src/app/components/FileInput.module.css
+++ b/coral/src/app/components/FileInput.module.css
@@ -1,0 +1,34 @@
+.wrapper {
+    position: relative;
+}
+
+.overlay {
+    z-index: 2;
+    position: absolute;
+    top: 0;
+    background-color: white;
+    cursor: pointer;
+    width: 100%;
+}
+
+.file-input-wrapper {
+    z-index: 1;
+}
+
+.file-input-label {
+    display: inline-block;
+    padding: 6px 12px;
+    font-size: 14px;
+}
+
+.file-input-label:focus-within {
+    outline: 2px solid var(--interactive-elements-focus) !important;
+}
+
+input.file-input {
+    cursor: pointer;
+}
+
+:root input.file-input:focus-visible {
+    outline: 0 !important;
+}

--- a/coral/src/app/components/FileInput.module.css
+++ b/coral/src/app/components/FileInput.module.css
@@ -1,34 +1,34 @@
-.wrapper {
-    position: relative;
-}
+/*z-index and positions are needed to */
+/*get the right focus behavior for*/
 
-.overlay {
-    z-index: 2;
-    position: absolute;
-    top: 0;
-    background-color: white;
-    cursor: pointer;
-    width: 100%;
+.fake-button {
+  position: relative;
+  z-index: 2;
+  cursor: pointer;
 }
 
 .file-input-wrapper {
-    z-index: 1;
+  position: relative;
+  z-index: 1;
 }
 
-.file-input-label {
-    display: inline-block;
-    padding: 6px 12px;
-    font-size: 14px;
+.file-input-wrapper:focus-within {
+  outline: 2px solid var(--interactive-elements-focus) !important;
 }
 
-.file-input-label:focus-within {
-    outline: 2px solid var(--interactive-elements-focus) !important;
-}
-
-input.file-input {
-    cursor: pointer;
-}
-
-:root input.file-input:focus-visible {
-    outline: 0 !important;
+.file-input {
+  /*the width is an arbitrary value*/
+  /*it has to be small enough to hide*/
+  /*the input field behind the fake-button*/
+  /*I chose a bigger width instead of*/
+  /*opting for a very save "1px" */
+  /*because visual focus information */
+  /*are a bit confusing when element*/
+  /*is focused by the screen reader: */
+  /*- screen reader applies its own focus on the */
+  /*input element (with this width here)*/
+  /*and there is an additional visual feedback*/
+  /*based on our styles - but that is applied*/
+  /*to the fake-button.*/
+  width: 120px;
 }

--- a/coral/src/app/components/FileInput.module.css
+++ b/coral/src/app/components/FileInput.module.css
@@ -30,5 +30,5 @@
   /*and there is an additional visual feedback*/
   /*based on our styles - but that is applied*/
   /*to the fake-button.*/
-  width: 120px;
+  width: 80px;
 }

--- a/coral/src/app/components/FileInput.test.tsx
+++ b/coral/src/app/components/FileInput.test.tsx
@@ -42,7 +42,6 @@ describe("FileInput.tsx", () => {
       const fileInput = screen.getByLabelText<HTMLInputElement>(testLabelText);
 
       expect(fileInput).toBeEnabled();
-      expect(fileInput).not.toBeRequired();
       expect(fileInput.tagName).toBe("INPUT");
     });
 

--- a/coral/src/app/components/FileInput.test.tsx
+++ b/coral/src/app/components/FileInput.test.tsx
@@ -1,0 +1,184 @@
+import { cleanup, render, screen } from "@testing-library/react";
+import { FileInput } from "src/app/components/FileInput";
+import userEvent from "@testing-library/user-event";
+
+const mockIconRender = jest.fn();
+// mocks out Icon component to avoid clutter
+// Icon is used purely decoratively
+jest.mock("@aivenio/aquarium", () => {
+  return {
+    __esModule: true,
+    ...jest.requireActual("@aivenio/aquarium"),
+    Icon: () => mockIconRender(),
+  };
+});
+
+const testValid = true;
+const testLabelText = "Upload your favorite dog pic!";
+const testButtonText = "Upload picture";
+const testHelperText = "This is an error";
+const testNoFileText = "No file chosen";
+const testAccept = "image/jpeg";
+
+const requiredProps = {
+  valid: testValid,
+  labelText: testLabelText,
+  buttonText: testButtonText,
+  helperText: testHelperText,
+  noFileText: testNoFileText,
+  accept: testAccept,
+};
+
+describe("FileInput.tsx", () => {
+  describe("renders all necessary elements with required props", () => {
+    beforeAll(() => {
+      render(<FileInput {...requiredProps} />);
+    });
+
+    afterAll(cleanup);
+
+    it("renders a file upload input", () => {
+      // input type=file does not have a role to look for
+      const fileInput = screen.getByLabelText<HTMLInputElement>(testLabelText);
+
+      expect(fileInput).toBeEnabled();
+      expect(fileInput).not.toBeRequired();
+      expect(fileInput.tagName).toBe("INPUT");
+    });
+
+    it("marks the input as not required", () => {
+      // input type=file does not have a role to look for
+      const fileInput = screen.getByLabelText<HTMLInputElement>(testLabelText);
+
+      expect(fileInput).not.toBeRequired();
+    });
+
+    it("marks the input as not invalid when valid is true", () => {
+      const fileInput = screen.getByLabelText<HTMLInputElement>(testLabelText);
+
+      expect(fileInput).not.toBeInvalid();
+    });
+
+    it("shows a label looking text hidden from assistive technology", () => {
+      const visualLabel = screen.getByTestId("file-input-fake-label");
+
+      expect(visualLabel).toBeVisible();
+      expect(visualLabel).toHaveTextContent(testLabelText);
+      expect(visualLabel).toHaveAttribute("aria-hidden", "true");
+    });
+
+    it("shows a button looking element hidden from assistive technology", () => {
+      const visualUploadElement = screen.getByTestId("file-input-fake-button");
+
+      expect(visualUploadElement).toBeVisible();
+      expect(visualUploadElement).toHaveTextContent(testButtonText);
+      expect(visualUploadElement).toHaveAttribute("aria-hidden", "true");
+    });
+
+    it("shows an information for no filename available hidden from assistive technology", () => {
+      const visualFileNameInfo = screen.getByTestId("file-input-filename-info");
+
+      expect(visualFileNameInfo).toBeVisible();
+      expect(visualFileNameInfo).toHaveTextContent(testNoFileText);
+      expect(visualFileNameInfo).toHaveAttribute("aria-hidden", "true");
+    });
+
+    it("does not show an error message when valid is true", () => {
+      const errorMessage = screen.queryByText(testHelperText);
+
+      expect(errorMessage).not.toBeInTheDocument();
+    });
+  });
+
+  describe("renders an invalid input with an error message when valid is false", () => {
+    beforeAll(() => {
+      render(<FileInput {...requiredProps} valid={false} />);
+    });
+
+    afterAll(cleanup);
+
+    it("renders a file upload input", () => {
+      // input type=file does not have a role to look for
+      const fileInput = screen.getByLabelText<HTMLInputElement>(testLabelText);
+
+      expect(fileInput).toBeEnabled();
+      expect(fileInput.tagName).toBe("INPUT");
+    });
+
+    it("marks the input as invalid", () => {
+      const fileInput = screen.getByLabelText<HTMLInputElement>(testLabelText);
+
+      expect(fileInput).toBeInvalid();
+    });
+
+    it("does show the error message", () => {
+      const errorMessage = screen.getByText(testHelperText);
+
+      expect(errorMessage).toBeVisible();
+    });
+
+    it("associates the error message with the input field", () => {
+      const fileInput = screen.getByLabelText<HTMLInputElement>(testLabelText);
+
+      expect(fileInput).toHaveAccessibleDescription(testHelperText);
+    });
+  });
+
+  describe("renders a required input prop required is true", () => {
+    beforeAll(() => {
+      render(<FileInput {...requiredProps} required={true} />);
+    });
+
+    afterAll(cleanup);
+
+    it("renders a file upload input", () => {
+      // input type=file does not have a role to look for
+      const fileInput = screen.getByLabelText<HTMLInputElement>(testLabelText);
+
+      expect(fileInput).toBeEnabled();
+      expect(fileInput.tagName).toBe("INPUT");
+    });
+
+    it("marks the input as required", () => {
+      const fileInput = screen.getByLabelText<HTMLInputElement>(testLabelText);
+
+      expect(fileInput).toBeRequired();
+    });
+
+    it("shows fake label with * symbol as information for visual users", () => {
+      const visualLabel = screen.getByTestId("file-input-fake-label");
+
+      expect(visualLabel).toBeVisible();
+      expect(visualLabel).toHaveTextContent(`${testLabelText}*`);
+      expect(visualLabel).toHaveAttribute("aria-hidden", "true");
+    });
+  });
+
+  describe("handles user uploading  files", () => {
+    const fileName = "my-awesome-dog.jpeg";
+    const testFile: File = new File(["I am a dog picture"], fileName, {
+      type: "image/jpeg",
+    });
+
+    const onChangeMock = jest.fn();
+
+    beforeEach(() => {
+      render(<FileInput {...requiredProps} onChange={onChangeMock} />);
+    });
+
+    afterEach(() => {
+      jest.resetAllMocks();
+      cleanup();
+    });
+
+    it("enables user to upload a file", async () => {
+      const fileInput = screen.getByLabelText<HTMLInputElement>(testLabelText);
+      await userEvent.upload(fileInput, testFile);
+
+      expect(fileInput.files?.[0]).toBe(testFile);
+      expect(onChangeMock).toHaveBeenCalledWith(
+        expect.objectContaining({ target: fileInput })
+      );
+    });
+  });
+});

--- a/coral/src/app/components/FileInput.tsx
+++ b/coral/src/app/components/FileInput.tsx
@@ -6,14 +6,18 @@ import cloudUpload from "@aivenio/aquarium/dist/src/icons/cloudUpload";
 
 type FileInputProps = InputHTMLAttributes<HTMLInputElement> & {
   valid: boolean;
+  // labelText is where the important information for
+  // visual and AT users is transported!
   labelText: string;
+  // buttonText is not conveyed to e.g. screen reader
+  // users, treat is as more decorative text
+  buttonText: string;
   helperText: string;
   noFileText: string;
-  accept: string;
 };
 
 function FileInput(props: FileInputProps) {
-  const { valid, labelText, helperText, noFileText } = props;
+  const { valid, labelText, buttonText, helperText, noFileText } = props;
 
   const inputRef = useRef<null | HTMLInputElement>(null);
   const inputId = uniqueId("file_upload_");
@@ -22,6 +26,7 @@ function FileInput(props: FileInputProps) {
   const propsPassed = omit(props, [
     "valid",
     "labelText",
+    "buttonText",
     "helperText",
     "noFileText",
     "fileName",
@@ -33,7 +38,11 @@ function FileInput(props: FileInputProps) {
 
   return (
     <div>
-      <Box aria-hidden={true} marginBottom={"2"}>
+      <Box
+        aria-hidden={true}
+        marginBottom={"2"}
+        data-testid="file-input-fake-label"
+      >
         <Typography.Caption fontWeight={"500"}>
           {labelText}
           {props.required && <span className={"text-error-50"}>*</span>}
@@ -61,6 +70,7 @@ function FileInput(props: FileInputProps) {
             backgroundColor={"white"}
             className={`${classes.fakeButton}`}
             onClick={handleWrapperClick}
+            data-testid="file-input-fake-button"
           >
             <Box
               component={"div"}
@@ -75,7 +85,7 @@ function FileInput(props: FileInputProps) {
               className={`${!valid && "border-error-50"}`}
             >
               <Icon icon={cloudUpload} />
-              <span>{labelText}</span>
+              <span>{buttonText}</span>
             </Box>
           </Box>
         </GridItem>
@@ -90,6 +100,7 @@ function FileInput(props: FileInputProps) {
             paddingX={"l1"}
             paddingY={"3"}
             aria-hidden={true}
+            data-testid="file-input-filename-info"
           >
             {inputRef.current?.files?.[0].name || noFileText}
           </Box>
@@ -122,6 +133,7 @@ function FileInput(props: FileInputProps) {
         </GridItem>
         <Box
           component={"p"}
+          id={errorMessageId}
           marginTop={"1"}
           marginBottom={"3"}
           className={"text-error-50 typography-caption-default"}

--- a/coral/src/app/components/FileInput.tsx
+++ b/coral/src/app/components/FileInput.tsx
@@ -22,6 +22,7 @@ function FileInput(props: FileInputProps) {
   const inputRef = useRef<null | HTMLInputElement>(null);
   const inputId = uniqueId("file_upload_");
   const errorMessageId = uniqueId("file_upload_error_message");
+  const currentFileName = inputRef.current?.files?.[0]?.name;
 
   const inputAttributes = omit(props, [
     "valid",
@@ -102,7 +103,7 @@ function FileInput(props: FileInputProps) {
             aria-hidden={true}
             data-testid="file-input-filename-info"
           >
-            {inputRef.current?.files?.[0]?.name || noFileText}
+            {currentFileName || noFileText}
           </Box>
         </GridItem>
 
@@ -115,7 +116,7 @@ function FileInput(props: FileInputProps) {
         >
           <label htmlFor={inputId}>
             <span className={"visually-hidden"}>
-              {inputRef.current?.files?.[0]?.name
+              {currentFileName
                 ? `Uploaded file, name: ${inputRef.current?.files?.[0]?.name}. Click to upload new file.`
                 : labelText}
             </span>

--- a/coral/src/app/components/FileInput.tsx
+++ b/coral/src/app/components/FileInput.tsx
@@ -1,0 +1,104 @@
+import { Icon, Box } from "@aivenio/aquarium";
+import { omit, uniqueId } from "lodash";
+import { InputHTMLAttributes, useRef } from "react";
+import classes from "src/app/components/FileInput.module.css";
+import cloudUpload from "@aivenio/aquarium/dist/src/icons/cloudUpload";
+
+type FileInputProps = InputHTMLAttributes<HTMLInputElement> & {
+  valid: boolean;
+  labelText: string;
+  helperText: string;
+  noFileText: string;
+  fileName?: string;
+};
+
+function FileInput(props: FileInputProps) {
+  const { valid, labelText, helperText, noFileText, fileName } = props;
+
+  const inputRef = useRef<null | HTMLInputElement>(null);
+  const inputId = uniqueId("file_upload_");
+  const errorMessageId = uniqueId("file_upload_error_message");
+
+  const propsPassed = omit(props, [
+    "valid",
+    "labelText",
+    "helperText",
+    "noFileText",
+    "fileName",
+  ]);
+
+  function handleWrapperClick() {
+    inputRef?.current?.click();
+  }
+
+  return (
+    <div className={classes.wrapper}>
+      <div
+        className={classes.overlay}
+        aria-hidden={"true"}
+        onClick={handleWrapperClick}
+      >
+        <Box display={"flex"} alignItems={"center"}>
+          <Box
+            component={"div"}
+            display={"flex"}
+            alignItems={"center"}
+            colGap={"2"}
+            borderWidth={"1px"}
+            borderColor={"grey-30"}
+            borderRadius={"2px"}
+            paddingX={"l1"}
+            paddingY={"3"}
+          >
+            <Icon icon={cloudUpload} />
+            <span>{labelText}</span>
+          </Box>
+          <Box
+            grow={"1"}
+            borderWidth={"1px"}
+            borderRadius={"2px"}
+            borderColor={"grey-20"}
+            backgroundColor={"grey-5"}
+            paddingX={"l1"}
+            paddingY={"3"}
+            marginLeft={"l1"}
+          >
+            {fileName ? fileName : noFileText}
+          </Box>
+        </Box>
+      </div>
+      <div className={classes.fileInputWrapper}>
+        <Box display={"flex"} flexDirection={"column"} colGap={"1"}>
+          <label
+            htmlFor={inputId}
+            className={`${classes.fileInputLabel} ${
+              !valid && "border-error-50"
+            }`}
+          >
+            {labelText}
+            <input
+              {...propsPassed}
+              id={inputId}
+              type={"file"}
+              ref={inputRef}
+              aria-invalid={`${!valid}`}
+              className={classes.fileInput}
+              {...(!valid && { "aria-describedby": errorMessageId })}
+            />
+          </label>
+          <Box
+            component={"p"}
+            marginTop={"1"}
+            marginBottom={"3"}
+            className={"text-error-50 typography-caption-default"}
+          >
+            {valid ? <>&nbsp;</> : <>{helperText}</>}
+          </Box>
+        </Box>
+      </div>
+    </div>
+  );
+}
+
+export { FileInput };
+export type { FileInputProps };

--- a/coral/src/app/components/FileInput.tsx
+++ b/coral/src/app/components/FileInput.tsx
@@ -102,7 +102,7 @@ function FileInput(props: FileInputProps) {
             aria-hidden={true}
             data-testid="file-input-filename-info"
           >
-            {inputRef.current?.files?.[0].name || noFileText}
+            {inputRef.current?.files?.[0]?.name || noFileText}
           </Box>
         </GridItem>
 
@@ -115,8 +115,8 @@ function FileInput(props: FileInputProps) {
         >
           <label htmlFor={inputId}>
             <span className={"visually-hidden"}>
-              {inputRef.current?.files?.[0].name
-                ? `Uploaded file, name: ${inputRef.current?.files?.[0].name}. Click to upload new file.`
+              {inputRef.current?.files?.[0]?.name
+                ? `Uploaded file, name: ${inputRef.current?.files?.[0]?.name}. Click to upload new file.`
                 : labelText}
             </span>
             <input

--- a/coral/src/app/components/FileInput.tsx
+++ b/coral/src/app/components/FileInput.tsx
@@ -23,7 +23,7 @@ function FileInput(props: FileInputProps) {
   const inputId = uniqueId("file_upload_");
   const errorMessageId = uniqueId("file_upload_error_message");
 
-  const propsPassed = omit(props, [
+  const inputAttributes = omit(props, [
     "valid",
     "labelText",
     "buttonText",
@@ -120,7 +120,7 @@ function FileInput(props: FileInputProps) {
                 : labelText}
             </span>
             <input
-              {...propsPassed}
+              {...inputAttributes}
               id={inputId}
               type={"file"}
               ref={inputRef}

--- a/coral/src/app/components/FileInput.tsx
+++ b/coral/src/app/components/FileInput.tsx
@@ -1,4 +1,4 @@
-import { Icon, Box } from "@aivenio/aquarium";
+import { Icon, Box, Typography, Grid, GridItem } from "@aivenio/aquarium";
 import { omit, uniqueId } from "lodash";
 import { InputHTMLAttributes, useRef } from "react";
 import classes from "src/app/components/FileInput.module.css";
@@ -9,11 +9,11 @@ type FileInputProps = InputHTMLAttributes<HTMLInputElement> & {
   labelText: string;
   helperText: string;
   noFileText: string;
-  fileName?: string;
+  accept: string;
 };
 
 function FileInput(props: FileInputProps) {
-  const { valid, labelText, helperText, noFileText, fileName } = props;
+  const { valid, labelText, helperText, noFileText } = props;
 
   const inputRef = useRef<null | HTMLInputElement>(null);
   const inputId = uniqueId("file_upload_");
@@ -32,27 +32,55 @@ function FileInput(props: FileInputProps) {
   }
 
   return (
-    <div className={classes.wrapper}>
-      <div
-        className={classes.overlay}
-        aria-hidden={"true"}
-        onClick={handleWrapperClick}
+    <div>
+      <Box aria-hidden={true} marginBottom={"2"}>
+        <Typography.Caption fontWeight={"500"}>
+          {labelText}
+          {props.required && <span className={"text-error-50"}>*</span>}
+        </Typography.Caption>
+      </Box>
+      <Grid
+        colGap={"l1"}
+        cols={"2"}
+        rows={"1"}
+        style={{
+          gridTemplateColumns: "max-content auto",
+        }}
       >
-        <Box display={"flex"} alignItems={"center"}>
+        <GridItem
+          colStart={"1"}
+          colEnd={"1"}
+          rowStart={"1"}
+          rowEnd={"1"}
+          width={"fit"}
+        >
           <Box
-            component={"div"}
+            aria-hidden={true}
             display={"flex"}
             alignItems={"center"}
-            colGap={"2"}
-            borderWidth={"1px"}
-            borderColor={"grey-30"}
-            borderRadius={"2px"}
-            paddingX={"l1"}
-            paddingY={"3"}
+            backgroundColor={"white"}
+            className={`${classes.fakeButton}`}
+            onClick={handleWrapperClick}
           >
-            <Icon icon={cloudUpload} />
-            <span>{labelText}</span>
+            <Box
+              component={"div"}
+              display={"flex"}
+              alignItems={"center"}
+              colGap={"2"}
+              borderWidth={"1px"}
+              borderColor={"grey-30"}
+              borderRadius={"2px"}
+              paddingX={"l1"}
+              paddingY={"3"}
+              className={`${!valid && "border-error-50"}`}
+            >
+              <Icon icon={cloudUpload} />
+              <span>{labelText}</span>
+            </Box>
           </Box>
+        </GridItem>
+
+        <GridItem colStart={"2"} colEnd={"2"} rowStart={"1"} rowEnd={"1"}>
           <Box
             grow={"1"}
             borderWidth={"1px"}
@@ -61,41 +89,46 @@ function FileInput(props: FileInputProps) {
             backgroundColor={"grey-5"}
             paddingX={"l1"}
             paddingY={"3"}
-            marginLeft={"l1"}
+            aria-hidden={true}
           >
-            {fileName ? fileName : noFileText}
+            {inputRef.current?.files?.[0].name || noFileText}
           </Box>
-        </Box>
-      </div>
-      <div className={classes.fileInputWrapper}>
-        <Box display={"flex"} flexDirection={"column"} colGap={"1"}>
-          <label
-            htmlFor={inputId}
-            className={`${classes.fileInputLabel} ${
-              !valid && "border-error-50"
-            }`}
-          >
-            {labelText}
+        </GridItem>
+
+        <GridItem
+          className={classes.fileInputWrapper}
+          colStart={"1"}
+          colEnd={"1"}
+          rowStart={"1"}
+          rowEnd={"1"}
+        >
+          <label htmlFor={inputId}>
+            <span className={"visually-hidden"}>
+              {inputRef.current?.files?.[0].name
+                ? `Uploaded file, name: ${inputRef.current?.files?.[0].name}. Click to upload new file.`
+                : labelText}
+            </span>
             <input
               {...propsPassed}
               id={inputId}
               type={"file"}
               ref={inputRef}
+              aria-required={props.required}
               aria-invalid={`${!valid}`}
-              className={classes.fileInput}
+              className={`${classes.fileInput}`}
               {...(!valid && { "aria-describedby": errorMessageId })}
             />
           </label>
-          <Box
-            component={"p"}
-            marginTop={"1"}
-            marginBottom={"3"}
-            className={"text-error-50 typography-caption-default"}
-          >
-            {valid ? <>&nbsp;</> : <>{helperText}</>}
-          </Box>
+        </GridItem>
+        <Box
+          component={"p"}
+          marginTop={"1"}
+          marginBottom={"3"}
+          className={"text-error-50 typography-caption-default"}
+        >
+          {valid ? <>&nbsp;</> : <>{helperText}</>}
         </Box>
-      </div>
+      </Grid>
     </div>
   );
 }


### PR DESCRIPTION
# What this change does:

(also body for commit message!) 

- adds a component `FileInput` that implements a styled and accessible version for `input type="file"`
- adds `FileInput` in `Form` context
- fixes style issue that the * in label text for required inputs was not red


## Details

### Implementation for `FileInput` 🗳
I based my implementation on the approach from [US Gov Design System](https://designsystem.digital.gov/components/file-input/) (and a bit research and testing 👩‍💻):

- the actual functionality is added by the native `input` element. This provides a lot of accessibility already!
- I added a change to the (visually hidden) label: it will include the file name of the uploaded file, so the user gets information about the value for this input and know that did successfully add a file. It mirrors (roughly) how screen readers inform about a text input with a value.
- this input is not styleable, so there are elements overlaying the input that provide the same, but visual information to users. 
  - these elements are `aria-hidden`, 🙈 which _may_ not be respected by one of the Windows screen readers, I would like to test that again later. I did not find another approach (other than staying native) that covers more assistive technology though.
- the fake button has an `onClick` event. Otherwise, mouse user can't click the `input` (since it's under the fake button)
- I used two tw classes (`text-error-50` and `border-error-50` since both values are not exposed in the global vars by the design system. It's sub-optimal since we try to avoid using this kind of class. For now, I feel it's the most pragmatic way to match the styles of the DS. An alternative would be to use custom classes with hard set values for e.g. color, which is more brittle.

### Current state usage (screenrecordings) 🎥
- works for mouse, keyboard, screenreader (VO mac)

#### Usage mouse 🖱
- [recording first version](https://user-images.githubusercontent.com/943800/211995944-ebb5aba3-01d6-4342-a690-928391134d86.mov)

Current version:

https://user-images.githubusercontent.com/943800/212265456-20c359c8-79d6-4db7-947e-64ce3e92be89.mov


#### Usage keyboard ⌨️
- [recording first version](https://user-images.githubusercontent.com/943800/211995974-927e8ac2-2f8f-42aa-90e5-f5dad7a6207e.mov)

Current version:

https://user-images.githubusercontent.com/943800/212265510-7ecd11b6-6f37-4e31-9394-5f589dc66d19.mov

#### Usage screenreader 🗣

- focus visual feedback is a bit off in this case 😔 but I hope that's ok'ish, since it's probably less important to screenreader users? Couldn't think of a way to make that better.
-  [recording first version](https://user-images.githubusercontent.com/943800/211996014-aeb13edf-9732-4ab5-9735-a18947dbb78b.mov)

Current version:

https://user-images.githubusercontent.com/943800/212265542-008d72e9-dac8-4b9f-8423-0a0b3fed57ca.mov


