### PR TITLE
feat(coral): add CoralNavigate component

### DIFF
--- a/coral/src/app/components/CoralNavigate.test.tsx
+++ b/coral/src/app/components/CoralNavigate.test.tsx
@@ -1,0 +1,78 @@
+import { cleanup, render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import CoralNavigate from "src/app/components/CoralNavigate";
+
+const NavigateMock = jest.fn();
+jest.mock("react-router-dom", () => ({
+  ...jest.requireActual("react-router-dom"),
+  Navigate: (args: { to: string }) => {
+    NavigateMock(args);
+    return (
+      <div data-testid="mockedRedirectComponent">
+        This dummy component represents &lt;Navigate&gt;
+      </div>
+    );
+  },
+}));
+
+describe("CoralNavigate", () => {
+  const locationAssignSpy = jest.fn();
+  let originalLocation: Location;
+  beforeAll(() => {
+    originalLocation = window.location;
+    Object.defineProperty(global.window, "location", {
+      writable: true,
+      value: {
+        assign: locationAssignSpy,
+      },
+    });
+  });
+  afterAll(() => {
+    global.window.location = originalLocation;
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe("when using legacy paths", () => {
+    beforeAll(() => {
+      render(<CoralNavigate to="/this-is-absolute-path" useLegacy={true} />);
+    });
+    afterAll(() => {
+      cleanup();
+    });
+    it("calls window.location.assign with correct value", () => {
+      expect(locationAssignSpy).toHaveBeenCalledTimes(1);
+      expect(locationAssignSpy).toHaveBeenCalledWith("/this-is-absolute-path");
+    });
+    it("does not render React Router <Navigate />", () => {
+      expect(screen.queryByTestId("mockedRedirectComponent")).toBeNull();
+      expect(locationAssignSpy).not.toHaveBeenCalledWith();
+    });
+  });
+
+  describe("when using non legacy", () => {
+    beforeAll(() => {
+      render(
+        <MemoryRouter>
+          <CoralNavigate to="/this-is-absolute-path" useLegacy={false} />
+        </MemoryRouter>
+      );
+    });
+    afterAll(() => {
+      cleanup();
+    });
+    it("does not render React Router <Navigate />", () => {
+      screen.getByTestId("mockedRedirectComponent");
+      expect(NavigateMock).toHaveBeenCalledTimes(1);
+      expect(NavigateMock).toHaveBeenCalledWith({
+        to: "/this-is-absolute-path",
+      });
+    });
+
+    it("does not call window.location.assign", () => {
+      expect(locationAssignSpy).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/coral/src/app/components/CoralNavigate.tsx
+++ b/coral/src/app/components/CoralNavigate.tsx
@@ -1,0 +1,23 @@
+import { Navigate, NavigateProps } from "react-router-dom";
+
+type Props = Omit<NavigateProps, "to"> & {
+  to: `/${string}`;
+  useLegacy: boolean;
+};
+
+/**
+ * CoralNavigate is a convenience component, which provides unified API
+ * to do navigation either with React Router or by using window.location API
+ *
+ * Once the Reactification is complete, we should migrate all instances of
+ * <CoralNavigate /> to use the React Router <Navigate />
+ */
+function CoralNavigate({ useLegacy, to, ...navigateProps }: Props) {
+  if (useLegacy) {
+    window.location.assign(to);
+    return <></>;
+  }
+  return <Navigate to={to} {...navigateProps} />;
+}
+
+export default CoralNavigate;

--- a/coral/src/app/features/topics/request/TopicRequest.tsx
+++ b/coral/src/app/features/topics/request/TopicRequest.tsx
@@ -19,9 +19,9 @@ import { Environment } from "src/domain/environment";
 import { getEnvironmentsForTeam } from "src/domain/environment/environment-api";
 import AdvancedConfiguration from "src/app/features/topics/request/components/AdvancedConfiguration";
 import { requestTopic } from "src/domain/topic/topic-api";
-import { Navigate } from "react-router-dom";
 import { parseErrorMsg } from "src/services/mutation-utils";
 import { createTopicRequestPayload } from "src/app/features/topics/request/utils";
+import CoralNavigate from "src/app/components/CoralNavigate";
 
 function TopicRequest() {
   const { data: environments } = useQuery<Environment[], Error>(
@@ -60,7 +60,12 @@ function TopicRequest() {
       reqsType: "created",
       topicCreated: "true",
     });
-    return <Navigate to={`/myTopicRequests?${params.toString()}`} />;
+    return (
+      <CoralNavigate
+        to={`/myTopicRequests?${params.toString()}`}
+        useLegacy={true}
+      />
+    );
   }
 
   return (


### PR DESCRIPTION
The component implements a single component API to create component redirect navigation operations with either React Router or by using browser native navigation

Use component in <TopicRequest />

Signed-off-by: Samuli Suortti <smulis@aiven.io>