### PR TITLE
refactor(coral): Make css class names consistent

### DIFF
--- a/coral/README.md
+++ b/coral/README.md
@@ -109,6 +109,13 @@ Coral uses the component library of Aiven's Aquarium design system:
 
 As a rule, please don't use css classes from the design system. All styles should be created by using the existing components and their properties.
 
+### Custom styles
+When we need custom styles - which should not be the case very often - we use [css modules](https://github.com/css-modules/css-modules). This enables us to add scoped css rules. Class names should be written in camelCases. 
+
+#### 💁‍♀️ Special custom styles
+-  We use styles in [`accessibility.modules.css`](./src/app/accessibility.module.css) to add css rules in order to improve accessibility. Add these styles with caution, since they are globally available. 
+- In [`main.modules.css`](./src/app/main.module.css) are global styles that are needed as fundamentals.
+
 **🔄 Work in progress related to styles**
 
 - We plan to add css variables based on the design system's tokens.

--- a/coral/README.md
+++ b/coral/README.md
@@ -110,7 +110,7 @@ Coral uses the component library of Aiven's Aquarium design system:
 As a rule, please don't use css classes from the design system. All styles should be created by using the existing components and their properties.
 
 ### Custom styles
-When we need custom styles - which should not be the case very often - we use [css modules](https://github.com/css-modules/css-modules). This enables us to add scoped css rules. Class names should be written in camelCases. 
+When we need custom styles - which should not be the case very often - we use [css modules](https://github.com/css-modules/css-modules). This enables us to add scoped css rules. Class names should be written in camelCase. 
 
 #### 💁‍♀️ Special custom styles
 -  We use styles in [`accessibility.modules.css`](./src/app/accessibility.module.css) to add css rules in order to improve accessibility. Add these styles with caution, since they are globally available. 

--- a/coral/src/app/features/topics/browse/components/topic-table/TopicTable.module.css
+++ b/coral/src/app/features/topics/browse/components/topic-table/TopicTable.module.css
@@ -2,7 +2,7 @@
 /* changes color to be accessible contrast */
 /* changes font size and weight to be */
 /* distinguishable from table cells font */
-.topic-table-col-head {
+.topicTableColHead {
   color: black;
   font-size: 16px;
   font-weight: 500;
@@ -12,7 +12,7 @@
 /* th element outside of thead right now */
 /* usage of <th> manually works, but there are */
 /* no styles for it, so this class is temp needed */
-.topic-table-row-head {
+.topicTableRowHead {
   padding-left: 12px;
   padding-right: 12px;
   border-bottom-width: 1px;

--- a/coral/src/app/layout/main-navigation/MainNavigationLink.module.css
+++ b/coral/src/app/layout/main-navigation/MainNavigationLink.module.css
@@ -2,18 +2,18 @@
    defined and active styles is not meeting
    accessibility standards */
 
-.main-navigation-link a {
+.mainNavigationLink a {
   color: var(--body-text-color);
 }
 
-.main-navigation-link a:hover,
-.main-navigation-link:focus-within {
+.mainNavigationLink a:hover,
+.mainNavigationLink:focus-within {
   color: var(--main-navigation-hover);
 }
 
-.main-navigation-link-active a {
+.mainNavigationLinkActive a {
   color: var(--main-navigation-active);
 }
-.main-navigation-link-active {
+.mainNavigationLinkActive {
   background-color: white;
 }

--- a/coral/src/app/layout/main-navigation/MainNavigationSubmenuList.module.css
+++ b/coral/src/app/layout/main-navigation/MainNavigationSubmenuList.module.css
@@ -1,8 +1,8 @@
-.main-navigation-submenu-button {
+.mainNavigationSubmenuButton {
   margin-left: 7px;
 }
 /*temp class until we have a solution for that*/
-.main-navigation-submenu-button:hover,
-.main-navigation-submenu-button:focus-within {
+.mainNavigationSubmenuButton:hover,
+.mainNavigationSubmenuButton:focus-within {
   color: var(--main-navigation-hover);
 }

--- a/coral/src/app/layout/skip-link/SkipLink.module.css
+++ b/coral/src/app/layout/skip-link/SkipLink.module.css
@@ -2,7 +2,7 @@
 /*technology like screenreader and while navigating*/
 /*Klaw with the keyboard. */
 
-.skip-link {
+.skipLink {
   position: absolute;
   left: -10000px;
   top: auto;
@@ -11,11 +11,11 @@
   overflow: hidden;
 }
 
-.skip-link:hover {
+.skipLink:hover {
   cursor: default;
 }
 
-.skip-link:focus-visible {
+.skipLink:focus-visible {
   position: absolute;
   top: 0;
   left: calc(50% - 100px);


### PR DESCRIPTION
# About this change - What it does

- uses camelCase in all CSS module classes 
  - except in `accessibility.module.css` since it's a globally available class that is used as string
- add short section in README about use of module CSS

Resolves: #436

