### PR TITLE
Display service accounts for a new subscription on Aiven env

### DIFF
--- a/cluster-api/src/main/java/io/aiven/klaw/clusterapi/controller/ClusterApiController.java
+++ b/cluster-api/src/main/java/io/aiven/klaw/clusterapi/controller/ClusterApiController.java
@@ -142,6 +142,23 @@ public class ClusterApiController {
     return new ResponseEntity<>(apiResponse, HttpStatus.OK);
   }
 
+  /*
+  Based on the project, service, user service accounts (in Aiven system) are retrieved.
+   */
+  @RequestMapping(
+      value = "/serviceAccounts/project/{projectName}/service/{serviceName}",
+      method = RequestMethod.GET,
+      produces = {MediaType.APPLICATION_JSON_VALUE})
+  public ResponseEntity<ApiResponse> getServiceAccounts(
+      @PathVariable String projectName, @PathVariable String serviceName) {
+    ApiResponse apiResponse =
+        ApiResponse.builder()
+            .data(aivenApiService.getServiceAccountUsers(projectName, serviceName))
+            .result(ApiResultStatus.SUCCESS.value)
+            .build();
+    return new ResponseEntity<>(apiResponse, HttpStatus.OK);
+  }
+
   @RequestMapping(
       value = "/getSchema/{bootstrapServers}/{protocol}/{clusterIdentification}/{topicName}",
       method = RequestMethod.GET,

--- a/cluster-api/src/main/resources/application.properties
+++ b/cluster-api/src/main/resources/application.properties
@@ -82,3 +82,4 @@ klaw.clusters.addacls.api=https://api.aiven.io/v1/project/projectName/service/se
 klaw.clusters.deleteacls.api=https://api.aiven.io/v1/project/projectName/service/serviceName/acl/aclId
 klaw.clusters.addserviceaccount.api=https://api.aiven.io/v1/project/projectName/service/serviceName/user
 klaw.clusters.getserviceaccount.api=https://api.aiven.io/v1/project/projectName/service/serviceName/user/userName
+klaw.clusters.servicedetails.api=https://api.aiven.io/v1/project/projectName/service/serviceName

--- a/core/src/main/java/io/aiven/klaw/controller/AclController.java
+++ b/core/src/main/java/io/aiven/klaw/controller/AclController.java
@@ -143,4 +143,13 @@ public class AclController {
         aclControllerService.getAivenServiceAccountDetails(envId, topicName, userName, aclReqNo),
         HttpStatus.OK);
   }
+
+  // Aiven api call - get ServiceAccounts for an environment
+  @RequestMapping(
+      value = "/getAivenServiceAccounts",
+      method = RequestMethod.GET,
+      produces = {MediaType.APPLICATION_JSON_VALUE})
+  public ResponseEntity<ApiResponse> getAivenServiceAccounts(@RequestParam("env") String envId) {
+    return new ResponseEntity<>(aclControllerService.getAivenServiceAccounts(envId), HttpStatus.OK);
+  }
 }

--- a/core/src/main/java/io/aiven/klaw/service/AclControllerService.java
+++ b/core/src/main/java/io/aiven/klaw/service/AclControllerService.java
@@ -1,5 +1,12 @@
 package io.aiven.klaw.service;
 
+import static io.aiven.klaw.model.enums.MailType.ACL_DELETE_REQUESTED;
+import static io.aiven.klaw.model.enums.MailType.ACL_REQUESTED;
+import static io.aiven.klaw.model.enums.MailType.ACL_REQUEST_APPROVED;
+import static io.aiven.klaw.model.enums.MailType.ACL_REQUEST_DENIED;
+import static io.aiven.klaw.model.enums.MailType.ACL_REQUEST_FAILURE;
+import static org.springframework.beans.BeanUtils.copyProperties;
+
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.aiven.klaw.config.ManageDatabase;
 import io.aiven.klaw.dao.Acl;
@@ -22,12 +29,6 @@ import io.aiven.klaw.model.enums.MailType;
 import io.aiven.klaw.model.enums.PermissionType;
 import io.aiven.klaw.model.enums.RequestOperationType;
 import io.aiven.klaw.model.enums.RequestStatus;
