### PR TITLE
fix(coral): ACL request form: do not show Consumer Group field if Environment is Aiven cluster

### DIFF
--- a/coral/src/app/features/topics/acl-request/TopicAclRequest.test.tsx
+++ b/coral/src/app/features/topics/acl-request/TopicAclRequest.test.tsx
@@ -185,13 +185,12 @@ describe("<TopicAclRequest />", () => {
 
       await userEvent.click(aclConsumerTypeInput);
 
-      // Only rendered in Consumer form
-      const consumerGroupInput = screen.getByRole("textbox", {
-        name: "Consumer group *",
-      });
+      // Only rendered in Producer form
+      const transactionalIdInput = screen.queryByLabelText("Transactional ID");
+
       expect(aclConsumerTypeInput).toBeChecked();
       expect(aclProducerTypeInput).not.toBeChecked();
-      expect(consumerGroupInput).toBeVisible();
+      expect(transactionalIdInput).toBeNull();
     });
   });
 
@@ -542,7 +541,7 @@ describe("<TopicAclRequest />", () => {
     });
   });
 
-  describe("User interaction (TopicConsumerForm)", () => {
+  describe("User interaction (TopicConsumerForm, NOT Aiven cluster)", () => {
     beforeEach(() => {
       dataSetup({ isAivenCluster: false });
 
@@ -792,6 +791,13 @@ describe("<TopicAclRequest />", () => {
       });
       await userEvent.click(aclConsumerTypeInput);
 
+      await selectTestEnvironment();
+      await waitFor(() => {
+        return screen.findByRole("textbox", {
+          name: "Consumer group *",
+        });
+      });
+
       const consumerGroupInput = screen.getByRole("textbox", {
         name: "Consumer group *",
       });
@@ -815,6 +821,13 @@ describe("<TopicAclRequest />", () => {
       });
       await userEvent.click(aclConsumerTypeInput);
 
+      await selectTestEnvironment();
+      await waitFor(() => {
+        return screen.findByRole("textbox", {
+          name: "Consumer group *",
+        });
+      });
+
       const consumerGroupInput = screen.getByRole("textbox", {
         name: "Consumer group *",
       });
@@ -830,13 +843,20 @@ describe("<TopicAclRequest />", () => {
       );
     });
 
-    it("does errors when entering a wrong value in Consumer group field", async () => {
+    it("does not error when entering a correct value in Consumer group field", async () => {
       await assertSkeleton();
 
       const aclConsumerTypeInput = screen.getByRole("radio", {
         name: "Consumer",
       });
       await userEvent.click(aclConsumerTypeInput);
+
+      await selectTestEnvironment();
+      await waitFor(() => {
+        return screen.findByRole("textbox", {
+          name: "Consumer group *",
+        });
+      });
 
       const consumerGroupInput = screen.getByRole("textbox", {
         name: "Consumer group *",
@@ -996,9 +1016,10 @@ describe("<TopicAclRequest />", () => {
       });
     });
   });
+
   describe("Form submission (TopicConsumerForm)", () => {
     beforeEach(async () => {
-      dataSetup({ isAivenCluster: true });
+      dataSetup({ isAivenCluster: false });
 
       customRender(
         <Routes>
@@ -1049,26 +1070,22 @@ describe("<TopicAclRequest />", () => {
 
         await waitFor(() =>
           expect(
-            screen.getByRole("radio", { name: "Service account" })
+            screen.getByRole("radio", { name: "Principal" })
           ).toBeInTheDocument()
         );
-        await userEvent.click(
-          screen.getByRole("radio", { name: "Service account" })
+        await userEvent.click(screen.getByRole("radio", { name: "Principal" }));
+        await waitFor(() =>
+          expect(screen.getByRole("radio", { name: "Principal" })).toBeChecked()
         );
-
-        const consumerGroupInput = screen.getByRole("textbox", {
-          name: "Consumer group *",
-        });
-        await userEvent.type(consumerGroupInput, "Group");
 
         await waitFor(() => {
           return screen.findByRole("textbox", {
-            name: "Service accounts *",
+            name: "SSL DN strings / Usernames *",
           });
         });
 
         const visiblePrincipalField = screen.getByRole("textbox", {
-          name: "Service accounts *",
+          name: "SSL DN strings / Usernames *",
         });
         expect(visiblePrincipalField).toBeVisible();
         expect(visiblePrincipalField).toBeEnabled();
@@ -1092,7 +1109,7 @@ describe("<TopicAclRequest />", () => {
           environment: "1",
           topictype: "Consumer",
           teamname: "Ospo",
-          consumergroup: "Group",
+          consumergroup: "-na-",
         });
 
         const alert = await screen.findByRole("alert");
@@ -1124,23 +1141,24 @@ describe("<TopicAclRequest />", () => {
         // Fill form with valid data
         await selectTestEnvironment();
 
-        const consumerGroupInput = screen.getByRole("textbox", {
-          name: "Consumer group *",
-        });
-
         await waitFor(() =>
           expect(
-            screen.getByRole("radio", { name: "Service account" })
+            screen.getByRole("radio", { name: "Principal" })
           ).toBeInTheDocument()
         );
-        await userEvent.click(
-          screen.getByRole("radio", { name: "Service account" })
+        await userEvent.click(screen.getByRole("radio", { name: "Principal" }));
+        await waitFor(() =>
+          expect(screen.getByRole("radio", { name: "Principal" })).toBeChecked()
         );
 
-        await userEvent.type(consumerGroupInput, "Group");
+        await waitFor(() => {
+          return screen.findByRole("textbox", {
+            name: "SSL DN strings / Usernames *",
+          });
+        });
 
         const visiblePrincipalField = screen.getByRole("textbox", {
-          name: "Service accounts *",
+          name: "SSL DN strings / Usernames *",
         });
         expect(visiblePrincipalField).toBeVisible();
         expect(visiblePrincipalField).toBeEnabled();
@@ -1164,7 +1182,7 @@ describe("<TopicAclRequest />", () => {
           environment: "1",
           topictype: "Consumer",
           teamname: "Ospo",
-          consumergroup: "Group",
+          consumergroup: "-na-",
         });
 
         await waitFor(() => {

--- a/coral/src/app/features/topics/acl-request/TopicAclRequest.tsx
+++ b/coral/src/app/features/topics/acl-request/TopicAclRequest.tsx
@@ -48,6 +48,7 @@ const TopicAclRequest = () => {
       topicname: topicName,
       environment: ENVIRONMENT_NOT_INITIALIZED,
       topictype: "Consumer",
+      consumergroup: "-na-",
     },
   });
 

--- a/coral/src/app/features/topics/acl-request/forms/TopicConsumerForm.test.tsx
+++ b/coral/src/app/features/topics/acl-request/forms/TopicConsumerForm.test.tsx
@@ -98,13 +98,12 @@ describe("<TopicConsumerForm />", () => {
       expect(topicNameField).toHaveDisplayValue("aiventopic1");
     });
 
-    it("renders consumergroup field", () => {
-      const consumergroupField = screen.getByRole("textbox", {
+    it("does not render consumergroup field", () => {
+      const consumergroupField = screen.queryByRole("textbox", {
         name: "Consumer group *",
       });
 
-      expect(consumergroupField).toBeVisible();
-      expect(consumergroupField).toBeEnabled();
+      expect(consumergroupField).toBeNull();
     });
 
     it("renders TopicNameField", () => {
@@ -115,15 +114,6 @@ describe("<TopicConsumerForm />", () => {
       expect(topicNameField).toBeVisible();
       expect(topicNameField).toBeEnabled();
       expect(topicNameField).toHaveDisplayValue("aiventopic1");
-    });
-
-    it("renders consumergroup field", () => {
-      const consumergroupField = screen.getByRole("textbox", {
-        name: "Consumer group *",
-      });
-
-      expect(consumergroupField).toBeVisible();
-      expect(consumergroupField).toBeEnabled();
     });
 
     it("renders AclIpPrincipleTypeField", () => {
@@ -230,13 +220,12 @@ describe("<TopicConsumerForm />", () => {
       expect(topicNameField).toHaveDisplayValue("aiventopic1");
     });
 
-    it("renders consumergroup field", () => {
-      const consumergroupField = screen.getByRole("textbox", {
+    it("does not render consumergroup field", () => {
+      const consumergroupField = screen.queryByRole("textbox", {
         name: "Consumer group *",
       });
 
-      expect(consumergroupField).toBeVisible();
-      expect(consumergroupField).toBeEnabled();
+      expect(consumergroupField).toBeNull();
     });
 
     it("renders AclIpPrincipleTypeField with IP field disabled and Principal field enabled and checked", () => {

--- a/coral/src/app/features/topics/acl-request/forms/TopicConsumerForm.tsx
+++ b/coral/src/app/features/topics/acl-request/forms/TopicConsumerForm.tsx
@@ -70,6 +70,11 @@ const TopicConsumerForm = ({
     navigate(-1);
   };
 
+  const hideConsumerGroupField =
+    clusterInfo === undefined || clusterInfo.aivenCluster === "true";
+  const hideIpOrPrincipalField =
+    aclIpPrincipleType === undefined || clusterInfo === undefined;
+
   return (
     <>
       {isError && (
@@ -92,19 +97,23 @@ const TopicConsumerForm = ({
             <TopicNameField topicNames={topicNames} />
           </GridItem>
           <GridItem>
-            <TextInput
-              name="consumergroup"
-              labelText="Consumer group"
-              placeholder="Add Consumer group here"
-              required
-            />
+            {hideConsumerGroupField ? (
+              <Box data-testid={"empty"} style={{ height: "87px" }} />
+            ) : (
+              <TextInput
+                name="consumergroup"
+                labelText="Consumer group"
+                placeholder="Add Consumer group here"
+                required
+              />
+            )}
           </GridItem>
 
           <GridItem>
             <AclIpPrincipleTypeField clusterInfo={clusterInfo} />
           </GridItem>
           <GridItem>
-            {aclIpPrincipleType === undefined || clusterInfo === undefined ? (
+            {hideIpOrPrincipalField ? (
               <Box data-testid={"empty"} style={{ height: "87px" }} />
             ) : (
               <IpOrPrincipalField

--- a/coral/src/app/features/topics/acl-request/forms/TopicProducerForm.tsx
+++ b/coral/src/app/features/topics/acl-request/forms/TopicProducerForm.tsx
@@ -83,6 +83,10 @@ const TopicProducerForm = ({
     navigate(-1);
   };
 
+  const hideIpOrPrincipalField =
+    aclIpPrincipleType === undefined || clusterInfo === undefined;
+  const hideTopicNameOrPrefixField = aclPatternType === undefined;
+
   return (
     <>
       {isError && (
@@ -112,7 +116,7 @@ const TopicProducerForm = ({
             </RadioButtonGroup>
           </GridItem>
           <GridItem>
-            {aclPatternType === undefined ? (
+            {hideTopicNameOrPrefixField ? (
               <Box data-testid="empty" style={{ height: "87px" }} />
             ) : (
               <TopicNameOrPrefixField
@@ -134,7 +138,7 @@ const TopicProducerForm = ({
             <AclIpPrincipleTypeField clusterInfo={clusterInfo} />
           </GridItem>
           <GridItem>
-            {aclIpPrincipleType === undefined || clusterInfo === undefined ? (
+            {hideIpOrPrincipalField ? (
               <Box data-testid={"empty"} style={{ height: "87px" }} />
             ) : (
               <IpOrPrincipalField


### PR DESCRIPTION
## About this change - What it does

Consumer group is not relevant if the environment is an Aiven cluster:
- make default value for `consumergroup` field `-na-`
- only render the Consumer group field id the cluster is NOT an Aiven cluster

