### PR TITLE
Add jdk19 to ci

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -19,7 +19,7 @@ jobs:
   build:
     strategy:
       matrix:
-        java-version: [17]
+        java-version: [17, 19]
         runs-on: [ubuntu-latest]
     name: Jdk ${{ matrix.java-version }}, os ${{ matrix.runs-on }}
     runs-on: ${{ matrix.runs-on }}


### PR DESCRIPTION

About this change - What it does
Make ci check 2 JDKs: one LTS (17) and the latest available (19)
to be able to detect issues earlier to simplify support for next LTS
Resolves: #xxxxx
Why this way