-import lombok.extern.slf4j.Slf4j;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.http.ResponseEntity;
-import org.springframework.security.core.context.SecurityContextHolder;
-import org.springframework.stereotype.Service;
-
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -38,13 +39,11 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
-
-import static io.aiven.klaw.model.enums.MailType.ACL_DELETE_REQUESTED;
-import static io.aiven.klaw.model.enums.MailType.ACL_REQUESTED;
-import static io.aiven.klaw.model.enums.MailType.ACL_REQUEST_APPROVED;
-import static io.aiven.klaw.model.enums.MailType.ACL_REQUEST_DENIED;
-import static io.aiven.klaw.model.enums.MailType.ACL_REQUEST_FAILURE;
-import static org.springframework.beans.BeanUtils.copyProperties;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Service;
 
 @Service
 @Slf4j

--- a/core/src/main/java/io/aiven/klaw/service/AclControllerService.java
+++ b/core/src/main/java/io/aiven/klaw/service/AclControllerService.java
@@ -1,8 +1,5 @@
 package io.aiven.klaw.service;
 
-import static io.aiven.klaw.model.enums.MailType.*;
-import static org.springframework.beans.BeanUtils.copyProperties;
-
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.aiven.klaw.config.ManageDatabase;
 import io.aiven.klaw.dao.Acl;
@@ -25,6 +22,12 @@ import io.aiven.klaw.model.enums.MailType;
 import io.aiven.klaw.model.enums.PermissionType;
 import io.aiven.klaw.model.enums.RequestOperationType;
 import io.aiven.klaw.model.enums.RequestStatus;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Service;
+
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -35,11 +38,13 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
-import lombok.extern.slf4j.Slf4j;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.http.ResponseEntity;
-import org.springframework.security.core.context.SecurityContextHolder;
-import org.springframework.stereotype.Service;
+
+import static io.aiven.klaw.model.enums.MailType.ACL_DELETE_REQUESTED;
+import static io.aiven.klaw.model.enums.MailType.ACL_REQUESTED;
+import static io.aiven.klaw.model.enums.MailType.ACL_REQUEST_APPROVED;
+import static io.aiven.klaw.model.enums.MailType.ACL_REQUEST_DENIED;
+import static io.aiven.klaw.model.enums.MailType.ACL_REQUEST_FAILURE;
+import static org.springframework.beans.BeanUtils.copyProperties;
 
 @Service
 @Slf4j

--- a/core/src/main/java/io/aiven/klaw/service/AclControllerService.java
+++ b/core/src/main/java/io/aiven/klaw/service/AclControllerService.java
@@ -1,10 +1,6 @@
 package io.aiven.klaw.service;
 
-import static io.aiven.klaw.model.enums.MailType.ACL_DELETE_REQUESTED;
-import static io.aiven.klaw.model.enums.MailType.ACL_REQUESTED;
-import static io.aiven.klaw.model.enums.MailType.ACL_REQUEST_APPROVED;
-import static io.aiven.klaw.model.enums.MailType.ACL_REQUEST_DENIED;
-import static io.aiven.klaw.model.enums.MailType.ACL_REQUEST_FAILURE;
+import static io.aiven.klaw.model.enums.MailType.*;
 import static org.springframework.beans.BeanUtils.copyProperties;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -699,6 +695,24 @@ public class AclControllerService {
           kwClusters.getProjectName(), kwClusters.getServiceName(), serviceAccount, tenantId);
     } catch (Exception e) {
       log.error("Ignoring error while retrieving service account credentials {} ", e.toString());
+    }
+    return ApiResponse.builder().result(ApiResultStatus.FAILURE.value).build();
+  }
+
+  public ApiResponse getAivenServiceAccounts(String envId) {
+    String loggedInUser = getCurrentUserName();
+    int tenantId = commonUtilsService.getTenantId(loggedInUser);
+    log.info("Retrieving service accounts for environment {}", envId);
+    try {
+      // Get details from Cluster Api
+      KwClusters kwClusters =
+          manageDatabase
+              .getClusters(KafkaClustersType.KAFKA, tenantId)
+              .get(getEnvDetails(envId, tenantId).getClusterId());
+      return clusterApiService.getAivenServiceAccounts(
+          kwClusters.getProjectName(), kwClusters.getServiceName(), tenantId);
+    } catch (Exception e) {
+      log.error("Ignoring error while retrieving service accounts {} ", e.toString());
     }
     return ApiResponse.builder().result(ApiResultStatus.FAILURE.value).build();
   }

