### PR TITLE
feat(coral): implement advanced topic config request as JSON editor 

### DIFF
--- a/coral/jest.config.ts
+++ b/coral/jest.config.ts
@@ -9,7 +9,10 @@ export default {
   preset: "ts-jest",
   testEnvironment: "jsdom",
   setupFiles: ["@testing-library/react/dont-cleanup-after-each"],
-  setupFilesAfterEnv: ["<rootDir>/test-setup/setup-files-after-env.ts"],
+  setupFilesAfterEnv: [
+    "<rootDir>/test-setup/setup-files-after-env.ts",
+    "<rootDir>/test-setup/mock-monaco-editor.tsx",
+  ],
   moduleNameMapper: {
     ".+\\.(png|jpg|ttf|woff|woff2|svg)$": "jest-transform-stub",
     "\\.css$": "identity-obj-proxy",

--- a/coral/package.json
+++ b/coral/package.json
@@ -16,7 +16,7 @@
     "lint": "prettier --check src && eslint .",
     "lint-staged": "lint-staged",
     "prepare": "cd .. && husky install coral/.husky",
-    "preview": "vite preview",
+    "preview": "vite build --mode remote-api && cp mockServiceWorker.js dist/mockServiceWorker.js && vite preview --mode remote-api",
     "reformat": "prettier --write src",
     "test": "jest",
     "test-dev": "jest --watch",

--- a/coral/package.json
+++ b/coral/package.json
@@ -39,7 +39,9 @@
   "dependencies": {
     "@aivenio/aquarium": "^1.2.1",
     "@hookform/resolvers": "^2.9.10",
+    "@monaco-editor/react": "^4.4.6",
     "@tanstack/react-query": "^4.14.1",
+    "monaco-editor": "^0.34.1",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-hook-form": "^7.38.0",

--- a/coral/pnpm-lock.yaml
+++ b/coral/pnpm-lock.yaml
@@ -3,6 +3,7 @@ lockfileVersion: 5.4
 specifiers:
   '@aivenio/aquarium': ^1.2.1
   '@hookform/resolvers': ^2.9.10
+  '@monaco-editor/react': ^4.4.6
   '@tanstack/react-query': ^4.14.1
   '@tanstack/react-query-devtools': ^4.14.1
   '@testing-library/dom': ^8.19.0
@@ -32,6 +33,7 @@ specifiers:
   jest-transform-stub: ^2.0.0
   lint-staged: ^13.0.3
   lodash: ^4.17.21
+  monaco-editor: ^0.34.1
   msw: ^0.47.4
   openapi-typescript: ^5.4.1
   prettier: ^2.7.1
@@ -51,7 +53,9 @@ specifiers:
 dependencies:
   '@aivenio/aquarium': 1.2.1_pvnihi4muhoy7kenlmiyxwzuqy
   '@hookform/resolvers': 2.9.10_react-hook-form@7.38.0
+  '@monaco-editor/react': 4.4.6_6vrjaj6ridxbohi43n7zt4gn7q
   '@tanstack/react-query': 4.14.1_biqbaboplfbrettd7655fr4n2y
+  monaco-editor: 0.34.1
   react: 18.2.0
   react-dom: 18.2.0_react@18.2.0
   react-hook-form: 7.38.0_react@18.2.0
@@ -935,6 +939,29 @@ packages:
       '@jridgewell/resolve-uri': 3.1.0
       '@jridgewell/sourcemap-codec': 1.4.14
     dev: true
+
+  /@monaco-editor/loader/1.3.2_monaco-editor@0.34.1:
+    resolution: {integrity: sha512-BTDbpHl3e47r3AAtpfVFTlAi7WXv4UQ/xZmz8atKl4q7epQV5e7+JbigFDViWF71VBi4IIBdcWP57Hj+OWuc9g==}
+    peerDependencies:
+      monaco-editor: '>= 0.21.0 < 1'
+    dependencies:
+      monaco-editor: 0.34.1
+      state-local: 1.0.7
+    dev: false
+
+  /@monaco-editor/react/4.4.6_6vrjaj6ridxbohi43n7zt4gn7q:
+    resolution: {integrity: sha512-Gr3uz3LYf33wlFE3eRnta4RxP5FSNxiIV9ENn2D2/rN8KgGAD8ecvcITRtsbbyuOuNkwbuHYxfeaz2Vr+CtyFA==}
+    peerDependencies:
+      monaco-editor: '>= 0.25.0 < 1'
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0
+      react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0
+    dependencies:
+      '@monaco-editor/loader': 1.3.2_monaco-editor@0.34.1
+      monaco-editor: 0.34.1
+      prop-types: 15.8.1
+      react: 18.2.0
+      react-dom: 18.2.0_react@18.2.0
+    dev: false
 
   /@mswjs/cookies/0.2.2:
     resolution: {integrity: sha512-mlN83YSrcFgk7Dm1Mys40DLssI1KdJji2CMKN8eOlBqsTADYzj2+jWzsANsUTFbxDMWPD5e9bfA1RGqBpS3O1g==}
@@ -5793,6 +5820,10 @@ packages:
     resolution: {integrity: sha512-bzfL1YUZsP41gmu/qjrEk0Q6i2ix/cVeAhbCbqH9u3zYutS1cLg00qhrD0M2MVdCcx4Sc0UpP2eBWo9rotpq6g==}
     dev: true
 
+  /monaco-editor/0.34.1:
+    resolution: {integrity: sha512-FKc80TyiMaruhJKKPz5SpJPIjL+dflGvz4CpuThaPMc94AyN7SeC9HQ8hrvaxX7EyHdJcUY5i4D0gNyJj1vSZQ==}
+    dev: false
+
   /ms/2.0.0:
     resolution: {integrity: sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==}
     dev: true
@@ -6728,6 +6759,10 @@ packages:
     dependencies:
       escape-string-regexp: 2.0.0
     dev: true
+
+  /state-local/1.0.7:
+    resolution: {integrity: sha512-HTEHMNieakEnoe33shBYcZ7NX83ACUjCu8c40iOGEZsngj9zRnkqS9j1pqQPXwobB0ZcVTk27REb7COQ0UR59w==}
+    dev: false
 
   /statuses/2.0.1:
     resolution: {integrity: sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==}

--- a/coral/src/app/features/topics/request/TopicRequest.test.tsx
+++ b/coral/src/app/features/topics/request/TopicRequest.test.tsx
@@ -6,6 +6,10 @@ import { createMockEnvironmentDTO } from "src/domain/environment/environment-tes
 import { mockGetEnvironmentsForTeam } from "src/domain/environment/environment-api.msw";
 import { server } from "src/services/api-mocks/server";
 import TopicRequest from "src/app/features/topics/request/TopicRequest";
+import {
+  defaultGetTopicAdvanvedConfigOptionsResponse,
+  mockGetTopicAdvanvedConfigOptions,
+} from "src/domain/topic/topic-api.msw";
 
 describe("<TopicRequest />", () => {
   let user: ReturnType<typeof userEvent.setup>;
@@ -34,12 +38,13 @@ describe("<TopicRequest />", () => {
           ],
         },
       });
-      customRender(
-        <AquariumContext>
-          <TopicRequest />
-        </AquariumContext>,
-        { queryClient: true }
-      );
+      mockGetTopicAdvanvedConfigOptions({
+        mswInstance: server,
+        response: {
+          data: defaultGetTopicAdvanvedConfigOptionsResponse,
+        },
+      });
+      customRender(<TopicRequest />, { queryClient: true });
     });
     afterAll(() => {
       cleanup();
@@ -125,6 +130,12 @@ describe("<TopicRequest />", () => {
             ],
           },
         });
+        mockGetTopicAdvanvedConfigOptions({
+          mswInstance: server,
+          response: {
+            data: defaultGetTopicAdvanvedConfigOptionsResponse,
+          },
+        });
 
         customRender(
           <AquariumContext>
@@ -169,6 +180,12 @@ describe("<TopicRequest />", () => {
                 topicsuffix: "-test",
               }),
             ],
+          },
+        });
+        mockGetTopicAdvanvedConfigOptions({
+          mswInstance: server,
+          response: {
+            data: defaultGetTopicAdvanvedConfigOptionsResponse,
           },
         });
 
