### PR TITLE
fix(coral): Fix broken error message handling in some Form elements

### DIFF
--- a/coral/src/app/accessibility.module.css
+++ b/coral/src/app/accessibility.module.css
@@ -75,7 +75,8 @@ a:focus-visible {
 */
 
 :root input:focus-visible,
-:root select:focus-visible {
+:root select:focus-visible,
+:root textarea:focus-visible {
   outline: 1px solid var(--interactive-elements-focus) !important;
   outline-offset: 0 !important;
 }
@@ -85,9 +86,14 @@ a:focus-visible {
   outline-offset: 0 !important;
 }
 
+/*Applies styles to all label text*/
+:root label span {
+  /*represents body-small*/
+  font-size: 12px !important;
+}
+
+/*Applies color only to label text that is not in error state*/
 :root label span:not([class*="error"]) {
   /*represents grey-70 */
   color: #4a4b57 !important;
-  /*represents body-small*/
-  font-size: 12px !important;
 }

--- a/coral/src/app/components/Form.test.tsx
+++ b/coral/src/app/components/Form.test.tsx
@@ -541,9 +541,7 @@ describe("Form", () => {
 
   describe("<MultiInput>", () => {
     const schema = z.object({
-      cities: z.string().array().nonempty({
-        message: "Can't be empty!",
-      }),
+      cities: z.string().array().nonempty(),
     });
     type Schema = z.infer<typeof schema>;
 
@@ -584,26 +582,21 @@ describe("Form", () => {
       assertSubmitted({ cities: ["Berlin", "Helsinki"] });
     });
 
-    it("shows an error if user does not fill out required field", async () => {
+    it("shows an error if user does not fill out required field and wants to submit", async () => {
+      const errorMsgEmpty = "Required";
       const citiesInput = screen.getByRole<HTMLInputElement>("textbox");
 
-      await user.type(citiesInput, "Berlin");
-      expect(citiesInput.value).toBe("Berlin");
-      await userEvent.keyboard("{Enter}");
+      expect(screen.queryByText(errorMsgEmpty)).not.toBeInTheDocument();
+      expect(citiesInput).toBeValid();
 
-      await user.type(citiesInput, "Helsinki");
-      expect(citiesInput.value).toBe("Helsinki");
-      await user.keyboard("{Enter}");
-
-      const berlinPill = screen.getByText("Berlin");
-      const helsinkiPill = screen.getByText("Helsinki");
-      expect(berlinPill).toBeVisible();
-      expect(helsinkiPill).toBeVisible();
-      expect(screen.getByRole("button", { name: "Submit" })).toBeVisible();
-      expect(screen.getByRole("button", { name: "Submit" })).toBeEnabled();
+      await user.click(citiesInput);
+      await user.tab();
 
       await submit();
-      assertSubmitted({ cities: ["Berlin", "Helsinki"] });
+
+      await waitFor(() => expect(citiesInput).toBeInvalid());
+      expect(screen.getByText(errorMsgEmpty)).toBeVisible();
+      expect(onSubmit).not.toHaveBeenCalled();
     });
   });
 

--- a/coral/src/app/components/Form.tsx
+++ b/coral/src/app/components/Form.tsx
@@ -251,14 +251,35 @@ function _SubmitButton<T extends FieldValues>({
 //
 function _MultiInput<T extends FieldValues>({
   name,
+  helperText,
   formContext: form,
   ...props
 }: BaseMultiInputProps<T> & FormInputProps<T> & FormRegisterProps<T>) {
+  // Field level error (eg "Cannot be empty")
+  const error = parseFieldErrorMessage(form.formState, name);
+  // Single items level error (MultiInput returns an array of errors when single items fail validation)
+  const itemsErrors = parseFieldErrorsArray(form.formState, name);
+  const itemErrorsAccumulatedMessages = (itemsErrors || [])
+    .reduce(
+      (accumulatedErrorMessages: string[], currentItemError): string[] => {
+        if (
+          currentItemError.message === undefined ||
+          accumulatedErrorMessages.includes(currentItemError.message)
+        ) {
+          return accumulatedErrorMessages;
+        }
+        return [...accumulatedErrorMessages, currentItemError.message];
+      },
+      []
+    )
+    .join(", ");
+  const isValid = error === undefined && itemErrorsAccumulatedMessages === "";
+
   return (
     <_Controller
       name={name}
       control={form.control}
-      render={({ field: { value, name }, fieldState: { error } }) => {
+      render={({ field: { value, name } }) => {
         return (
           <BaseMultiInput
             {...props}
@@ -271,7 +292,22 @@ function _MultiInput<T extends FieldValues>({
                 shouldDirty: true,
               });
             }}
-            error={error?.message}
+            valid={isValid}
+            isItemValid={(_, index) => {
+              if (itemsErrors === undefined) {
+                return true;
+              }
+
+              const isCurrentItemValid = itemsErrors[index] === undefined;
+
+              return isCurrentItemValid;
+            }}
+            error={error}
+            helperText={
+              itemsErrors !== undefined
+                ? itemErrorsAccumulatedMessages
+                : helperText
+            }
           />
         );
       }}
@@ -421,6 +457,25 @@ export const SubmitButton = <T extends FieldValues>(
   const ctx = useFormContext<T>();
   return <SubmitButtonMemo formContext={ctx} {...props} />;
 };
+
+function parseFieldErrorsArray<T extends FieldValues>(
+  { errors }: FormState<T>,
+  name: keyof T
+): undefined | { index: number; message: string }[] {
+  if (name in errors) {
+    const fieldErrors = errors[name];
+
+    if (fieldErrors !== undefined && Array.isArray(fieldErrors)) {
+      return fieldErrors.map(
+        ({ index, message }): { index: number; message: string } => ({
+          index,
+          message,
+        })
+      );
+    }
+  }
+  return undefined;
+}
 
 function parseFieldErrorMessage<T extends FieldValues>(
   { errors }: FormState<T>,

--- a/coral/src/app/components/Form.tsx
+++ b/coral/src/app/components/Form.tsx
@@ -304,6 +304,7 @@ function _NativeSelect<T extends FieldValues>({
 }: BaseNativeSelectProps & FormInputProps<T> & FormRegisterProps<T>) {
   const { isSubmitting } = form.formState;
   const error = parseFieldErrorMessage(form.formState, name);
+
   return (
     <BaseNativeSelect
       {...props}
@@ -426,7 +427,7 @@ function parseFieldErrorMessage<T extends FieldValues>(
   name: keyof T
 ): undefined | string {
   if (name in errors) {
-    const fieldError = errors.name;
+    const fieldError = errors[name];
     if (fieldError !== undefined) {
       if (typeof fieldError.message === "string") {
         return fieldError.message;

--- a/coral/src/app/components/__snapshots__/Form.test.tsx.snap
+++ b/coral/src/app/components/__snapshots__/Form.test.tsx.snap
@@ -8,8 +8,8 @@ exports[`Form <PasswordInput> should render <PasswordInput> 1`] = `
     >
       <label
         class="w-full"
-        for="input-613"
-        id="input-613-label"
+        for="input-1135"
+        id="input-1135-label"
       >
         <span
           class="inline-block mb-2 font-medium typography-body-small text-grey-60"
@@ -21,7 +21,7 @@ exports[`Form <PasswordInput> should render <PasswordInput> 1`] = `
         >
           <input
             class="block w-full rounded-sm disabled:cursor-not-allowed disabled:border-grey-20 disabled:bg-grey-5 typography-body-small text-grey-70 disabled:text-grey-40 placeholder:text-grey-40 focus:outline-none px-3 py-3 border border-grey-20 hover:border-grey-50 focus:border-info-70"
-            id="input-613"
+            id="input-1135"
             name="password"
             type="password"
           />

--- a/coral/src/app/components/__snapshots__/Form.test.tsx.snap
+++ b/coral/src/app/components/__snapshots__/Form.test.tsx.snap
@@ -8,8 +8,8 @@ exports[`Form <PasswordInput> should render <PasswordInput> 1`] = `
     >
       <label
         class="w-full"
-        for="input-1127"
-        id="input-1127-label"
+        for="input-613"
+        id="input-613-label"
       >
         <span
           class="inline-block mb-2 font-medium typography-body-small text-grey-60"
@@ -21,7 +21,7 @@ exports[`Form <PasswordInput> should render <PasswordInput> 1`] = `
         >
           <input
             class="block w-full rounded-sm disabled:cursor-not-allowed disabled:border-grey-20 disabled:bg-grey-5 typography-body-small text-grey-70 disabled:text-grey-40 placeholder:text-grey-40 focus:outline-none px-3 py-3 border border-grey-20 hover:border-grey-50 focus:border-info-70"
-            id="input-1127"
+            id="input-613"
             name="password"
             type="password"
           />
@@ -64,7 +64,7 @@ exports[`Form <TextInput> should render <TextInput> 1`] = `
           <input
             class="block w-full rounded-sm disabled:cursor-not-allowed disabled:border-grey-20 disabled:bg-grey-5 typography-body-small text-grey-70 disabled:text-grey-40 placeholder:text-grey-40 focus:outline-none px-3 py-3 border border-grey-20 hover:border-grey-50 focus:border-info-70"
             id="input-13"
-            name="name"
+            name="formFieldsCustomName"
             type="text"
           />
         </span>


### PR DESCRIPTION
# Detailed bug report

https://github.com/aiven/klaw/issues/448

## This change
- updates the `formSchema` objects used in tests. They mostly used `name="name"`, this covered a bug in error handling. 
- update `parseFieldErrorMessage` in `Form` to use `errors[name]` (e.g. errors[myFieldName]`) instead of `errors.name`
- remove usage of `const error = get(errors, name)?.message as string;` that now is not needed anymore
- updated `MultiInput` in `Form` to show error messages in some cases: 
    -  error is shown and field marked as invalid when user wants to submit an empty MultiInput that is required 
    - error is shown when user adds something to MultiInput that may not be valid and tabs out
    - error is shown (for an required MI) when user adds something and removes it again 
    

## Screenshots for this implementation

<img width="547" alt="Screenshot 2023-01-19 at 15 56 19" src="https://user-images.githubusercontent.com/943800/213482190-37325d98-d823-4abe-a2d1-25ea61ac0ebd.png">


Resolves: #448

