### PR TITLE
Pem support for trust store cert

### DIFF
--- a/cluster-api/src/main/java/io/aiven/klaw/clusterapi/utils/ClusterApiUtils.java
+++ b/cluster-api/src/main/java/io/aiven/klaw/clusterapi/utils/ClusterApiUtils.java
@@ -358,6 +358,14 @@ public class ClusterApiUtils {
             env.getProperty(clusterIdentification.toLowerCase() + ".kafkassl.keystore.key"));
       }
       if (!Strings.isNullOrEmpty(
+          env.getProperty(
+              clusterIdentification.toLowerCase() + ".kafkassl.truststore.certificates"))) {
+        props.put(
+            SslConfigs.SSL_TRUSTSTORE_CERTIFICATES_CONFIG,
+            env.getProperty(
+                clusterIdentification.toLowerCase() + ".kafkassl.truststore.certificates"));
+      }
+      if (!Strings.isNullOrEmpty(
           env.getProperty(clusterIdentification.toLowerCase() + ".kafkassl.keystore.location"))) {
         props.put(
             SslConfigs.SSL_KEYSTORE_LOCATION_CONFIG,


### PR DESCRIPTION
Signed-off-by: muralibasani <muralidahr.basani@aiven.io>

About this change - What it does

pem cert support for trust stores

Resolves: #181 
Why this way

Support for both key and trust stores
