### PR TITLE
Full name fix, provider route url fix

### DIFF
--- a/core/src/main/java/io/aiven/klaw/auth/KwAuthenticationSuccessHandler.java
+++ b/core/src/main/java/io/aiven/klaw/auth/KwAuthenticationSuccessHandler.java
@@ -26,7 +26,7 @@ public class KwAuthenticationSuccessHandler extends SavedRequestAwareAuthenticat
     response.sendRedirect(contextPath.concat(getRedirectPage(request)));
   }
 
-  private String getRedirectPage(HttpServletRequest request) {
+  public String getRedirectPage(HttpServletRequest request) {
     DefaultSavedRequest defaultSavedRequest =
         (DefaultSavedRequest) request.getSession().getAttribute("SPRING_SECURITY_SAVED_REQUEST");
     String indexPage = "index";

--- a/core/src/main/java/io/aiven/klaw/auth/KwAuthenticationSuccessHandler.java
+++ b/core/src/main/java/io/aiven/klaw/auth/KwAuthenticationSuccessHandler.java
@@ -6,7 +6,6 @@ import java.io.IOException;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.core.Authentication;
-import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.web.authentication.SavedRequestAwareAuthenticationSuccessHandler;
 import org.springframework.security.web.savedrequest.DefaultSavedRequest;
 import org.springframework.stereotype.Component;
@@ -22,7 +21,7 @@ public class KwAuthenticationSuccessHandler extends SavedRequestAwareAuthenticat
   public void onAuthenticationSuccess(
       HttpServletRequest request, HttpServletResponse response, Authentication authentication)
       throws IOException {
-    log.info("User logged in : {}", ((UserDetails) authentication.getPrincipal()).getUsername());
+    log.debug("User logged in : {}", authentication.getPrincipal());
     super.clearAuthenticationAttributes(request);
     response.sendRedirect(contextPath.concat(getRedirectPage(request)));
   }
@@ -31,6 +30,8 @@ public class KwAuthenticationSuccessHandler extends SavedRequestAwareAuthenticat
     DefaultSavedRequest defaultSavedRequest =
         (DefaultSavedRequest) request.getSession().getAttribute("SPRING_SECURITY_SAVED_REQUEST");
     String indexPage = "index";
+    String rootPath = "/";
+    String providerRoute = "{{ provider }}";
 
     if (defaultSavedRequest == null) {
       return indexPage;
@@ -42,6 +43,9 @@ public class KwAuthenticationSuccessHandler extends SavedRequestAwareAuthenticat
     if (requestUri != null && requestUri.contains("login")) {
       return indexPage;
     }
+
+    if (defaultSavedRequest.getServletPath() != null
+        && defaultSavedRequest.getServletPath().contains(providerRoute)) return rootPath;
 
     if (requestUri != null && queryString != null) {
       return requestUri.concat("?").concat(queryString);

--- a/core/src/main/java/io/aiven/klaw/config/ConfigUtils.java
+++ b/core/src/main/java/io/aiven/klaw/config/ConfigUtils.java
@@ -1,5 +1,7 @@
 package io.aiven.klaw.config;
 
+import io.aiven.klaw.auth.KwAuthenticationFailureHandler;
+import io.aiven.klaw.auth.KwAuthenticationSuccessHandler;
 import java.util.ArrayList;
 import java.util.List;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
@@ -45,7 +47,11 @@ public class ConfigUtils {
     return staticResourcesHtmlArray;
   }
 
-  protected static void applyHttpSecurityConfig(HttpSecurity http, boolean coralEnabled)
+  protected static void applyHttpSecurityConfig(
+      HttpSecurity http,
+      boolean coralEnabled,
+      KwAuthenticationSuccessHandler kwAuthenticationSuccessHandler,
+      KwAuthenticationFailureHandler kwAuthenticationFailureHandler)
       throws Exception {
     http.csrf()
         .disable()
@@ -56,6 +62,9 @@ public class ConfigUtils {
         .authenticated()
         .and()
         .oauth2Login()
+        .successHandler(kwAuthenticationSuccessHandler)
+        .failureHandler(kwAuthenticationFailureHandler)
+        .failureUrl("/login?error")
         .loginPage("/login")
         .permitAll()
         .and()

--- a/core/src/main/java/io/aiven/klaw/config/SecurityConfigSSO.java
+++ b/core/src/main/java/io/aiven/klaw/config/SecurityConfigSSO.java
@@ -1,7 +1,10 @@
 package io.aiven.klaw.config;
 
+import io.aiven.klaw.auth.KwAuthenticationFailureHandler;
+import io.aiven.klaw.auth.KwAuthenticationSuccessHandler;
 import java.util.Properties;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Bean;
@@ -30,10 +33,15 @@ public class SecurityConfigSSO {
   @Value("${klaw.coral.enabled:false}")
   private boolean coralEnabled;
 
+  @Autowired KwAuthenticationSuccessHandler kwAuthenticationSuccessHandler;
+
+  @Autowired KwAuthenticationFailureHandler kwAuthenticationFailureHandler;
+
   @Bean
   public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
     log.info("SSO enabled");
-    ConfigUtils.applyHttpSecurityConfig(http, coralEnabled);
+    ConfigUtils.applyHttpSecurityConfig(
+        http, coralEnabled, kwAuthenticationSuccessHandler, kwAuthenticationFailureHandler);
     return http.build();
   }
 

--- a/core/src/main/java/io/aiven/klaw/service/UiControllerLoginService.java
+++ b/core/src/main/java/io/aiven/klaw/service/UiControllerLoginService.java
@@ -321,7 +321,11 @@ public class UiControllerLoginService {
         registerUserInfoModel.setRegisteredTime(new Timestamp(System.currentTimeMillis()));
         registerUserInfoModel.setUsername(userName);
         registerUserInfoModel.setPwd("");
-        if (fullName != null) registerUserInfoModel.setFullname((String) fullName);
+        if (fullName != null) {
+          String fullNameStr =
+              ((String) fullName).replaceAll(",", ""); // Look for other characters in names
+          registerUserInfoModel.setFullname(fullNameStr);
+        }
 
         RegisterUserInfo registerUserInfo = new RegisterUserInfo();
         copyProperties(registerUserInfoModel, registerUserInfo);

--- a/core/src/main/java/io/aiven/klaw/service/UsersTeamsControllerService.java
+++ b/core/src/main/java/io/aiven/klaw/service/UsersTeamsControllerService.java
@@ -437,8 +437,8 @@ public class UsersTeamsControllerService {
 
   public ApiResponse addNewUser(UserInfoModel newUser, boolean isExternal) throws KlawException {
     log.info("addNewUser {} {} {}", newUser.getUsername(), newUser.getTeam(), newUser.getRole());
-    Matcher m = getPattern().matcher(newUser.getUsername());
-    if (!m.matches()) {
+    boolean userNamePatternCheck = userNamePatternValidation(newUser.getUsername());
+    if (!userNamePatternCheck) {
       return ApiResponse.builder().result("Invalid username/mail id").build();
     }
 
@@ -481,7 +481,6 @@ public class UsersTeamsControllerService {
       userInfo.setPwd(newUser.getUserPassword());
       String result = dbHandle.addNewUser(userInfo);
 
-      //            log.info("pwd : "+decodePwd(newUser.getUserPassword()));
       if (isExternal) {
         if ("".equals(newUser.getUserPassword())) {
           mailService.sendMail(
@@ -950,11 +949,9 @@ public class UsersTeamsControllerService {
     return SecurityContextHolder.getContext().getAuthentication().getPrincipal();
   }
 
-  private Pattern getPattern() {
-    if (SAAS.equals(kwInstallationType) || ssoEnabled) {
-      return saasPattern;
-    } else {
-      return defaultPattern;
-    }
+  private boolean userNamePatternValidation(String userName) {
+    Matcher m1 = saasPattern.matcher(userName);
+    Matcher m2 = defaultPattern.matcher(userName);
+    return m1.matches() || m2.matches();
   }
 }

--- a/core/src/test/java/io/aiven/klaw/auth/KwAuthenticationSuccessHandlerTest.java
+++ b/core/src/test/java/io/aiven/klaw/auth/KwAuthenticationSuccessHandlerTest.java
@@ -1,0 +1,76 @@
+package io.aiven.klaw.auth;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpSession;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.springframework.security.web.savedrequest.DefaultSavedRequest;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+@ExtendWith(SpringExtension.class)
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+public class KwAuthenticationSuccessHandlerTest {
+
+  @Mock HttpServletRequest httpServletRequest;
+
+  @Mock HttpSession httpSession;
+
+  @Mock DefaultSavedRequest defaultSavedRequest;
+
+  private KwAuthenticationSuccessHandler kwAuthenticationSuccessHandler;
+  String springSavedReqAttribute;
+
+  @BeforeEach
+  void setUp() {
+    springSavedReqAttribute = "SPRING_SECURITY_SAVED_REQUEST";
+    kwAuthenticationSuccessHandler = new KwAuthenticationSuccessHandler();
+  }
+
+  @AfterEach
+  void tearDown() {}
+
+  @Test
+  void getRedirectPageWhenSavedReqIsNullReturnIndexTest() {
+    when(httpServletRequest.getSession()).thenReturn(httpSession);
+    defaultSavedRequest = null;
+    when(httpSession.getAttribute(springSavedReqAttribute)).thenReturn(defaultSavedRequest);
+    String redirectedPage = kwAuthenticationSuccessHandler.getRedirectPage(httpServletRequest);
+    assertThat(redirectedPage).isEqualTo("index");
+  }
+
+  @Test
+  void getRedirectPageReturnIndexLoginTest() {
+    when(httpServletRequest.getSession()).thenReturn(httpSession);
+    when(httpSession.getAttribute(springSavedReqAttribute)).thenReturn(defaultSavedRequest);
+    when(defaultSavedRequest.getRequestURI()).thenReturn("/login");
+    String redirectedPage = kwAuthenticationSuccessHandler.getRedirectPage(httpServletRequest);
+    assertThat(redirectedPage).isEqualTo("index");
+  }
+
+  @Test
+  void getRedirectPageReturnRootForServletPathCheckTest() {
+    when(httpServletRequest.getSession()).thenReturn(httpSession);
+    when(httpSession.getAttribute(springSavedReqAttribute)).thenReturn(defaultSavedRequest);
+    when(defaultSavedRequest.getServletPath()).thenReturn("/{{ provider }}");
+    String redirectedPage = kwAuthenticationSuccessHandler.getRedirectPage(httpServletRequest);
+    assertThat(redirectedPage).isEqualTo("/");
+  }
+
+  @Test
+  void getRedirectPageReturnFullPathRequestUriQueryTest() {
+    when(httpServletRequest.getSession()).thenReturn(httpSession);
+    when(httpSession.getAttribute(springSavedReqAttribute)).thenReturn(defaultSavedRequest);
+    when(defaultSavedRequest.getRequestURI()).thenReturn("/browseTopics");
+    when(defaultSavedRequest.getQueryString()).thenReturn("topicName=testtopic");
+    String redirectedPage = kwAuthenticationSuccessHandler.getRedirectPage(httpServletRequest);
+    assertThat(redirectedPage).isEqualTo("/browseTopics?topicName=testtopic");
+  }
+}


### PR DESCRIPTION
Signed-off-by: muralibasani <muralidahr.basani@aiven.io>

About this change - What it does

- When provider routes user back to application, user is sent a url /{{provider}} which is not a valid one. Now user is sent to root page.
- Sometimes new users are directed form providers, full names consist of "," which are not accepted in Klaw during registration. They are replaced with empty strings now. 

Resolves: #493
Why this way
to continue with smooth redirection of user
