### PR TITLE
feat(coral): connect "Request new schema" form with api data

### DIFF
--- a/coral/src/app/features/topics/schema-request/TopicSchemaRequest.test.tsx
+++ b/coral/src/app/features/topics/schema-request/TopicSchemaRequest.test.tsx
@@ -620,7 +620,7 @@ describe("TopicSchemaRequest", () => {
         environment: "1",
         remarks: "",
         schemafull: "{}",
-        topicName: "my-awesome-topic",
+        topicname: "my-awesome-topic",
       });
     });
 

--- a/coral/src/app/features/topics/schema-request/schemas/topic-schema-request-form.ts
+++ b/coral/src/app/features/topics/schema-request/schemas/topic-schema-request-form.ts
@@ -2,7 +2,7 @@ import z from "zod";
 
 const topicRequestFormSchema = z.object({
   environment: z.string().min(1, { message: "The environment is required." }),
-  topicName: z.string(),
+  topicname: z.string(),
   schemafull: z.string(),
   remarks: z.string().optional(),
 });

--- a/coral/src/domain/schema-request/schema-request-api.ts
+++ b/coral/src/domain/schema-request/schema-request-api.ts
@@ -1,20 +1,23 @@
 import { KlawApiRequest, KlawApiResponse } from "types/utils";
 import api from "src/services/api";
+import {
+  SchemaRequest,
+  SchemaRequestPayload,
+} from "src/domain/schema-request/schema-request-types";
 
 const createSchemaRequest = (
-  params: KlawApiRequest<"schemaUpload">
+  params: SchemaRequest
 ): Promise<KlawApiResponse<"schemaUpload">> => {
-  const schemaUploadParams = {
+  const payload: SchemaRequestPayload = {
     ...params,
-    // schemaversion and appname
-    // should be hard coded at the moment
     schemaversion: "1.0",
     appname: "App",
   };
+
   return api.post<
     KlawApiResponse<"schemaUpload">,
     KlawApiRequest<"schemaUpload">
-  >("/uploadSchema", schemaUploadParams);
+  >(`/uploadSchema`, payload);
 };
 
 export { createSchemaRequest };

--- a/coral/src/domain/schema-request/schema-request-types.ts
+++ b/coral/src/domain/schema-request/schema-request-types.ts
@@ -1,5 +1,18 @@
 import { KlawApiModel } from "types/utils";
 
-type SchemaRequest = KlawApiModel<"SchemaRequest">;
+type SchemaRequest = Required<
+  Pick<
+    KlawApiModel<"SchemaRequest">,
+    "environment" | "schemafull" | "topicname"
+  >
+> &
+  Pick<KlawApiModel<"SchemaRequest">, "remarks">;
 
-export type { SchemaRequest };
+type SchemaRequestPayload = SchemaRequest & {
+  // schemaversion and appname
+  // should be hard coded at the moment
+  schemaversion: "1.0";
+  appname: "App";
+};
+
+export type { SchemaRequest, SchemaRequestPayload };


### PR DESCRIPTION
# About this change - What it does

- removes the api mocks from `TopicRequestSchema`
- adds precise types for `SchemaRequest` and `SchemaRequestPayload` to be used in the api call and make typing stricter there
- adds stricter typing to the useMutation hook for creating a new schema

Resolves: #372
