### PR TITLE
Fix: Create Edit Topic Requests

### DIFF
--- a/core/src/main/java/io/aiven/klaw/controller/TopicController.java
+++ b/core/src/main/java/io/aiven/klaw/controller/TopicController.java
@@ -1,9 +1,12 @@
 package io.aiven.klaw.controller;
 
 import io.aiven.klaw.error.KlawException;
+import io.aiven.klaw.error.KlawNotAuthorizedException;
 import io.aiven.klaw.model.ApiResponse;
+import io.aiven.klaw.model.TopicCreateRequestModel;
 import io.aiven.klaw.model.TopicInfo;
 import io.aiven.klaw.model.TopicRequestModel;
+import io.aiven.klaw.model.TopicUpdateRequestModel;
 import io.aiven.klaw.model.enums.AclPatternType;
 import io.aiven.klaw.service.TopicControllerService;
 import jakarta.validation.Valid;
@@ -29,10 +32,19 @@ public class TopicController {
   @Autowired private TopicControllerService topicControllerService;
 
   @PostMapping(value = "/createTopics")
-  public ResponseEntity<ApiResponse> createTopicsRequest(
-      @Valid @RequestBody TopicRequestModel addTopicRequest) throws KlawException {
+  public ResponseEntity<ApiResponse> createTopicsCreateRequest(
+      @Valid @RequestBody TopicCreateRequestModel addTopicRequest)
+      throws KlawException, KlawNotAuthorizedException {
     return new ResponseEntity<>(
-        topicControllerService.createTopicsRequest(addTopicRequest), HttpStatus.OK);
+        topicControllerService.createTopicsCreateRequest(addTopicRequest), HttpStatus.OK);
+  }
+
+  @PostMapping(value = "/updateTopics")
+  public ResponseEntity<ApiResponse> createTopicsUpdateRequest(
+      @Valid @RequestBody TopicUpdateRequestModel addTopicRequest)
+      throws KlawException, KlawNotAuthorizedException {
+    return new ResponseEntity<>(
+        topicControllerService.createTopicsUpdateRequest(addTopicRequest), HttpStatus.OK);
   }
 
   @PostMapping(
@@ -40,7 +52,7 @@ public class TopicController {
       produces = {MediaType.APPLICATION_JSON_VALUE})
   public ResponseEntity<ApiResponse> createTopicDeleteRequest(
       @RequestParam("topicName") String topicName, @RequestParam("env") String envId)
-      throws KlawException {
+      throws KlawException, KlawNotAuthorizedException {
     return new ResponseEntity<>(
         topicControllerService.createTopicDeleteRequest(topicName, envId), HttpStatus.OK);
   }

--- a/core/src/main/java/io/aiven/klaw/error/KlawExceptionHandler.java
+++ b/core/src/main/java/io/aiven/klaw/error/KlawExceptionHandler.java
@@ -1,6 +1,7 @@
 package io.aiven.klaw.error;
 
 import io.aiven.klaw.model.ApiResponse;
+import io.aiven.klaw.model.enums.ApiResultStatus;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
@@ -19,11 +20,20 @@ public class KlawExceptionHandler extends ResponseEntityExceptionHandler {
       "Unable to process the request. Please contact our Administrator !!";
 
   @ExceptionHandler({KlawException.class})
-  protected ResponseEntity<ApiResponse> handleExceptionInternal(
+  protected ResponseEntity<ApiResponse> handleKlawExceptionInternal(
       KlawException ex, WebRequest request) {
     log.error("Error ", ex);
     return new ResponseEntity<>(
         ApiResponse.builder().message(ERROR_MSG).build(), HttpStatus.INTERNAL_SERVER_ERROR);
+  }
+
+  @ExceptionHandler({KlawNotAuthorizedException.class})
+  protected ResponseEntity<ApiResponse> handleKlawNotAuthoirzedExceptionInternal(
+      KlawException ex, WebRequest request) {
+    log.error("Error ", ex);
+    return new ResponseEntity<>(
+        ApiResponse.builder().result(ApiResultStatus.NOT_AUTHORIZED.value).build(),
+        HttpStatus.UNAUTHORIZED);
   }
 
   @Override

--- a/core/src/main/java/io/aiven/klaw/error/KlawNotAuthorizedException.java
+++ b/core/src/main/java/io/aiven/klaw/error/KlawNotAuthorizedException.java
@@ -1,0 +1,7 @@
+package io.aiven.klaw.error;
+
+public class KlawNotAuthorizedException extends Exception {
+  public KlawNotAuthorizedException(String error) {
+    super(error);
+  }
+}

--- a/core/src/main/java/io/aiven/klaw/model/TopicCreateRequestModel.java
+++ b/core/src/main/java/io/aiven/klaw/model/TopicCreateRequestModel.java
@@ -1,0 +1,14 @@
+package io.aiven.klaw.model;
+
+import io.aiven.klaw.model.enums.PermissionType;
+import io.aiven.klaw.validation.TopicRequestValidator;
+import java.io.Serializable;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.ToString;
+
+@Getter
+@Setter
+@ToString
+@TopicRequestValidator(getPermissionType = PermissionType.REQUEST_CREATE_TOPICS)
+public class TopicCreateRequestModel extends TopicRequestModel implements Serializable {}

--- a/core/src/main/java/io/aiven/klaw/model/TopicRequestModel.java
+++ b/core/src/main/java/io/aiven/klaw/model/TopicRequestModel.java
@@ -1,7 +1,5 @@
 package io.aiven.klaw.model;
 
-import io.aiven.klaw.model.enums.PermissionType;
-import io.aiven.klaw.validation.TopicRequestValidator;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Pattern;
@@ -15,7 +13,6 @@ import lombok.ToString;
 @Getter
 @Setter
 @ToString
-@TopicRequestValidator(getPermissionType = PermissionType.REQUEST_CREATE_TOPICS)
 public class TopicRequestModel implements Serializable {
 
   @NotNull

--- a/core/src/main/java/io/aiven/klaw/model/TopicUpdateRequestModel.java
+++ b/core/src/main/java/io/aiven/klaw/model/TopicUpdateRequestModel.java
@@ -1,0 +1,14 @@
+package io.aiven.klaw.model;
+
+import io.aiven.klaw.model.enums.PermissionType;
+import io.aiven.klaw.validation.TopicRequestValidator;
+import java.io.Serializable;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.ToString;
+
+@Getter
+@Setter
+@ToString
+@TopicRequestValidator(getPermissionType = PermissionType.REQUEST_EDIT_TOPICS)
+public class TopicUpdateRequestModel extends TopicRequestModel implements Serializable {}

--- a/core/src/main/java/io/aiven/klaw/model/enums/PermissionType.java
+++ b/core/src/main/java/io/aiven/klaw/model/enums/PermissionType.java
@@ -2,7 +2,6 @@ package io.aiven.klaw.model.enums;
 
 public enum PermissionType {
   REQUEST_CREATE_TOPICS("To request for Topics"),
-
   REQUEST_EDIT_TOPICS("To request for Editing Topics"),
   REQUEST_DELETE_TOPICS("To request for deletion of topics"),
   REQUEST_CREATE_SUBSCRIPTIONS("To request for Producer or Consumer subscriptions"),

--- a/core/src/main/java/io/aiven/klaw/model/enums/PermissionType.java
+++ b/core/src/main/java/io/aiven/klaw/model/enums/PermissionType.java
@@ -2,6 +2,8 @@ package io.aiven.klaw.model.enums;
 
 public enum PermissionType {
   REQUEST_CREATE_TOPICS("To request for Topics"),
+
+  REQUEST_EDIT_TOPICS("To request for Editing Topics"),
   REQUEST_DELETE_TOPICS("To request for deletion of topics"),
   REQUEST_CREATE_SUBSCRIPTIONS("To request for Producer or Consumer subscriptions"),
   REQUEST_DELETE_SUBSCRIPTIONS("To request for deletion of subscriptions"),

--- a/core/src/main/java/io/aiven/klaw/perf/CreateBulkTests.java
+++ b/core/src/main/java/io/aiven/klaw/perf/CreateBulkTests.java
@@ -1,6 +1,7 @@
 package io.aiven.klaw.perf;
 
 import io.aiven.klaw.error.KlawException;
+import io.aiven.klaw.error.KlawNotAuthorizedException;
 import io.aiven.klaw.model.TopicInfo;
 import io.aiven.klaw.model.TopicRequestModel;
 import io.aiven.klaw.service.TopicControllerService;
@@ -63,8 +64,8 @@ public class CreateBulkTests {
       topicRequest.setTeamname("Octopus");
 
       try {
-        topicControllerService.createTopicsRequest(topicRequest);
-      } catch (KlawException e) {
+        topicControllerService.createTopicsCreateRequest(topicRequest);
+      } catch (KlawException | KlawNotAuthorizedException e) {
         log.error("Exception:", e);
       }
     }

--- a/core/src/main/java/io/aiven/klaw/service/DefaultDataService.java
+++ b/core/src/main/java/io/aiven/klaw/service/DefaultDataService.java
@@ -327,6 +327,8 @@ public class DefaultDataService {
     defaultUserPermissionsList.put(
         "REQUEST_DELETE_TOPICS", PermissionType.REQUEST_DELETE_TOPICS.getDescription());
     defaultUserPermissionsList.put(
+        "REQUEST_EDIT_TOPICS", PermissionType.REQUEST_EDIT_TOPICS.getDescription());
+    defaultUserPermissionsList.put(
         "REQUEST_DELETE_SUBSCRIPTIONS",
         PermissionType.REQUEST_DELETE_SUBSCRIPTIONS.getDescription());
     defaultUserPermissionsList.put(

--- a/core/src/main/java/io/aiven/klaw/service/TopicControllerService.java
+++ b/core/src/main/java/io/aiven/klaw/service/TopicControllerService.java
@@ -92,7 +92,7 @@ public class TopicControllerService {
   public ApiResponse createTopicsUpdateRequest(TopicRequestModel topicRequestReq)
       throws KlawException, KlawNotAuthorizedException {
     log.info("createTopicsUpdateRequest {}", topicRequestReq);
-    // check if authorized user to delete topic request
+    // check if authorized user to edit topic request
     checkIsAuthorized(PermissionType.REQUEST_EDIT_TOPICS);
     return createTopicRequest(topicRequestReq);
   }

--- a/core/src/main/java/io/aiven/klaw/service/TopicOverviewService.java
+++ b/core/src/main/java/io/aiven/klaw/service/TopicOverviewService.java
@@ -157,8 +157,7 @@ public class TopicOverviewService extends BaseOverviewService {
       }
 
       // show edit button only for restricted envs
-      if (Objects.equals(topicOwnerTeamId, loggedInUserTeam)
-          && reqTopicsEnvsList.contains(topicInfo.getClusterId())) {
+      if (Objects.equals(topicOwnerTeamId, loggedInUserTeam)) {
         topicInfo.setShowEditTopic(true);
       }
     }

--- a/core/src/main/java/io/aiven/klaw/service/TopicOverviewService.java
+++ b/core/src/main/java/io/aiven/klaw/service/TopicOverviewService.java
@@ -156,7 +156,7 @@ public class TopicOverviewService extends BaseOverviewService {
         prefixedAclsInfo.addAll(tmpAclPrefixed);
       }
 
-      // show edit button only for restricted envs
+      // show edit button only forenv owned by your team
       if (Objects.equals(topicOwnerTeamId, loggedInUserTeam)) {
         topicInfo.setShowEditTopic(true);
       }

--- a/core/src/main/java/io/aiven/klaw/validation/TopicRequestValidatorImpl.java
+++ b/core/src/main/java/io/aiven/klaw/validation/TopicRequestValidatorImpl.java
@@ -43,11 +43,23 @@ public class TopicRequestValidatorImpl
       return false;
     }
 
-    // Verify if topic request type is Create
-    if (!TopicRequestTypes.Create.name().equals(topicRequestModel.getTopictype())) {
-      updateConstraint(
-          constraintValidatorContext,
-          "Failure. Invalid Topic request type. Possible Value : Create");
+    if (permissionType.equals(PermissionType.REQUEST_CREATE_TOPICS)) {
+      // Verify if topic request type is Create
+      if (!TopicRequestTypes.Create.name().equals(topicRequestModel.getTopictype())) {
+        updateConstraint(
+            constraintValidatorContext,
+            "Failure. Invalid Topic request type. Possible Value : Create");
+        return false;
+      }
+    } else if (permissionType.equals(PermissionType.REQUEST_EDIT_TOPICS)) {
+      if (!TopicRequestTypes.Update.name().equals(topicRequestModel.getTopictype())) {
+        updateConstraint(
+            constraintValidatorContext,
+            "Failure. Invalid Topic request type. Possible Value : Update");
+        return false;
+      }
+    } else {
+      updateConstraint(constraintValidatorContext, "Failure. Invalid Permission Type for request.");
       return false;
     }
 

--- a/core/src/main/resources/static/js/requestTopics.js
+++ b/core/src/main/resources/static/js/requestTopics.js
@@ -266,12 +266,17 @@ app.controller("requestTopicsCtrl", function($scope, $http, $location, $window) 
                              closeOnConfirm: true,
                              closeOnCancel: true
                          }).then(function(isConfirm){
+                         if(serviceInput['remarks'] === undefined ){
+                               serviceInput['remarks'] = "Warning To decrease partitions of a topic the topic has to be deleted";
+                         } else {
+                               serviceInput['remarks'] += " Warning To decrease partitions of a topic the topic has to be deleted";
+                         }
                              if (isConfirm.dismiss !== "cancel") {
-                                 $scope.httpCreateTopicReq(serviceInput);
+                                 $scope.httpCreateUpdateTopicReq(serviceInput);
                              }
                          });
-                    }else {
-                        $scope.httpCreateTopicReq(serviceInput);
+                    } else {
+                        $scope.httpCreateUpdateTopicReq(serviceInput);
                     }
             }
 
@@ -305,6 +310,34 @@ app.controller("requestTopicsCtrl", function($scope, $http, $location, $window) 
                     }
                 );
         }
+
+        $scope.httpCreateUpdateTopicReq = function(serviceInput){
+                    $http({
+                            method: "POST",
+                            url: "updateTopics",
+                            headers : { 'Content-Type' : 'application/json' },
+                            data: serviceInput
+                        }).success(function(output) {
+                            if(output.result === 'success'){
+                                swal({
+                                         title: "Awesome !",
+                                         text: "Topic Request : "+output.result,
+                                         showConfirmButton: true
+                                     }).then(function(isConfirm){
+                                            $window.location.href = $window.location.origin + $scope.dashboardDetails.contextPath + "/myTopicRequests?reqsType=created&topicCreated=true";
+                                     });
+                            }
+                            else{
+                                    $scope.alert = "Topic Request : "+output.result;
+                                    $scope.showSubmitFailed('','');
+                                }
+                        }).error(
+                            function(error)
+                            {
+                                $scope.handleValidationErrors(error);
+                            }
+                        );
+                }
 
         $scope.cancelRequest = function() {
             $window.location.href = $window.location.origin + $scope.dashboardDetails.contextPath + "/browseTopics";

--- a/core/src/main/resources/swagger_spec.json
+++ b/core/src/main/resources/swagger_spec.json
@@ -315,13 +315,13 @@
     },
     "/createTopics" : {
       "post" : {
-        "operationId" : "createTopicsRequest",
+        "operationId" : "createTopicsCreateRequest",
         "parameters" : [ {
           "in" : "body",
           "name" : "body",
           "required" : false,
           "schema" : {
-            "$ref" : "#/definitions/TopicRequestModel"
+            "$ref" : "#/definitions/TopicCreateRequestModel"
           }
         } ],
         "responses" : {
@@ -3247,6 +3247,27 @@
         }
       }
     },
+    "/updateTopics" : {
+      "post" : {
+        "operationId" : "createTopicsUpdateRequest",
+        "parameters" : [ {
+          "in" : "body",
+          "name" : "body",
+          "required" : false,
+          "schema" : {
+            "$ref" : "#/definitions/TopicUpdateRequestModel"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "schema" : {
+              "$ref" : "#/definitions/ApiResponse"
+            }
+          }
+        }
+      }
+    },
     "/updateUser" : {
       "post" : {
         "operationId" : "updateUser",
@@ -4525,6 +4546,106 @@
         }
       }
     },
+    "TopicCreateRequestModel" : {
+      "type" : "object",
+      "properties" : {
+        "topicname" : {
+          "type" : "string"
+        },
+        "environment" : {
+          "type" : "string"
+        },
+        "topicpartitions" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "teamname" : {
+          "type" : "string"
+        },
+        "remarks" : {
+          "type" : "string"
+        },
+        "description" : {
+          "type" : "string"
+        },
+        "replicationfactor" : {
+          "type" : "string"
+        },
+        "environmentName" : {
+          "type" : "string"
+        },
+        "topicid" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "advancedTopicConfigEntries" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/TopicConfigEntry"
+          }
+        },
+        "appname" : {
+          "type" : "string"
+        },
+        "topictype" : {
+          "type" : "string"
+        },
+        "requestor" : {
+          "type" : "string"
+        },
+        "requesttime" : {
+          "type" : "string",
+          "format" : "date-time"
+        },
+        "requesttimestring" : {
+          "type" : "string"
+        },
+        "topicstatus" : {
+          "type" : "string"
+        },
+        "approver" : {
+          "type" : "string"
+        },
+        "approvingtime" : {
+          "type" : "string",
+          "format" : "date-time"
+        },
+        "sequence" : {
+          "type" : "string"
+        },
+        "username" : {
+          "type" : "string"
+        },
+        "totalNoPages" : {
+          "type" : "string"
+        },
+        "approvingTeamDetails" : {
+          "type" : "string"
+        },
+        "otherParams" : {
+          "type" : "string"
+        },
+        "teamId" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "allPageNos" : {
+          "type" : "array",
+          "items" : {
+            "type" : "string"
+          }
+        },
+        "possibleTeams" : {
+          "type" : "array",
+          "items" : {
+            "type" : "string"
+          }
+        },
+        "currentPage" : {
+          "type" : "string"
+        }
+      }
+    },
     "TopicHistory" : {
       "type" : "object",
       "properties" : {
@@ -4676,6 +4797,106 @@
       }
     },
     "TopicRequestModel" : {
+      "type" : "object",
+      "properties" : {
+        "topicname" : {
+          "type" : "string"
+        },
+        "environment" : {
+          "type" : "string"
+        },
+        "topicpartitions" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "teamname" : {
+          "type" : "string"
+        },
+        "remarks" : {
+          "type" : "string"
+        },
+        "description" : {
+          "type" : "string"
+        },
+        "replicationfactor" : {
+          "type" : "string"
+        },
+        "environmentName" : {
+          "type" : "string"
+        },
+        "topicid" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "advancedTopicConfigEntries" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/TopicConfigEntry"
+          }
+        },
+        "appname" : {
+          "type" : "string"
+        },
+        "topictype" : {
+          "type" : "string"
+        },
+        "requestor" : {
+          "type" : "string"
+        },
+        "requesttime" : {
+          "type" : "string",
+          "format" : "date-time"
+        },
+        "requesttimestring" : {
+          "type" : "string"
+        },
+        "topicstatus" : {
+          "type" : "string"
+        },
+        "approver" : {
+          "type" : "string"
+        },
+        "approvingtime" : {
+          "type" : "string",
+          "format" : "date-time"
+        },
+        "sequence" : {
+          "type" : "string"
+        },
+        "username" : {
+          "type" : "string"
+        },
+        "totalNoPages" : {
+          "type" : "string"
+        },
+        "approvingTeamDetails" : {
+          "type" : "string"
+        },
+        "otherParams" : {
+          "type" : "string"
+        },
+        "teamId" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "allPageNos" : {
+          "type" : "array",
+          "items" : {
+            "type" : "string"
+          }
+        },
+        "possibleTeams" : {
+          "type" : "array",
+          "items" : {
+            "type" : "string"
+          }
+        },
+        "currentPage" : {
+          "type" : "string"
+        }
+      }
+    },
+    "TopicUpdateRequestModel" : {
       "type" : "object",
       "properties" : {
         "topicname" : {

--- a/core/src/test/java/io/aiven/klaw/TopicAclControllerIT.java
+++ b/core/src/test/java/io/aiven/klaw/TopicAclControllerIT.java
@@ -233,7 +233,7 @@ public class TopicAclControllerIT {
   @Test
   @Order(5)
   public void createTopicRequest() throws Exception {
-    TopicRequestModel addTopicRequest = utilMethods.getTopicRequestModel(topicId);
+    TopicRequestModel addTopicRequest = utilMethods.getTopicCreateRequestModel(topicId);
     String jsonReq = OBJECT_MAPPER.writer().writeValueAsString(addTopicRequest);
     String response =
         mvc.perform(
@@ -323,7 +323,7 @@ public class TopicAclControllerIT {
   @Test
   public void declineTopicRequest() throws Exception {
     int topicIdLocal = 1002;
-    TopicRequestModel addTopicRequest = utilMethods.getTopicRequestModel(topicIdLocal);
+    TopicRequestModel addTopicRequest = utilMethods.getTopicCreateRequestModel(topicIdLocal);
     String jsonReq = OBJECT_MAPPER.writer().writeValueAsString(addTopicRequest);
     String response =
         mvc.perform(
@@ -379,7 +379,7 @@ public class TopicAclControllerIT {
   @Test
   public void deleteTopicRequest() throws Exception {
 
-    TopicRequestModel addTopicRequest = utilMethods.getTopicRequestModel(1003);
+    TopicRequestModel addTopicRequest = utilMethods.getTopicCreateRequestModel(1003);
     String jsonReq = OBJECT_MAPPER.writer().writeValueAsString(addTopicRequest);
     String response =
         mvc.perform(

--- a/core/src/test/java/io/aiven/klaw/UtilMethods.java
+++ b/core/src/test/java/io/aiven/klaw/UtilMethods.java
@@ -21,9 +21,11 @@ import io.aiven.klaw.model.ServerConfigProperties;
 import io.aiven.klaw.model.SyncAclUpdates;
 import io.aiven.klaw.model.SyncTopicUpdates;
 import io.aiven.klaw.model.TeamModel;
+import io.aiven.klaw.model.TopicCreateRequestModel;
 import io.aiven.klaw.model.TopicInfo;
 import io.aiven.klaw.model.TopicOverview;
 import io.aiven.klaw.model.TopicRequestModel;
+import io.aiven.klaw.model.TopicUpdateRequestModel;
 import io.aiven.klaw.model.UserInfoModel;
 import io.aiven.klaw.model.enums.AclIPPrincipleType;
 import io.aiven.klaw.model.enums.AclPatternType;
@@ -346,8 +348,8 @@ public class UtilMethods {
     return topicRequest;
   }
 
-  public TopicRequestModel getTopicRequestModel(int topicId) {
-    TopicRequestModel topicRequest = new TopicRequestModel();
+  public TopicCreateRequestModel getTopicCreateRequestModel(int topicId) {
+    TopicCreateRequestModel topicRequest = new TopicCreateRequestModel();
     topicRequest.setTopicid(topicId);
     topicRequest.setUsername("kwusera");
     topicRequest.setTopicname("testtopic" + topicId);
@@ -355,6 +357,19 @@ public class UtilMethods {
     topicRequest.setReplicationfactor("1");
     topicRequest.setEnvironment("1");
     topicRequest.setTopictype(RequestOperationType.CREATE.value);
+    topicRequest.setDescription("Test desc");
+    return topicRequest;
+  }
+
+  public TopicUpdateRequestModel getTopicUpdateRequestModel(int topicId) {
+    TopicUpdateRequestModel topicRequest = new TopicUpdateRequestModel();
+    topicRequest.setTopicid(topicId);
+    topicRequest.setUsername("kwusera");
+    topicRequest.setTopicname("testtopic" + topicId);
+    topicRequest.setTopicpartitions(2);
+    topicRequest.setReplicationfactor("1");
+    topicRequest.setEnvironment("1");
+    topicRequest.setTopictype(RequestOperationType.UPDATE.value);
     topicRequest.setDescription("Test desc");
     return topicRequest;
   }

--- a/core/src/test/java/io/aiven/klaw/controller/TopicControllerTest.java
+++ b/core/src/test/java/io/aiven/klaw/controller/TopicControllerTest.java
@@ -77,11 +77,11 @@ public class TopicControllerTest {
   @Test
   @Order(1)
   public void createTopics() throws Exception {
-    TopicRequestModel addTopicRequest = utilMethods.getTopicRequestModel(1001);
+    TopicRequestModel addTopicRequest = utilMethods.getTopicCreateRequestModel(1001);
     String jsonReq = OBJECT_MAPPER.writer().writeValueAsString(addTopicRequest);
     ApiResponse apiResponse =
         ApiResponse.builder().result(ApiResultStatus.SUCCESS.value).status(HttpStatus.OK).build();
-    when(topicControllerService.createTopicsRequest(any())).thenReturn(apiResponse);
+    when(topicControllerService.createTopicsCreateRequest(any())).thenReturn(apiResponse);
 
     mvc.perform(
             MockMvcRequestBuilders.post("/createTopics")
@@ -272,5 +272,23 @@ public class TopicControllerTest {
                 .accept(MediaType.APPLICATION_JSON))
         .andExpect(status().isOk())
         .andExpect(jsonPath("$.*", hasSize(1)));
+  }
+
+  @Test
+  @Order(12)
+  public void updateTopic() throws Exception {
+    TopicRequestModel addTopicRequest = utilMethods.getTopicUpdateRequestModel(1001);
+    String jsonReq = OBJECT_MAPPER.writer().writeValueAsString(addTopicRequest);
+    ApiResponse apiResponse =
+        ApiResponse.builder().result(ApiResultStatus.SUCCESS.value).status(HttpStatus.OK).build();
+    when(topicControllerService.createTopicsUpdateRequest(any())).thenReturn(apiResponse);
+
+    mvc.perform(
+            MockMvcRequestBuilders.post("/updateTopics")
+                .content(jsonReq)
+                .contentType(MediaType.APPLICATION_JSON)
+                .accept(MediaType.APPLICATION_JSON))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.result", is(ApiResultStatus.SUCCESS.value)));
   }
 }


### PR DESCRIPTION
Fix: Allows the creation of an edit topic config request and ensure it is available on all environments.

Signed-off-by: Aindriu Lavelle <aindriu.lavelle@aiven.io>

About this change - What it does
Resolves issue #503 which due to validation the edit topic will not be created.
It also resolves an issue where the edit button was not available on all environments if the requestTopicsEnvironmentsList is set to a subset of environments.
Resolves: #xxxxx
Why this way
Maximizes code re-use and minimizes changes to the API to maintain stability during the Front End coral updates.