### PR TITLE
feature(coral): Add experimental UI banner for topic request

### DIFF
--- a/core/src/main/resources/templates/requestTopics.html
+++ b/core/src/main/resources/templates/requestTopics.html
@@ -416,6 +416,14 @@
 		<div class="container-fluid">
 			<div class="row page-titles">
 			</div>
+			<div class="row" ng-if="dashboardDetails.coralEnabled === 'true'">
+				<div class="ribbon-wrapper card col-lg-6 col-md-6 col-xlg-2 col-xs-6">
+					<div class="ribbon ribbon-success">New user interface available</div>
+					<p class="ribbon-content">
+						Check out the new interface for <a href="coral/topics/request">topic request.</a>
+					</p>
+				</div>
+			</div>
 
 			<!-- Row -->
 


### PR DESCRIPTION
If user has `klaw.coral.enabled=true` show user a banner with link to topic request in Coral.

https://user-images.githubusercontent.com/1408173/214078637-3b5c47dc-1b5e-4af6-8a71-2e7c0e8c1269.mov