### PR TITLE
feat(coral): Update ACL request route, add Angular CTA

### DIFF
--- a/coral/src/app/layout/main-navigation/MainNavigation.tsx
+++ b/coral/src/app/layout/main-navigation/MainNavigation.tsx
@@ -47,9 +47,9 @@ function MainNavigation() {
                 // This link is only intended to be rendered in dev environment
                 // So the path does not have a coral/ prefix
                 // @TODO: delete when Topic overview / top nac Request dropdown are implemented
-                href={"/topic/aivtopic1/acl/request"}
+                href={"/topic/aivtopic1/subscribe"}
                 linkText={"Subscribe"}
-                active={pathname.includes("/acl/request")}
+                active={pathname.includes("/subscribe")}
               />
             ) : (
               <></>

--- a/coral/src/app/router.tsx
+++ b/coral/src/app/router.tsx
@@ -21,7 +21,7 @@ const routes: Array<RouteObject> = [
     element: <RequestTopic />,
   },
   {
-    path: "/topic/:topicName/acl/request",
+    path: "/topic/:topicName/subscribe",
     element: <AclRequest />,
   },
   {

--- a/core/src/main/resources/templates/requestAcls.html
+++ b/core/src/main/resources/templates/requestAcls.html
@@ -415,6 +415,15 @@
 			<div class="row page-titles">
 			</div>
 
+			<div class="row" ng-if="dashboardDetails.coralEnabled === 'true'">
+				<div class="ribbon-wrapper card col-lg-6 col-md-6 col-xlg-2 col-xs-6">
+					<div class="ribbon ribbon-success">New user interface available</div>
+					<p class="ribbon-content">
+						Check out the new interface for <a href="coral/topic/{{ addAcl.topicname }}/subscribe">ACL requests.</a>
+					</p>
+				</div>
+			</div>
+
 			<!-- Row -->
 
 			<div class="row" ng-show="alert != null && alert != ''" ng-init="">


### PR DESCRIPTION
## About this change - What it does

- render ACL form at route `/topic/:topicName/subscribe` as per https://github.com/aiven/klaw/issues/452
- add CTA in Angular UI 

## Why this way

I also wanted to implement the `reuqest/acl` route, but there are issues to be solved, as currently the forms are very reliant on having a `topicname` in the route params. The full resoltution of https://github.com/aiven/klaw/issues/452 should be a separate PR.