--- a/core/src/main/java/io/aiven/klaw/service/ClusterApiService.java
+++ b/core/src/main/java/io/aiven/klaw/service/ClusterApiService.java
@@ -585,6 +585,32 @@ public class ClusterApiService {
     }
   }
 
+  public ApiResponse getAivenServiceAccounts(String projectName, String serviceName, int tenantId)
+      throws KlawException {
+    getClusterApiProperties(tenantId);
+    try {
+      String uriGetServiceAccounts =
+          clusterConnUrl + "/topics/serviceAccounts/project/projectName/service/serviceName";
+      uriGetServiceAccounts =
+          uriGetServiceAccounts
+              .replace("projectName", projectName)
+              .replace("serviceName", serviceName);
+
+      HttpEntity<String> entity = getHttpEntity();
+      ResponseEntity<ApiResponse> apiResponseResponseEntity =
+          getRestTemplate()
+              .exchange(
+                  uriGetServiceAccounts,
+                  HttpMethod.GET,
+                  entity,
+                  new ParameterizedTypeReference<>() {});
+      return apiResponseResponseEntity.getBody();
+    } catch (Exception e) {
+      log.error("Error from getAivenServiceAccounts", e);
+      throw new KlawException("Could not retrieve service accounts. Please contact Administrator.");
+    }
+  }
+
   ResponseEntity<ApiResponse> postSchema(
       SchemaRequest schemaRequest, String env, String topicName, int tenantId)
       throws KlawException {

--- a/core/src/main/resources/static/js/requestAcls.js
+++ b/core/src/main/resources/static/js/requestAcls.js
@@ -194,6 +194,7 @@ app.controller("requestAclsCtrl", function($scope, $http, $location, $window) {
                         else{
                             $scope.acl_ip_ssl = 'SSL';
                             $scope.selectedAclType="PRINCIPAL";
+                            $scope.getAivenServiceAccounts(envName);
                         }
                     }).error(
                         function(error)
@@ -202,6 +203,22 @@ app.controller("requestAclsCtrl", function($scope, $http, $location, $window) {
                         }
                     );
             }
+
+        $scope.getAivenServiceAccounts = function(environment){
+            $http({
+                method: "GET",
+                url: "getAivenServiceAccounts",
+                headers : { 'Content-Type' : 'application/json' },
+                params: {'env' : environment},
+            }).success(function(output) {
+                $scope.serviceAccounts = output.data;
+            }).error(
+                function(error)
+                {
+                    $scope.handleErrorMessage(error);
+                }
+            );
+        }
 
             // set default
             $scope.disable_consumergrp = false;

--- a/core/src/main/resources/swagger_spec.json
+++ b/core/src/main/resources/swagger_spec.json
@@ -3549,10 +3549,10 @@
         "titleForReport" : {
           "type" : "string"
         },
-        "xaxisLabel" : {
+        "yaxisLabel" : {
           "type" : "string"
         },
-        "yaxisLabel" : {
+        "xaxisLabel" : {
           "type" : "string"
         }
       }

--- a/core/src/main/resources/swagger_spec.json
+++ b/core/src/main/resources/swagger_spec.json
@@ -966,6 +966,26 @@
         }
       }
     },
