### PR TITLE
chore: add postgres dependency

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -134,6 +134,10 @@
             <artifactId>spring-security-test</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.postgresql</groupId>
+            <artifactId>postgresql</artifactId>
+        </dependency>
     </dependencies>
 
     <build>


### PR DESCRIPTION
Signed-off-by: Callaert Anthony <callaertanthony@gmail.com>

Starting `klaw-core` with postgresql as database throws an error.

Configuration:
```
spring.datasource.url=jdbc:postgresql://localhost:5432/klaw?cachePrepStmts=true&useServerPrepStmts=true&rewriteBatchedStatements=true
spring.datasource.username=kafkauser
spring.datasource.password=klaw
spring.datasource.driver.class=org.postgresql.Driver
spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.PostgreSQL92Dialect
```
```
Caused by: java.lang.RuntimeException: Failed to load driver class org.postgresql.Driver in either of HikariConfig class loader or Thread context classloader
```

This is because the postgresql dependancy is not present and driver cannot be loaded.

It's possible to add few test to ensure no regression in the futur. The easiest way is to add `testcontainer` as dependency and test that the application starts.
I didn't do it yet because I didn't see any test for mysql and it will add docker as requirement for testing.

