### PR TITLE
feat(coral): Add error handling in frontend

### DIFF
--- a/coral/src/services/mutation-utils.ts
+++ b/coral/src/services/mutation-utils.ts
@@ -1,18 +1,5 @@
 import isString from "lodash/isString";
-
-function objectHasProperty<T extends string>(
-  object: unknown,
-  key: T
-): object is Record<T, unknown> {
-  if (
-    object !== null &&
-    object !== undefined &&
-    Object.prototype.hasOwnProperty.call(object, key)
-  ) {
-    return true;
-  }
-  return false;
-}
+import { objectHasProperty } from "src/services/type-utils";
 
 function parseErrorMsg(error: unknown): string {
   if (

--- a/coral/src/services/type-utils.ts
+++ b/coral/src/services/type-utils.ts
@@ -1,0 +1,15 @@
+function objectHasProperty<T extends string>(
+  object: unknown,
+  key: T
+): object is Record<T, unknown> {
+  if (
+    object !== null &&
+    object !== undefined &&
+    Object.prototype.hasOwnProperty.call(object, key)
+  ) {
+    return true;
+  }
+  return false;
+}
+
+export { objectHasProperty };


### PR DESCRIPTION
# About this change

Klaw currently does not return ERRORs from the API but always a 200.

An error is always following this pattern:

```
{
   status: null,
   timestamp: null,
   message: null,
   debugMessage: null,
   result: "Failure. <SOME MORE TEXT>",
   data: null,
};
```

To provide error messages for the user, we added `checkForFailureHiddenAsSuccess` 
as a temporary fix.