@@ -230,6 +247,12 @@ describe("<TopicRequest />", () => {
               defaultReplicationFactor: "4",
             }),
           ],
+        },
+      });
+      mockGetTopicAdvanvedConfigOptions({
+        mswInstance: server,
+        response: {
+          data: defaultGetTopicAdvanvedConfigOptionsResponse,
         },
       });
 
@@ -336,6 +359,12 @@ describe("<TopicRequest />", () => {
           ],
         },
       });
+      mockGetTopicAdvanvedConfigOptions({
+        mswInstance: server,
+        response: {
+          data: defaultGetTopicAdvanvedConfigOptionsResponse,
+        },
+      });
 
       customRender(
         <AquariumContext>
@@ -408,6 +437,45 @@ describe("<TopicRequest />", () => {
           );
         });
       });
+    });
+  });
+
+  describe("AdvancedConfiguration", () => {
+    beforeAll(async () => {
+      mockGetEnvironmentsForTeam({
+        mswInstance: server,
+        response: {
+          data: [createMockEnvironmentDTO({ name: "DEV", id: "1" })],
+        },
+      });
+
+      mockGetTopicAdvanvedConfigOptions({
+        mswInstance: server,
+        response: {
+          data: defaultGetTopicAdvanvedConfigOptionsResponse,
+        },
+      });
+
+      customRender(
+        <AquariumContext>
+          <TopicRequest />
+        </AquariumContext>,
+        { queryClient: true }
+      );
+
+      await screen.findByLabelText("Environment");
+      await screen.findByRole("option", { name: "DEV" });
+    });
+    afterAll(() => {
+      cleanup();
+    });
+
+    it("has field which accepts value", async () => {
+      const mockedAdvancedConfig = screen.getByTestId("advancedConfiguration");
+      await user.type(mockedAdvancedConfig, '{{"another":"value"}');
+      expect(mockedAdvancedConfig).toHaveDisplayValue(
+        JSON.stringify({ another: "value" })
+      );
     });
   });
 });

--- a/coral/src/app/features/topics/request/TopicRequest.test.tsx
+++ b/coral/src/app/features/topics/request/TopicRequest.test.tsx
@@ -7,8 +7,8 @@ import { mockGetEnvironmentsForTeam } from "src/domain/environment/environment-a
 import { server } from "src/services/api-mocks/server";
 import TopicRequest from "src/app/features/topics/request/TopicRequest";
 import {
-  defaultGetTopicAdvanvedConfigOptionsResponse,
-  mockGetTopicAdvanvedConfigOptions,
+  defaultgetTopicAdvancedConfigOptionsResponse,
+  mockgetTopicAdvancedConfigOptions,
 } from "src/domain/topic/topic-api.msw";
 
 describe("<TopicRequest />", () => {
@@ -38,10 +38,10 @@ describe("<TopicRequest />", () => {
           ],
         },
       });
-      mockGetTopicAdvanvedConfigOptions({
+      mockgetTopicAdvancedConfigOptions({
         mswInstance: server,
         response: {
-          data: defaultGetTopicAdvanvedConfigOptionsResponse,
+          data: defaultgetTopicAdvancedConfigOptionsResponse,
         },
       });
       customRender(<TopicRequest />, { queryClient: true });
@@ -130,10 +130,10 @@ describe("<TopicRequest />", () => {
             ],
           },
         });
-        mockGetTopicAdvanvedConfigOptions({
+        mockgetTopicAdvancedConfigOptions({
           mswInstance: server,
           response: {
-            data: defaultGetTopicAdvanvedConfigOptionsResponse,
+            data: defaultgetTopicAdvancedConfigOptionsResponse,
           },
         });
 
@@ -182,10 +182,10 @@ describe("<TopicRequest />", () => {
             ],
           },
         });
-        mockGetTopicAdvanvedConfigOptions({
+        mockgetTopicAdvancedConfigOptions({
           mswInstance: server,
           response: {
-            data: defaultGetTopicAdvanvedConfigOptionsResponse,
+            data: defaultgetTopicAdvancedConfigOptionsResponse,
           },
         });
 
@@ -249,10 +249,10 @@ describe("<TopicRequest />", () => {
           ],
         },
       });
-      mockGetTopicAdvanvedConfigOptions({
+      mockgetTopicAdvancedConfigOptions({
         mswInstance: server,
         response: {
-          data: defaultGetTopicAdvanvedConfigOptionsResponse,
+          data: defaultgetTopicAdvancedConfigOptionsResponse,
         },
       });
 
@@ -359,10 +359,10 @@ describe("<TopicRequest />", () => {
           ],
         },
       });
