### PR TITLE
coral(style): Add linting rule for lodash imports

### DIFF
--- a/coral/.eslintrc.cjs
+++ b/coral/.eslintrc.cjs
@@ -74,6 +74,7 @@ module.exports = {
         "react",
         "@typescript-eslint",
         "no-relative-import-paths",
+        "lodash"
     ],
     "settings": {
         "react": {
@@ -96,6 +97,7 @@ module.exports = {
         "import/no-cycle": "error",
         "import/exports-last": "error",
         "import/no-anonymous-default-export": "error",
-        "import/group-exports": "error"
-    }
+        "import/group-exports": "error",
+        "lodash/import-scope": "error"
+}
 }

--- a/coral/package.json
+++ b/coral/package.json
@@ -70,6 +70,7 @@
     "eslint-config-prettier": "^8.5.0",
     "eslint-import-resolver-typescript": "^3.5.2",
     "eslint-plugin-import": "^2.26.0",
+    "eslint-plugin-lodash": "^7.4.0",
     "eslint-plugin-no-relative-import-paths": "^1.4.0",
     "eslint-plugin-react": "^7.31.10",
     "husky": "^8.0.1",

--- a/coral/pnpm-lock.yaml
+++ b/coral/pnpm-lock.yaml
@@ -24,6 +24,7 @@ specifiers:
   eslint-config-prettier: ^8.5.0
   eslint-import-resolver-typescript: ^3.5.2
   eslint-plugin-import: ^2.26.0
+  eslint-plugin-lodash: ^7.4.0
   eslint-plugin-no-relative-import-paths: ^1.4.0
   eslint-plugin-react: ^7.31.10
   husky: ^8.0.1
@@ -82,6 +83,7 @@ devDependencies:
   eslint-config-prettier: 8.5.0_eslint@8.25.0
   eslint-import-resolver-typescript: 3.5.2_fyln4uq2tv75svthy6prqvt6lm
   eslint-plugin-import: 2.26.0_5r7jgxw73ljm6f74emcsxw3vua
+  eslint-plugin-lodash: 7.4.0_eslint@8.25.0
   eslint-plugin-no-relative-import-paths: 1.5.0
   eslint-plugin-react: 7.31.10_eslint@8.25.0
   husky: 8.0.1
@@ -4136,6 +4138,16 @@ packages:
       - eslint-import-resolver-typescript
       - eslint-import-resolver-webpack
       - supports-color
+    dev: true
+
+  /eslint-plugin-lodash/7.4.0_eslint@8.25.0:
+    resolution: {integrity: sha512-Tl83UwVXqe1OVeBRKUeWcfg6/pCW1GTRObbdnbEJgYwjxp5Q92MEWQaH9+dmzbRt6kvYU1Mp893E79nJiCSM8A==}
+    engines: {node: '>=10'}
+    peerDependencies:
+      eslint: '>=2'
+    dependencies:
+      eslint: 8.25.0
+      lodash: 4.17.21
     dev: true
 
   /eslint-plugin-no-relative-import-paths/1.5.0:

--- a/coral/src/app/components/FileInput.tsx
+++ b/coral/src/app/components/FileInput.tsx
@@ -1,5 +1,6 @@
 import { Icon, Box, Typography, Grid, GridItem } from "@aivenio/aquarium";
-import { omit, uniqueId } from "lodash";
+import omit from "lodash/omit";
+import uniqueId from "lodash/uniqueId";
 import { InputHTMLAttributes, useRef } from "react";
 import classes from "src/app/components/FileInput.module.css";
 import cloudUpload from "@aivenio/aquarium/dist/src/icons/cloudUpload";

--- a/coral/src/app/features/topics/acl-request/TopicAclRequest.test.tsx
+++ b/coral/src/app/features/topics/acl-request/TopicAclRequest.test.tsx
@@ -426,7 +426,6 @@ describe("<TopicAclRequest />", () => {
 
       const transactionalIdInput = screen.getByLabelText("Transactional ID");
       const tooLong = new Array(152).join("a");
-      console.log(tooLong);
       await userEvent.type(transactionalIdInput, tooLong);
       await userEvent.tab();
 
@@ -776,7 +775,6 @@ describe("<TopicAclRequest />", () => {
         name: "Consumer group *",
       });
       const tooLong = new Array(152).join("a");
-      console.log(tooLong);
       await userEvent.type(consumerGroupInput, tooLong);
       await userEvent.tab();
 


### PR DESCRIPTION
# About this change - What it does

Add rule to make sure we always import

`import thing from 'lodash/thing'`

instead of

`import { thing } from 'lodash'`

Resolves: #429 

