### PR TITLE
fix(coral): ACL request form - Redirect to My requests page on success

### DIFF
--- a/coral/src/app/features/topics/acl-request/TopicAclRequest.test.tsx
+++ b/coral/src/app/features/topics/acl-request/TopicAclRequest.test.tsx
@@ -1009,10 +1009,11 @@ describe("<TopicAclRequest />", () => {
           teamname: "Ospo",
         });
 
-        await waitFor(() => {
-          expect(mockedNavigate).toHaveBeenCalledTimes(1);
-          expect(mockedNavigate).toHaveBeenCalledWith(-1);
-        });
+        // @TODO use when Klaw migration is completed and redirect is handling with react-router
+        // await waitFor(() => {
+        //   expect(mockedNavigate).toHaveBeenCalledTimes(1);
+        //   expect(mockedNavigate).toHaveBeenCalledWith(-1);
+        // });
       });
     });
   });
@@ -1150,6 +1151,11 @@ describe("<TopicAclRequest />", () => {
         await waitFor(() =>
           expect(screen.getByRole("radio", { name: "Principal" })).toBeChecked()
         );
+        await waitFor(() =>
+          expect(
+            screen.getByRole("radio", { name: "Service account" })
+          ).toBeChecked()
+        );
 
         await waitFor(() => {
           return screen.findByRole("textbox", {
@@ -1185,10 +1191,11 @@ describe("<TopicAclRequest />", () => {
           consumergroup: "-na-",
         });
 
-        await waitFor(() => {
-          expect(mockedNavigate).toHaveBeenCalledTimes(1);
-          expect(mockedNavigate).toHaveBeenCalledWith(-1);
-        });
+        // @TODO use when Klaw migration is completed and redirect is handling with react-router
+        // await waitFor(() => {
+        //   expect(mockedNavigate).toHaveBeenCalledTimes(1);
+        //   expect(mockedNavigate).toHaveBeenCalledWith(-1);
+        // });
       });
     });
   });

--- a/coral/src/app/features/topics/acl-request/TopicAclRequest.test.tsx
+++ b/coral/src/app/features/topics/acl-request/TopicAclRequest.test.tsx
@@ -15,7 +15,6 @@ import {
   mockedResponseTopicTeamLiteral,
   mockGetTopicNames,
   mockGetTopicTeam,
-  mockRequestTopic,
 } from "src/domain/topic/topic-api.msw";
 import api from "src/services/api";
 import { server } from "src/services/api-mocks/server";