-      mockGetTopicAdvanvedConfigOptions({
+      mockgetTopicAdvancedConfigOptions({
         mswInstance: server,
         response: {
-          data: defaultGetTopicAdvanvedConfigOptionsResponse,
+          data: defaultgetTopicAdvancedConfigOptionsResponse,
         },
       });
 
@@ -449,10 +449,10 @@ describe("<TopicRequest />", () => {
         },
       });
 
-      mockGetTopicAdvanvedConfigOptions({
+      mockgetTopicAdvancedConfigOptions({
         mswInstance: server,
         response: {
-          data: defaultGetTopicAdvanvedConfigOptionsResponse,
+          data: defaultgetTopicAdvancedConfigOptionsResponse,
         },
       });
 

--- a/coral/src/app/features/topics/request/TopicRequest.test.tsx
+++ b/coral/src/app/features/topics/request/TopicRequest.test.tsx
@@ -470,7 +470,21 @@ describe("<TopicRequest />", () => {
       cleanup();
     });
 
-    it("has field which accepts value", async () => {
+    it("renders a sub heading", () => {
+      screen.getByRole("heading", { name: "Advanced Topic Configuration" });
+    });
+
+    it("renders a link to official kafka documentation", () => {
+      const link = screen.getByRole("link", {
+        name: "Apache Kafka Documentation",
+      });
+      expect(link).toHaveAttribute(
+        "href",
+        "https://kafka.apache.org/documentation/#topicconfigs"
+      );
+    });
+
+    it("renders a field which accespts JSON values", async () => {
       const mockedAdvancedConfig = screen.getByTestId("advancedConfiguration");
       await user.type(mockedAdvancedConfig, '{{"another":"value"}');
       expect(mockedAdvancedConfig).toHaveDisplayValue(

--- a/coral/src/app/features/topics/request/TopicRequest.tsx
+++ b/coral/src/app/features/topics/request/TopicRequest.tsx
@@ -147,17 +147,23 @@ function TopicRequest() {
           <Box paddingY={"l1"}>
             <Divider />
           </Box>
-
-          <Textarea<Schema>
-            name="description"
-            labelText="Description"
-            rows={5}
-          />
-          <Textarea<Schema>
-            name="remarks"
-            labelText="Message for approval"
-            rows={5}
-          />
+          <Box component={Flexbox} gap={"l1"}>
+            <Box component={FlexboxItem} grow={1} width={"1/2"}>
+              <Textarea<Schema>
+                name="description"
+                labelText="Description"
+                rows={5}
+              />
+            </Box>
+            <Box component={FlexboxItem} grow={1} width={"1/2"}>
+              {" "}
+              <Textarea<Schema>
+                name="remarks"
+                labelText="Message for approval"
+                rows={5}
+              />
+            </Box>
+          </Box>
         </Box>
 
         <SubmitButton>Request topic</SubmitButton>

--- a/coral/src/app/features/topics/request/TopicRequest.tsx
+++ b/coral/src/app/features/topics/request/TopicRequest.tsx
@@ -20,6 +20,7 @@ import { createMockEnvironmentDTO } from "src/domain/environment/environment-tes
 import { mockGetEnvironmentsForTeam } from "src/domain/environment/environment-api.msw";
 import { Environment } from "src/domain/environment";
 import { getEnvironmentsForTeam } from "src/domain/environment/environment-api";
+import AdvancedConfiguration from "src/app/features/topics/request/components/AdvancedConfiguration";
 
 const mockedData = [
   createMockEnvironmentDTO({
@@ -71,6 +72,7 @@ function TopicRequest() {
         topicname: "",
         remarks: "",
         description: "",
+        advancedConfiguration: "{\n}",
       }
     : undefined;
 
@@ -91,9 +93,9 @@ function TopicRequest() {
   });
 
   return (
-    <Box style={{ maxWidth: 600 }}>
+    <Box style={{ maxWidth: 1200 }}>
       <Form {...form} onSubmit={onSubmit} onError={onError}>
-        <Box width={"1/2"}>
+        <Box width={"full"}>
           {Array.isArray(environments) ? (
             <ComplexNativeSelect<Schema, Environment>
               name="environment"
@@ -107,38 +109,56 @@ function TopicRequest() {
             <NativeSelect.Skeleton></NativeSelect.Skeleton>
           )}
         </Box>
-        <Box paddingY={"l1"}>
-          <Divider />
+        <Box>
+          <Box paddingY={"l1"}>
+            <Divider />
+          </Box>
+          <TextInput<Schema>
+            name={"topicname"}
+            labelText="Topic name"
+            placeholder="e.g. my-topic"
+            required={true}
+          />
+          <Box component={Flexbox} gap={"l1"}>
+            <Box component={FlexboxItem} grow={1} width={"1/2"}>
+              <SelectOrNumberInput
+                name={"topicpartitions"}
+                label={"Topic partitions"}
+                max={selectedEnvironment?.maxPartitions}
+              />
+            </Box>
+            <Box component={FlexboxItem} grow={1} width={"1/2"}>
+              <SelectOrNumberInput
+                name={"replicationfactor"}
+                label={"Replication factor"}
+                max={selectedEnvironment?.maxReplicationFactor}
+              />
+            </Box>
+          </Box>
         </Box>
-        <TextInput<Schema>
-          name={"topicname"}
-          labelText="Topic name"
-          placeholder="e.g. my-topic"
-          required={true}
-        />
+        <Box>
+          <Box paddingY={"l1"}>
+            <Divider />
+          </Box>
+          <AdvancedConfiguration name={"advancedConfiguration"} />
+        </Box>
 
-        <Textarea<Schema> name="description" labelText="Description" rows={5} />
-        <Box component={Flexbox} gap={"l1"}>
-          <Box component={FlexboxItem} grow={1} width={"1/2"}>
-            <SelectOrNumberInput
-              name={"topicpartitions"}
-              label={"Topic partitions"}
-              max={selectedEnvironment?.maxPartitions}
-            />
+        <Box>
+          <Box paddingY={"l1"}>
+            <Divider />
           </Box>
-          <Box component={FlexboxItem} grow={1} width={"1/2"}>
-            <SelectOrNumberInput
-              name={"replicationfactor"}
-              label={"Replication factor"}
-              max={selectedEnvironment?.maxReplicationFactor}
-            />
-          </Box>
+
+          <Textarea<Schema>
+            name="description"
+            labelText="Description"
+            rows={5}
+          />
+          <Textarea<Schema>
+            name="remarks"
+            labelText="Message for approval"
+            rows={5}
+          />
         </Box>
-        <Textarea<Schema>
-          name="remarks"
-          labelText="Message for approval"
-          rows={5}
-        />
 
         <SubmitButton>Request topic</SubmitButton>
       </Form>

--- a/coral/src/app/features/topics/request/components/AdvancedConfiguration.tsx
+++ b/coral/src/app/features/topics/request/components/AdvancedConfiguration.tsx
@@ -8,7 +8,7 @@ import { useQuery } from "@tanstack/react-query";
 import isString from "lodash/isString";
 import { Position, editor } from "monaco-editor";
 import { useEffect, useRef } from "react";
-import { getTopicAdvanvedConfigOptions } from "src/domain/topic/topic-api";
+import { getTopicAdvancedConfigOptions } from "src/domain/topic/topic-api";
 import { TopicAdvancedConfigurationOptions } from "src/domain/topic/topic-types";
 import { Schema } from "src/app/features/topics/request/schemas/topic-request-form";
 import { BorderBox, Box, Flexbox, Typography } from "@aivenio/aquarium";
@@ -24,8 +24,8 @@ function AdvancedConfiguration({ name }: Props) {
   const monaco = useMonaco();
 
   const { data: advancedConfigurationOptions } = useQuery({
-    queryKey: ["getTopicAdvanvedConfigOptions"],
-    queryFn: getTopicAdvanvedConfigOptions,
+    queryKey: ["getTopicAdvancedConfigOptions"],
+    queryFn: getTopicAdvancedConfigOptions,
   });
 
   useEffect(

--- a/coral/src/app/features/topics/request/components/AdvancedConfiguration.tsx
+++ b/coral/src/app/features/topics/request/components/AdvancedConfiguration.tsx
@@ -72,15 +72,15 @@ function AdvancedConfiguration({ name }: Props) {
         Advanced Topic Configuration
       </Typography.Subheading>
       <Typography.Caption>
-        Instead of hiding instructions, we could have those inline here. For the
-        supported values refer to official{" "}
+        For advanced topic-level configurations, refer to the official{" "}
         <a
           href="https://kafka.apache.org/documentation/#topicconfigs"
           target="_blank"
           rel="noreferrer"
         >
           Apache Kafka Documentation
-        </a>{" "}
+        </a>
+        .
       </Typography.Caption>
       <BorderBox borderColor="grey-20">
         <_Controller

--- a/coral/src/app/features/topics/request/components/AdvancedConfiguration.tsx
+++ b/coral/src/app/features/topics/request/components/AdvancedConfiguration.tsx
@@ -1,0 +1,294 @@
+import {
+  Controller as _Controller,
+  useFormContext,
+  UseFormSetError,
+} from "react-hook-form";
+import Editor, { Monaco, useMonaco } from "@monaco-editor/react";
+import { useQuery } from "@tanstack/react-query";
+import isString from "lodash/isString";
+import { Position, editor } from "monaco-editor";
+import { useEffect, useRef } from "react";
+import { getTopicAdvanvedConfigOptions } from "src/domain/topic/topic-api";
+import { TopicAdvancedConfigurationOptions } from "src/domain/topic/topic-types";
+import { Schema } from "src/app/features/topics/request/schemas/topic-request-form";
+import { BorderBox, Box, Flexbox, Typography } from "@aivenio/aquarium";
+
+type Props = {
+  name: "advancedConfiguration";
+};
+
+function AdvancedConfiguration({ name }: Props) {
+  const setModelMarkers = useRef<typeof editor.setModelMarkers>();
+  const monacoEditor = useRef<editor.IStandaloneCodeEditor>();
+  const { setValue, setError, control, getValues } = useFormContext<Schema>();
+  const monaco = useMonaco();
+
+  const { data: advancedConfigurationOptions } = useQuery({
+    queryKey: ["getTopicAdvanvedConfigOptions"],
+    queryFn: getTopicAdvanvedConfigOptions,
+  });
+
+  useEffect(
+    () => setupAutocompleteAndTooltips(monaco, advancedConfigurationOptions),
+    [monaco, advancedConfigurationOptions]
+  );
+
+  useEffect(() => {
+    validateUnknownConfigurationKeys({
+      value: getValues("advancedConfiguration"),
+      advancedConfigurationOptions,
+      setModelMarkers: setModelMarkers.current,
+      monacoEditor: monacoEditor.current,
+      setError,
+    });
+  }, [
+    getValues("advancedConfiguration"),
+    advancedConfigurationOptions,
+    setModelMarkers,
+    monacoEditor,
+    setError,
+  ]);
+
+  function handleEditorValidation(markers: editor.IMarker[]) {
+    if (markers.length > 0) {
+      setError("advancedConfiguration", {
+        message: markers[0].message,
+        type: "custom",
+      });
+    }
+  }
+
+  function handleEditorMount(
+    editor: editor.IStandaloneCodeEditor,
+    monaco: Monaco
+  ) {
+    setModelMarkers.current = monaco.editor.setModelMarkers;
+    monacoEditor.current = editor;
+  }
+
+  return (
+    <Box component={Flexbox} gap={"l1"} direction={"column"}>
+      <Typography.Subheading>
+        Advanced Topic Configuration
+      </Typography.Subheading>
+      <Typography.Caption>
+        Instead of hiding instructions, we could have those inline here. For the
+        supported values refer to official{" "}
+        <a
+          href="https://kafka.apache.org/documentation/#topicconfigs"
+          target="_blank"
+          rel="noreferrer"
+        >
+          Apache Kafka Documentation
+        </a>{" "}
+      </Typography.Caption>
+      <BorderBox borderColor="grey-20">
+        <_Controller
+          name={name}
+          control={control}
+          render={({ field: { name, value } }) => {
+            return (
+              <>
+                <Editor
+                  data-testid="advancedConfiguration"
+                  height="300px"
+                  defaultLanguage={"json"}
+                  value={value}
+                  defaultValue={"{\n}"}
+                  onMount={handleEditorMount}
+                  onChange={(value) => {
+                    if (isString(value)) {
+                      setValue(name, value, {
+                        shouldValidate: true,
+                        shouldTouch: true,
+                        shouldDirty: true,
+                      });
+                    }
+                  }}
+                  onValidate={handleEditorValidation}
+                  options={{
+                    minimap: { enabled: false },
+                    folding: false,
+                    lineNumbers: "off",
+                    scrollbar: {
+                      vertical: "hidden",
+                      horizontal: "hidden",
+                      handleMouseWheel: false,
+                    },
+                  }}
+                />
+              </>
+            );
+          }}
+        />
+      </BorderBox>
+    </Box>
+  );
+}
+
+function setupAutocompleteAndTooltips(
+  monaco: ReturnType<typeof useMonaco>,
+  advancedConfigurationOptions: TopicAdvancedConfigurationOptions[] | undefined
+) {
+  if (monaco && advancedConfigurationOptions !== undefined) {
+    const completionProvider = monaco.languages.registerCompletionItemProvider(
+      "json",
+      {
+        provideCompletionItems: autocompleteOptionNames(
+          advancedConfigurationOptions
+        ),
+      }
+    );
+    const hoverProvider = monaco.languages.registerHoverProvider("json", {
+      provideHover: wordMatchesOptionName(advancedConfigurationOptions),
+    });
+
+    return () => {
+      completionProvider.dispose();
+      hoverProvider.dispose();
+    };
+  }
+}
+
+function getRange(model: editor.ITextModel, position: Position) {
+  const word = model.getWordUntilPosition(position);
+  return {
+    startLineNumber: position.lineNumber,
+    endLineNumber: position.lineNumber,
+    startColumn: word.startColumn,
+    endColumn: word.endColumn,
+  };
+}
+
+const autocompleteOptionNames = (
+  options: TopicAdvancedConfigurationOptions[]
+) => {
+  return (model: editor.ITextModel, position: Position) => {
+    const range = getRange(model, position);
+    return {
+      suggestions: options
+        .filter((option) => !model.getValue().includes(`"${option}"`))
+        .map((option) => {
+          return {
+            label: `"${option.name}"`,
+            range: range,
+            kind: 9, //languages.CompletionItemKind.Property
+            insertText: `"${option.name}": "",`,
+          };
+        }),
+    };
+  };
+};
+
+const wordMatchesOptionName = (
+  options: TopicAdvancedConfigurationOptions[]
+) => {
+  return (model: editor.ITextModel, position: Position) => {
+    const wordAtPosition = model.getWordAtPosition(position);
+    if (wordAtPosition && isString(wordAtPosition.word)) {
+      const configuration = options.find((o) => o.name === wordAtPosition.word);
+      if (configuration !== undefined) {
+        return {
+          range: getRange(model, position),
+          contents: [
+            { value: `**${configuration.name}**` },
+            ...(configuration.documentation
+              ? [
+                  { value: configuration.documentation?.text },
+                  {
+                    value: configuration.documentation?.link,
+                  },
+                ]
+              : []),
+          ],
+        };
+      }
+    }
+  };
+};
+
+function getUnknownConfigKeys(
+  value: string,
+  options: TopicAdvancedConfigurationOptions[]
+): string[] {
+  try {
+    const valueAsObject = JSON.parse(value);
+    const supportedKeys = new Set(options.map((o) => o.name));
+    return Object.keys(valueAsObject).filter(
+      (name) => !supportedKeys.has(name)
+    );
+  } catch {
+    return [];
+  }
+}
+
+function findMatchesFromModel(
+  keys: string[],
+  model: editor.IModel
+): { configName: string; matches: editor.FindMatch[] }[] {
+  return keys
+    .map((configName) => ({
+      configName,
+      matches: model.findMatches(
+        configName, // searchString
+        true, // searchOnlyEditableRange
+        false, // isRegex
+        true, // matchCase
+        null, // wordSeparators
+        true // captureMatches
+      ),
+    }))
+    .filter(({ matches }) => matches.length > 0);
+}
+
+function unknownConfigKeyIntoMarker(
+  configKey: string,
+  match: editor.FindMatch
+): editor.IMarkerData {
+  return {
+    severity: 8, // https://microsoft.github.io/monaco-editor/api/enums/monaco.MarkerSeverity.html#Error
+    message: `"${configKey}" is an unknown topic configuration`,
+    startLineNumber: match.range.startLineNumber,
+    startColumn: match.range.startColumn,
+    endLineNumber: match.range.endLineNumber,
+    endColumn: match.range.endColumn,
+  };
+}
+
+type ValidateUnknownConfigurationKeysArgs = {
+  value: string | undefined;
+  advancedConfigurationOptions: TopicAdvancedConfigurationOptions[] | undefined;
+  setModelMarkers: typeof editor.setModelMarkers | undefined;
+  monacoEditor: editor.IStandaloneCodeEditor | undefined;
+  setError: UseFormSetError<Schema>;
+};
+
+const validateUnknownConfigurationKeys = ({
+  value,
+  advancedConfigurationOptions,
+  setModelMarkers,
+  monacoEditor,
+}: ValidateUnknownConfigurationKeysArgs) => {
+  if (
+    value !== undefined &&
+    advancedConfigurationOptions !== undefined &&
+    setModelMarkers !== undefined &&
+    monacoEditor !== undefined
+  ) {
+    const unknownConfigKeys = getUnknownConfigKeys(
+      value,
+      advancedConfigurationOptions
+    );
+    const model = monacoEditor.getModel();
+    if (model) {
+      const markers = findMatchesFromModel(unknownConfigKeys, model)
+        .map(({ configName, matches }) =>
+          matches.map((match) => unknownConfigKeyIntoMarker(configName, match))
+        )
+        .reduce((acc, curr) => [...acc, ...curr], []);
+      setModelMarkers(model, "custom-component-validation", markers);
+    }
+  }
+};
+
+export default AdvancedConfiguration;

--- a/coral/src/app/features/topics/request/components/AdvancedConfiguration.tsx
+++ b/coral/src/app/features/topics/request/components/AdvancedConfiguration.tsx
@@ -140,7 +140,9 @@ function setupAutocompleteAndTooltips(
       }
     );
     const hoverProvider = monaco.languages.registerHoverProvider("json", {
-      provideHover: wordMatchesOptionName(advancedConfigurationOptions),
+      provideHover: showConfigDocumentationOnKeyHover(
+        advancedConfigurationOptions
+      ),
     });
 
     return () => {
@@ -180,7 +182,7 @@ const autocompleteOptionNames = (
   };
 };
 
-const wordMatchesOptionName = (
+const showConfigDocumentationOnKeyHover = (
   options: TopicAdvancedConfigurationOptions[]
 ) => {
   return (model: editor.ITextModel, position: Position) => {

--- a/coral/src/app/features/topics/request/components/AdvancedConfiguration.tsx
+++ b/coral/src/app/features/topics/request/components/AdvancedConfiguration.tsx
@@ -241,7 +241,7 @@ function findMatchesFromModel(
     .filter(({ matches }) => matches.length > 0);
 }
 
-function unknownConfigKeyIntoMarker(
+function parseUnknownConfigKeyMatchIntoMarker(
   configKey: string,
   match: editor.FindMatch
 ): editor.IMarkerData {
@@ -283,7 +283,9 @@ const validateUnknownConfigurationKeys = ({
     if (model) {
       const markers = findMatchesFromModel(unknownConfigKeys, model)
         .map(({ configName, matches }) =>
-          matches.map((match) => unknownConfigKeyIntoMarker(configName, match))
+          matches.map((match) =>
+            parseUnknownConfigKeyMatchIntoMarker(configName, match)
+          )
         )
         .reduce((acc, curr) => [...acc, ...curr], []);
       setModelMarkers(model, "custom-component-validation", markers);

--- a/coral/src/app/features/topics/request/schemas/topic-request-form.ts
+++ b/coral/src/app/features/topics/request/schemas/topic-request-form.ts
@@ -23,12 +23,15 @@ const environmentField = z.object({
   topicNameSuffix: z.string().optional(),
 });
 
+const advancedConfigurationField = z.string().optional();
+
 const formSchema = z
   .object({
     environment: environmentField,
     topicpartitions: topicPartitionsField,
     replicationfactor: replicationFactorField,
     topicname: topicNameField,
+    advancedConfiguration: advancedConfigurationField,
     remarks: z.string(),
     description: z.string(),
   })

--- a/coral/src/app/main.tsx
+++ b/coral/src/app/main.tsx
@@ -10,6 +10,9 @@ import { isUnauthorizedError } from "src/services/api";
 import "/src/app/accessibility.module.css";
 import "/src/app/main.module.css";
 
+// https://github.com/microsoft/monaco-editor/tree/main/samples/browser-esm-vite-react
+import "/src/services/configure-monaco-editor";
+
 const DEV_MODE = import.meta.env.DEV;
 
 const root = createRoot(document.getElementById("root") as HTMLElement);

--- a/coral/src/domain/topic/topic-api.msw.ts
+++ b/coral/src/domain/topic/topic-api.msw.ts
@@ -45,6 +45,55 @@ function mockTopicGetRequest({
   mswInstance.use(...handlers);
 }
 
+function mockGetTopicAdvanvedConfigOptions({
+  mswInstance,
+  response,
+}: {
+  mswInstance: MswInstance;
+  response: {
+    status?: number;
+    data: KlawApiResponse<"topicAdvancedConfigGet"> | { message: string };
+  };
+}) {
+  const url = `${getHTTPBaseAPIUrl()}/getAdvancedTopicConfigs`;
+  mswInstance.use(
+    rest.get(url, async (req, res, ctx) => {
+      return res(ctx.status(response.status ?? 200), ctx.json(response.data));
+    })
+  );
+}
+
+const defaultGetTopicAdvanvedConfigOptionsResponse = {
+  CLEANUP_POLICY: "cleanup.policy",
+  COMPRESSION_TYPE: "compression.type",
+  DELETE_RETENTION_MS: "delete.retention.ms",
+  FILE_DELETE_DELAY_MS: "file.delete.delay.ms",
+  FLUSH_MESSAGES: "flush.messages",
+  FLUSH_MS: "flush.ms",
+  FOLLOWER_REPLICATION_THROTTLED_REPLICAS:
+    "follower.replication.throttled.replicas",
+  INDEX_INTERVAL_BYTES: "index.interval.bytes",
+  LEADER_REPLICATION_THROTTLED_REPLICAS:
+    "leader.replication.throttled.replicas",
+  MAX_COMPACTION_LAG_MS: "max.compaction.lag.ms",
+  MAX_MESSAGE_BYTES: "max.message.bytes",
+  MESSAGE_DOWNCONVERSION_ENABLE: "message.downconversion.enable",
+  MESSAGE_FORMAT_VERSION: "message.format.version",
+  MESSAGE_TIMESTAMP_DIFFERENCE_MAX_MS: "message.timestamp.difference.max.ms",
+  MESSAGE_TIMESTAMP_TYPE: "message.timestamp.type",
+  MIN_CLEANABLE_DIRTY_RATIO: "min.cleanable.dirty.ratio",
+  MIN_COMPACTION_LAG_MS: "min.compaction.lag.ms",
+  MIN_INSYNC_REPLICAS: "min.insync.replicas",
+  PREALLOCATE: "preallocate",
+  RETENTION_BYTES: "retention.bytes",
+  RETENTION_MS: "retention.ms",
+  SEGMENT_BYTES: "segment.bytes",
+  SEGMENT_INDEX_BYTES: "segment.index.bytes",
+  SEGMENT_JITTER_MS: "segment.jitter.ms",
+  SEGMENT_MS: "segment.ms",
+  UNCLEAN_LEADER_ELECTION_ENABLE: "unclean.leader.election.enable",
+};
+
 const mockedResponseSinglePage: KlawApiResponse<"topicsGet"> =
   createMockTopicApiResponse({
     entries: 10,
@@ -89,9 +138,11 @@ const mockedResponseTransformed = transformTopicApiResponse(
 
 export {
   mockTopicGetRequest,
+  mockGetTopicAdvanvedConfigOptions,
   mockedResponseTransformed,
   mockedResponseMultiplePageTransformed,
   mockedResponseSinglePage,
   mockedResponseMultiplePage,
   mockedResponseTopicEnv,
+  defaultGetTopicAdvanvedConfigOptionsResponse,
 };

--- a/coral/src/domain/topic/topic-api.msw.ts
+++ b/coral/src/domain/topic/topic-api.msw.ts
@@ -45,7 +45,7 @@ function mockTopicGetRequest({
   mswInstance.use(...handlers);
 }
 
-function mockGetTopicAdvanvedConfigOptions({
+function mockgetTopicAdvancedConfigOptions({
   mswInstance,
   response,
 }: {
@@ -63,7 +63,7 @@ function mockGetTopicAdvanvedConfigOptions({
   );
 }
 
-const defaultGetTopicAdvanvedConfigOptionsResponse = {
+const defaultgetTopicAdvancedConfigOptionsResponse = {
   CLEANUP_POLICY: "cleanup.policy",
   COMPRESSION_TYPE: "compression.type",
   DELETE_RETENTION_MS: "delete.retention.ms",
@@ -138,11 +138,11 @@ const mockedResponseTransformed = transformTopicApiResponse(
 
 export {
   mockTopicGetRequest,
-  mockGetTopicAdvanvedConfigOptions,
+  mockgetTopicAdvancedConfigOptions,
   mockedResponseTransformed,
   mockedResponseMultiplePageTransformed,
   mockedResponseSinglePage,
   mockedResponseMultiplePage,
   mockedResponseTopicEnv,
-  defaultGetTopicAdvanvedConfigOptionsResponse,
+  defaultgetTopicAdvancedConfigOptionsResponse,
 };

--- a/coral/src/domain/topic/topic-api.ts
+++ b/coral/src/domain/topic/topic-api.ts
@@ -1,8 +1,14 @@
 import { ALL_ENVIRONMENTS_VALUE } from "src/domain/environment";
 import { Team } from "src/domain/team";
 import { ALL_TEAMS_VALUE } from "src/domain/team/team-types";
-import { transformTopicApiResponse } from "src/domain/topic/topic-transformer";
-import { TopicApiResponse } from "src/domain/topic/topic-types";
+import {
+  transformGetTopicAdvanvedConfigOptionsResponse,
+  transformTopicApiResponse,
+} from "src/domain/topic/topic-transformer";
+import {
+  TopicAdvancedConfigurationOptions,
+  TopicApiResponse,
+} from "src/domain/topic/topic-types";
 import api from "src/services/api";
 import { KlawApiResponse } from "types/utils";
 
@@ -66,4 +72,16 @@ const getTopicTeam = async ({
   );
 };
 
-export { getTopics, getTopicNames, getTopicTeam };
+const getTopicAdvanvedConfigOptions = (): Promise<
+  TopicAdvancedConfigurationOptions[]
+> =>
+  api
+    .get<KlawApiResponse<"topicAdvancedConfigGet">>("/getAdvancedTopicConfigs")
+    .then(transformGetTopicAdvanvedConfigOptionsResponse);
+
+export {
+  getTopics,
+  getTopicNames,
+  getTopicTeam,
+  getTopicAdvanvedConfigOptions,
+};

--- a/coral/src/domain/topic/topic-api.ts
+++ b/coral/src/domain/topic/topic-api.ts
@@ -2,7 +2,7 @@ import { ALL_ENVIRONMENTS_VALUE } from "src/domain/environment";
 import { Team } from "src/domain/team";
 import { ALL_TEAMS_VALUE } from "src/domain/team/team-types";
 import {
-  transformGetTopicAdvanvedConfigOptionsResponse,
+  transformgetTopicAdvancedConfigOptionsResponse,
   transformTopicApiResponse,
 } from "src/domain/topic/topic-transformer";
 import {
@@ -72,16 +72,16 @@ const getTopicTeam = async ({
   );
 };
 
-const getTopicAdvanvedConfigOptions = (): Promise<
+const getTopicAdvancedConfigOptions = (): Promise<
   TopicAdvancedConfigurationOptions[]
 > =>
   api
     .get<KlawApiResponse<"topicAdvancedConfigGet">>("/getAdvancedTopicConfigs")
-    .then(transformGetTopicAdvanvedConfigOptionsResponse);
+    .then(transformgetTopicAdvancedConfigOptionsResponse);
 
 export {
   getTopics,
   getTopicNames,
   getTopicTeam,
-  getTopicAdvanvedConfigOptions,
+  getTopicAdvancedConfigOptions,
 };

--- a/coral/src/domain/topic/topic-transformer.test.ts
+++ b/coral/src/domain/topic/topic-transformer.test.ts
@@ -63,7 +63,7 @@ describe("topic-transformer.ts", () => {
           name: "min.compaction.lag.ms",
           documentation: {
             link: "https://kafka.apache.org/documentation/#topicconfigs_min.compaction.lag.ms",
-            text: "",
+            text: "Specify the minimum time a message will remain uncompacted in the log.",
           },
         },
       ];

--- a/coral/src/domain/topic/topic-transformer.test.ts
+++ b/coral/src/domain/topic/topic-transformer.test.ts
@@ -1,4 +1,7 @@
-import { transformTopicApiResponse } from "src/domain/topic/topic-transformer";
+import {
+  transformgetTopicAdvancedConfigOptionsResponse,
+  transformTopicApiResponse,
+} from "src/domain/topic/topic-transformer";
 import { Topic, TopicApiResponse } from "src/domain/topic/topic-types";
 import {
   baseTestObjectMockedTopic,
@@ -46,6 +49,41 @@ describe("topic-transformer.ts", () => {
       };
 
       expect(transformTopicApiResponse(apiResponse)).toStrictEqual(result);
+    });
+  });
+
+  describe("transformgetTopicAdvancedConfigOptionsResponse", () => {
+    it("transforms an config without known documenation", () => {
+      const apiResponse: KlawApiResponse<"topicAdvancedConfigGet"> = {
+        MIN_COMPACTION_LAG_MS: "min.compaction.lag.ms",
+      };
+      const result = [
+        {
+          key: "MIN_COMPACTION_LAG_MS",
+          name: "min.compaction.lag.ms",
+          documentation: {
+            link: "https://kafka.apache.org/documentation/#topicconfigs_min.compaction.lag.ms",
+            text: "",
+          },
+        },
+      ];
+      expect(
+        transformgetTopicAdvancedConfigOptionsResponse(apiResponse)
+      ).toStrictEqual(result);
+    });
+    it("transforms an config without known documenation", () => {
+      const apiResponse: KlawApiResponse<"topicAdvancedConfigGet"> = {
+        CONFIG_WITHOUT_DOCUMENTATION: "config.without.documentation",
+      };
+      const result = [
+        {
+          key: "CONFIG_WITHOUT_DOCUMENTATION",
+          name: "config.without.documentation",
+        },
+      ];
+      expect(
+        transformgetTopicAdvancedConfigOptionsResponse(apiResponse)
+      ).toStrictEqual(result);
     });
   });
 });

--- a/coral/src/domain/topic/topic-transformer.ts
+++ b/coral/src/domain/topic/topic-transformer.ts
@@ -29,107 +29,107 @@ const ADVANCED_TOPIC_CONFIG_DOCUMENTATION: Record<
 > = {
   "cleanup.policy": {
     link: "https://kafka.apache.org/documentation/#topicconfigs_cleanup.policy",
-    text: "",
+    text: "Specify the cleanup policy for log segments in a topic.",
   },
   "compression.type": {
     link: "https://kafka.apache.org/documentation/#topicconfigs_compression.type",
-    text: "",
+    text: "Specify the type of compression used for log segments in a topic.",
   },
   "delete.retention.ms": {
     link: "https://kafka.apache.org/documentation/#topicconfigs_delete.retention.ms",
-    text: "",
+    text: "Specify retention time in milliseconds for the delete tombstone markers for log compacted topics.",
   },
   "file.delete.delay.ms": {
     link: "https://kafka.apache.org/documentation/#topicconfigs_file.delete.delay.ms",
-    text: "",
+    text: "Specify the wait time in milliseconds before deleting a file from the filesystem.",
   },
   "flush.messages": {
     link: "https://kafka.apache.org/documentation/#topicconfigs_flush.messages",
-    text: "",
+    text: "Specify the number of messages that must be written to a topic before a flush is forced.",
   },
   "flush.ms": {
     link: "https://kafka.apache.org/documentation/#topicconfigs_flush.ms",
-    text: "",
+    text: "Specify the wait time in milliseconds before forcing a flush of data.",
   },
   "follower.replication.throttled.replicas": {
     link: "https://kafka.apache.org/documentation/#topicconfigs_follower.replication.throttled.replicas",
-    text: "",
+    text: "Specify the list of replicas that are currently throttled for replication for this topic.",
   },
   "index.interval.bytes": {
     link: "https://kafka.apache.org/documentation/#topicconfigs_index.interval.bytes",
-    text: "",
+    text: "Specify the interval at which log file offsets will be indexed.",
   },
   "leader.replication.throttled.replicas": {
     link: "https://kafka.apache.org/documentation/#topicconfigs_leader.replication.throttled.replicas",
-    text: "",
+    text: "Specify replicas for which log replication should be throttled on the leader side.",
   },
   "max.compaction.lag.ms": {
     link: "https://kafka.apache.org/documentation/#topicconfigs_max.compaction.lag.ms",
-    text: "",
+    text: "Specify maximum time a message will remain ineligible for compaction in the log.",
   },
   "max.message.bytes": {
     link: "https://kafka.apache.org/documentation/#topicconfigs_max.message.bytes",
-    text: "",
+    text: "Specify the maximum size in bytes for a batch.",
   },
   "message.downconversion.enable": {
     link: "https://kafka.apache.org/documentation/#topicconfigs_message.downconversion.enable",
-    text: "",
+    text: "Enable or disable automatic down conversion of messages.",
   },
   "message.format.version": {
     link: "https://kafka.apache.org/documentation/#topicconfigs_message.format.version",
-    text: "",
+    text: "Specify the message format version to be used by the broker to append messages to logs.",
   },
   "message.timestamp.difference.max.ms": {
     link: "https://kafka.apache.org/documentation/#topicconfigs_message.timestamp.difference.max.ms",
-    text: "",
+    text: "Specify the maximum time difference in milliseconds allowed between the timestamp of a message and time received.",
   },
   "message.timestamp.type": {
     link: "https://kafka.apache.org/documentation/#topicconfigs_message.timestamp.type",
-    text: "",
+    text: "Specify if `CreateTime` or `LogAppendTime` should be used as the timestamp of the message.",
   },
   "min.cleanable.dirty.ratio": {
     link: "https://kafka.apache.org/documentation/#topicconfigs_min.cleanable.dirty.ratio",
-    text: "",
+    text: "Specify the ratio of log to retention size to initiate log compaction.",
   },
   "min.compaction.lag.ms": {
     link: "https://kafka.apache.org/documentation/#topicconfigs_min.compaction.lag.ms",
-    text: "",
+    text: "Specify the minimum time a message will remain uncompacted in the log.",
   },
   "min.insync.replicas": {
     link: "https://kafka.apache.org/documentation/#topicconfigs_min.insync.replicas",
-    text: "",
+    text: "Specify the minimum number of replicas required for a write to be considered successful.",
   },
   preallocate: {
     link: "https://kafka.apache.org/documentation/#topicconfigs_preallocate",
-    text: "",
+    text: "Enable or disable preallocation of file disk for a new log segment.",
   },
   "retention.bytes": {
     link: "https://kafka.apache.org/documentation/#topicconfigs_retention.bytes",
-    text: "",
+    text: "Specify the maximum size a partition before log segment are discarded to free up space.",
   },
   "retention.ms": {
     link: "https://kafka.apache.org/documentation/#topicconfigs_retention.ms",
-    text: "",
+    text: "Specify the retention period in milliseconds for logs before discarding it to free up space.",
   },
   "segment.bytes": {
     link: "https://kafka.apache.org/documentation/#topicconfigs_segment.bytes",
-    text: "",
+    text: "Specify the maximum size of a log segment file in bytes.",
   },
   "segment.index.bytes": {
     link: "https://kafka.apache.org/documentation/#topicconfigs_segment.index.bytes",
-    text: "",
+    text: "Specify the maximum size of the index in bytes that maps offsets to file positions.",
   },
   "segment.jitter.ms": {
     link: "https://kafka.apache.org/documentation/#topicconfigs_segment.jitter.ms",
-    text: "",
+    text: "Specify the maximum jitter time in milliseconds.",
   },
   "segment.ms": {
     link: "https://kafka.apache.org/documentation/#topicconfigs_segment.ms",
-    text: "",
+    text: "Specify the maximum time in milliseconds before a log segment is rolled.",
   },
   "unclean.leader.election.enable": {
     link: "https://kafka.apache.org/documentation/#topicconfigs_unclean.leader.election.enable",
-    text: "",
+    text: "Enable or disable unclean leader election.",
   },
 };
 

--- a/coral/src/domain/topic/topic-transformer.ts
+++ b/coral/src/domain/topic/topic-transformer.ts
@@ -133,7 +133,7 @@ const ADVANCED_TOPIC_CONFIG_DOCUMENTATION: Record<
   },
 };
 
-function transformGetTopicAdvanvedConfigOptionsResponse(
+function transformgetTopicAdvancedConfigOptionsResponse(
   apiResponse: KlawApiResponse<"topicAdvancedConfigGet">
 ): TopicAdvancedConfigurationOptions[] {
   return Object.entries(apiResponse).map(([key, name]) => ({
@@ -145,5 +145,5 @@ function transformGetTopicAdvanvedConfigOptionsResponse(
 
 export {
   transformTopicApiResponse,
-  transformGetTopicAdvanvedConfigOptionsResponse,
+  transformgetTopicAdvancedConfigOptionsResponse,
 };

--- a/coral/src/domain/topic/topic-transformer.ts
+++ b/coral/src/domain/topic/topic-transformer.ts
@@ -136,11 +136,16 @@ const ADVANCED_TOPIC_CONFIG_DOCUMENTATION: Record<
 function transformgetTopicAdvancedConfigOptionsResponse(
   apiResponse: KlawApiResponse<"topicAdvancedConfigGet">
 ): TopicAdvancedConfigurationOptions[] {
-  return Object.entries(apiResponse).map(([key, name]) => ({
-    key,
-    name,
-    documentation: ADVANCED_TOPIC_CONFIG_DOCUMENTATION[name],
-  }));
+  return Object.entries(apiResponse).map(([key, name]) => {
+    const base = { key, name };
+    if (name in ADVANCED_TOPIC_CONFIG_DOCUMENTATION) {
+      return {
+        ...base,
+        documentation: ADVANCED_TOPIC_CONFIG_DOCUMENTATION[name],
+      };
+    }
+    return base;
+  });
 }
 
 export {

--- a/coral/src/domain/topic/topic-transformer.ts
+++ b/coral/src/domain/topic/topic-transformer.ts
@@ -23,10 +23,124 @@ function transformTopicApiResponse(
   };
 }
 
+const ADVANCED_TOPIC_CONFIG_DOCUMENTATION: Record<
+  string,
+  { link: string; text: string }
+> = {
+  "cleanup.policy": {
+    link: "https://kafka.apache.org/documentation/#topicconfigs_cleanup.policy",
+    text: "",
+  },
+  "compression.type": {
+    link: "https://kafka.apache.org/documentation/#topicconfigs_compression.type",
+    text: "",
+  },
+  "delete.retention.ms": {
+    link: "https://kafka.apache.org/documentation/#topicconfigs_delete.retention.ms",
+    text: "",
+  },
+  "file.delete.delay.ms": {
+    link: "https://kafka.apache.org/documentation/#topicconfigs_file.delete.delay.ms",
+    text: "",
+  },
+  "flush.messages": {
+    link: "https://kafka.apache.org/documentation/#topicconfigs_flush.messages",
+    text: "",
+  },
+  "flush.ms": {
+    link: "https://kafka.apache.org/documentation/#topicconfigs_flush.ms",
+    text: "",
+  },
+  "follower.replication.throttled.replicas": {
+    link: "https://kafka.apache.org/documentation/#topicconfigs_follower.replication.throttled.replicas",
+    text: "",
+  },
+  "index.interval.bytes": {
+    link: "https://kafka.apache.org/documentation/#topicconfigs_index.interval.bytes",
+    text: "",
+  },
+  "leader.replication.throttled.replicas": {
+    link: "https://kafka.apache.org/documentation/#topicconfigs_leader.replication.throttled.replicas",
+    text: "",
+  },
+  "max.compaction.lag.ms": {
+    link: "https://kafka.apache.org/documentation/#topicconfigs_max.compaction.lag.ms",
+    text: "",
+  },
+  "max.message.bytes": {
+    link: "https://kafka.apache.org/documentation/#topicconfigs_max.message.bytes",
+    text: "",
+  },
+  "message.downconversion.enable": {
+    link: "https://kafka.apache.org/documentation/#topicconfigs_message.downconversion.enable",
+    text: "",
+  },
+  "message.format.version": {
+    link: "https://kafka.apache.org/documentation/#topicconfigs_message.format.version",
+    text: "",
+  },
+  "message.timestamp.difference.max.ms": {
+    link: "https://kafka.apache.org/documentation/#topicconfigs_message.timestamp.difference.max.ms",
+    text: "",
+  },
+  "message.timestamp.type": {
+    link: "https://kafka.apache.org/documentation/#topicconfigs_message.timestamp.type",
+    text: "",
+  },
+  "min.cleanable.dirty.ratio": {
+    link: "https://kafka.apache.org/documentation/#topicconfigs_min.cleanable.dirty.ratio",
+    text: "",
+  },
+  "min.compaction.lag.ms": {
+    link: "https://kafka.apache.org/documentation/#topicconfigs_min.compaction.lag.ms",
+    text: "",
+  },
+  "min.insync.replicas": {
+    link: "https://kafka.apache.org/documentation/#topicconfigs_min.insync.replicas",
+    text: "",
+  },
+  preallocate: {
+    link: "https://kafka.apache.org/documentation/#topicconfigs_preallocate",
+    text: "",
+  },
+  "retention.bytes": {
+    link: "https://kafka.apache.org/documentation/#topicconfigs_retention.bytes",
+    text: "",
+  },
+  "retention.ms": {
+    link: "https://kafka.apache.org/documentation/#topicconfigs_retention.ms",
+    text: "",
+  },
+  "segment.bytes": {
+    link: "https://kafka.apache.org/documentation/#topicconfigs_segment.bytes",
+    text: "",
+  },
+  "segment.index.bytes": {
+    link: "https://kafka.apache.org/documentation/#topicconfigs_segment.index.bytes",
+    text: "",
+  },
+  "segment.jitter.ms": {
+    link: "https://kafka.apache.org/documentation/#topicconfigs_segment.jitter.ms",
+    text: "",
+  },
+  "segment.ms": {
+    link: "https://kafka.apache.org/documentation/#topicconfigs_segment.ms",
+    text: "",
+  },
+  "unclean.leader.election.enable": {
+    link: "https://kafka.apache.org/documentation/#topicconfigs_unclean.leader.election.enable",
+    text: "",
+  },
+};
+
 function transformGetTopicAdvanvedConfigOptionsResponse(
   apiResponse: KlawApiResponse<"topicAdvancedConfigGet">
 ): TopicAdvancedConfigurationOptions[] {
-  return Object.entries(apiResponse).map(([key, name]) => ({ key, name }));
+  return Object.entries(apiResponse).map(([key, name]) => ({
+    key,
+    name,
+    documentation: ADVANCED_TOPIC_CONFIG_DOCUMENTATION[name],
+  }));
 }
 
 export {

--- a/coral/src/domain/topic/topic-transformer.ts
+++ b/coral/src/domain/topic/topic-transformer.ts
@@ -1,4 +1,7 @@
-import { TopicApiResponse } from "src/domain/topic/topic-types";
+import {
+  TopicAdvancedConfigurationOptions,
+  TopicApiResponse,
+} from "src/domain/topic/topic-types";
 import { KlawApiResponse } from "types/utils";
 
 // @TODO check zod for this!
@@ -20,4 +23,13 @@ function transformTopicApiResponse(
   };
 }
 
-export { transformTopicApiResponse };
+function transformGetTopicAdvanvedConfigOptionsResponse(
+  apiResponse: KlawApiResponse<"topicAdvancedConfigGet">
+): TopicAdvancedConfigurationOptions[] {
+  return Object.entries(apiResponse).map(([key, name]) => ({ key, name }));
+}
+
+export {
+  transformTopicApiResponse,
+  transformGetTopicAdvanvedConfigOptionsResponse,
+};

--- a/coral/src/domain/topic/topic-types.ts
+++ b/coral/src/domain/topic/topic-types.ts
@@ -12,4 +12,15 @@ type Topic = KlawApiModel<"TopicInfo">;
 type TopicNames = KlawApiModel<"TopicsGetOnlyResponse">;
 type TopicTeam = KlawApiModel<"TopicGetTeamResponse">;
 
-export type { Topic, TopicNames, TopicTeam, TopicApiResponse };
+type TopicAdvancedConfigurationOptions = {
+  key: string;
+  name: string;
+};
+
+export type {
+  Topic,
+  TopicNames,
+  TopicTeam,
+  TopicApiResponse,
+  TopicAdvancedConfigurationOptions,
+};

--- a/coral/src/domain/topic/topic-types.ts
+++ b/coral/src/domain/topic/topic-types.ts
@@ -15,6 +15,10 @@ type TopicTeam = KlawApiModel<"TopicGetTeamResponse">;
 type TopicAdvancedConfigurationOptions = {
   key: string;
   name: string;
+  documentation?: {
+    link: string;
+    text: string;
+  };
 };
 
 export type {

--- a/coral/src/services/configure-monaco-editor.ts
+++ b/coral/src/services/configure-monaco-editor.ts
@@ -1,0 +1,29 @@
+import * as monaco from "monaco-editor";
+import editorWorker from "monaco-editor/esm/vs/editor/editor.worker?worker";
+// eslint-disable-next-line import/default
+import jsonWorker from "monaco-editor/esm/vs/language/json/json.worker?worker";
+// eslint-disable-next-line import/default
+import cssWorker from "monaco-editor/esm/vs/language/css/css.worker?worker";
+// eslint-disable-next-line import/default
+import htmlWorker from "monaco-editor/esm/vs/language/html/html.worker?worker";
+import tsWorker from "monaco-editor/esm/vs/language/typescript/ts.worker?worker";
+
+self.MonacoEnvironment = {
+  getWorker(_: unknown, label: string) {
+    if (label === "json") {
+      return new jsonWorker();
+    }
+    if (label === "css" || label === "scss" || label === "less") {
+      return new cssWorker();
+    }
+    if (label === "html" || label === "handlebars" || label === "razor") {
+      return new htmlWorker();
+    }
+    if (label === "typescript" || label === "javascript") {
+      return new tsWorker();
+    }
+    return new editorWorker();
+  },
+};
+
+monaco.languages.typescript.typescriptDefaults.setEagerModelSync(true);

--- a/coral/test-setup/mock-monaco-editor.tsx
+++ b/coral/test-setup/mock-monaco-editor.tsx
@@ -5,8 +5,13 @@ jest.mock("@monaco-editor/react", () => {
   return {
     __esModule: true,
     ...jest.requireActual("@monaco-editor/react"),
-    default: jest.fn(() => {
-      return <textarea></textarea>;
+    default: jest.fn(({ onChange, ...rest }) => {
+      return (
+        <textarea
+          data-testid={rest["data-testid"] ?? "mocked-monaco-editor"}
+          onChange={(event) => onChange(event.target.value)}
+        ></textarea>
+      );
     }),
   };
 });

--- a/coral/test-setup/mock-monaco-editor.tsx
+++ b/coral/test-setup/mock-monaco-editor.tsx
@@ -1,0 +1,12 @@
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+import React from "react";
+
+jest.mock("@monaco-editor/react", () => {
+  return {
+    __esModule: true,
+    ...jest.requireActual("@monaco-editor/react"),
+    default: jest.fn(() => {
+      return <textarea></textarea>;
+    }),
+  };
+});

--- a/coral/vite.config.ts
+++ b/coral/vite.config.ts
@@ -146,6 +146,12 @@ export default defineConfig(({ mode }) => {
       },
     },
     server: {
+      port: 5173,
+      https: getServerHTTPSConfig(environment),
+      proxy: getServerProxyConfig(environment),
+    },
+    preview: {
+      port: 5173,
       https: getServerHTTPSConfig(environment),
       proxy: getServerProxyConfig(environment),
     },

--- a/coral/vite.config.ts
+++ b/coral/vite.config.ts
@@ -155,5 +155,19 @@ export default defineConfig(({ mode }) => {
       https: getServerHTTPSConfig(environment),
       proxy: getServerProxyConfig(environment),
     },
+    build: {
+      rollupOptions: {
+        output: {
+          manualChunks: (id: string) => {
+            if (id.includes("node_modules")) {
+              if (id.includes("monaco-editor")) {
+                return "monaco-editor";
+              }
+              return "vendor";
+            }
+          },
+        },
+      },
+    },
   };
 });


### PR DESCRIPTION
Includes [Monaco Editor](https://microsoft.github.io/monaco-editor/) as a new dependency. The form field is type `z.string()` in order keep the type same as Monaco Editor. As a result, we would need to run `JSON.parse(...)` in order to pass the advanced config. The Monaco editor should take care of the `json` validation out of the box. 

UX candy:
- auto suggest for known advanced configuration keys
- help tooltip when a valid property name is hovered
- red squiggly and error msg on hover for unknown key

Missing nice-to-haves:
- Monaco editor lazy loaded only when needed. Currently it is loaded for each page. Not the end of the world due browser caching, but not optimal
- Advanced config field value validation. Preferably the API would return a JSON Schema to describe the schemas for each field. 
 
Partly implements: #355

Lets close #355 once we get a :+1: from a demo session from the core team.
