### PR TITLE
fix(coral): Add acl_ssl item length validation

### DIFF
--- a/coral/src/app/features/topics/acl-request/TopicAclRequest.tsx
+++ b/coral/src/app/features/topics/acl-request/TopicAclRequest.tsx
@@ -111,7 +111,7 @@ const TopicAclRequest = () => {
           envSelected: selectedEnvironment,
           envType: selectedEnvironmentType,
         }),
-      keepPreviousData: false,
+      keepPreviousData: true,
       enabled:
         selectedEnvironment !== ENVIRONMENT_NOT_INITIALIZED &&
         environments !== undefined &&

--- a/coral/src/app/features/topics/acl-request/schemas/topic-acl-request-shared-fields.ts
+++ b/coral/src/app/features/topics/acl-request/schemas/topic-acl-request-shared-fields.ts
@@ -20,7 +20,7 @@ const acl_ip = z
   .max(15, { message: "Maximum 15 elements allowed." })
   .optional();
 const acl_ssl = z
-  .array(z.string())
+  .array(z.string().min(3, { message: "Must be more than 2 characters." }))
   .min(1, { message: "Enter at least one element." })
   .max(5, { message: "Maximum 5 elements allowed." })
   .optional();


### PR DESCRIPTION
## About this change - What it does

The `creatAcl` does not accept `acl_ssl` values that are < 3 characters:
- add `zod` schema validation to forbid `acl_ssl` values < 3 characters
<img width="1029" alt="Screenshot 2023-01-30 at 14 14 26" src="https://user-images.githubusercontent.com/20607294/215489052-1309f686-63ac-42dc-b148-ff106f39bc22.png">


## Other change

Noticed that we had `keepPreviousData: false` in the `clusterInfo` query. This would cause `clusterInfo` to be undefined when the form re-render because of a server error, making it impossible to interact with the `IP / SSL` checkboxes and fields:
- changed it to be `keepPreviousData: true`
