### PR TITLE
fix(coral): bundle monaco editor together with rest of vendor

### DIFF
--- a/coral/vite.config.ts
+++ b/coral/vite.config.ts
@@ -160,9 +160,6 @@ export default defineConfig(({ mode }) => {
         output: {
           manualChunks: (id: string) => {
             if (id.includes("node_modules")) {
-              if (id.includes("monaco-editor")) {
-                return "monaco-editor";
-              }
               return "vendor";
             }
           },


### PR DESCRIPTION
When the build was run with 'NODE_ENV=production' it resulted in an require error. The monaco editor bundle has a requirement to JSX as the monaco editor we have in the project already has bindings to React.

Signed-off-by: Samuli Suortti <smulis@aiven.io>