### PR TITLE
Fallback to Global Schema when Subject not set

### DIFF
--- a/cluster-api/src/main/java/io/aiven/klaw/clusterapi/services/SchemaService.java
+++ b/cluster-api/src/main/java/io/aiven/klaw/clusterapi/services/SchemaService.java
@@ -73,14 +73,17 @@ public class SchemaService {
             "RegisterSchema - original Schema Compatibility {} for Topic {}",
             schemaCompatibility,
             clusterSchemaRequest.getTopicName());
-        setSchemaCompatibility(
-            clusterSchemaRequest.getEnv(),
-            clusterSchemaRequest.getTopicName(),
-            clusterSchemaRequest.isForceRegister(),
-            clusterSchemaRequest.getProtocol(),
-            clusterSchemaRequest.getClusterIdentification(),
-            null,
-            schemaCompatibility.getLeft().equals(SUBJECT));
+        // only reset if we have the previous schema to revert to.
+        if (schemaCompatibilityCompleted) {
+          setSchemaCompatibility(
+              clusterSchemaRequest.getEnv(),
+              clusterSchemaRequest.getTopicName(),
+              clusterSchemaRequest.isForceRegister(),
+              clusterSchemaRequest.getProtocol(),
+              clusterSchemaRequest.getClusterIdentification(),
+              null,
+              schemaCompatibility.getLeft().equals(SUBJECT));
+        }
       }
       String suffixUrl =
           clusterSchemaRequest.getEnv()
@@ -348,7 +351,7 @@ public class SchemaService {
       log.info("Current Schema Compatibility set to {}", schemaCompatibility);
       return true;
     } else {
-      throw new Exception("Unable to retrieve the current Schema Compatibility setting.");
+      return false;
     }
   }
 