+    "/getAivenServiceAccounts" : {
+      "get" : {
+        "operationId" : "getAivenServiceAccounts",
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "env",
+          "in" : "query",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "schema" : {
+              "$ref" : "#/definitions/ApiResponse"
+            }
+          }
+        }
+      }
+    },
     "/getAllServerConfig" : {
       "get" : {
         "operationId" : "getAllProperties",

--- a/core/src/main/resources/templates/requestAcls.html
+++ b/core/src/main/resources/templates/requestAcls.html
@@ -694,6 +694,20 @@
 
 												<small class="form-control-feedback"> Ex: alice</small><br>
 												<small class="form-control-feedback"> <b>Note:</b> Service Account is created in Aiven Console if it doesn't exist !</small>
+												<br>
+												<small class="form-control-feedback" ng-if = "serviceAccounts != null && serviceAccounts.length > 0">
+													<b>Note:</b>
+													The following service accounts exist for this environment !!
+													<table style="border: 1px gray;">
+														<tr valign="top" ng-repeat="serviceAccount in serviceAccounts track by $index">
+															<td>{{ serviceAccount }}</td>
+														</tr>
+													</table>
+												</small>
+												<small class="form-control-feedback" ng-if = "serviceAccounts == null || serviceAccounts.length == 0">
+													<b>Note:</b>
+													There are no service accounts for this environment !!
+												</small>
 											</div>
 										</div>
 										<!--/span-->

--- a/core/src/test/java/io/aiven/klaw/service/AclControllerServiceTest.java
+++ b/core/src/test/java/io/aiven/klaw/service/AclControllerServiceTest.java
@@ -32,6 +32,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.MethodOrderer;
@@ -610,6 +611,64 @@ public class AclControllerServiceTest {
         aclControllerService.getAivenServiceAccountDetails("1", "testtopic", "service", reqNo);
 
     assertThat(resultResp.getResult()).isEqualTo(ApiResultStatus.FAILURE.value);
+  }
+
+  @Test
+  @Order(28)
+  public void getAivenServiceAccounts() throws KlawException {
+    stubUserInfo();
+    mockKafkaFlavor();
+    Set<String> serviceAccountInfoSet = new HashSet<>();
+    serviceAccountInfoSet.add("user1");
+    serviceAccountInfoSet.add("user2");
+
+    ApiResponse apiResponse =
+        ApiResponse.builder()
+            .result(ApiResultStatus.SUCCESS.value)
+            .data(serviceAccountInfoSet)
+            .build();
+
+    when(commonUtilsService.getTenantId(userDetails.getUsername())).thenReturn(1);
+    when(commonUtilsService.getTeamId(anyString())).thenReturn(101);
+    when(commonUtilsService.getEnvsFromUserId(anyString()))
+        .thenReturn(new HashSet<>(Collections.singletonList("1")));
+
+    when(clusterApiService.getAivenServiceAccounts(anyString(), anyString(), anyInt()))
+        .thenReturn(apiResponse);
+
+    ApiResponse resultResp = aclControllerService.getAivenServiceAccounts("1");
+    Set<String> resultObj = (Set) resultResp.getData();
+
+    assertThat(resultResp.getResult()).isEqualTo(ApiResultStatus.SUCCESS.value);
+    assertThat(resultObj).hasSize(2);
+  }
+
+  @Test
+  @Order(29)
+  public void getAivenServiceAccountsDontExist() throws KlawException {
+    stubUserInfo();
+    mockKafkaFlavor();
+    Set<String> serviceAccountInfoSet = new HashSet<>();
+
+    ApiResponse apiResponse =
+        ApiResponse.builder()
+            .result(ApiResultStatus.SUCCESS.value)
+            .data(serviceAccountInfoSet)
+            .build();
+
+    when(commonUtilsService.getTenantId(userDetails.getUsername())).thenReturn(1);
+    when(commonUtilsService.getTeamId(anyString())).thenReturn(101);
+    when(commonUtilsService.getEnvsFromUserId(anyString()))
+        .thenReturn(new HashSet<>(Collections.singletonList("1")));
+
+    when(clusterApiService.getAivenServiceAccounts(anyString(), anyString(), anyInt()))
+        .thenReturn(apiResponse);
+
+    ApiResponse resultResp = aclControllerService.getAivenServiceAccounts("1");
+    Set<String> resultObj = (Set) resultResp.getData();
+
+    assertThat(resultResp.getResult()).isEqualTo(ApiResultStatus.SUCCESS.value);
+    assertThat(resultObj).hasSize(0);
   }
 
   private AclRequestsModel getAclRequestProducer() {


### PR DESCRIPTION
Signed-off-by: muralibasani <muralidahr.basani@aiven.io>

About this change - What it does

Currently in a subscription request on an Aiven environment, user is allowed to enter a service account. He is not sure which exist and which don't. 
This Pr, retrieves the service accounts and displays in the Acl request form, and user can choose which one to use or create a new one.

Resolves: #431 
Why this way

User does not have to login to see the service accounts, rather, view in klaw and request a subscription.
