### PR TITLE
refactor(coral): Refactor render-with-wrapper

### DIFF
--- a/coral/src/services/test-utils/render-with-wrappers.tsx
+++ b/coral/src/services/test-utils/render-with-wrappers.tsx
@@ -117,6 +117,9 @@ function customRender(
     return withQueryClient(ui, options);
   }
 
+  console.error(
+    "You have not passed any renderWith option, which returns the non-custom render."
+  );
   return render(ui, options);
 }
 export { customRender };

--- a/coral/src/services/test-utils/render-with-wrappers.tsx
+++ b/coral/src/services/test-utils/render-with-wrappers.tsx
@@ -1,12 +1,12 @@
 import { QueryClientProvider } from "@tanstack/react-query";
-import { ReactElement } from "react";
 import { render, RenderOptions } from "@testing-library/react";
+import { ReactElement } from "react";
 import { BrowserRouter, MemoryRouter } from "react-router-dom";
 import { getQueryClientForTests } from "src/services/test-utils/query-client-tests";
 
 function withQueryClient(ui: ReactElement, options?: RenderOptions) {
   const queryClient = getQueryClientForTests();
-  render(ui, {
+  return render(ui, {
     wrapper: ({ children }) => (
       <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
     ),
@@ -23,7 +23,7 @@ function withMemoryRouter({
   customRoutePath?: string;
   options?: RenderOptions;
 }) {
-  render(ui, {
+  return render(ui, {
     wrapper: ({ children }) => (
       <MemoryRouter initialEntries={[customRoutePath || ""]}>
         {children}
@@ -43,7 +43,7 @@ function withMemoryRouterAndQueryClient({
   options?: RenderOptions;
 }) {
   const queryClient = getQueryClientForTests();
-  render(ui, {
+  return render(ui, {
     wrapper: ({ children }) => (
       <QueryClientProvider client={queryClient}>
         <MemoryRouter initialEntries={[customRoutePath || ""]}>
@@ -65,7 +65,7 @@ function withBrowserRouterAndQueryClient({
   options?: RenderOptions;
 }) {
   const queryClient = getQueryClientForTests();
-  render(ui, {
+  return render(ui, {
     wrapper: ({ children }) => (
       <QueryClientProvider client={queryClient}>
         <BrowserRouter>{children}</BrowserRouter>
@@ -74,43 +74,49 @@ function withBrowserRouterAndQueryClient({
     ...options,
   });
 }
+type ValidOptions =
+  | "queryClient"
+  | "memoryRouter"
+  | "browserRouter"
+  | "customRoutePath";
 
 type CustomRenderOption = {
-  queryClient?: boolean;
-  memoryRouter?: boolean;
-  browserRouter?: boolean;
-  customRoutePath?: string;
+  [K in ValidOptions]?: K extends
+    | "queryClient"
+    | "memoryRouter"
+    | "browserRouter"
+    ? boolean
+    : string;
 };
+
 function customRender(
   ui: ReactElement,
-  renderWith?: CustomRenderOption,
+  renderWith: CustomRenderOption,
   options?: RenderOptions
 ) {
-  if (!renderWith) {
-    return render(ui, options);
-  }
-  if (renderWith.queryClient && renderWith.memoryRouter) {
+  if (renderWith?.queryClient && renderWith?.memoryRouter) {
     return withMemoryRouterAndQueryClient({
       ui,
-      customRoutePath: renderWith.customRoutePath,
+      customRoutePath: renderWith?.customRoutePath,
       options,
     });
   }
 
-  if (renderWith.queryClient && renderWith.browserRouter) {
+  if (renderWith?.queryClient && renderWith?.browserRouter) {
     return withBrowserRouterAndQueryClient({ ui, options });
   }
 
-  if (renderWith.memoryRouter) {
+  if (renderWith?.memoryRouter) {
     return withMemoryRouter({
       ui,
-      customRoutePath: renderWith.customRoutePath,
+      customRoutePath: renderWith?.customRoutePath,
       options,
     });
   }
-  if (renderWith.queryClient) {
+  if (renderWith?.queryClient) {
     return withQueryClient(ui, options);
   }
-  console.error("Option don't match, please check.");
+
+  return render(ui, options);
 }
 export { customRender };


### PR DESCRIPTION
Signed-off-by: Mathieu Anderson <mathieu.anderson@aiven.io>

# About this change - What it does

(for commit description)

- Make return values from `render` available from `customRender` (notably `rerender`)
- Remove `console.error` default case, return vanilla `render` instead
- Improve type safety of the `renderWith` argument to keep the functionality lost by removing `console.error`: it is now not optional (using `customRender` without custom behaviour is probably not a thing), and TS should complain about non-existing option.
![Screenshot 2023-01-18 at 17 40 59](https://user-images.githubusercontent.com/20607294/213242491-dd6806d9-8825-4292-8f0e-77ecaf652ee9.png)

# Why this way

https://github.com/aiven/klaw/pull/398 needs to call `rerender` to test some behaviour, and `customRender` did not allow to access the method.