--- a/cluster-api/src/main/java/io/aiven/klaw/clusterapi/services/SchemaService.java
+++ b/cluster-api/src/main/java/io/aiven/klaw/clusterapi/services/SchemaService.java
@@ -162,7 +162,7 @@ public class SchemaService {
               clusterApiUtils.getRequestDetails(suffixUrl, protocol);
 
           Map<String, String> params = new HashMap<>();
-          HttpEntity<Object> request = createSchmeaRegistryRequest(clusterIdentification);
+          HttpEntity<Object> request = createSchemaRegistryRequest(clusterIdentification);
 
           ResponseEntity<Map<String, Object>> responseNew =
               reqDetails
@@ -202,7 +202,7 @@ public class SchemaService {
           clusterApiUtils.getRequestDetails(suffixUrl, protocol);
 
       Map<String, String> params = new HashMap<>();
-      HttpEntity<Object> request = createSchmeaRegistryRequest(clusterIdentification);
+      HttpEntity<Object> request = createSchemaRegistryRequest(clusterIdentification);
 
       ResponseEntity<List<Integer>> responseList =
           reqDetails
@@ -237,8 +237,8 @@ public class SchemaService {
           clusterApiUtils.getRequestDetails(suffixUrl, protocol);
 
       ResponseEntity<Map<String, String>> responseList =
-          getSubjectSchemaCompatibility(
-              reqDetails, new HashMap<>(), createSchmeaRegistryRequest(clusterIdentification));
+          getSubjectSchemaCompatibilityRequest(
+              reqDetails, new HashMap<>(), createSchemaRegistryRequest(clusterIdentification));
       log.info("Schema compatibility " + responseList);
       return responseList.getBody().get("compatibilityLevel");
     } catch (Exception e) {
@@ -247,14 +247,14 @@ public class SchemaService {
     }
   }
 
-  private HttpEntity<Object> createSchmeaRegistryRequest(String clusterIdentification) {
+  private HttpEntity<Object> createSchemaRegistryRequest(String clusterIdentification) {
     HttpHeaders headers =
         clusterApiUtils.createHeaders(clusterIdentification, KafkaClustersType.SCHEMA_REGISTRY);
     HttpEntity<Object> request = new HttpEntity<>(headers);
     return request;
   }
 
-  private static ResponseEntity<Map<String, String>> getSubjectSchemaCompatibility(
+  private static ResponseEntity<Map<String, String>> getSubjectSchemaCompatibilityRequest(
       Pair<String, RestTemplate> reqDetails,
       Map<String, String> params,
       HttpEntity<Object> request) {
@@ -325,7 +325,7 @@ public class SchemaService {
     String suffixUrl = environmentVal + "/subjects";
     Pair<String, RestTemplate> reqDetails = clusterApiUtils.getRequestDetails(suffixUrl, protocol);
 
-    HttpEntity<Object> request = createSchmeaRegistryRequest(clusterIdentification);
+    HttpEntity<Object> request = createSchemaRegistryRequest(clusterIdentification);
 
     try {
       reqDetails

--- a/cluster-api/src/main/java/io/aiven/klaw/clusterapi/services/SchemaService.java
+++ b/cluster-api/src/main/java/io/aiven/klaw/clusterapi/services/SchemaService.java
@@ -40,8 +40,6 @@ public class SchemaService {
   public static final String SCHEMA_REGISTRY_CONTENT_TYPE =
       "application/vnd.schemaregistry.v1+json";
   public static final String SCHEMA_COMPATIBILITY_NOT_SET = "NOT SET";
-  public static final String SUBJECT = "Subject";
-  public static final String GLOBAL = "Global";
 
   @Value("${klaw.schemaregistry.compatibility.default:BACKWARD}")
   private String defaultSchemaCompatibility;

--- a/cluster-api/src/test/java/io/aiven/klaw/clusterapi/services/SchemaServiceRegisterSchemaTest.java
+++ b/cluster-api/src/test/java/io/aiven/klaw/clusterapi/services/SchemaServiceRegisterSchemaTest.java
@@ -371,7 +371,7 @@ class SchemaServiceRegisterSchemaTest {
     when(restTemplate.postForEntity(anyString(), any(HttpEntity.class), eq(String.class)))
         .thenReturn(createSchemaRegisterResponseEntity(HttpStatus.OK));
 
-    String globalCompatibility = "BACKWARD";
+
     when(restTemplate.exchange(
             eq(REGISTRY_URL),
             any(HttpMethod.class),

--- a/cluster-api/src/test/java/io/aiven/klaw/clusterapi/services/SchemaServiceRegisterSchemaTest.java
+++ b/cluster-api/src/test/java/io/aiven/klaw/clusterapi/services/SchemaServiceRegisterSchemaTest.java
@@ -371,7 +371,6 @@ class SchemaServiceRegisterSchemaTest {
     when(restTemplate.postForEntity(anyString(), any(HttpEntity.class), eq(String.class)))
         .thenReturn(createSchemaRegisterResponseEntity(HttpStatus.OK));
 
-
     when(restTemplate.exchange(
             eq(REGISTRY_URL),
             any(HttpMethod.class),

--- a/cluster-api/src/test/java/io/aiven/klaw/clusterapi/services/SchemaServiceRegisterSchemaTest.java
+++ b/cluster-api/src/test/java/io/aiven/klaw/clusterapi/services/SchemaServiceRegisterSchemaTest.java
@@ -299,8 +299,8 @@ class SchemaServiceRegisterSchemaTest {
     schemaService.registerSchema(schemaReq);
     // change schema compatibility never called as exception occurs.
     verify(restTemplate, times(0)).put(any(), schemaCompatibility.capture(), eq(String.class));
-    // 1 call to get the current SchemaCompatibility 1 call to get global
-    verify(restTemplate, times(2))
+    // 1 call to get the current SchemaCompatibility
+    verify(restTemplate, times(1))
         .exchange(
             eq(REGISTRY_URL),
             any(HttpMethod.class),
@@ -352,7 +352,7 @@ class SchemaServiceRegisterSchemaTest {
   @Test
   @Order(9)
   public void
-      givenSchemaWithForceRegisterEnabled_NotFoundFallBackToGlobalSchemaSettingReturnedAndResetSchemaCompatability() {
+      givenSchemaWithForceRegisterEnabled_NotFoundFallBackToGlobalSchemaSettingReturnedNoResetSchemaCompatability() {
 
     ClusterSchemaRequest schemaReq =
         ClusterSchemaRequest.builder()
@@ -378,17 +378,10 @@ class SchemaServiceRegisterSchemaTest {
             any(HttpEntity.class),
             eq(new ParameterizedTypeReference<Map<String, String>>() {}),
             any(HashMap.class)))
-        .thenReturn(createErrorCompatibilityResponseEntity(HttpStatus.NOT_FOUND))
-        .thenReturn(createCompatibilityResponseEntity(globalCompatibility));
+        .thenReturn(createErrorCompatibilityResponseEntity(HttpStatus.NOT_FOUND));
 
     schemaService.registerSchema(schemaReq);
-    verify(restTemplate, times(2)).put(any(), schemaCompatibility.capture(), eq(String.class));
-
-    // resets it to previous compatability
-    assertThat(schemaCompatibility.getAllValues().get(1).getBody().get(COMPATIBILITY_NODE_KEY))
-        .isEqualTo(globalCompatibility);
-    assertThat(schemaCompatibility.getAllValues().get(0).getBody().get(COMPATIBILITY_NODE_KEY))
-        .isEqualTo("NONE");
+    verify(restTemplate, times(0)).put(any(), schemaCompatibility.capture(), eq(String.class));
   }
 
   @Test
@@ -426,7 +419,7 @@ class SchemaServiceRegisterSchemaTest {
     verify(restTemplate, times(1))
         .postForEntity(anyString(), any(HttpEntity.class), eq(String.class));
     // 0 calls to get the current SchemaCompatibility as isForce==false
-    verify(restTemplate, times(2))
+    verify(restTemplate, times(1))
         .exchange(
             eq(REGISTRY_URL),
             any(HttpMethod.class),

--- a/core/src/main/java/io/aiven/klaw/model/cluster/ClusterSchemaRequest.java
+++ b/core/src/main/java/io/aiven/klaw/model/cluster/ClusterSchemaRequest.java
@@ -17,4 +17,6 @@ public class ClusterSchemaRequest implements Serializable {
   @JsonProperty private String fullSchema;
 
   @JsonProperty private String clusterIdentification;
+
+  @JsonProperty private boolean forceRegister;
 }

--- a/core/src/main/java/io/aiven/klaw/service/ClusterApiService.java
+++ b/core/src/main/java/io/aiven/klaw/service/ClusterApiService.java
@@ -621,6 +621,7 @@ public class ClusterApiService {
               .topicName(topicName)
               .fullSchema(schemaRequest.getSchemafull())
               .clusterIdentification(kwClusters.getClusterName() + kwClusters.getClusterId())
+              .forceRegister(schemaRequest.isForceRegister())
               .build();
 
       HttpHeaders headers = createHeaders(clusterApiUser);

--- a/core/src/main/resources/swagger_spec.json
+++ b/core/src/main/resources/swagger_spec.json
@@ -3571,10 +3571,10 @@
         "titleForReport" : {
           "type" : "string"
         },
-        "yaxisLabel" : {
+        "xaxisLabel" : {
           "type" : "string"
         },
-        "xaxisLabel" : {
+        "yaxisLabel" : {
           "type" : "string"
         }
       }


### PR DESCRIPTION
About this change - What it does
This change will first attempt to get the schema compatibility at the subject (topic level) , if that fails it will then get the subject at the Global level. It will then set the global compatibility to NONE on a force change change the Schema and then revert the global compatibility to the previous type.
Resolves: #xxxxx
Why this way
This allows users to force a schema through on a topic in must need situations.