### PR TITLE
Limit Env dropdown based on tenant config

### DIFF
--- a/core/src/main/java/io/aiven/klaw/controller/EnvsClustersTenantsController.java
+++ b/core/src/main/java/io/aiven/klaw/controller/EnvsClustersTenantsController.java
@@ -164,12 +164,12 @@ public class EnvsClustersTenantsController {
   }
 
   @RequestMapping(
-      value = "/getRequestForSchemas",
+      value = "/getEnvsForSchemaRequests",
       method = RequestMethod.GET,
       produces = {MediaType.APPLICATION_JSON_VALUE})
   public ResponseEntity<List<EnvModel>> getRequestForSchemas() {
     return new ResponseEntity<>(
-        envsClustersTenantsControllerService.getRequestSchemaEnvs(), HttpStatus.OK);
+        envsClustersTenantsControllerService.getEnvsForSchemaRequests(), HttpStatus.OK);
   }
 
   @RequestMapping(

--- a/core/src/main/java/io/aiven/klaw/controller/EnvsClustersTenantsController.java
+++ b/core/src/main/java/io/aiven/klaw/controller/EnvsClustersTenantsController.java
@@ -164,6 +164,15 @@ public class EnvsClustersTenantsController {
   }
 
   @RequestMapping(
+      value = "/getRequestForSchemas",
+      method = RequestMethod.GET,
+      produces = {MediaType.APPLICATION_JSON_VALUE})
+  public ResponseEntity<List<EnvModel>> getRequestForSchemas() {
+    return new ResponseEntity<>(
+        envsClustersTenantsControllerService.getRequestSchemaEnvs(), HttpStatus.OK);
+  }
+
+  @RequestMapping(
       value = "/getKafkaConnectEnvs",
       method = RequestMethod.GET,
       produces = {MediaType.APPLICATION_JSON_VALUE})

--- a/core/src/main/java/io/aiven/klaw/service/EnvsClustersTenantsControllerService.java
+++ b/core/src/main/java/io/aiven/klaw/service/EnvsClustersTenantsControllerService.java
@@ -568,8 +568,7 @@ public class EnvsClustersTenantsControllerService {
     return envModelList;
   }
 
-  private List<EnvModel> filterEnvironmentModelList(
-      String[] reqEnvs, List<EnvModel> envModelList) {
+  private List<EnvModel> filterEnvironmentModelList(String[] reqEnvs, List<EnvModel> envModelList) {
     envModelList =
         envModelList.stream()
             .filter(

--- a/core/src/main/java/io/aiven/klaw/service/EnvsClustersTenantsControllerService.java
+++ b/core/src/main/java/io/aiven/klaw/service/EnvsClustersTenantsControllerService.java
@@ -568,7 +568,7 @@ public class EnvsClustersTenantsControllerService {
     return envModelList;
   }
 
-  private static List<EnvModel> filterEnvironmentModelList(
+  private List<EnvModel> filterEnvironmentModelList(
       String[] reqEnvs, List<EnvModel> envModelList) {
     envModelList =
         envModelList.stream()

--- a/core/src/main/java/io/aiven/klaw/service/MailUtils.java
+++ b/core/src/main/java/io/aiven/klaw/service/MailUtils.java
@@ -397,6 +397,10 @@ public class MailUtils {
           tenantModel
               .getOrderOfSchemaPromotionEnvsList()
               .forEach(a -> intOrderEnvsList.add(Integer.parseInt(a)));
+        case "REQUEST_SCHEMA_OF_ENVS":
+          tenantModel
+              .getRequestSchemaEnvironmentsList()
+              .forEach(a -> intOrderEnvsList.add(Integer.parseInt(a)));
           break;
       }
 

--- a/core/src/main/java/io/aiven/klaw/service/MailUtils.java
+++ b/core/src/main/java/io/aiven/klaw/service/MailUtils.java
@@ -379,28 +379,34 @@ public class MailUtils {
           }
           break;
         case "REQUEST_TOPICS_OF_ENVS":
-          tenantModel
-              .getRequestTopicsEnvironmentsList()
-              .forEach(a -> intOrderEnvsList.add(Integer.parseInt(a)));
+          List<String> requestTopics = tenantModel.getRequestTopicsEnvironmentsList();
+          if (requestTopics != null && !requestTopics.isEmpty()) {
+            requestTopics.forEach(a -> intOrderEnvsList.add(Integer.parseInt(a)));
+          }
           break;
         case "ORDER_OF_KAFKA_CONNECT_ENVS":
-          tenantModel
-              .getOrderOfConnectorsPromotionEnvsList()
-              .forEach(a -> intOrderEnvsList.add(Integer.parseInt(a)));
+          List<String> orderOfConn = tenantModel.getOrderOfConnectorsPromotionEnvsList();
+          if (orderOfConn != null && !orderOfConn.isEmpty()) {
+            orderOfConn.forEach(a -> intOrderEnvsList.add(Integer.parseInt(a)));
+          }
           break;
         case "REQUEST_CONNECTORS_OF_KAFKA_CONNECT_ENVS":
-          tenantModel
-              .getRequestConnectorsEnvironmentsList()
-              .forEach(a -> intOrderEnvsList.add(Integer.parseInt(a)));
+          List<String> requestConn = tenantModel.getRequestConnectorsEnvironmentsList();
+          if (requestConn != null && !requestConn.isEmpty()) {
+            requestConn.forEach(a -> intOrderEnvsList.add(Integer.parseInt(a)));
+          }
           break;
         case "ORDER_OF_SCHEMA_ENVS":
-          tenantModel
-              .getOrderOfSchemaPromotionEnvsList()
-              .forEach(a -> intOrderEnvsList.add(Integer.parseInt(a)));
+          List<String> orderOfSchema = tenantModel.getOrderOfSchemaPromotionEnvsList();
+          if (orderOfSchema != null && !orderOfSchema.isEmpty()) {
+            orderOfSchema.forEach(a -> intOrderEnvsList.add(Integer.parseInt(a)));
+          }
+          break;
         case "REQUEST_SCHEMA_OF_ENVS":
-          tenantModel
-              .getRequestSchemaEnvironmentsList()
-              .forEach(a -> intOrderEnvsList.add(Integer.parseInt(a)));
+          List<String> requestSchema = tenantModel.getRequestSchemaEnvironmentsList();
+          if (requestSchema != null && !requestSchema.isEmpty()) {
+            requestSchema.forEach(a -> intOrderEnvsList.add(Integer.parseInt(a)));
+          }
           break;
       }
 

--- a/core/src/main/resources/static/js/requestAvroSchemaUpload.js
+++ b/core/src/main/resources/static/js/requestAvroSchemaUpload.js
@@ -72,7 +72,7 @@ app.controller("requestSchemaCtrl", function($scope, $http, $location, $window) 
 
         $http({
             method: "GET",
-            url: "getRequestForSchemas",
+            url: "getEnvsForSchemaRequests",
             headers : { 'Content-Type' : 'application/json' }
         }).success(function(output) {
             $scope.allschemaenvs = output;

--- a/core/src/main/resources/static/js/requestAvroSchemaUpload.js
+++ b/core/src/main/resources/static/js/requestAvroSchemaUpload.js
@@ -72,7 +72,7 @@ app.controller("requestSchemaCtrl", function($scope, $http, $location, $window) 
 
         $http({
             method: "GET",
-            url: "getSchemaRegEnvs",
+            url: "getRequestForSchemas",
             headers : { 'Content-Type' : 'application/json' }
         }).success(function(output) {
             $scope.allschemaenvs = output;

--- a/core/src/main/resources/static/js/requestTopics.js
+++ b/core/src/main/resources/static/js/requestTopics.js
@@ -314,7 +314,7 @@ app.controller("requestTopicsCtrl", function($scope, $http, $location, $window) 
 
                 $http({
                     method: "GET",
-                    url: "getEnvsBaseClusterFilteredForTeam",
+                    url: "getEnvsBaseCluster",
                     headers : { 'Content-Type' : 'application/json' }
                 }).success(function(output) {
                     $scope.allenvs = output;

--- a/core/src/main/resources/swagger_spec.json
+++ b/core/src/main/resources/swagger_spec.json
@@ -1695,6 +1695,23 @@
         }
       }
     },
+    "/getEnvsForSchemaRequests" : {
+      "get" : {
+        "operationId" : "getRequestForSchemas",
+        "produces" : [ "application/json" ],
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "schema" : {
+              "type" : "array",
+              "items" : {
+                "$ref" : "#/definitions/EnvModel"
+              }
+            }
+          }
+        }
+      }
+    },
     "/getEnvsPaginated" : {
       "get" : {
         "operationId" : "getEnvsPaginated",
@@ -1895,23 +1912,6 @@
                     "type" : "boolean"
                   }
                 }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/getRequestForSchemas" : {
-      "get" : {
-        "operationId" : "getRequestForSchemas",
-        "produces" : [ "application/json" ],
-        "responses" : {
-          "200" : {
-            "description" : "successful operation",
-            "schema" : {
-              "type" : "array",
-              "items" : {
-                "$ref" : "#/definitions/EnvModel"
               }
             }
           }

--- a/core/src/main/resources/swagger_spec.json
+++ b/core/src/main/resources/swagger_spec.json
@@ -1901,6 +1901,23 @@
         }
       }
     },
+    "/getRequestForSchemas" : {
+      "get" : {
+        "operationId" : "getRequestForSchemas",
+        "produces" : [ "application/json" ],
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "schema" : {
+              "type" : "array",
+              "items" : {
+                "$ref" : "#/definitions/EnvModel"
+              }
+            }
+          }
+        }
+      }
+    },
     "/getRequestTypeStatuses" : {
       "get" : {
         "operationId" : "getRequestTypeStatuses",

--- a/core/src/test/java/io/aiven/klaw/UtilMethods.java
+++ b/core/src/test/java/io/aiven/klaw/UtilMethods.java
@@ -511,6 +511,30 @@ public class UtilMethods {
     return envList;
   }
 
+  public List<EnvModel> getDEVSchemaEnvList() {
+    List<EnvModel> envList = new ArrayList<>();
+    EnvModel env = new EnvModel();
+    env.setId("1");
+    env.setName("DEV");
+    env.setClusterType(KafkaClustersType.SCHEMA_REGISTRY);
+    env.setClusterId(101);
+    envList.add(env);
+
+    return envList;
+  }
+
+  public List<EnvModel> getTSTSchemaEnvList() {
+    List<EnvModel> envList = new ArrayList<>();
+    EnvModel env = new EnvModel();
+    env.setId("4");
+    env.setName("TST");
+    env.setClusterType(KafkaClustersType.SCHEMA_REGISTRY);
+    env.setClusterId(101);
+    envList.add(env);
+
+    return envList;
+  }
+
   public List<Map<String, String>> getSyncEnv() {
     List<Map<String, String>> envList = new ArrayList<>();
 

--- a/core/src/test/java/io/aiven/klaw/service/UiConfigControllerServiceTest.java
+++ b/core/src/test/java/io/aiven/klaw/service/UiConfigControllerServiceTest.java
@@ -142,7 +142,7 @@ public class UiConfigControllerServiceTest {
     when(mailService.getEnvProperty(eq(101), eq("REQUEST_SCHEMA_OF_ENVS"))).thenReturn("");
     when(handleDbRequests.selectAllSchemaRegEnvs(1)).thenReturn(getAllSchemaEnvs());
     when(manageDatabase.getSchemaRegEnvList(eq(101))).thenReturn(getAllSchemaEnvs());
-    List<EnvModel> envsList = envsClustersTenantsControllerService.getRequestSchemaEnvs();
+    List<EnvModel> envsList = envsClustersTenantsControllerService.getEnvsForSchemaRequests();
 
     assertThat(envsList).isEmpty();
   }
@@ -159,7 +159,7 @@ public class UiConfigControllerServiceTest {
     when(manageDatabase.getSchemaRegEnvList(eq(101))).thenReturn(getAllSchemaEnvs());
     when(manageDatabase.getClusters(eq(KafkaClustersType.SCHEMA_REGISTRY), eq(101)))
         .thenReturn(getSchemaRegistryClusters());
-    List<EnvModel> envsList = envsClustersTenantsControllerService.getRequestSchemaEnvs();
+    List<EnvModel> envsList = envsClustersTenantsControllerService.getEnvsForSchemaRequests();
 
     assertThat(envsList.get(0).getName()).isEqualTo("DEV");
     assertThat(envsList.size()).isEqualTo(1);
@@ -177,7 +177,7 @@ public class UiConfigControllerServiceTest {
     when(manageDatabase.getSchemaRegEnvList(eq(101))).thenReturn(getAllSchemaEnvs());
     when(manageDatabase.getClusters(eq(KafkaClustersType.SCHEMA_REGISTRY), eq(101)))
         .thenReturn(getSchemaRegistryClusters());
-    List<EnvModel> envsList = envsClustersTenantsControllerService.getRequestSchemaEnvs();
+    List<EnvModel> envsList = envsClustersTenantsControllerService.getEnvsForSchemaRequests();
 
     assertThat(envsList.get(0).getName()).isEqualTo("DEV");
     assertThat(envsList.size()).isEqualTo(1);
@@ -195,7 +195,7 @@ public class UiConfigControllerServiceTest {
     when(manageDatabase.getSchemaRegEnvList(eq(101))).thenReturn(getAllSchemaEnvs());
     when(manageDatabase.getClusters(eq(KafkaClustersType.SCHEMA_REGISTRY), eq(101)))
         .thenReturn(getSchemaRegistryClusters());
-    List<EnvModel> envsList = envsClustersTenantsControllerService.getRequestSchemaEnvs();
+    List<EnvModel> envsList = envsClustersTenantsControllerService.getEnvsForSchemaRequests();
 
     assertThat(envsList.get(0).getName()).isEqualTo("DEV");
     assertThat(envsList.get(1).getName()).isEqualTo("TST");
@@ -215,7 +215,7 @@ public class UiConfigControllerServiceTest {
     when(manageDatabase.getSchemaRegEnvList(eq(101))).thenReturn(getAllSchemaEnvs());
     when(manageDatabase.getClusters(eq(KafkaClustersType.SCHEMA_REGISTRY), eq(101)))
         .thenReturn(getSchemaRegistryClusters());
-    List<EnvModel> envsList = envsClustersTenantsControllerService.getRequestSchemaEnvs();
+    List<EnvModel> envsList = envsClustersTenantsControllerService.getEnvsForSchemaRequests();
 
     assertThat(envsList.get(0).getName()).isEqualTo("DEV");
     assertThat(envsList.get(1).getName()).isEqualTo("TST");

--- a/core/src/test/java/io/aiven/klaw/service/UiConfigControllerServiceTest.java
+++ b/core/src/test/java/io/aiven/klaw/service/UiConfigControllerServiceTest.java
@@ -4,8 +4,10 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.when;
 
+import io.aiven.klaw.UtilMethods;
 import io.aiven.klaw.config.ManageDatabase;
 import io.aiven.klaw.dao.ActivityLog;
 import io.aiven.klaw.dao.Env;
@@ -18,6 +20,7 @@ import io.aiven.klaw.model.UserInfoModel;
 import io.aiven.klaw.model.enums.KafkaClustersType;
 import java.sql.Timestamp;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import org.junit.jupiter.api.BeforeEach;
@@ -130,6 +133,103 @@ public class UiConfigControllerServiceTest {
     assertThat(envsList).isEmpty();
   }
 
+  @Test
+  @Order(5)
+  public void getRequestSchemaEnvs_IsEmpty() {
+    stubUserInfo();
+    when(commonUtilsService.isNotAuthorizedUser(any(), any())).thenReturn(false);
+    when(mailService.getEnvProperty(eq(101), eq("ORDER_OF_SCHEMA_ENVS"))).thenReturn("DEV,TST");
+    when(mailService.getEnvProperty(eq(101), eq("REQUEST_SCHEMA_OF_ENVS"))).thenReturn("");
+    when(handleDbRequests.selectAllSchemaRegEnvs(1)).thenReturn(getAllSchemaEnvs());
+    when(manageDatabase.getSchemaRegEnvList(eq(101))).thenReturn(getAllSchemaEnvs());
+    List<EnvModel> envsList = envsClustersTenantsControllerService.getRequestSchemaEnvs();
+
+    assertThat(envsList).isEmpty();
+  }
+
+  @Test
+  @Order(6)
+  public void getRequestSchemaEnvs_ReturnDevEnv() {
+
+    stubUserInfo();
+    when(commonUtilsService.isNotAuthorizedUser(any(), any())).thenReturn(false);
+    when(mailService.getEnvProperty(eq(101), eq("ORDER_OF_SCHEMA_ENVS"))).thenReturn("DEV,TST");
+    when(mailService.getEnvProperty(eq(101), eq("REQUEST_SCHEMA_OF_ENVS"))).thenReturn("DEV");
+    when(handleDbRequests.selectAllSchemaRegEnvs(1)).thenReturn(getAllSchemaEnvs());
+    when(manageDatabase.getSchemaRegEnvList(eq(101))).thenReturn(getAllSchemaEnvs());
+    when(manageDatabase.getClusters(eq(KafkaClustersType.SCHEMA_REGISTRY), eq(101)))
+        .thenReturn(getSchemaRegistryClusters());
+    List<EnvModel> envsList = envsClustersTenantsControllerService.getRequestSchemaEnvs();
+
+    assertThat(envsList.get(0).getName()).isEqualTo("DEV");
+    assertThat(envsList.size()).isEqualTo(1);
+  }
+
+  @Test
+  @Order(7)
+  public void getRequestSchemaEnvs_GivenWrongSchemaEnvNameReturnDevEnvOnly() {
+    // sTT is a misspelt env one tht does not exist and so should not be returned.
+    stubUserInfo();
+    when(commonUtilsService.isNotAuthorizedUser(any(), any())).thenReturn(false);
+    when(mailService.getEnvProperty(eq(101), eq("ORDER_OF_SCHEMA_ENVS"))).thenReturn("DEV,TST");
+    when(mailService.getEnvProperty(eq(101), eq("REQUEST_SCHEMA_OF_ENVS"))).thenReturn("DEV,sTT");
+    when(handleDbRequests.selectAllSchemaRegEnvs(1)).thenReturn(getAllSchemaEnvs());
+    when(manageDatabase.getSchemaRegEnvList(eq(101))).thenReturn(getAllSchemaEnvs());
+    when(manageDatabase.getClusters(eq(KafkaClustersType.SCHEMA_REGISTRY), eq(101)))
+        .thenReturn(getSchemaRegistryClusters());
+    List<EnvModel> envsList = envsClustersTenantsControllerService.getRequestSchemaEnvs();
+
+    assertThat(envsList.get(0).getName()).isEqualTo("DEV");
+    assertThat(envsList.size()).isEqualTo(1);
+  }
+
+  @Test
+  @Order(8)
+  public void getRequestSchemaEnvs_GivenTwoSchemaEnvsReturnBoth() {
+    // DEV and TSTS are both spelt correctly and configured so both should be returned.
+    stubUserInfo();
+    when(commonUtilsService.isNotAuthorizedUser(any(), any())).thenReturn(false);
+    when(mailService.getEnvProperty(eq(101), eq("ORDER_OF_SCHEMA_ENVS"))).thenReturn("DEV,TST");
+    when(mailService.getEnvProperty(eq(101), eq("REQUEST_SCHEMA_OF_ENVS"))).thenReturn("DEV,TST");
+    when(handleDbRequests.selectAllSchemaRegEnvs(1)).thenReturn(getAllSchemaEnvs());
+    when(manageDatabase.getSchemaRegEnvList(eq(101))).thenReturn(getAllSchemaEnvs());
+    when(manageDatabase.getClusters(eq(KafkaClustersType.SCHEMA_REGISTRY), eq(101)))
+        .thenReturn(getSchemaRegistryClusters());
+    List<EnvModel> envsList = envsClustersTenantsControllerService.getRequestSchemaEnvs();
+
+    assertThat(envsList.get(0).getName()).isEqualTo("DEV");
+    assertThat(envsList.get(1).getName()).isEqualTo("TST");
+    assertThat(envsList.size()).isEqualTo(2);
+  }
+
+  @Test
+  @Order(9)
+  public void getRequestSchemaEnvs_GivenThreeSchemaEnvsReturnOnlyTheTwoConfigured() {
+    // only two kWclusters are configured DEV and TST so UAT should not return.
+    stubUserInfo();
+    when(commonUtilsService.isNotAuthorizedUser(any(), any())).thenReturn(false);
+    when(mailService.getEnvProperty(eq(101), eq("ORDER_OF_SCHEMA_ENVS"))).thenReturn("DEV,TST,UAT");
+    when(mailService.getEnvProperty(eq(101), eq("REQUEST_SCHEMA_OF_ENVS")))
+        .thenReturn("DEV,TST,UAT");
+    when(handleDbRequests.selectAllSchemaRegEnvs(1)).thenReturn(getAllSchemaEnvs());
+    when(manageDatabase.getSchemaRegEnvList(eq(101))).thenReturn(getAllSchemaEnvs());
+    when(manageDatabase.getClusters(eq(KafkaClustersType.SCHEMA_REGISTRY), eq(101)))
+        .thenReturn(getSchemaRegistryClusters());
+    List<EnvModel> envsList = envsClustersTenantsControllerService.getRequestSchemaEnvs();
+
+    assertThat(envsList.get(0).getName()).isEqualTo("DEV");
+    assertThat(envsList.get(1).getName()).isEqualTo("TST");
+    assertThat(envsList.size()).isEqualTo(2);
+  }
+
+  private Map<Integer, KwClusters> getSchemaRegistryClusters() {
+    Map<Integer, KwClusters> map = new HashMap<>();
+    UtilMethods util = new UtilMethods();
+    map.put(1, util.getKwClusters());
+    map.put(4, util.getKwClusters());
+    return map;
+  }
+
   private List<ActivityLog> getAcitivityList(int size) {
     List<ActivityLog> actList = new ArrayList<>();
 
@@ -194,10 +294,14 @@ public class UiConfigControllerServiceTest {
 
     Env env = new Env();
     env.setName("DEV");
+    env.setId("DEV");
+    env.setClusterId(1);
     listEnvs.add(env);
 
     env = new Env();
     env.setName("TST");
+    env.setId("TST");
+    env.setClusterId(4);
     listEnvs.add(env);
 
     return listEnvs;
@@ -233,6 +337,7 @@ public class UiConfigControllerServiceTest {
   private void stubUserInfo() {
     when(handleDbRequests.getUsersInfo(anyString())).thenReturn(userInfo);
     when(userInfo.getTeamId()).thenReturn(101);
+    when(userInfo.getTenantId()).thenReturn(101);
     when(mailService.getUserName(any())).thenReturn("kwusera");
   }
 }


### PR DESCRIPTION
Signed-off-by: Aindriu Lavelle <aindriu.lavelle@aiven.io>

About this change - What it does
This change ensures that the environments that are selectable for a 'Request Topic' or 'My Schema Request' are filtered to only show the topics defined in the tenant model under requestTopicsEnvironmentsList and requestSchemaEnvironmentsList.

Resolves: #xxxxx
Why this way
This parses out any data that should not be available as an option to the user and resolves issue #491 so that superadmin has the ability to force users to use the promotion capabilities to promote topics and schemas to higher environments.