### PR TITLE
feat(coral): Improve validation in forms

### DIFF
--- a/coral/src/app/features/topics/acl-request/TopicAclRequest.test.tsx
+++ b/coral/src/app/features/topics/acl-request/TopicAclRequest.test.tsx
@@ -249,7 +249,7 @@ describe("<TopicAclRequest />", () => {
       expect(visiblePrincipalsField).toBeInTheDocument();
       expect(visiblePrincipalsField).toBeEnabled();
 
-      await userEvent.tripleClick(ipField);
+      await userEvent.click(ipField);
 
       await waitFor(() =>
         screen.findByRole("textbox", {
@@ -289,6 +289,9 @@ describe("<TopicAclRequest />", () => {
 
       await userEvent.type(visibleIpsField, "invalid{Enter}");
       await waitFor(() => expect(visibleIpsField).toBeInvalid());
+      await waitFor(() =>
+        expect(screen.getByText("Invalid IP address.")).toBeVisible()
+      );
     });
 
     it("does not error when entering valid IP in IPs field", async () => {
@@ -316,6 +319,136 @@ describe("<TopicAclRequest />", () => {
 
       await userEvent.type(visibleIpsField, "111.111.11.11{Enter}");
       expect(visibleIpsField).toBeValid();
+    });
+
+    it("errors when entering more than 15 IPs in IPs field", async () => {
+      await assertSkeleton();
+
+      const ipField = screen.getByRole("radio", { name: "IP" });
+
+      await selectTestEnvironment();
+
+      await waitFor(() => expect(ipField).toBeEnabled());
+
+      await userEvent.click(ipField);
+
+      await waitFor(() => expect(ipField).toBeChecked());
+
+      await waitFor(() =>
+        screen.findByRole("textbox", {
+          name: "IP addresses *",
+        })
+      );
+
+      const visibleIpsField = await screen.getByRole("textbox", {
+        name: "IP addresses *",
+      });
+
+      await userEvent.type(visibleIpsField, "111.111.11.11{Enter}");
+      await userEvent.type(visibleIpsField, "111.111.11.12{Enter}");
+      await userEvent.type(visibleIpsField, "111.111.11.13{Enter}");
+      await userEvent.type(visibleIpsField, "111.111.11.14{Enter}");
+      await userEvent.type(visibleIpsField, "111.111.11.15{Enter}");
+      await userEvent.type(visibleIpsField, "111.111.11.16{Enter}");
+      await userEvent.type(visibleIpsField, "111.111.11.17{Enter}");
+      await userEvent.type(visibleIpsField, "111.111.11.18{Enter}");
+      await userEvent.type(visibleIpsField, "111.111.11.19{Enter}");
+      await userEvent.type(visibleIpsField, "111.111.11.20{Enter}");
+      await userEvent.type(visibleIpsField, "111.111.11.21{Enter}");
+      await userEvent.type(visibleIpsField, "111.111.11.22{Enter}");
+      await userEvent.type(visibleIpsField, "111.111.11.23{Enter}");
+      await userEvent.type(visibleIpsField, "111.111.11.24{Enter}");
+      await userEvent.type(visibleIpsField, "111.111.11.25{Enter}");
+      await userEvent.type(visibleIpsField, "111.111.11.26{Enter}");
+
+      await waitFor(() => expect(visibleIpsField).not.toBeValid());
+      await waitFor(() =>
+        expect(screen.getByText("Maximum 15 elements allowed.")).toBeVisible()
+      );
+    });
+
+    it("errors when entering more than 5 elements in Principal field", async () => {
+      await assertSkeleton();
+
+      const principalField = screen.getByRole("radio", { name: "Principal" });
+
+      await selectTestEnvironment();
+
+      await waitFor(() => expect(principalField).toBeEnabled());
+
+      await userEvent.click(principalField);
+
+      await waitFor(() => expect(principalField).toBeChecked());
+
+      await waitFor(() =>
+        screen.findByRole("textbox", {
+          name: "SSL DN strings / Usernames *",
+        })
+      );
+
+      const visiblePrincipalsField = screen.getByRole("textbox", {
+        name: "SSL DN strings / Usernames *",
+      });
+      expect(visiblePrincipalsField).toBeInTheDocument();
+      expect(visiblePrincipalsField).toBeEnabled();
+
+      await userEvent.type(visiblePrincipalsField, "Alice1{Enter}");
+      await userEvent.type(visiblePrincipalsField, "Alice2{Enter}");
+      await userEvent.type(visiblePrincipalsField, "Alice3{Enter}");
+      await userEvent.type(visiblePrincipalsField, "Alice4{Enter}");
+      await userEvent.type(visiblePrincipalsField, "Alice5{Enter}");
+      await userEvent.type(visiblePrincipalsField, "Alice6{Enter}");
+
+      await waitFor(() => expect(visiblePrincipalsField).not.toBeValid());
+      await waitFor(() =>
+        expect(screen.getByText("Maximum 5 elements allowed.")).toBeVisible()
+      );
+    });
+
+    it("errors when entering a wrong value in Transactional ID field", async () => {
+      await assertSkeleton();
+
+      const transactionalIdInput = screen.getByLabelText("Transactional ID");
+
+      await userEvent.type(transactionalIdInput, "Hello invalid");
+      await userEvent.tab();
+
+      await waitFor(() => expect(transactionalIdInput).not.toBeValid());
+      await waitFor(() =>
+        expect(
+          screen.getByText("Only characters allowed: a-z, A-Z, 0-9, ., _,-.")
+        ).toBeVisible()
+      );
+    });
+
+    it("errors when entering a too long value in Transactional ID field", async () => {
+      await assertSkeleton();
+
+      const transactionalIdInput = screen.getByLabelText("Transactional ID");
+      const tooLong = new Array(152).join("a");
+      console.log(tooLong);
+      await userEvent.type(transactionalIdInput, tooLong);
+      await userEvent.tab();
+
+      await waitFor(() => expect(transactionalIdInput).not.toBeValid());
+      await waitFor(() =>
+        expect(
+          screen.getByText(
+            "Transactional ID cannot be more than 150 characters."
+          )
+        ).toBeVisible()
+      );
+    });
+
+    it("does errors when entering a wrong value in Transactional ID field", async () => {
+      await assertSkeleton();
+
+      const transactionalIdInput = screen.getByLabelText("Transactional ID");
+
+      await userEvent.type(transactionalIdInput, "HelloValid");
+      await userEvent.tab();
+
+      await waitFor(() => expect(transactionalIdInput).toBeValid());
     });
 
     it("renders correct fields when selecting Literal or Prefixed in aclPatternType fields", async () => {
@@ -435,7 +568,7 @@ describe("<TopicAclRequest />", () => {
       expect(visiblePrincipalsField).toBeInTheDocument();
       expect(visiblePrincipalsField).toBeEnabled();
 
-      await userEvent.tripleClick(ipField);
+      await userEvent.click(ipField);
 
       await waitFor(() =>
         screen.findByRole("textbox", {
@@ -464,7 +597,7 @@ describe("<TopicAclRequest />", () => {
 
       await waitFor(() => expect(ipField).toBeEnabled());
 
-      await userEvent.tripleClick(ipField);
+      await userEvent.click(ipField);
 
       await waitFor(() => expect(ipField).toBeChecked());
 
@@ -512,6 +645,165 @@ describe("<TopicAclRequest />", () => {
 
       await userEvent.type(visibleIpsField, "111.111.11.11{Enter}");
       await waitFor(() => expect(visibleIpsField).toBeValid());
+    });
+
+    it("errors when entering more than 15 IPs in IPs field", async () => {
+      await assertSkeleton();
+
+      const aclConsumerTypeInput = screen.getByRole("radio", {
+        name: "Consumer",
+      });
+      await userEvent.click(aclConsumerTypeInput);
+
+      const ipField = screen.getByRole("radio", { name: "IP" });
+
+      await selectTestEnvironment();
+
+      await waitFor(() => expect(ipField).toBeEnabled());
+
+      await userEvent.click(ipField);
+
+      await waitFor(() => expect(ipField).toBeChecked());
+
+      await waitFor(() =>
+        screen.findByRole("textbox", {
+          name: "IP addresses *",
+        })
+      );
+
+      const visibleIpsField = await screen.getByRole("textbox", {
+        name: "IP addresses *",
+      });
+
+      await userEvent.type(visibleIpsField, "111.111.11.11{Enter}");
+      await userEvent.type(visibleIpsField, "111.111.11.12{Enter}");
+      await userEvent.type(visibleIpsField, "111.111.11.13{Enter}");
+      await userEvent.type(visibleIpsField, "111.111.11.14{Enter}");
+      await userEvent.type(visibleIpsField, "111.111.11.15{Enter}");
+      await userEvent.type(visibleIpsField, "111.111.11.16{Enter}");
+      await userEvent.type(visibleIpsField, "111.111.11.17{Enter}");
+      await userEvent.type(visibleIpsField, "111.111.11.18{Enter}");
+      await userEvent.type(visibleIpsField, "111.111.11.19{Enter}");
+      await userEvent.type(visibleIpsField, "111.111.11.20{Enter}");
+      await userEvent.type(visibleIpsField, "111.111.11.21{Enter}");
+      await userEvent.type(visibleIpsField, "111.111.11.22{Enter}");
+      await userEvent.type(visibleIpsField, "111.111.11.23{Enter}");
+      await userEvent.type(visibleIpsField, "111.111.11.24{Enter}");
+      await userEvent.type(visibleIpsField, "111.111.11.25{Enter}");
+      await userEvent.type(visibleIpsField, "111.111.11.26{Enter}");
+
+      await waitFor(() => expect(visibleIpsField).not.toBeValid());
+      await waitFor(() =>
+        expect(screen.getByText("Maximum 15 elements allowed.")).toBeVisible()
+      );
+    });
+
+    it("errors when entering more than 5 elements in Principal field", async () => {
+      await assertSkeleton();
+
+      const aclConsumerTypeInput = screen.getByRole("radio", {
+        name: "Consumer",
+      });
+      await userEvent.click(aclConsumerTypeInput);
+
+      const principalField = screen.getByRole("radio", { name: "Principal" });
+
+      await selectTestEnvironment();
+
+      await waitFor(() => expect(principalField).toBeEnabled());
+
+      await userEvent.click(principalField);
+
+      await waitFor(() => expect(principalField).toBeChecked());
+
+      await waitFor(() =>
+        screen.findByRole("textbox", {
+          name: "SSL DN strings / Usernames *",
+        })
+      );
+
+      const visiblePrincipalsField = screen.getByRole("textbox", {
+        name: "SSL DN strings / Usernames *",
+      });
+      expect(visiblePrincipalsField).toBeInTheDocument();
+      expect(visiblePrincipalsField).toBeEnabled();
+
+      await userEvent.type(visiblePrincipalsField, "Alice1{Enter}");
+      await userEvent.type(visiblePrincipalsField, "Alice2{Enter}");
+      await userEvent.type(visiblePrincipalsField, "Alice3{Enter}");
+      await userEvent.type(visiblePrincipalsField, "Alice4{Enter}");
+      await userEvent.type(visiblePrincipalsField, "Alice5{Enter}");
+      await userEvent.type(visiblePrincipalsField, "Alice6{Enter}");
+
+      await waitFor(() => expect(visiblePrincipalsField).not.toBeValid());
+      await waitFor(() =>
+        expect(screen.getByText("Maximum 5 elements allowed.")).toBeVisible()
+      );
+    });
+
+    it("errors when entering a wrong value in Consumer Group field", async () => {
+      await assertSkeleton();
+
+      const aclConsumerTypeInput = screen.getByRole("radio", {
+        name: "Consumer",
+      });
+      await userEvent.click(aclConsumerTypeInput);
+
+      const consumerGroupInput = screen.getByRole("textbox", {
+        name: "Consumer group *",
+      });
+
+      await userEvent.type(consumerGroupInput, "Hello invalid");
+      await userEvent.tab();
+
+      await waitFor(() => expect(consumerGroupInput).not.toBeValid());
+      await waitFor(() =>
+        expect(
+          screen.getByText("Only characters allowed: a-z, A-Z, 0-9, ., _,-.")
+        ).toBeVisible()
+      );
+    });
+
+    it("errors when entering a too long value in Consumer group field", async () => {
+      await assertSkeleton();
+
+      const aclConsumerTypeInput = screen.getByRole("radio", {
+        name: "Consumer",
+      });
+      await userEvent.click(aclConsumerTypeInput);
+
+      const consumerGroupInput = screen.getByRole("textbox", {
+        name: "Consumer group *",
+      });
+      const tooLong = new Array(152).join("a");
+      console.log(tooLong);
+      await userEvent.type(consumerGroupInput, tooLong);
+      await userEvent.tab();
+
+      await waitFor(() => expect(consumerGroupInput).not.toBeValid());
+      await waitFor(() =>
+        expect(
+          screen.getByText("Consumer group cannot be more than 150 characters.")
+        ).toBeVisible()
+      );
+    });
+
+    it("does errors when entering a wrong value in Consumer group field", async () => {
+      await assertSkeleton();
+
+      const aclConsumerTypeInput = screen.getByRole("radio", {
+        name: "Consumer",
+      });
+      await userEvent.click(aclConsumerTypeInput);
+
+      const consumerGroupInput = screen.getByRole("textbox", {
+        name: "Consumer group *",
+      });
+
+      await userEvent.type(consumerGroupInput, "HelloValid");
+      await userEvent.tab();
+
+      await waitFor(() => expect(consumerGroupInput).toBeValid());
     });
   });
 });

--- a/coral/src/app/features/topics/acl-request/forms/TopicProducerForm.tsx
+++ b/coral/src/app/features/topics/acl-request/forms/TopicProducerForm.tsx
@@ -123,7 +123,6 @@ const TopicProducerForm = ({
             name="transactionalId"
             labelText="Transactional ID"
             placeholder="Necessary for exactly-once semantics on producer"
-            helperText="Necessary for exactly-once semantics on producer"
           />
         </GridItem>
 

--- a/coral/src/app/features/topics/acl-request/schemas/topic-acl-request-consumer.ts
+++ b/coral/src/app/features/topics/acl-request/schemas/topic-acl-request-consumer.ts
@@ -6,12 +6,19 @@ import {
   topicname,
   environment,
 } from "src/app/features/topics/acl-request/schemas/topic-acl-request-shared-fields";
-import { validateAclPrincipleValue } from "src/app/features/topics/acl-request/schemas/validation";
+import {
+  hasOnlyValidCharacters,
+  validateAclPrincipleValue,
+} from "src/app/features/topics/acl-request/schemas/validation";
 import { z } from "zod";
 
 const consumergroup = z
   .string()
-  .min(1, { message: "Consumer group cannot be empty." });
+  .min(1, { message: "Consumer group cannot be empty." })
+  .max(150, { message: "Consumer group cannot be more than 150 characters." })
+  .regex(hasOnlyValidCharacters, {
+    message: "Only characters allowed: a-z, A-Z, 0-9, ., _,-.",
+  });
 const aclPatternType = z.literal("LITERAL");
 const topictype = z.literal("Consumer");
 

--- a/coral/src/app/features/topics/acl-request/schemas/topic-acl-request-producer.ts
+++ b/coral/src/app/features/topics/acl-request/schemas/topic-acl-request-producer.ts
@@ -6,12 +6,21 @@ import {
   topicname,
   environment,
 } from "src/app/features/topics/acl-request/schemas/topic-acl-request-shared-fields";
-import { validateAclPrincipleValue } from "src/app/features/topics/acl-request/schemas/validation";
+import {
+  hasOnlyValidCharacters,
+  validateAclPrincipleValue,
+} from "src/app/features/topics/acl-request/schemas/validation";
 import { z } from "zod";
 
 const aclPatternType = z.union([z.literal("LITERAL"), z.literal("PREFIXED")]);
 const topictype = z.literal("Producer");
-const transactionalId = z.string().optional();
+const transactionalId = z
+  .string()
+  .regex(hasOnlyValidCharacters, {
+    message: "Only characters allowed: a-z, A-Z, 0-9, ., _,-.",
+  })
+  .max(150, { message: "Transactional ID cannot be more than 150 characters." })
+  .optional();
 
 const topicProducerFormSchema = z
   .object({

--- a/coral/src/app/features/topics/acl-request/schemas/topic-acl-request-shared-fields.ts
+++ b/coral/src/app/features/topics/acl-request/schemas/topic-acl-request-shared-fields.ts
@@ -17,10 +17,12 @@ const aclIpPrincipleType = z.union([
 const acl_ip = z
   .array(z.string().regex(isIpRegex, { message: "Invalid IP address." }))
   .min(1, { message: "Enter at least one element." })
+  .max(15, { message: "Maximum 15 elements allowed." })
   .optional();
 const acl_ssl = z
   .array(z.string())
   .min(1, { message: "Enter at least one element." })
+  .max(5, { message: "Maximum 5 elements allowed." })
   .optional();
 const aclPatternType = z.union([z.literal("LITERAL"), z.literal("PREFIXED")]);
 const topicname = z.string().min(1, { message: "Please enter a prefix." });

--- a/coral/src/app/features/topics/acl-request/schemas/validation.ts
+++ b/coral/src/app/features/topics/acl-request/schemas/validation.ts
@@ -19,9 +19,16 @@ const ipv6 = `
   .trim();
 
 const isIpRegex = new RegExp(`(?:^${ipv4}$)|(?:^${ipv6}$)`);
+// This matches:
+// - a-z, A-Z, 0-9, . (dot), _ (underscore), and - (dash)
+// OR
+// - empty string
+// The empty string clause is because this will be the default value of fields running this validation
+// And if it's not added, then validation will always fail when field is optional
+const hasOnlyValidCharacters = new RegExp(/^[a-zA-Z0-9._-]*$/);
 
 const validateAclPrincipleValue = (value: string[] | undefined) => {
   return value !== undefined && value.length >= 1;
 };
 
-export { isIpRegex, validateAclPrincipleValue };
+export { isIpRegex, hasOnlyValidCharacters, validateAclPrincipleValue };


### PR DESCRIPTION
Signed-off-by: Mathieu Anderson <mathieu.anderson@aiven.io>

### About this change - What it does

Following on acceptance test with @muralibasani, added more validation to the forms:
- allowed characters for transactional ID and consumer group
- allowed character length for transactional ID and consumer group
- allowed amount of IPs and Principal items in IPs and Principal fields

https://user-images.githubusercontent.com/20607294/214543947-7c38fd68-f409-46b1-a61d-8472e5c191aa.mov


https://user-images.githubusercontent.com/20607294/214543997-f239c89a-5752-4794-9a1b-e0b3c817b771.mov




