### PR TITLE
fix(coral): Fix FileInput button overlay width

### DIFF
--- a/coral/src/app/components/FileInput.tsx
+++ b/coral/src/app/components/FileInput.tsx
@@ -58,13 +58,7 @@ function FileInput(props: FileInputProps) {
           gridTemplateColumns: "max-content auto",
         }}
       >
-        <GridItem
-          colStart={"1"}
-          colEnd={"1"}
-          rowStart={"1"}
-          rowEnd={"1"}
-          width={"fit"}
-        >
+        <GridItem colStart={"1"} colEnd={"1"} rowStart={"1"} rowEnd={"1"}>
           <Box
             aria-hidden={true}
             display={"flex"}
@@ -84,6 +78,7 @@ function FileInput(props: FileInputProps) {
               borderRadius={"2px"}
               paddingX={"l1"}
               paddingY={"3"}
+              minWidth={"full"}
               className={`${!valid && "border-error-50"}`}
             >
               <Icon icon={cloudUpload} />


### PR DESCRIPTION
Signed-off-by: Mathieu Anderson <mathieu.anderson@aiven.io>

## About this change - What it does

With a short button text, the File input button overlay was not covering the native UI.
<img width="262" alt="Screenshot 2023-01-26 at 14 23 23" src="https://user-images.githubusercontent.com/20607294/214846646-7180ca41-0151-4553-b705-06b4068e0014.png">

Small adjustments to the styles lead to this result:

<img width="274" alt="Screenshot 2023-01-26 at 14 23 05" src="https://user-images.githubusercontent.com/20607294/214846704-140e95b3-607a-4b16-8270-d043e6b504a0.png">

