### PR TITLE
Automatically add additional SSO Providers once configured

### DIFF
--- a/core/src/main/java/io/aiven/klaw/controller/UtilController.java
+++ b/core/src/main/java/io/aiven/klaw/controller/UtilController.java
@@ -42,7 +42,7 @@ public class UtilController {
       value = "/getBasicInfo",
       method = RequestMethod.GET,
       produces = {MediaType.APPLICATION_JSON_VALUE})
-  public ResponseEntity<Map<String, String>> getBasicInfo() {
+  public ResponseEntity<Map<String, Object>> getBasicInfo() {
     return new ResponseEntity<>(utilControllerService.getBasicInfo(), HttpStatus.OK);
   }
 

--- a/core/src/main/java/io/aiven/klaw/model/SSODetails.java
+++ b/core/src/main/java/io/aiven/klaw/model/SSODetails.java
@@ -5,6 +5,4 @@ import lombok.Data;
 @Data
 public class SSODetails {
   private String imageURI;
-  private String ssoProvider;
-  private String url;
 }

--- a/core/src/main/java/io/aiven/klaw/model/SSODetails.java
+++ b/core/src/main/java/io/aiven/klaw/model/SSODetails.java
@@ -1,0 +1,10 @@
+package io.aiven.klaw.model;
+
+import lombok.Data;
+
+@Data
+public class SSODetails {
+  private String imageURI;
+  private String ssoProvider;
+  private String url;
+}

--- a/core/src/main/java/io/aiven/klaw/model/SSODetails.java
+++ b/core/src/main/java/io/aiven/klaw/model/SSODetails.java
@@ -1,8 +1,0 @@
-package io.aiven.klaw.model;
-
-import lombok.Data;
-
-@Data
-public class SSODetails {
-  private String imageURI;
-}

--- a/core/src/main/java/io/aiven/klaw/service/UtilControllerService.java
+++ b/core/src/main/java/io/aiven/klaw/service/UtilControllerService.java
@@ -44,6 +44,7 @@ import org.springframework.stereotype.Service;
 @ConfigurationProperties(prefix = "spring.security.oauth2.client", ignoreInvalidFields = false)
 public class UtilControllerService {
 
+  public static final String IMAGE_URI = ".imageURI";
   @Autowired ManageDatabase manageDatabase;
 
   @Autowired MailUtils mailService;
@@ -625,7 +626,7 @@ public class UtilControllerService {
         .forEach(
             k -> {
               String providerName = k.substring(0, k.indexOf("."));
-              ssoProviders.put(providerName, registration.get(providerName + ".imageURI"));
+              ssoProviders.put(providerName, registration.get(providerName + IMAGE_URI));
             });
 
     return ssoProviders;

--- a/core/src/main/java/io/aiven/klaw/service/UtilControllerService.java
+++ b/core/src/main/java/io/aiven/klaw/service/UtilControllerService.java
@@ -42,7 +42,7 @@ import org.springframework.stereotype.Service;
 
 @Service
 @Slf4j
-@ConfigurationProperties(prefix = "klaw.sso.server")
+@ConfigurationProperties(prefix = "spring.security.oauth2.client")
 public class UtilControllerService {
 
   @Autowired ManageDatabase manageDatabase;
@@ -72,7 +72,7 @@ public class UtilControllerService {
   @Value("${klaw.coral.enabled:false}")
   private boolean coralEnabled;
 
-  private Map<String, SSODetails> loginurl;
+  private Map<String, SSODetails> registration;
 
   @Autowired private ConfigurableApplicationContext context;
 
@@ -600,7 +600,7 @@ public class UtilControllerService {
   public Map<String, Object> getBasicInfo() {
     Map<String, Object> resultBasicInfo = new HashMap<>();
     resultBasicInfo.put("contextPath", kwContextPath);
-    resultBasicInfo.put("ssoProviders", loginurl);
+    resultBasicInfo.put("ssoProviders", registration);
 
     // error codes of active directory authorization errors
     resultBasicInfo.put(ACTIVE_DIRECTORY_ERR_CODE_101, AD_ERROR_101_NO_MATCHING_ROLE);
@@ -643,11 +643,11 @@ public class UtilControllerService {
     }
   }
 
-  public Map<String, SSODetails> getLoginurl() {
-    return loginurl;
+  public Map<String, SSODetails> getRegistration() {
+    return registration;
   }
 
-  public void setLoginurl(Map<String, SSODetails> loginurl) {
-    this.loginurl = loginurl;
+  public void setRegistration(Map<String, SSODetails> registration) {
+    this.registration = registration;
   }
 }

--- a/core/src/main/java/io/aiven/klaw/service/UtilControllerService.java
+++ b/core/src/main/java/io/aiven/klaw/service/UtilControllerService.java
@@ -14,6 +14,7 @@ import io.aiven.klaw.dao.UserInfo;
 import io.aiven.klaw.helpers.HandleDbRequests;
 import io.aiven.klaw.helpers.KwConstants;
 import io.aiven.klaw.model.KwMetadataUpdates;
+import io.aiven.klaw.model.SSODetails;
 import io.aiven.klaw.model.enums.ApiResultStatus;
 import io.aiven.klaw.model.enums.PermissionType;
 import io.aiven.klaw.model.enums.RequestStatus;
@@ -32,6 +33,7 @@ import java.util.stream.Collectors;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.context.ConfigurableApplicationContext;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
@@ -40,6 +42,7 @@ import org.springframework.stereotype.Service;
 
 @Service
 @Slf4j
+@ConfigurationProperties(prefix = "klaw.sso.server")
 public class UtilControllerService {
 
   @Autowired ManageDatabase manageDatabase;
@@ -69,11 +72,7 @@ public class UtilControllerService {
   @Value("${klaw.coral.enabled:false}")
   private boolean coralEnabled;
 
-  @Value("${klaw.sso.server.loginurl.azure}")
-  private String ssoServerLoginUrlAzure;
-
-  @Value("${klaw.sso.server.loginurl.google}")
-  private String ssoServerLoginUrlGoogle;
+  private Map<String, SSODetails> loginurl;
 
   @Autowired private ConfigurableApplicationContext context;
 
@@ -598,12 +597,10 @@ public class UtilControllerService {
     return SecurityContextHolder.getContext().getAuthentication().getPrincipal();
   }
 
-  public Map<String, String> getBasicInfo() {
-    Map<String, String> resultBasicInfo = new HashMap<>();
+  public Map<String, Object> getBasicInfo() {
+    Map<String, Object> resultBasicInfo = new HashMap<>();
     resultBasicInfo.put("contextPath", kwContextPath);
-
-    resultBasicInfo.put("ssoServerUrlAzure", ssoServerLoginUrlAzure);
-    resultBasicInfo.put("ssoServerUrlGoogle", ssoServerLoginUrlGoogle);
+    resultBasicInfo.put("ssoProviders", loginurl);
 
     // error codes of active directory authorization errors
     resultBasicInfo.put(ACTIVE_DIRECTORY_ERR_CODE_101, AD_ERROR_101_NO_MATCHING_ROLE);
@@ -644,5 +641,13 @@ public class UtilControllerService {
     } catch (InterruptedException | ExecutionException e) {
       log.error("Error from resetCache ", e);
     }
+  }
+
+  public Map<String, SSODetails> getLoginurl() {
+    return loginurl;
+  }
+
+  public void setLoginurl(Map<String, SSODetails> loginurl) {
+    this.loginurl = loginurl;
   }
 }

--- a/core/src/main/resources/application.properties
+++ b/core/src/main/resources/application.properties
@@ -59,7 +59,6 @@ klaw.enable.sso=false
 #spring.security.oauth2.client.registration.google.scope=profile, email
 
 
-
 # Uncomment the below OAuth2 configuration to enable Azure AD based authentication
 #spring.security.oauth2.registration.provider.azure.imageURI=assets/images/clients/azuread.svg
 #spring.security.oauth2.client.registration.azure.client-id=

--- a/core/src/main/resources/application.properties
+++ b/core/src/main/resources/application.properties
@@ -65,7 +65,10 @@ klaw.enable.sso=false
 #spring.security.oauth2.client.registration.azure.provider=azure-active-directory
 #spring.security.oauth2.client.registration.azure.scope=openid, profile, email
 #spring.security.oauth2.client.provider.azure-active-directory.issuer-uri=https://login.microsoftonline.com/{tenantid}/v2.0
-
+#github
+#spring.security.oauth2.client.registration.github.client-id=
+#spring.security.oauth2.client.registration.github.client-secret=
+#spring.security.oauth2.client.registration.github.scope=openid, profile, email
 # Uncomment the below to establish connectivity between core and cluster apis.
 # Provide a base 64 encoded string. The same secret should be configured in Klaw Cluster Api.
 klaw.clusterapi.access.base64.secret=
@@ -168,8 +171,19 @@ spring.jpa.hibernate.jdbc.lob.non_contextual_creation=true
 spring.jpa.properties.hibernate.naming.physical-strategy=org.hibernate.boot.model.naming.PhysicalNamingStrategyStandardImpl
 
 # Azure, Google OAuth2 login url
-klaw.sso.server.loginurl.azure=/oauth2/authorization/azure
-klaw.sso.server.loginurl.google=/oauth2/authorization/google
+klaw.sso.server.loginurl.azure.url=/oauth2/authorization/azure
+klaw.sso.server.loginurl.google.url=/oauth2/authorization/google
+#klaw.sso.server.loginurl.github.url=/oauth2/authorization/github
+
+klaw.sso.server.loginurl.azure.imageURI=assets/images/clients/azuread.svg
+klaw.sso.server.loginurl.google.imageURI=assets/images/clients/google.svg
+#klaw.sso.server.loginurl.github.imageURI=
+
+klaw.sso.server.loginurl.azure.ssoProvider=Azure
+klaw.sso.server.loginurl.google.ssoProvider=Google
+#klaw.sso.server.loginurl.github.ssoProvider=GitHub
+
+
 
 # Default attributes to extract for AD authentication
 klaw.ad.username.attribute=preferred_username

--- a/core/src/main/resources/application.properties
+++ b/core/src/main/resources/application.properties
@@ -73,6 +73,7 @@ klaw.enable.sso=false
 #spring.security.oauth2.client.registration.github.client-id=
 #spring.security.oauth2.client.registration.github.client-secret=
 #spring.security.oauth2.client.registration.github.scope=openid, profile, email
+#spring.security.oauth2.client.registration.github.redirect-uri=
 
 # Uncomment the below to establish connectivity between core and cluster apis.
 # Provide a base 64 encoded string. The same secret should be configured in Klaw Cluster Api.

--- a/core/src/main/resources/application.properties
+++ b/core/src/main/resources/application.properties
@@ -51,24 +51,30 @@ klaw.enable.authorization.ad=false
 
 # sso config
 klaw.enable.sso=false
-
 # Uncomment the below OAuth2 configuration to enable Google based authentication
+#spring.security.oauth2.client.registration.google.imageURI=assets/images/clients/google.svg
 #spring.security.oauth2.client.registration.google.client-id=
 #spring.security.oauth2.client.registration.google.client-secret=
 #spring.security.oauth2.client.registration.google.redirect-uri=https://localhost:9097/login/oauth2/code/google
 #spring.security.oauth2.client.registration.google.scope=profile, email
 
+
+
 # Uncomment the below OAuth2 configuration to enable Azure AD based authentication
+#spring.security.oauth2.registration.provider.azure.imageURI=assets/images/clients/azuread.svg
 #spring.security.oauth2.client.registration.azure.client-id=
 #spring.security.oauth2.client.registration.azure.client-secret=
 #spring.security.oauth2.client.registration.azure.redirect-uri=https://localhost:9097/login/oauth2/code/
 #spring.security.oauth2.client.registration.azure.provider=azure-active-directory
 #spring.security.oauth2.client.registration.azure.scope=openid, profile, email
 #spring.security.oauth2.client.provider.azure-active-directory.issuer-uri=https://login.microsoftonline.com/{tenantid}/v2.0
+
 #github
+#spring.security.oauth2.client.registration.github.imageURI=
 #spring.security.oauth2.client.registration.github.client-id=
 #spring.security.oauth2.client.registration.github.client-secret=
 #spring.security.oauth2.client.registration.github.scope=openid, profile, email
+
 # Uncomment the below to establish connectivity between core and cluster apis.
 # Provide a base 64 encoded string. The same secret should be configured in Klaw Cluster Api.
 klaw.clusterapi.access.base64.secret=
@@ -169,20 +175,6 @@ spring.jpa.hibernate.generate-ddl=false
 spring.jpa.hibernate.ddl-auto=update
 spring.jpa.hibernate.jdbc.lob.non_contextual_creation=true
 spring.jpa.properties.hibernate.naming.physical-strategy=org.hibernate.boot.model.naming.PhysicalNamingStrategyStandardImpl
-
-# Azure, Google OAuth2 login url
-klaw.sso.server.loginurl.azure.url=/oauth2/authorization/azure
-klaw.sso.server.loginurl.google.url=/oauth2/authorization/google
-#klaw.sso.server.loginurl.github.url=/oauth2/authorization/github
-
-klaw.sso.server.loginurl.azure.imageURI=assets/images/clients/azuread.svg
-klaw.sso.server.loginurl.google.imageURI=assets/images/clients/google.svg
-#klaw.sso.server.loginurl.github.imageURI=
-
-klaw.sso.server.loginurl.azure.ssoProvider=Azure
-klaw.sso.server.loginurl.google.ssoProvider=Google
-#klaw.sso.server.loginurl.github.ssoProvider=GitHub
-
 
 
 # Default attributes to extract for AD authentication

--- a/core/src/main/resources/application.properties
+++ b/core/src/main/resources/application.properties
@@ -68,7 +68,7 @@ klaw.enable.sso=false
 #spring.security.oauth2.client.registration.azure.scope=openid, profile, email
 #spring.security.oauth2.client.provider.azure-active-directory.issuer-uri=https://login.microsoftonline.com/{tenantid}/v2.0
 
-#github
+# Uncomment the below OAuth2 configuration to enable Github based authentication
 #spring.security.oauth2.client.registration.github.imageURI=
 #spring.security.oauth2.client.registration.github.client-id=
 #spring.security.oauth2.client.registration.github.client-secret=

--- a/core/src/main/resources/application.properties
+++ b/core/src/main/resources/application.properties
@@ -60,7 +60,7 @@ klaw.enable.sso=false
 
 
 # Uncomment the below OAuth2 configuration to enable Azure AD based authentication
-#spring.security.oauth2.registration.provider.azure.imageURI=assets/images/clients/azuread.svg
+#spring.security.oauth2.client.registration.azure.imageURI=assets/images/clients/azuread.svg
 #spring.security.oauth2.client.registration.azure.client-id=
 #spring.security.oauth2.client.registration.azure.client-secret=
 #spring.security.oauth2.client.registration.azure.redirect-uri=https://localhost:9097/login/oauth2/code/

--- a/core/src/main/resources/swagger_spec.json
+++ b/core/src/main/resources/swagger_spec.json
@@ -1101,7 +1101,7 @@
             "schema" : {
               "type" : "object",
               "additionalProperties" : {
-                "type" : "string"
+                "type" : "object"
               }
             }
           }

--- a/core/src/main/resources/templates/oauthLogin.html
+++ b/core/src/main/resources/templates/oauthLogin.html
@@ -108,12 +108,12 @@
     <section id="wrapper">
         <div class="login-register" id="grad1">
             <div class="login-box card">
-                <div class="card-body" ng-repeat="provider in dashboardDetails.ssoProviders">
+                <div class="card-body" ng-repeat="(name, provider) in dashboardDetails.ssoProviders">
                     <div class="form-group text-center mt-3">
                         <div class="col-xs-12">
                             <button class="btn btn-info btn-lg btn-block text-uppercase waves-effect waves-light" id="grad1">
-                                <a class="btn btn-block btn-social btn-google" href="{{ provider.url }}"
-                                   style="color:white;"><img width="17%" src="{{ provider.imageURI }}"/> {{ provider.ssoProvider }} Login</a>
+                                <a class="btn btn-block btn-social btn-google" href="/oauth2/authorization/{{ name }}"
+                                   style="color:white;"><img width="17%" src="{{ provider.imageURI }}"/> {{ name }} Login</a>
                             </button>
                         </div>
                     </div>

--- a/core/src/main/resources/templates/oauthLogin.html
+++ b/core/src/main/resources/templates/oauthLogin.html
@@ -108,20 +108,12 @@
     <section id="wrapper">
         <div class="login-register" id="grad1">
             <div class="login-box card">
-                <div class="card-body">
+                <div class="card-body" ng-repeat="provider in dashboardDetails.ssoProviders">
                     <div class="form-group text-center mt-3">
                         <div class="col-xs-12">
                             <button class="btn btn-info btn-lg btn-block text-uppercase waves-effect waves-light" id="grad1">
-                                <a class="btn btn-block btn-social btn-google" href="{{ dashboardDetails.ssoServerUrlAzure }}"
-                                   style="color:white;"><img width="17%" src="assets/images/clients/azuread.svg"/> Azure Login</a>
-                            </button>
-                        </div>
-                    </div>
-                    <div class="form-group text-center mt-3">
-                        <div class="col-xs-12">
-                            <button class="btn btn-info btn-lg btn-block text-uppercase waves-effect waves-light" id="grad1">
-                                <a class="btn btn-block btn-social btn-google" href="{{ dashboardDetails.ssoServerUrlGoogle }}"
-                                   style="color:white;"><img src="assets/images/clients/google.svg"/> Google Login</a>
+                                <a class="btn btn-block btn-social btn-google" href="{{ provider.url }}"
+                                   style="color:white;"><img width="17%" src="{{ provider.imageURI }}"/> {{ provider.ssoProvider }} Login</a>
                             </button>
                         </div>
                     </div>

--- a/core/src/main/resources/templates/oauthLogin.html
+++ b/core/src/main/resources/templates/oauthLogin.html
@@ -113,7 +113,7 @@
                         <div class="col-xs-12">
                             <button class="btn btn-info btn-lg btn-block text-uppercase waves-effect waves-light" id="grad1">
                                 <a class="btn btn-block btn-social btn-google" href="/oauth2/authorization/{{ name }}"
-                                   style="color:white;"><img width="17%" src="{{ provider.imageURI }}"/> {{ name }} Login</a>
+                                   style="color:white;"><img width="17%" src="{{ provider }}"/> {{ name }} Login</a>
                             </button>
                         </div>
                     </div>


### PR DESCRIPTION
Signed-off-by: Aindriu Lavelle <aindriu.lavelle@aiven.io>

About this change - What it does
This changes the returned SSO Providers into a standard object, this configuration is pulled directly from the application.properties file.
This object is then iterated over in the oauthLogin.html page and gives all configured providers as options to select for authentication.
Resolves: #xxxxx
Why this way
This allows any SSO OAuth provider including internal and custom providers to be used for authentication.
It does require an update to the documentation aswell.
#471 is resolved from this update.