### PR TITLE
feat(coral): Update API schema, types, handler for /getTopicsOnly

### DIFF
--- a/coral/src/domain/topic/topic-api.ts
+++ b/coral/src/domain/topic/topic-api.ts
@@ -45,11 +45,18 @@ const getTopics = async ({
 
 type GetTopicNamesArgs = Partial<{
   onlyMyTeamTopics: boolean;
+  envSelected?: string;
 }>;
 
-const getTopicNames = async ({ onlyMyTeamTopics }: GetTopicNamesArgs = {}) => {
+const getTopicNames = async ({
+  onlyMyTeamTopics,
+  envSelected = "ALL",
+}: GetTopicNamesArgs = {}) => {
   const isMyTeamTopics = onlyMyTeamTopics ?? false;
-  const params = { isMyTeamTopics: isMyTeamTopics.toString() };
+  const params = {
+    isMyTeamTopics: isMyTeamTopics.toString(),
+    envSelected,
+  };
 
   return api.get<KlawApiResponse<"topicsGetOnly">>(
     `/getTopicsOnly?${new URLSearchParams(params)}`

--- a/coral/types/api.d.ts
+++ b/coral/types/api.d.ts
@@ -874,6 +874,8 @@ export type operations = {
       query: {
         /** Set to true to only get the topic names for topics belonging to the team of the current user */
         isMyTeamTopics?: components["schemas"]["TopicsGetOnlyResponse"];
+        /** Pass an environment name to get only the names of the topics in that environment */
+        envSelected?: components["schemas"]["TopicsGetOnlyResponse"];
       };
     };
     responses: {

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -127,7 +127,7 @@ paths:
         - name: envSelected
           in: query
           required: false
-          description: Pass an environment name to get only the names of the topics in that environment
+          description: Pass an environment ID to get only the names of the topics in that environment
           schema:
             $ref: "#/components/schemas/TopicsGetOnlyResponse"
       responses:

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -124,6 +124,12 @@ paths:
           description: Set to true to only get the topic names for topics belonging to the team of the current user
           schema:
             $ref: "#/components/schemas/TopicsGetOnlyResponse"
+        - name: envSelected
+          in: query
+          required: false
+          description: Pass an environment name to get only the names of the topics in that environment
+          schema:
+            $ref: "#/components/schemas/TopicsGetOnlyResponse"
       responses:
         "200":
           description: OK


### PR DESCRIPTION
## About this change - What it does

https://github.com/aiven/klaw/pull/476 introduces a new param to the `/getTopicsOnly` endpoint to be able to pass an environment ID (or `"ALL"`), which allows to fetch only the topics that are available in the given environment.

This PR reflect these changes in API in the `coral` frontend:
- update the `openapi.yaml`
- generates the TS types
- updates `topic-api.ts` 

## Followup issue

[feat(coral): ACL Request Form - Only load the topic names that belong to the selected topic](https://github.com/aiven/klaw/issues/483)
