### PR TITLE
Enable custom filter, add constants for cluster api endpoints

### DIFF
--- a/core/src/main/java/io/aiven/klaw/auth/KwAuthenticationSuccessHandler.java
+++ b/core/src/main/java/io/aiven/klaw/auth/KwAuthenticationSuccessHandler.java
@@ -2,7 +2,6 @@ package io.aiven.klaw.auth;
 
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
-import java.io.IOException;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.core.Authentication;
@@ -20,18 +19,18 @@ public class KwAuthenticationSuccessHandler extends SavedRequestAwareAuthenticat
 
   @Override
   public void onAuthenticationSuccess(
-      HttpServletRequest request, HttpServletResponse response, Authentication authentication)
-      throws IOException {
+      HttpServletRequest request, HttpServletResponse response, Authentication authentication) {
     log.info("User logged in : {}", ((UserDetails) authentication.getPrincipal()).getUsername());
     super.clearAuthenticationAttributes(request);
-    response.sendRedirect(contextPath.concat(getRedirectPage(request)));
+    this.setAlwaysUseDefaultTargetUrl(false);
+    this.setDefaultTargetUrl(contextPath.concat(getRedirectPage(request)));
   }
 
   private String getRedirectPage(HttpServletRequest request) {
     DefaultSavedRequest defaultSavedRequest =
         (DefaultSavedRequest) request.getSession().getAttribute("SPRING_SECURITY_SAVED_REQUEST");
     String loggedInQuery = "loggedin=true";
-    String indexPage = "index";
+    String indexPage = "/index";
     String urlSeparator = "?";
     String defaultPage = indexPage.concat(urlSeparator).concat(loggedInQuery);
 

--- a/core/src/main/java/io/aiven/klaw/helpers/KwConstants.java
+++ b/core/src/main/java/io/aiven/klaw/helpers/KwConstants.java
@@ -83,4 +83,28 @@ public class KwConstants {
 
   public static final int DAYS_EXPIRY_DEFAULT_TENANT = 365 * 10;
   public static final int DAYS_TRIAL_PERIOD = 7;
+
+  public static final String URI_CLUSTER_API = "/topics/getApiStatus";
+  public static final String URI_KAFKA_SR_CONN_STATUS = "/topics/getStatus/";
+  public static final String URI_GET_CONSUMER_OFFSETS = "/topics/getConsumerOffsets/";
+  public static final String URI_GET_TOPIC_CONTENTS = "/topics/getTopicContents/";
+  public static final String URI_GET_ACLS = "/topics/getAcls/";
+  public static final String URI_CREATE_ACLS = "/topics/createAcls";
+  public static final String URI_DELETE_ACLS = "/topics/deleteAcls";
+  public static final String URI_GET_TOPICS = "/topics/getTopics/";
+  public static final String URI_CREATE_TOPICS = "/topics/createTopics";
+  public static final String URI_UPDATE_TOPICS = "/topics/updateTopics";
+  public static final String URI_DELETE_TOPICS = "/topics/deleteTopics";
+  public static final String URI_POST_CONNECTOR = "/topics/postConnector";
+  public static final String URI_UPDATE_CONNECTOR = "/topics/updateConnector";
+  public static final String URI_DELETE_CONNECTOR = "/topics/deleteConnector";
+  public static final String URI_CONNECTOR_DETAILS = "/topics/getConnectorDetails";
+  public static final String URI_GET_ALL_CONNECTORS = "/topics/getAllConnectors/";
+  public static final String URI_POST_SCHEMA = "/topics/postSchema";
+  public static final String URI_GET_SCHEMA = "/topics/getSchema/";
+  public static final String URI_GET_METRICS = "/metrics/getMetrics";
+  public static final String URI_AIVEN_SERVICE_ACCOUNT_DETAIL =
+      "/topics/serviceAccountDetails/project/projectName/service/serviceName/user/userName";
+  public static final String URI_AIVEN_SERVICE_ACCOUNTS =
+      "/topics/serviceAccounts/project/projectName/service/serviceName";
 }

--- a/core/src/main/java/io/aiven/klaw/service/ClusterApiService.java
+++ b/core/src/main/java/io/aiven/klaw/service/ClusterApiService.java
@@ -1,6 +1,6 @@
 package io.aiven.klaw.service;
 
-import static io.aiven.klaw.helpers.KwConstants.CLUSTER_CONN_URL_KEY;
+import static io.aiven.klaw.helpers.KwConstants.*;
 
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -88,9 +88,6 @@ public class ClusterApiService {
   private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
   private static final String URL_DELIMITER = "/";
 
-  private static final String URI_CREATE_TOPICS = "/topics/createTopics";
-  private static final String URI_UPDATE_TOPICS = "/topics/updateTopics";
-  private static final String URI_DELETE_TOPICS = "/topics/deleteTopics";
   @Autowired private ManageDatabase manageDatabase;
 
   @Value("${server.ssl.key-store:null}")
@@ -143,7 +140,7 @@ public class ClusterApiService {
         "getClusterApiStatus clusterApiUrl {} testConnection{}", clusterApiUrl, testConnection);
     getClusterApiProperties(tenantId);
     try {
-      String uriClusterApiStatus = "/topics/getApiStatus";
+      String uriClusterApiStatus = URI_CLUSTER_API;
       String uri;
       if (testConnection) {
         uri = clusterApiUrl + uriClusterApiStatus;
@@ -170,10 +167,9 @@ public class ClusterApiService {
     getClusterApiProperties(tenantId);
 
     try {
-      String uriEnvStatus = "/topics/getStatus/";
       String uri =
           clusterConnUrl
-              + uriEnvStatus
+              + URI_KAFKA_SR_CONN_STATUS
               + bootstrapHost
               + URL_DELIMITER
               + String.join(URL_DELIMITER, protocol.getName(), clusterIdentification, clusterType);
@@ -199,7 +195,7 @@ public class ClusterApiService {
     getClusterApiProperties(tenantId);
     List<Map<String, String>> offsetsMap;
     try {
-      String url = "/topics/getConsumerOffsets/";
+      String url = URI_GET_CONSUMER_OFFSETS;
       url =
           clusterConnUrl
               + url
@@ -235,7 +231,7 @@ public class ClusterApiService {
     getClusterApiProperties(tenantId);
     Map<String, String> eventsMap;
     try {
-      String url = "/topics/getTopicContents/";
+      String url = URI_GET_TOPIC_CONTENTS;
       url =
           clusterConnUrl
               + url
@@ -270,7 +266,7 @@ public class ClusterApiService {
 
     List<Map<String, String>> aclListOriginal;
     try {
-      String uriGetAcls = "/topics/getAcls/";
+      String uriGetAcls = URI_GET_ACLS;
       KwClusters kwClusters =
           manageDatabase
               .getClusters(KafkaClustersType.KAFKA, tenantId)
@@ -328,10 +324,9 @@ public class ClusterApiService {
     getClusterApiProperties(tenantId);
     List<Map<String, String>> topicsList;
     try {
-      String uriGetTopics = "/topics/getTopics/";
       String uriGetTopicsFull =
           clusterConnUrl
-              + uriGetTopics
+              + URI_GET_TOPICS
               + bootstrapHost
               + URL_DELIMITER
               + String.join(URL_DELIMITER, protocol.getName(), clusterIdentification);
@@ -373,14 +368,13 @@ public class ClusterApiService {
               .build();
 
       String uri;
-      String uriGetTopics = "/topics/";
 
       if (RequestOperationType.CREATE.value.equals(connectorType)) {
-        uri = clusterConnUrl + uriGetTopics + "postConnector";
+        uri = clusterConnUrl + URI_POST_CONNECTOR;
       } else if (RequestOperationType.UPDATE.value.equals(connectorType)) {
-        uri = clusterConnUrl + uriGetTopics + "updateConnector";
+        uri = clusterConnUrl + URI_UPDATE_CONNECTOR;
       } else {
-        uri = clusterConnUrl + uriGetTopics + "deleteConnector";
+        uri = clusterConnUrl + URI_DELETE_CONNECTOR;
       }
 
       HttpHeaders headers = createHeaders(clusterApiUser);
@@ -472,8 +466,6 @@ public class ClusterApiService {
     try {
       String env = aclReq.getEnvironment();
       String uri;
-      String uriCreateAcls = "/topics/createAcls";
-      String uriDeleteAcls = "/topics/deleteAcls";
 
       ClusterAclRequest clusterAclRequest;
       Env envSelected = manageDatabase.getHandleDbRequests().selectEnvDetails(env, tenantId);
@@ -533,11 +525,11 @@ public class ClusterApiService {
       }
 
       if (RequestOperationType.CREATE.value.equals(aclReq.getAclType())) {
-        uri = clusterConnUrl + uriCreateAcls;
+        uri = clusterConnUrl + URI_CREATE_ACLS;
         clusterAclRequest =
             clusterAclRequest.toBuilder().requestOperationType(RequestOperationType.CREATE).build();
       } else {
-        uri = clusterConnUrl + uriDeleteAcls;
+        uri = clusterConnUrl + URI_DELETE_ACLS;
         clusterAclRequest =
             clusterAclRequest.toBuilder().requestOperationType(RequestOperationType.DELETE).build();
       }
@@ -560,9 +552,7 @@ public class ClusterApiService {
       String projectName, String serviceName, String userName, int tenantId) throws KlawException {
     getClusterApiProperties(tenantId);
     try {
-      String uriGetServiceAccountDetails =
-          clusterConnUrl
-              + "/topics/serviceAccountDetails/project/projectName/service/serviceName/user/userName";
+      String uriGetServiceAccountDetails = clusterConnUrl + URI_AIVEN_SERVICE_ACCOUNT_DETAIL;
       uriGetServiceAccountDetails =
           uriGetServiceAccountDetails
               .replace("projectName", projectName)
@@ -589,8 +579,7 @@ public class ClusterApiService {
       throws KlawException {
     getClusterApiProperties(tenantId);
     try {
-      String uriGetServiceAccounts =
-          clusterConnUrl + "/topics/serviceAccounts/project/projectName/service/serviceName";
+      String uriGetServiceAccounts = clusterConnUrl + URI_AIVEN_SERVICE_ACCOUNTS;
       uriGetServiceAccounts =
           uriGetServiceAccounts
               .replace("projectName", projectName)
@@ -618,8 +607,7 @@ public class ClusterApiService {
     getClusterApiProperties(tenantId);
     ResponseEntity<ApiResponse> response;
     try {
-      String uriPostSchema = "/topics/postSchema";
-      String uri = clusterConnUrl + uriPostSchema;
+      String uri = clusterConnUrl + URI_POST_SCHEMA;
 
       Env envSelected = manageDatabase.getHandleDbRequests().selectEnvDetails(env, tenantId);
       KwClusters kwClusters =
@@ -659,10 +647,9 @@ public class ClusterApiService {
     TreeMap<Integer, Map<String, Object>> allVersionSchemas =
         new TreeMap<>(Collections.reverseOrder());
     try {
-      String uriGetSchema = "/topics/getSchema/";
       String uriGetTopicsFull =
           clusterConnUrl
-              + uriGetSchema
+              + URI_GET_SCHEMA
               + schemaRegistryHost
               + URL_DELIMITER
               + String.join(URL_DELIMITER, protocol.getName(), clusterIdentification, topicName);
@@ -701,7 +688,7 @@ public class ClusterApiService {
       String uriGetTopics =
           String.join(
               URL_DELIMITER,
-              "/topics/getConnectorDetails",
+              URI_CONNECTOR_DETAILS,
               connectorName,
               kafkaConnectHost,
               protocol.getName(),
@@ -730,12 +717,7 @@ public class ClusterApiService {
     getClusterApiProperties(tenantId);
     try {
       String uriGetTopics =
-          "/topics/getAllConnectors/"
-              + kafkaConnectHost
-              + "/"
-              + protocol
-              + "/"
-              + clusterIdentification;
+          URI_GET_ALL_CONNECTORS + kafkaConnectHost + "/" + protocol + "/" + clusterIdentification;
       String uriGetConnectorsFull = clusterConnUrl + uriGetTopics;
 
       ResponseEntity<ArrayList<String>> s =
@@ -758,12 +740,11 @@ public class ClusterApiService {
     log.info("retrieveMetrics {} {}", jmxUrl, objectName);
     getClusterApiProperties(101);
     try {
-      String uriGetTopics = "/metrics/getMetrics";
       MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
       params.add("jmxUrl", jmxUrl);
       params.add("objectName", objectName);
 
-      String uriGetTopicsFull = clusterConnUrl + uriGetTopics;
+      String uriGetTopicsFull = clusterConnUrl + URI_GET_METRICS;
       RestTemplate restTemplate = getRestTemplate();
 
       HttpHeaders headers = createHeaders(clusterApiUser);


### PR DESCRIPTION
Signed-off-by: muralibasani <muralidhar.basani@aiven.io>

About this change - What it does

- Enable back custom filter on spring Security (was removed after spring boot 3 upgrade)
- Add constants for cluster api endpoints

Resolves: #427 
Resolves: #440 
Why this way

Enabling filter will have a good control during/after authentication of a request 
