### PR TITLE
refactor(coral) Add "start" as alias for "pnpm dev".

### DIFF
--- a/coral/package.json
+++ b/coral/package.json
@@ -12,6 +12,7 @@
   "scripts": {
     "build": "tsc && vite build",
     "dev": "vite --mode remote-api",
+    "start": "pnpm dev",
     "dev-without-api": "vite",
     "lint": "prettier --check src && eslint .",
     "lint-staged": "lint-staged",


### PR DESCRIPTION
# About this change - What it does

`start` is (besides `dev`) a pretty common script for running development env. By adding the alias we can prevent people from running the familiar but wrong script and getting confused before checking our package.json 

(Me 😳 I am these "people")
