### PR TITLE
Update docker java

### DIFF
--- a/cluster-api/Dockerfile
+++ b/cluster-api/Dockerfile
@@ -1,4 +1,4 @@
-FROM amazoncorretto:17.0.5-alpine
+FROM eclipse-temurin:17-jre
 ARG PROJECT_VERSION
 ENV RELEASE_VERSION=$PROJECT_VERSION
 ARG JAR_FILE=./target/klaw-${RELEASE_VERSION}.jar

--- a/cluster-api/Dockerfile
+++ b/cluster-api/Dockerfile
@@ -1,4 +1,4 @@
-FROM adoptopenjdk/openjdk11:latest
+FROM amazoncorretto:17.0.5-alpine
 ARG PROJECT_VERSION
 ENV RELEASE_VERSION=$PROJECT_VERSION
 ARG JAR_FILE=./target/klaw-${RELEASE_VERSION}.jar

--- a/core/Dockerfile
+++ b/core/Dockerfile
@@ -1,4 +1,4 @@
-FROM amazoncorretto:17.0.5-alpine
+FROM eclipse-temurin:17-jre
 ARG PROJECT_VERSION
 ENV RELEASE_VERSION=$PROJECT_VERSION
 ARG JAR_FILE=./target/klaw-${RELEASE_VERSION}.jar

--- a/core/Dockerfile
+++ b/core/Dockerfile
@@ -1,4 +1,4 @@
-FROM adoptopenjdk/openjdk11:latest
+FROM amazoncorretto:17.0.5-alpine
 ARG PROJECT_VERSION
 ENV RELEASE_VERSION=$PROJECT_VERSION
 ARG JAR_FILE=./target/klaw-${RELEASE_VERSION}.jar


### PR DESCRIPTION
About this change - What it does
Updates the dockerfiles to pull a java 17 JRE as we have moved to spring-boot 3.0 which requires 17. (11 no longer supported)
Resolves: #xxxxx
Why this way
This JRE was recommended by AdoptOpenJDK which was the previous JRE we used and has now been deprecated.
