### PR TITLE
Pem cert support to connect to kafka clusters

### DIFF
--- a/cluster-api/src/main/java/io/aiven/klaw/clusterapi/utils/ClusterApiUtils.java
+++ b/cluster-api/src/main/java/io/aiven/klaw/clusterapi/utils/ClusterApiUtils.java
@@ -344,16 +344,18 @@ public class ClusterApiUtils {
 
     try {
       if (!Strings.isNullOrEmpty(
-              env.getProperty(clusterIdentification.toLowerCase() + ".kafkassl.keystore.certificate.chain"))) {
+          env.getProperty(
+              clusterIdentification.toLowerCase() + ".kafkassl.keystore.certificate.chain"))) {
         props.put(
-                SslConfigs.SSL_KEYSTORE_CERTIFICATE_CHAIN_CONFIG,
-                env.getProperty(clusterIdentification.toLowerCase() + ".kafkassl.keystore.certificate.chain"));
+            SslConfigs.SSL_KEYSTORE_CERTIFICATE_CHAIN_CONFIG,
+            env.getProperty(
+                clusterIdentification.toLowerCase() + ".kafkassl.keystore.certificate.chain"));
       }
       if (!Strings.isNullOrEmpty(
-              env.getProperty(clusterIdentification.toLowerCase() + ".kafkassl.keystore.key"))) {
+          env.getProperty(clusterIdentification.toLowerCase() + ".kafkassl.keystore.key"))) {
         props.put(
-                SslConfigs.SSL_KEYSTORE_KEY_CONFIG,
-                env.getProperty(clusterIdentification.toLowerCase() + ".kafkassl.keystore.key"));
+            SslConfigs.SSL_KEYSTORE_KEY_CONFIG,
+            env.getProperty(clusterIdentification.toLowerCase() + ".kafkassl.keystore.key"));
       }
       if (!Strings.isNullOrEmpty(
           env.getProperty(clusterIdentification.toLowerCase() + ".kafkassl.keystore.location"))) {

--- a/cluster-api/src/main/java/io/aiven/klaw/clusterapi/utils/ClusterApiUtils.java
+++ b/cluster-api/src/main/java/io/aiven/klaw/clusterapi/utils/ClusterApiUtils.java
@@ -344,6 +344,18 @@ public class ClusterApiUtils {
 
     try {
       if (!Strings.isNullOrEmpty(
+              env.getProperty(clusterIdentification.toLowerCase() + ".kafkassl.keystore.certificate.chain"))) {
+        props.put(
+                SslConfigs.SSL_KEYSTORE_CERTIFICATE_CHAIN_CONFIG,
+                env.getProperty(clusterIdentification.toLowerCase() + ".kafkassl.keystore.certificate.chain"));
+      }
+      if (!Strings.isNullOrEmpty(
+              env.getProperty(clusterIdentification.toLowerCase() + ".kafkassl.keystore.key"))) {
+        props.put(
+                SslConfigs.SSL_KEYSTORE_KEY_CONFIG,
+                env.getProperty(clusterIdentification.toLowerCase() + ".kafkassl.keystore.key"));
+      }
+      if (!Strings.isNullOrEmpty(
           env.getProperty(clusterIdentification.toLowerCase() + ".kafkassl.keystore.location"))) {
         props.put(
             SslConfigs.SSL_KEYSTORE_LOCATION_CONFIG,

--- a/cluster-api/src/main/resources/application.properties
+++ b/cluster-api/src/main/resources/application.properties
@@ -9,13 +9,14 @@
 
 # Uncomment the below SSL properties to connect to Kafka clusters over SSL.
 # Each of the below block can be repeated for a cluster with unique cluster identification id
+# JKS/PKCS12/PEM certificate types can be configured
 
 #clusterid.kafkassl.keystore.location=client.keystore.p12
 #clusterid.kafkassl.keystore.pwd=klaw1234
 #clusterid.kafkassl.key.pwd=klaw1234
+#clusterid.kafkassl.keystore.type=pkcs12
 #clusterid.kafkassl.truststore.location=client.truststore.jks
 #clusterid.kafkassl.truststore.pwd=klaw1234
-#clusterid.kafkassl.keystore.type=pkcs12
 #clusterid.kafkassl.truststore.type=JKS
 
 # Uncomment the below SASL properties to connect to Kafka clusters over SASL


### PR DESCRIPTION
About this change - What it does

Currently klaw can connect to kafka clusters over ssl, with cert types for jks and pkcs12. With this minor change, it should be able to connect to kafka clusters with pem cert types too.

Resolves: #181 
Why this way

With configuration enabled, it is now possible to connect to cluster with any certificate type
