### PR TITLE
feature(coral): implement topic request with mocks

### DIFF
--- a/coral/src/app/features/topics/request/TopicRequest.test.tsx
+++ b/coral/src/app/features/topics/request/TopicRequest.test.tsx
@@ -312,7 +312,7 @@ describe("<TopicRequest />", () => {
           await user.selectOptions(environmentSelect, "PROD");
 
           const replicationFactorSelect = screen.getByRole("combobox", {
-            name: "Replication factor",
+            name: "Replication factor *",
           });
           expect(replicationFactorSelect).toBeEnabled();
         });
@@ -324,7 +324,7 @@ describe("<TopicRequest />", () => {
           await user.selectOptions(environmentSelect, "DEV");
 
           const inputReplicationFactor = screen.getByRole("spinbutton", {
-            name: "Replication factor",
+            name: "Replication factor *",
           });
           expect(inputReplicationFactor).toBeEnabled();
         });
@@ -382,7 +382,7 @@ describe("<TopicRequest />", () => {
           name: "Environment",
         });
         const inputReplicationFactor = await screen.findByLabelText(
-          "Replication factor"
+          "Replication factor*"
         );
 
         expect(inputReplicationFactor).toHaveDisplayValue("");
@@ -401,7 +401,7 @@ describe("<TopicRequest />", () => {
         const inputReplicationFactorInput = await screen.findByRole(
           "spinbutton",
           {
-            name: "Replication factor",
+            name: "Replication factor *",
           }
         );
 
@@ -416,7 +416,7 @@ describe("<TopicRequest />", () => {
         const inputReplicationFactorSelect = await screen.findByRole(
           "combobox",
           {
-            name: "Replication factor",
+            name: "Replication factor *",
           }
         );
 
@@ -430,7 +430,7 @@ describe("<TopicRequest />", () => {
         await user.selectOptions(selectEnvironment, "PROD");
 
         const replicationFactorSelect = screen.getByRole("combobox", {
-          name: "Replication factor",
+          name: "Replication factor *",
         });
 
         await user.selectOptions(replicationFactorSelect, "4");
@@ -440,7 +440,7 @@ describe("<TopicRequest />", () => {
         expect(replicationFactorSelect).not.toBeInTheDocument();
 
         const replicationFactorInput = screen.getByRole("spinbutton", {
-          name: "Replication factor",
+          name: "Replication factor *",
         });
         expect(replicationFactorInput).toHaveDisplayValue("4");
       });
@@ -498,7 +498,7 @@ describe("<TopicRequest />", () => {
         await user.selectOptions(selectEnvironment, "PROD");
 
         const topicPartitionSelect = screen.getByRole("combobox", {
-          name: "Topic partitions",
+          name: "Topic partitions *",
         });
         expect(topicPartitionSelect).toBeEnabled();
       });
@@ -510,7 +510,7 @@ describe("<TopicRequest />", () => {
         await user.selectOptions(selectEnvironment, "DEV");
 
         const topicPartitionInput = screen.getByRole("spinbutton", {
-          name: "Topic partitions",
+          name: "Topic partitions *",
         });
         expect(topicPartitionInput).toBeEnabled();
       });
@@ -567,7 +567,7 @@ describe("<TopicRequest />", () => {
       await user.selectOptions(selectEnvironment, "WITH_DEFAULT_PARTITIONS");
 
       const topicPartitionsInput = screen.getByRole("spinbutton", {
-        name: "Topic partitions",
+        name: "Topic partitions *",
       });
       expect(topicPartitionsInput).toHaveDisplayValue("4");
     });
@@ -579,7 +579,7 @@ describe("<TopicRequest />", () => {
       await user.selectOptions(selectEnvironment, "DEV");
 
       const topicPartitionsInput = screen.getByRole("spinbutton", {
-        name: "Topic partitions",
+        name: "Topic partitions *",
       });
       expect(topicPartitionsInput).toHaveDisplayValue("2");
 
@@ -592,7 +592,7 @@ describe("<TopicRequest />", () => {
       expect(topicPartitionsInput).not.toBeInTheDocument();
 
       const topicPartitionsSelect = screen.getByRole("combobox", {
-        name: "Topic partitions",
+        name: "Topic partitions *",
       });
       expect(topicPartitionsSelect).toHaveDisplayValue("8");
     });
@@ -604,7 +604,7 @@ describe("<TopicRequest />", () => {
       await user.selectOptions(selectEnvironment, "PROD");
 
       const topicPartitionsSelect = screen.getByRole("combobox", {
-        name: "Topic partitions",
+        name: "Topic partitions *",
       });
 
       await user.selectOptions(topicPartitionsSelect, "16");

--- a/coral/src/app/features/topics/request/TopicRequest.tsx
+++ b/coral/src/app/features/topics/request/TopicRequest.tsx
@@ -153,6 +153,7 @@ function TopicRequest() {
                 name="description"
                 labelText="Description"
                 rows={5}
+                required={true}
               />
             </Box>
             <Box component={FlexboxItem} grow={1} width={"1/2"}>

--- a/coral/src/app/features/topics/request/TopicRequest.tsx
+++ b/coral/src/app/features/topics/request/TopicRequest.tsx
@@ -125,6 +125,7 @@ function TopicRequest() {
                 name={"topicpartitions"}
                 label={"Topic partitions"}
                 max={selectedEnvironment?.maxPartitions}
+                required={true}
               />
             </Box>
             <Box component={FlexboxItem} grow={1} width={"1/2"}>
@@ -132,6 +133,7 @@ function TopicRequest() {
                 name={"replicationfactor"}
                 label={"Replication factor"}
                 max={selectedEnvironment?.maxReplicationFactor}
+                required={true}
               />
             </Box>
           </Box>

--- a/coral/src/app/features/topics/request/TopicRequest.tsx
+++ b/coral/src/app/features/topics/request/TopicRequest.tsx
@@ -1,7 +1,7 @@
 import { useEffect } from "react";
 import { useMutation, useQuery } from "@tanstack/react-query";
 import { FieldErrorsImpl, SubmitHandler } from "react-hook-form";
-import { Box, Divider, Flexbox, FlexboxItem } from "@aivenio/aquarium";
+import { Alert, Box, Divider, Flexbox, FlexboxItem } from "@aivenio/aquarium";
 import {
   Form,
   SubmitButton,
@@ -21,6 +21,11 @@ import { mockGetEnvironmentsForTeam } from "src/domain/environment/environment-a
 import { Environment } from "src/domain/environment";
 import { getEnvironmentsForTeam } from "src/domain/environment/environment-api";
 import AdvancedConfiguration from "src/app/features/topics/request/components/AdvancedConfiguration";
+import { requestTopic } from "src/domain/topic/topic-api";
+import { mockRequestTopic } from "src/domain/topic/topic-api.msw";
+import { Navigate } from "react-router-dom";
+import { parseErrorMsg } from "src/services/mutation-utils";
+import { createTopicRequestPayload } from "src/app/features/topics/request/utils";
 
 const mockedData = [
   createMockEnvironmentDTO({
@@ -53,10 +58,25 @@ const mockedData = [
 
 function TopicRequest() {
   useEffect(() => {
+    // Remove these mock alltogether when we are happy with the functionality.
+    // With mocks it is easier to demonstrate the behaviour without requesting
+    // dummy topics.
     if (window.msw !== undefined) {
       mockGetEnvironmentsForTeam({
         mswInstance: window.msw,
         response: { data: mockedData },
+      });
+
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
+      const creationOK = { data: { data: { status: "200 OK" } }, status: 200 };
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
+      const creationFailed = {
+        data: { message: "Topic with such name already exists!" },
+        status: 400,
+      };
+      mockRequestTopic({
+        mswInstance: window.msw,
+        response: creationOK,
       });
     }
   }, []);
@@ -81,19 +101,31 @@ function TopicRequest() {
     defaultValues,
   });
 
-  const { mutate } = useMutation(() => Promise.resolve());
-  const onSubmit: SubmitHandler<Schema> = (data) => {
-    console.log(data);
-    mutate();
-  };
+  const { mutate, isLoading, isSuccess, isError, error } =
+    useMutation(requestTopic);
+  const onSubmit: SubmitHandler<Schema> = (data) =>
+    mutate(createTopicRequestPayload(data));
 
   const [selectedEnvironment] = form.getValues(["environment"]);
   useExtendedFormValidationAndTriggers(form, {
     isInitialized: defaultValues !== undefined,
   });
 
+  if (isSuccess) {
+    const params = new URLSearchParams({
+      reqsType: "created",
+      topicCreated: "true",
+    });
+    return <Navigate to={`myTopicRequests?${params.toString()}`} />;
+  }
+
   return (
     <Box style={{ maxWidth: 1200 }}>
+      {isError && (
+        <Box marginBottom={"l1"} role="alert">
+          <Alert description={parseErrorMsg(error)} type="warning"></Alert>
+        </Box>
+      )}
       <Form {...form} onSubmit={onSubmit} onError={onError}>
         <Box width={"full"}>
           {Array.isArray(environments) ? (
@@ -169,7 +201,7 @@ function TopicRequest() {
           </Box>
         </Box>
 
-        <SubmitButton>Request topic</SubmitButton>
+        <SubmitButton loading={isLoading}>Request topic</SubmitButton>
       </Form>
     </Box>
   );

--- a/coral/src/app/features/topics/request/components/SelectOrNumberInput.tsx
+++ b/coral/src/app/features/topics/request/components/SelectOrNumberInput.tsx
@@ -6,11 +6,12 @@ type Props = {
   label: string;
   name: "topicpartitions" | "replicationfactor";
   max?: number;
+  required: boolean;
 };
-const SelectOrNumberInput = ({ name, label, max }: Props) => {
+const SelectOrNumberInput = ({ name, label, max, required = false }: Props) => {
   if (isNumber(max)) {
     return (
-      <NativeSelect<Schema> name={name} labelText={label}>
+      <NativeSelect<Schema> name={name} labelText={label} required={required}>
         {[...Array(max).keys()]
           .map((i) => i + 1)
           .map((i) => (
@@ -22,7 +23,13 @@ const SelectOrNumberInput = ({ name, label, max }: Props) => {
     );
   } else {
     return (
-      <NumberInput<Schema> name={name} labelText={label} min={1} max={max} />
+      <NumberInput<Schema>
+        name={name}
+        labelText={label}
+        min={1}
+        max={max}
+        required={required}
+      />
     );
   }
 };

--- a/coral/src/app/features/topics/request/schemas/topic-request-form.ts
+++ b/coral/src/app/features/topics/request/schemas/topic-request-form.ts
@@ -33,7 +33,7 @@ const formSchema = z
     topicname: topicNameField,
     advancedConfiguration: advancedConfigurationField,
     remarks: z.string(),
-    description: z.string(),
+    description: z.string().min(1),
   })
   .superRefine(validateTopicPartitions)
   .superRefine(validateReplicationFactor)

--- a/coral/src/app/features/topics/request/utils.test.ts
+++ b/coral/src/app/features/topics/request/utils.test.ts
@@ -1,0 +1,105 @@
+import {
+  createTopicRequestPayload,
+  transformAdvancedConfigEntries,
+} from "src/app/features/topics/request/utils";
+
+describe("TopicRequest utils", () => {
+  describe("createTopicRequestPayload", () => {
+    it("returns expected payload", () => {
+      const formData = {
+        environment: {
+          id: "1",
+          name: "DEV",
+          defaultPartitions: 2,
+          maxPartitions: 6,
+          defaultReplicationFactor: 3,
+          maxReplicationFactor: 3,
+        },
+        remarks: "please approve this topic asap",
+        replicationfactor: "2",
+        topicpartitions: "3",
+        topicname: "example-topic-name",
+        description: "example description",
+        advancedConfiguration: "{}",
+      };
+      const res = createTopicRequestPayload(formData);
+
+      expect(res).toEqual({
+        environment: "1",
+        topicname: "example-topic-name",
+        replicationfactor: "2",
+        topicpartitions: 3,
+        advancedTopicConfigEntries: [],
+        description: "example description",
+        remarks: "please approve this topic asap",
+        topictype: "Create",
+      });
+    });
+  });
+  describe("transformAdvancedConfigEntries", () => {
+    it("transforms empty object into empty array", () => {
+      const res = transformAdvancedConfigEntries("{}");
+      expect(res).toEqual([]);
+    });
+
+    it.each([
+      {
+        configType: "string",
+        configValue: "delete",
+        expectedValue: "delete",
+      },
+      {
+        configType: "number",
+        configValue: 200,
+        expectedValue: "200",
+      },
+      {
+        configType: "boolean",
+        configValue: true,
+        expectedValue: "true",
+      },
+    ])(
+      "coerces item with type $configType into string",
+      ({ configValue, expectedValue }) => {
+        const res = transformAdvancedConfigEntries(
+          JSON.stringify({
+            "test.key": configValue,
+          })
+        );
+        expect(res.find((c) => c.configKey === "test.key")?.configValue).toBe(
+          expectedValue
+        );
+      }
+    );
+
+    it.each([
+      {
+        configKey: "cleanup.policy",
+        configType: "null",
+        configValue: null,
+      },
+      {
+        configKey: "cleanup.policy",
+        configType: "undefined",
+        configValue: undefined,
+      },
+      {
+        configKey: "cleanup.policy",
+        configType: "object",
+        configValue: { foo: "bar" },
+      },
+      {
+        configKey: "cleanup.policy",
+        configType: "array",
+        configValue: ["1"],
+      },
+    ])("drops items with type $configType", ({ configValue }) => {
+      const res = transformAdvancedConfigEntries(
+        JSON.stringify({
+          "test.key": configValue,
+        })
+      );
+      expect(res.find((c) => c.configKey === "test.key")).toBe(undefined);
+    });
+  });
+});

--- a/coral/src/app/features/topics/request/utils.ts
+++ b/coral/src/app/features/topics/request/utils.ts
@@ -1,0 +1,52 @@
+import isString from "lodash/isString";
+import { KlawApiRequest } from "types/utils";
+import { Schema } from "src/app/features/topics/request/schemas/topic-request-form";
+
+function createTopicRequestPayload(
+  formData: Schema
+): KlawApiRequest<"topicCreate"> {
+  return {
+    description: formData.description,
+    environment: formData.environment.id,
+    remarks: formData.remarks,
+    topicname: formData.topicname,
+    replicationfactor: formData.replicationfactor,
+    topicpartitions: parseInt(formData.topicpartitions, 10),
+    advancedTopicConfigEntries: transformAdvancedConfigEntries(
+      formData.advancedConfiguration
+    ),
+    topictype: "Create" as const,
+  };
+}
+function coerceToString(value: unknown): string | undefined {
+  switch (typeof value) {
+    case "string":
+      return value;
+    case "boolean":
+    case "number":
+      return value.toString();
+    default:
+      return undefined;
+  }
+}
+
+function transformAdvancedConfigEntries(
+  formData: string | undefined
+): { configKey: string; configValue: string }[] {
+  if (formData === undefined) {
+    return [];
+  }
+  // Add some try catches, but monaco should take care of this
+  const asObject = JSON.parse(formData);
+  return Object.entries(asObject)
+    .map(([key, value]) => ({ configKey: key, configValue: value }))
+    .reduce((acc, { configKey, configValue }) => {
+      const valueAsString = coerceToString(configValue);
+      if (isString(valueAsString)) {
+        return acc.concat([{ configKey, configValue: valueAsString }]);
+      }
+      return acc;
+    }, [] as { configKey: string; configValue: string }[]);
+}
+
+export { transformAdvancedConfigEntries, createTopicRequestPayload };

--- a/coral/src/domain/topic/topic-api.msw.ts
+++ b/coral/src/domain/topic/topic-api.msw.ts
@@ -63,6 +63,24 @@ function mockgetTopicAdvancedConfigOptions({
   );
 }
 
+function mockRequestTopic({
+  mswInstance,
+  response,
+}: {
+  mswInstance: MswInstance;
+  response: {
+    status?: number;
+    data: KlawApiResponse<"topicCreate"> | { message: string };
+  };
+}) {
+  const url = `${getHTTPBaseAPIUrl()}/createTopics`;
+  mswInstance.use(
+    rest.post(url, async (req, res, ctx) => {
+      return res(ctx.status(response.status ?? 200), ctx.json(response.data));
+    })
+  );
+}
+
 const defaultgetTopicAdvancedConfigOptionsResponse = {
   CLEANUP_POLICY: "cleanup.policy",
   COMPRESSION_TYPE: "compression.type",
@@ -139,6 +157,7 @@ const mockedResponseTransformed = transformTopicApiResponse(
 export {
   mockTopicGetRequest,
   mockgetTopicAdvancedConfigOptions,
+  mockRequestTopic,
   mockedResponseTransformed,
   mockedResponseMultiplePageTransformed,
   mockedResponseSinglePage,

--- a/coral/src/domain/topic/topic-api.test.ts
+++ b/coral/src/domain/topic/topic-api.test.ts
@@ -1,0 +1,43 @@
+import { requestTopic } from "src/domain/topic/topic-api";
+import { server } from "src/services/api-mocks/server";
+import api from "src/services/api";
+import { mockRequestTopic } from "src/domain/topic/topic-api.msw";
+
+describe("topic-api", () => {
+  beforeAll(() => {
+    server.listen();
+  });
+
+  afterAll(() => {
+    server.close();
+  });
+
+  describe("requestTopic", () => {
+    beforeEach(() => {
+      mockRequestTopic({
+        mswInstance: server,
+        response: {
+          data: {
+            status: "200 OK",
+          },
+        },
+      });
+    });
+    it("calls api.post with correct payload", () => {
+      const postSpy = jest.spyOn(api, "post");
+      const payload = {
+        environment: "DEV",
+        topicname: "topic-for-unittest",
+        topicpartitions: 1,
+        replicationfactor: "1",
+        advancedTopicConfigEntries: [],
+        description: "this-is-description",
+        remarks: "",
+        topictype: "Create" as const,
+      };
+      requestTopic(payload);
+      expect(postSpy).toHaveBeenCalledTimes(1);
+      expect(postSpy).toHaveBeenCalledWith("/createTopics", payload);
+    });
+  });
+});

--- a/coral/src/domain/topic/topic-api.ts
+++ b/coral/src/domain/topic/topic-api.ts
@@ -10,7 +10,7 @@ import {
   TopicApiResponse,
 } from "src/domain/topic/topic-types";
 import api from "src/services/api";
-import { KlawApiResponse } from "types/utils";
+import { KlawApiRequest, KlawApiResponse } from "types/utils";
 
 const getTopics = async ({
   currentPage = 1,
@@ -79,9 +79,19 @@ const getTopicAdvancedConfigOptions = (): Promise<
     .get<KlawApiResponse<"topicAdvancedConfigGet">>("/getAdvancedTopicConfigs")
     .then(transformgetTopicAdvancedConfigOptionsResponse);
 
+const requestTopic = (
+  payload: KlawApiRequest<"topicCreate">
+): Promise<unknown> => {
+  return api.post<
+    KlawApiResponse<"topicCreate">,
+    KlawApiRequest<"topicCreate">
+  >("/createTopics", payload);
+};
+
 export {
   getTopics,
   getTopicNames,
   getTopicTeam,
   getTopicAdvancedConfigOptions,
+  requestTopic,
 };

--- a/coral/src/services/mutation-utils.ts
+++ b/coral/src/services/mutation-utils.ts
@@ -1,0 +1,29 @@
+import isString from "lodash/isString";
+
+function objectHasProperty<T extends string>(
+  object: unknown,
+  key: T
+): object is Record<T, unknown> {
+  if (
+    object !== null &&
+    object !== undefined &&
+    Object.prototype.hasOwnProperty.call(object, key)
+  ) {
+    return true;
+  }
+  return false;
+}
+
+function parseErrorMsg(error: unknown): string {
+  if (
+    objectHasProperty(error, "data") &&
+    objectHasProperty(error.data, "message")
+  ) {
+    if (isString(error.data.message)) {
+      return error.data.message;
+    }
+  }
+  return "Unexpected error";
+}
+
+export { parseErrorMsg };

--- a/coral/types/api.d.ts
+++ b/coral/types/api.d.ts
@@ -471,7 +471,7 @@ export type components = {
        * Team name
        * @example Marketing
        */
-      teamname: string;
+      teamname?: string;
       /**
        * Remarks
        * @description Message for the approval

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -769,7 +769,6 @@ components:
           description,
           environment,
           replicationfactor,
-          teamname,
           topicname,
           topicpartitions,
         ]


### PR DESCRIPTION
This PR demonstrates how to change state on server. This PR still includes MSW API mocks as the overall functionality is easier to verify. After this PR is merged, we can have a final acceptance testing @muralibasani against the real API.