@@ -870,6 +869,23 @@ describe("<TopicAclRequest />", () => {
   });
 
   describe("Form submission (TopicProducerForm)", () => {
+    const locationAssignSpy = jest.fn();
+    let originalLocation: Location;
+
+    beforeAll(() => {
+      originalLocation = window.location;
+      Object.defineProperty(global.window, "location", {
+        writable: true,
+        value: {
+          assign: locationAssignSpy,
+        },
+      });
+    });
+
+    afterAll(() => {
+      global.window.location = originalLocation;
+    });
+
     beforeEach(async () => {
       dataSetup({ isAivenCluster: true });
 
@@ -957,13 +973,13 @@ describe("<TopicAclRequest />", () => {
 
     describe("when API request is successful", () => {
       beforeEach(async () => {
-        mockRequestTopic({
+        mockCreateAclRequest({
           mswInstance: server,
           response: { data: { status: "200 OK" } },
         });
       });
 
-      it("redirects user to previous page", async () => {
+      it("redirects user to /myAclRequests?reqsType=created&aclCreated=true", async () => {
         const spyPost = jest.spyOn(api, "post");
         await assertSkeleton();
         const submitButton = screen.getByRole("button", { name: "Submit" });
@@ -1010,15 +1026,33 @@ describe("<TopicAclRequest />", () => {
         });
 
         // @TODO use when Klaw migration is completed and redirect is handling with react-router
-        // await waitFor(() => {
-        //   expect(mockedNavigate).toHaveBeenCalledTimes(1);
-        //   expect(mockedNavigate).toHaveBeenCalledWith(-1);
-        // });
+        await waitFor(() => {
+          expect(locationAssignSpy).toHaveBeenLastCalledWith(
+            "/myAclRequests?reqsType=created&aclCreated=true"
+          );
+        });
       });
     });
   });
 
   describe("Form submission (TopicConsumerForm)", () => {
+    const locationAssignSpy = jest.fn();
+    let originalLocation: Location;
+
+    beforeAll(() => {
+      originalLocation = window.location;
+      Object.defineProperty(global.window, "location", {
+        writable: true,
+        value: {
+          assign: locationAssignSpy,
+        },
+      });
+    });
+
+    afterAll(() => {
+      global.window.location = originalLocation;
+    });
+
     beforeEach(async () => {
       dataSetup({ isAivenCluster: false });
 
@@ -1120,7 +1154,7 @@ describe("<TopicAclRequest />", () => {
 
     describe("when API request is successful", () => {
       beforeEach(async () => {
-        mockRequestTopic({
+        mockCreateAclRequest({
           mswInstance: server,
           response: { data: { status: "200 OK" } },
         });
@@ -1150,11 +1184,6 @@ describe("<TopicAclRequest />", () => {
         await userEvent.click(screen.getByRole("radio", { name: "Principal" }));
         await waitFor(() =>
           expect(screen.getByRole("radio", { name: "Principal" })).toBeChecked()
-        );
-        await waitFor(() =>
-          expect(
-            screen.getByRole("radio", { name: "Service account" })
-          ).toBeChecked()
         );
 
         await waitFor(() => {
@@ -1192,10 +1221,11 @@ describe("<TopicAclRequest />", () => {
         });
 
         // @TODO use when Klaw migration is completed and redirect is handling with react-router
-        // await waitFor(() => {
-        //   expect(mockedNavigate).toHaveBeenCalledTimes(1);
-        //   expect(mockedNavigate).toHaveBeenCalledWith(-1);
-        // });
+        await waitFor(() => {
+          expect(locationAssignSpy).toHaveBeenLastCalledWith(
+            "/myAclRequests?reqsType=created&aclCreated=true"
+          );
+        });
       });
     });
   });

--- a/coral/src/app/features/topics/acl-request/forms/TopicConsumerForm.tsx
+++ b/coral/src/app/features/topics/acl-request/forms/TopicConsumerForm.tsx
@@ -59,8 +59,10 @@ const TopicConsumerForm = ({
     topicConsumerForm.resetField("acl_ssl");
   }, [aclIpPrincipleType]);
 
-  const { mutate, isLoading, isError, isSuccess, error } = useMutation({
+  const { mutate, isLoading, isError, error } = useMutation({
     mutationFn: createAclRequest,
+    onSuccess: () =>
+      window.location.assign("/myAclRequests?reqsType=created&aclCreated=true"),
   });
 
   const onSubmitTopicConsumer: SubmitHandler<TopicConsumerFormSchema> = (
@@ -73,10 +75,6 @@ const TopicConsumerForm = ({
     clusterInfo === undefined || clusterInfo.aivenCluster === "true";
   const hideIpOrPrincipalField =
     aclIpPrincipleType === undefined || clusterInfo === undefined;
-
-  if (isSuccess) {
-    window.location.href = `${window.origin}/myAclRequests?reqsType=created&aclCreated=true`;
-  }
 
   return (
     <>

--- a/coral/src/app/features/topics/acl-request/forms/TopicConsumerForm.tsx
+++ b/coral/src/app/features/topics/acl-request/forms/TopicConsumerForm.tsx
@@ -59,7 +59,7 @@ const TopicConsumerForm = ({
     topicConsumerForm.resetField("acl_ssl");
   }, [aclIpPrincipleType]);
 
-  const { mutate, isLoading, isError, error } = useMutation({
+  const { mutate, isLoading, isError, isSuccess, error } = useMutation({
     mutationFn: createAclRequest,
   });
 
@@ -67,13 +67,16 @@ const TopicConsumerForm = ({
     formData
   ) => {
     mutate(formData);
-    navigate(-1);
   };
 
   const hideConsumerGroupField =
     clusterInfo === undefined || clusterInfo.aivenCluster === "true";
   const hideIpOrPrincipalField =
     aclIpPrincipleType === undefined || clusterInfo === undefined;
+
+  if (isSuccess) {
+    window.location.href = `${window.origin}/myAclRequests?reqsType=created&aclCreated=true`;
+  }
 
   return (
     <>

--- a/coral/src/app/features/topics/acl-request/forms/TopicProducerForm.tsx
+++ b/coral/src/app/features/topics/acl-request/forms/TopicProducerForm.tsx
@@ -72,8 +72,10 @@ const TopicProducerForm = ({
     topicProducerForm.resetField("topicname");
   }, [aclPatternType]);
 
-  const { mutate, isLoading, isError, isSuccess, error } = useMutation({
+  const { mutate, isLoading, isError, error } = useMutation({
     mutationFn: createAclRequest,
+    onSuccess: () =>
+      window.location.assign("/myAclRequests?reqsType=created&aclCreated=true"),
   });
 
   const onSubmitTopicProducer: SubmitHandler<TopicProducerFormSchema> = (
@@ -85,10 +87,6 @@ const TopicProducerForm = ({
   const hideIpOrPrincipalField =
     aclIpPrincipleType === undefined || clusterInfo === undefined;
   const hideTopicNameOrPrefixField = aclPatternType === undefined;
-
-  if (isSuccess) {
-    window.location.href = `${window.origin}/myAclRequests?reqsType=created&aclCreated=true`;
-  }
 
   return (
     <>

--- a/coral/src/app/features/topics/acl-request/forms/TopicProducerForm.tsx
+++ b/coral/src/app/features/topics/acl-request/forms/TopicProducerForm.tsx
@@ -72,7 +72,7 @@ const TopicProducerForm = ({
     topicProducerForm.resetField("topicname");
   }, [aclPatternType]);
 
-  const { mutate, isLoading, isError, error } = useMutation({
+  const { mutate, isLoading, isError, isSuccess, error } = useMutation({
     mutationFn: createAclRequest,
   });
 
@@ -80,12 +80,15 @@ const TopicProducerForm = ({
     formData
   ) => {
     mutate(formData);
-    navigate(-1);
   };
 
   const hideIpOrPrincipalField =
     aclIpPrincipleType === undefined || clusterInfo === undefined;
   const hideTopicNameOrPrefixField = aclPatternType === undefined;
+
+  if (isSuccess) {
+    window.location.href = `${window.origin}/myAclRequests?reqsType=created&aclCreated=true`;
+  }
 
   return (
     <>


### PR DESCRIPTION
Signed-off-by: Mathieu Anderson <mathieu.anderson@aiven.io>

## About this change - What it does

The behaviour of the current redirect (basically a `go back to previous page` action) is not desirable currently. So we redirect to the same page as the angular app (My request page filtered by `created`)

