### PR TITLE
Teamname optional in topic request

### DIFF
--- a/core/src/main/java/io/aiven/klaw/model/TopicRequestModel.java
+++ b/core/src/main/java/io/aiven/klaw/model/TopicRequestModel.java
@@ -28,10 +28,6 @@ public class TopicRequestModel implements Serializable {
   @Min(value = 1, message = "TopicPartitions must be greater than zero")
   private Integer topicpartitions;
 
-  @Pattern(
-      message = "Invalid Team name. Pattern [a-zA-z 0-9] (Spaces allowed)",
-      regexp = "^[a-zA-z 0-9]*$")
-  @NotNull
   private String teamname;
 
   @Pattern(message = "Invalid remarks", regexp = "^$|^[a-zA-Z 0-9_.,-]{3,}$")

--- a/core/src/main/resources/static/js/requestTopics.js
+++ b/core/src/main/resources/static/js/requestTopics.js
@@ -241,7 +241,6 @@ app.controller("requestTopicsCtrl", function($scope, $http, $location, $window) 
             serviceInput['topicname'] = $scope.addTopic.topicname;
             serviceInput['topicpartitions'] = tmpTopicPartitions;
             serviceInput['replicationfactor'] = tmpTopicRepFactor;
-            serviceInput['teamname'] = $scope.teamname;
             serviceInput['appname'] = "App";//$scope.addTopic.app;
             serviceInput['remarks'] = $scope.addTopic.remarks;
             serviceInput['description'] = $scope.addTopic.description;

--- a/core/src/test/java/io/aiven/klaw/TopicRequestValidatorImplIT.java
+++ b/core/src/test/java/io/aiven/klaw/TopicRequestValidatorImplIT.java
@@ -141,7 +141,7 @@ public class TopicRequestValidatorImplIT {
     when(commonUtilsService.getEnvsFromUserId(any())).thenReturn(Set.of("1"));
     when(commonUtilsService.getTenantId(any())).thenReturn(tenantId);
     when(topicControllerService.getTopicFromName(anyString(), anyInt())).thenReturn(List.of(topic));
-    when(commonUtilsService.verifyIfTeamExists(anyInt(), anyString())).thenReturn(true);
+    when(commonUtilsService.getTeamId(anyString())).thenReturn(101);
 
     Set<ConstraintViolation<TopicRequestModel>> violations = validator.validate(addTopicRequest);
     assertThat(violations).hasSize(1);
@@ -170,7 +170,6 @@ public class TopicRequestValidatorImplIT {
     when(topicControllerService.getSyncCluster(anyInt())).thenReturn("1");
     when(mailService.getEnvProperty(anyInt(), anyString())).thenReturn("1,2");
     when(topicControllerService.getEnvDetails(anyString())).thenReturn(env);
-    when(commonUtilsService.verifyIfTeamExists(anyInt(), anyString())).thenReturn(true);
 
     Set<ConstraintViolation<TopicRequestModel>> violations = validator.validate(addTopicRequest);
     assertThat(violations).hasSize(1);
@@ -204,7 +203,7 @@ public class TopicRequestValidatorImplIT {
     when(commonUtilsService.getEnvsFromUserId(any())).thenReturn(Set.of("1"));
     when(commonUtilsService.getTenantId(any())).thenReturn(tenantId);
     when(topicControllerService.getEnvDetails(anyString())).thenReturn(env);
-    when(commonUtilsService.verifyIfTeamExists(anyInt(), anyString())).thenReturn(true);
+    when(commonUtilsService.getTeamId(anyString())).thenReturn(101);
 
     Set<ConstraintViolation<TopicRequestModel>> violations = validator.validate(addTopicRequest);
     assertThat(violations).hasSize(1);
@@ -236,7 +235,7 @@ public class TopicRequestValidatorImplIT {
         .thenReturn(utilMethods.getEnvLists().get(0));
     when(topicControllerService.getExistingTopicRequests(addTopicRequest, tenantId))
         .thenReturn(List.of(topicRequest));
-    when(commonUtilsService.verifyIfTeamExists(anyInt(), anyString())).thenReturn(true);
+    when(commonUtilsService.getTeamId(anyString())).thenReturn(101);
 
     Set<ConstraintViolation<TopicRequestModel>> violations = validator.validate(addTopicRequest);
     assertThat(violations).hasSize(1);
@@ -263,7 +262,6 @@ public class TopicRequestValidatorImplIT {
     when(topicControllerService.getTopicFromName(anyString(), anyInt())).thenReturn(List.of(topic));
     when(topicControllerService.getExistingTopicRequests(any(), anyInt()))
         .thenReturn(Collections.emptyList());
-    when(commonUtilsService.verifyIfTeamExists(anyInt(), anyString())).thenReturn(true);
 
     Set<ConstraintViolation<TopicRequestModel>> violations = validator.validate(addTopicRequest);
     assertThat(violations).hasSize(1);

--- a/core/src/test/java/io/aiven/klaw/UtilMethods.java
+++ b/core/src/test/java/io/aiven/klaw/UtilMethods.java
@@ -348,8 +348,6 @@ public class UtilMethods {
   public TopicRequestModel getTopicRequestModel(int topicId) {
     TopicRequestModel topicRequest = new TopicRequestModel();
     topicRequest.setTopicid(topicId);
-    topicRequest.setTeamId(1001); // INFRATEAM
-    topicRequest.setTeamname("INFRATEAM");
     topicRequest.setUsername("kwusera");
     topicRequest.setTopicname("testtopic" + topicId);
     topicRequest.setTopicpartitions(2);


### PR DESCRIPTION
Signed-off-by: muralibasani <muralidahr.basani@aiven.io>

About this change - What it does

When submitting a new topic request, teamname is not required, as it can be retrieved from the user details of submitting request. 
So the field is made optional.

Even when apis are exposed, this should work, as teamname should be derived from logged in user.

Resolves: #xxxxx
Why this way

teamname is not required when submitting a request.

