### PR TITLE
feature(coral): Add rollup bundle analyzer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,3 +51,7 @@ coral/.env.remote-api
 
 # Coral HTTPS development environment default self signed certificate path 
 coral/.cert*
+
+# Coral bundle analysis
+coral/stats.html
+

--- a/coral/package.json
+++ b/coral/package.json
@@ -21,6 +21,7 @@
     "test": "jest",
     "test-dev": "jest --watch",
     "tsc": "tsc",
+    "bundle-analyze": "BUNDLE_ANALYZE=1 vite build",
     "extract-api-types": "openapi-typescript ../openapi.yaml --output types/api.d.ts --make-paths-enum --export-type"
   },
   "lint-staged": {
@@ -78,6 +79,7 @@
     "openapi-typescript": "^5.4.1",
     "prettier": "^2.7.1",
     "react-test-renderer": "^18.2.0",
+    "rollup-plugin-visualizer": "^5.9.0",
     "ts-jest": "^29.0.3",
     "ts-node": "^10.9.1",
     "typescript": "^4.6.4",

--- a/coral/pnpm-lock.yaml
+++ b/coral/pnpm-lock.yaml
@@ -40,6 +40,7 @@ specifiers:
   react-hook-form: ^7.38.0
   react-router-dom: ^6.4.2
   react-test-renderer: ^18.2.0
+  rollup-plugin-visualizer: ^5.9.0
   ts-jest: ^29.0.3
   ts-node: ^10.9.1
   typescript: ^4.6.4
@@ -90,6 +91,7 @@ devDependencies:
   openapi-typescript: 5.4.1
   prettier: 2.7.1
   react-test-renderer: 18.2.0_react@18.2.0
+  rollup-plugin-visualizer: 5.9.0
   ts-jest: 29.0.3_7yfpbkrrkkmtlepb2un4d37cti
   ts-node: 10.9.1_id5sxmpllzol2kp2zgqrnepaum
   typescript: 4.8.4
@@ -6540,6 +6542,22 @@ packages:
       glob: 7.2.3
     dev: true
 
+  /rollup-plugin-visualizer/5.9.0:
+    resolution: {integrity: sha512-bbDOv47+Bw4C/cgs0czZqfm8L82xOZssk4ayZjG40y9zbXclNk7YikrZTDao6p7+HDiGxrN0b65SgZiVm9k1Cg==}
+    engines: {node: '>=14'}
+    hasBin: true
+    peerDependencies:
+      rollup: 2.x || 3.x
+    peerDependenciesMeta:
+      rollup:
+        optional: true
+    dependencies:
+      open: 8.4.0
+      picomatch: 2.3.1
+      source-map: 0.7.4
+      yargs: 17.6.0
+    dev: true
+
   /rollup/2.78.1:
     resolution: {integrity: sha512-VeeCgtGi4P+o9hIg+xz4qQpRl6R401LWEXBmxYKOV4zlF82lyhgh2hTZnheFUbANE8l2A41F458iwj2vEYaXJg==}
     engines: {node: '>=10.0.0'}
@@ -6689,6 +6707,11 @@ packages:
   /source-map/0.6.1:
     resolution: {integrity: sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==}
     engines: {node: '>=0.10.0'}
+    dev: true
+
+  /source-map/0.7.4:
+    resolution: {integrity: sha512-l3BikUxvPOcn5E74dZiq5BGsTb5yEwhaTSzccU6t4sDOH8NWJCstKO5QT2CvtFoK6F0saL7p9xHAqHOlCPJygA==}
+    engines: {node: '>= 8'}
     dev: true
 
   /sourcemap-codec/1.4.8:

--- a/coral/vite.config.ts
+++ b/coral/vite.config.ts
@@ -1,5 +1,6 @@
-import { defineConfig, loadEnv, ProxyOptions } from "vite";
+import { defineConfig, loadEnv, PluginOption, ProxyOptions } from "vite";
 import react from "@vitejs/plugin-react";
+import { visualizer } from "rollup-plugin-visualizer";
 import { resolve } from "path";
 import fs from "fs";
 
@@ -106,11 +107,19 @@ function getServerProxyConfig(
   };
 }
 
+function getPlugins(environment: Record<string, string>): PluginOption[] {
+  const plugins: PluginOption[] = [react()];
+  if (environment.BUNDLE_ANALYZE) {
+    plugins.push(visualizer());
+  }
+  return plugins;
+}
+
 // https://vitejs.dev/config/
 export default defineConfig(({ mode }) => {
   const environment = loadEnv(mode, process.cwd(), "");
   return {
-    plugins: [react()],
+    plugins: getPlugins(environment),
     define: {
       // Vite does not use process.env (see https://vitejs.dev/guide/env-and-mode.html).
       // If a library depends on process.env (like "@aivenio/aquarium").
@@ -121,7 +130,9 @@ export default defineConfig(({ mode }) => {
       "process.env": {
         ROUTER_BASENAME: getRouterBasename(environment),
         API_BASE_URL: getApiBaseUrl(environment),
-        FEATURE_FLAG_TOPIC_REQUEST: ["development", "remote-api"].includes(mode).toString()
+        FEATURE_FLAG_TOPIC_REQUEST: ["development", "remote-api"]
+          .includes(mode)
+          .toString(),
       },
     },
     css: {


### PR DESCRIPTION
Adds new script `pnpm run bundle-analyze` that produces a gitignored "stats.html" file which can be used to see bundle contents

Signed-off-by: Samuli Suortti <smulis@aiven.io>
