### PR TITLE
feat(coral): Only load topic names that are available in given env in topic name field

### DIFF
--- a/coral/src/app/features/topics/acl-request/TopicAclRequest.test.tsx
+++ b/coral/src/app/features/topics/acl-request/TopicAclRequest.test.tsx
@@ -464,6 +464,8 @@ describe("<TopicAclRequest />", () => {
     it("renders correct fields when selecting Literal or Prefixed in aclPatternType fields", async () => {
       await assertSkeleton();
 
+      await selectTestEnvironment();
+
       const literalField = screen.getByRole("radio", { name: "Literal" });
       const prefixedField = screen.getByRole("radio", {
         name: "Prefixed",

--- a/coral/src/app/features/topics/acl-request/fields/TopicNameField.test.tsx
+++ b/coral/src/app/features/topics/acl-request/fields/TopicNameField.test.tsx
@@ -40,4 +40,18 @@ describe("TopicNameField", () => {
 
     expect(options).toHaveLength(mockedTopicNames.length + 1);
   });
+
+  it("renders disabled NativeSelect when topicNames is empty array", () => {
+    cleanup();
+
+    renderForm(<TopicNameField topicNames={[]} />, {
+      schema,
+      onSubmit,
+      onError,
+    });
+
+    const select = screen.getByRole("combobox");
+
+    expect(select).toBeDisabled();
+  });
 });

--- a/coral/src/app/features/topics/acl-request/fields/TopicNameField.tsx
+++ b/coral/src/app/features/topics/acl-request/fields/TopicNameField.tsx
@@ -7,7 +7,12 @@ interface TopicNameFieldProps {
 
 const TopicNameField = ({ topicNames }: TopicNameFieldProps) => {
   return (
-    <NativeSelect name="topicname" labelText="Topic name" required>
+    <NativeSelect
+      name="topicname"
+      labelText="Topic name"
+      disabled={topicNames.length === 0}
+      required
+    >
       <Option disabled>-- Select Topic --</Option>
       {topicNames.map((name) => (
         <Option key={name} value={name}>

--- a/coral/src/app/features/topics/acl-request/forms/TopicProducerForm.tsx
+++ b/coral/src/app/features/topics/acl-request/forms/TopicProducerForm.tsx
@@ -45,7 +45,8 @@ const TopicProducerForm = ({
   clusterInfo,
 }: TopicProducerFormProps) => {
   const navigate = useNavigate();
-  const { aclIpPrincipleType, aclPatternType } = topicProducerForm.getValues();
+  const { aclIpPrincipleType, aclPatternType, topicname } =
+    topicProducerForm.getValues();
   const { current: initialAclIpPrincipleType } = useRef(aclIpPrincipleType);
   const { current: initialAclPatternType } = useRef(aclPatternType);
 
@@ -66,10 +67,13 @@ const TopicProducerForm = ({
   // Avoids conflict when entering a prefix that is not an existing topic name
   useEffect(() => {
     // Prevents resetting when switching from Producer to Consumer forms
-    if (aclPatternType === initialAclPatternType) {
+    if (
+      aclPatternType === initialAclPatternType ||
+      topicNames.includes(topicname)
+    ) {
       return;
     }
-    topicProducerForm.resetField("topicname");
+    return topicProducerForm.setValue("topicname", topicNames[0]);
   }, [aclPatternType]);
 
   const { mutate, isLoading, isError, error } = useMutation({
@@ -111,7 +115,7 @@ const TopicProducerForm = ({
             <RadioButtonGroup
               name="aclPatternType"
               labelText="Topic pattern type"
-              disabled={isAivenCluster}
+              disabled={topicNames.length === 0 || isAivenCluster}
               required
             >
               <BaseRadioButton value="LITERAL">Literal</BaseRadioButton>

--- a/coral/src/app/features/topics/acl-request/queries/useEnvironmentTopics.tsx
+++ b/coral/src/app/features/topics/acl-request/queries/useEnvironmentTopics.tsx
@@ -1,0 +1,62 @@
+import { useQueries, useQuery } from "@tanstack/react-query";
+import { useState } from "react";
+import { Environment, getEnvironments } from "src/domain/environment";
+import { getTopicNames, TopicNames } from "src/domain/topic";
+
+interface ScopedTopicNames {
+  environmentId: string;
+  topicNames: string[];
+}
+
+const useEnvironmentTopics = () => {
+  const [scopedTopicNames, setScopedTopicNames] = useState<ScopedTopicNames[]>(
+    []
+  );
+  const { data: environments, isLoading: environmentsIsLoading } = useQuery<
+    Environment[],
+    Error
+  >(["topic-environments"], {
+    queryFn: getEnvironments,
+  });
+
+  const topicNamesQueries =
+    environments === undefined || environmentsIsLoading
+      ? []
+      : environments.map((env) => {
+          return {
+            queryKey: ["topicNames", env.id],
+            queryFn: () =>
+              getTopicNames({
+                onlyMyTeamTopics: false,
+                envSelected: env.id,
+              }),
+            onSuccess: (data: TopicNames) => {
+              setScopedTopicNames((prev) => [
+                ...prev,
+                { environmentId: env.id, topicNames: data },
+              ]);
+            },
+          };
+        });
+
+  const topicNamesData = useQueries({ queries: topicNamesQueries });
+  const scopedTopicNamesIsLoading = topicNamesData.some(
+    (data) => data.isLoading
+  );
+  const validEnvironments = (environments || []).filter((env) =>
+    new Set(
+      scopedTopicNames.map((scoped) =>
+        scoped.topicNames.length > 0 ? scoped.environmentId : undefined
+      )
+    ).has(env.id)
+  );
+
+  return {
+    scopedTopicNames,
+    scopedTopicNamesIsLoading,
+    environmentsIsLoading,
+    validEnvironments,
+  };
+};
+
+export default useEnvironmentTopics;


### PR DESCRIPTION
# About this change - What it does

- only topics that are available in the scope of the selected environment will be part of the Topic name field's dropdown
- if no environment is selected, Topic name field is disabled

https://user-images.githubusercontent.com/20607294/215762737-63c77613-f77a-40de-87ee-812bbd46ac9d.mov


https://user-images.githubusercontent.com/20607294/215763091-701c8e82-1a03-479b-aeb5-9e4b3aa85ec9.mov

# Approach

- We create a query for each environment and stash the results in state: https://github.com/aiven/klaw/pull/518/files#diff-068b6b4530a8332b187652e53e151f81552bacea92f0f4c2b9dcab507c4df59eR72-R87
- We pick the relevant data and pass it down to the forms https://github.com/aiven/klaw/pull/518/files#diff-068b6b4530a8332b187652e53e151f81552bacea92f0f4c2b9dcab507c4df59eR150-R153

# Follow up

I don't think it's very nice to have fields disabled for an implicit reason (no environment selected). Probably would need some instruction/info text to make it explicit. This is again related to this issue: [feat(coral): Better instructions for ACL Request Form (and maybe all forms)](https://github.com/aiven/klaw/issues/480)

Resolves: #483
