### PR TITLE
coral(fix): Fix Icon in PreviewBanner resizes with browser

### DIFF
--- a/coral/src/app/components/PreviewBanner.tsx
+++ b/coral/src/app/components/PreviewBanner.tsx
@@ -34,13 +34,10 @@ function PreviewBanner({ linkTarget }: { linkTarget: string }) {
       marginBottom={"l1"}
       aria-label={"Preview disclaimer"}
     >
-      <Icon
-        aria-hidden={true}
-        color={"info-50"}
-        fontSize={20}
-        icon={infoSign}
-      />
-      <Typography variant={"body-small"}>
+      <Typography.SmallText>
+        <Icon icon={infoSign} color={"info-50"} style={{ marginTop: "5px" }} />
+      </Typography.SmallText>
+      <Typography.SmallText>
         You are viewing a preview of the redesigned user interface. You are one
         of our early reviewers, and your{" "}
         <Link
@@ -52,7 +49,7 @@ function PreviewBanner({ linkTarget }: { linkTarget: string }) {
         />{" "}
         will help us improve the product. You can always go back to the{" "}
         <Link text={"old interface"} target={linkTarget} isRemote={false} />.
-      </Typography>
+      </Typography.SmallText>
     </Box>
   );
 }


### PR DESCRIPTION
# About this change - What it does

Icon resized with browser size, see screenshot:

![image](https://user-images.githubusercontent.com/943800/214802973-3c9f2f75-b6a5-42d4-9a2b-0ec3cc224946.png)


# 🐛 fix:
- wrap icon in Typography component to get font sizing inherited
- add fixed margin to Icon in order to equalize line-height and align icon properly with the font at top
- use `Typography.SmallText` since variant body-small is deprecated


Resolves: #482 

