### PR TITLE
fix(coral): ACL request form - If Aiven cluster, only LITERAL allowed, no Transactional ID field

### DIFF
--- a/coral/src/app/features/topics/acl-request/TopicAclRequest.test.tsx
+++ b/coral/src/app/features/topics/acl-request/TopicAclRequest.test.tsx
@@ -153,7 +153,7 @@ describe("<TopicAclRequest />", () => {
       await selectTestEnvironment();
 
       await waitFor(() => {
-        expect(principalField).toBeEnabled();
+        expect(principalField).not.toBeEnabled();
         expect(principalField).toBeChecked();
         expect(ipField).toBeDisabled();
         expect(ipField).not.toBeChecked();

--- a/coral/src/app/features/topics/acl-request/TopicAclRequest.test.tsx
+++ b/coral/src/app/features/topics/acl-request/TopicAclRequest.test.tsx
@@ -962,7 +962,6 @@ describe("<TopicAclRequest />", () => {
           topicname: "aivtopic1",
           environment: "1",
           topictype: "Producer",
-          transactionalId: "",
           teamname: "Ospo",
         });
 
@@ -1021,7 +1020,6 @@ describe("<TopicAclRequest />", () => {
           topicname: "aivtopic1",
           environment: "1",
           topictype: "Producer",
-          transactionalId: "",
           teamname: "Ospo",
         });
 

--- a/coral/src/app/features/topics/acl-request/TopicAclRequest.tsx
+++ b/coral/src/app/features/topics/acl-request/TopicAclRequest.tsx
@@ -119,11 +119,16 @@ const TopicAclRequest = () => {
         selectedEnvironmentType !== undefined,
       onSuccess: (data) => {
         const isAivenCluster = data?.aivenCluster === "true";
-        // Enable the only possible option when the environment chosen is Aiven Kafka flavor
+        // Enable the only possible options when the environment chosen is Aiven Kafka flavor
         if (isAivenCluster) {
-          return topicType === "Producer"
-            ? topicProducerForm.setValue("aclIpPrincipleType", "PRINCIPAL")
-            : topicConsumerForm.setValue("aclIpPrincipleType", "PRINCIPAL");
+          if (topicType === "Producer") {
+            topicProducerForm.setValue("aclPatternType", "LITERAL");
+            topicProducerForm.setValue("aclIpPrincipleType", "PRINCIPAL");
+            topicProducerForm.resetField("transactionalId");
+          }
+          if (topicType === "Consumer") {
+            topicConsumerForm.setValue("aclIpPrincipleType", "PRINCIPAL");
+          }
         }
       },
     }

--- a/coral/src/app/features/topics/acl-request/fields/AclIpPrincipleTypeField.test.tsx
+++ b/coral/src/app/features/topics/acl-request/fields/AclIpPrincipleTypeField.test.tsx
@@ -57,7 +57,7 @@ describe("AclIpPrincipleTypeField", () => {
     expect(ipRadioButtons).toBeEnabled();
   });
 
-  it("renders AclIpPrincipleTypeField with only Principal option enabled (Aiven cluster)", () => {
+  it("renders AclIpPrincipleTypeField with both options disabled (Aiven cluster)", () => {
     const result = renderForm(
       <AclIpPrincipleTypeField clusterInfo={clusterInfoIsAiven} />,
       { schema, onSubmit, onError }
@@ -65,11 +65,11 @@ describe("AclIpPrincipleTypeField", () => {
     const principalRadioButtons = result.getByLabelText("Service account");
     const ipRadioButtons = result.getByLabelText("IP");
 
-    expect(principalRadioButtons).toBeEnabled();
+    expect(principalRadioButtons).not.toBeEnabled();
     expect(ipRadioButtons).not.toBeEnabled();
   });
 
-  it("renders AclIpPrincipleTypeField with both options disabled", () => {
+  it("renders AclIpPrincipleTypeField with both options disabled (clusterInfo not fetched)", () => {
     const result = renderForm(
       <AclIpPrincipleTypeField clusterInfo={clusterInfoNotFetched} />,
       { schema, onSubmit, onError }

--- a/coral/src/app/features/topics/acl-request/fields/AclIpPrincipleTypeField.tsx
+++ b/coral/src/app/features/topics/acl-request/fields/AclIpPrincipleTypeField.tsx
@@ -19,7 +19,7 @@ const AclIpPrincipleTypeField = ({
       required
       // If clusterInfo is undefined, we have not yet fetched it (no environment selected)
       // So all the options are disabled
-      disabled={clusterInfo === undefined}
+      disabled={isAivenCluster || clusterInfo === undefined}
     >
       <BaseRadioButton value="IP_ADDRESS" disabled={isAivenCluster}>
         IP

--- a/coral/src/app/features/topics/acl-request/forms/TopicConsumerForm.test.tsx
+++ b/coral/src/app/features/topics/acl-request/forms/TopicConsumerForm.test.tsx
@@ -228,7 +228,7 @@ describe("<TopicConsumerForm />", () => {
       expect(consumergroupField).toBeNull();
     });
 
-    it("renders AclIpPrincipleTypeField with IP field disabled and Principal field enabled and checked", () => {
+    it("renders AclIpPrincipleTypeField with fields disabled and Principal field checked", () => {
       const ipField = screen.getByRole("radio", { name: "IP" });
       const principalField = screen.getByRole("radio", {
         name: "Service account",
@@ -237,7 +237,7 @@ describe("<TopicConsumerForm />", () => {
       expect(ipField).toBeVisible();
       expect(ipField).not.toBeEnabled();
       expect(principalField).toBeVisible();
-      expect(principalField).toBeEnabled();
+      expect(principalField).not.toBeEnabled();
       expect(principalField).toBeChecked();
     });
 

--- a/coral/src/app/features/topics/acl-request/forms/TopicProducerForm.test.tsx
+++ b/coral/src/app/features/topics/acl-request/forms/TopicProducerForm.test.tsx
@@ -207,16 +207,16 @@ describe("<TopicProducerForm />", () => {
       expect(environmentField).toHaveDisplayValue("DEV");
     });
 
-    it("renders aclPatternType field", () => {
+    it("renders aclPatternType field with Literal option disabled", () => {
       const literalField = screen.getByRole("radio", { name: "Literal" });
       const prefixedField = screen.getByRole("radio", {
         name: "Prefixed",
       });
 
       expect(literalField).toBeVisible();
-      expect(literalField).toBeEnabled();
+      expect(literalField).not.toBeEnabled();
       expect(prefixedField).toBeVisible();
-      expect(prefixedField).toBeEnabled();
+      expect(prefixedField).not.toBeEnabled();
     });
 
     it("does not render TopicNameOrPrefixField", () => {
@@ -231,13 +231,12 @@ describe("<TopicProducerForm />", () => {
       expect(prefixField).toBeNull();
     });
 
-    it("renders transactionalId field", () => {
+    it("does not render transactionalId field", () => {
       const transactionalIdField = screen.queryByRole("textbox", {
         name: "Transactional ID",
       });
 
-      expect(transactionalIdField).toBeVisible();
-      expect(transactionalIdField).toBeEnabled();
+      expect(transactionalIdField).toBeNull();
     });
 
     it("renders AclIpPrincipleTypeField with IP field disabled and Principal field enabled and checked", () => {

--- a/coral/src/app/features/topics/acl-request/forms/TopicProducerForm.test.tsx
+++ b/coral/src/app/features/topics/acl-request/forms/TopicProducerForm.test.tsx
@@ -239,7 +239,7 @@ describe("<TopicProducerForm />", () => {
       expect(transactionalIdField).toBeNull();
     });
 
-    it("renders AclIpPrincipleTypeField with IP field disabled and Principal field enabled and checked", () => {
+    it("renders AclIpPrincipleTypeField with fields disabled and Principal field checked", () => {
       const ipField = screen.getByRole("radio", { name: "IP" });
       const principalField = screen.getByRole("radio", {
         name: "Service account",
@@ -248,7 +248,7 @@ describe("<TopicProducerForm />", () => {
       expect(ipField).toBeVisible();
       expect(ipField).not.toBeEnabled();
       expect(principalField).toBeVisible();
-      expect(principalField).toBeEnabled();
+      expect(principalField).not.toBeEnabled();
       expect(principalField).toBeChecked();
     });
 

--- a/coral/src/app/features/topics/acl-request/forms/TopicProducerForm.tsx
+++ b/coral/src/app/features/topics/acl-request/forms/TopicProducerForm.tsx
@@ -130,7 +130,7 @@ const TopicProducerForm = ({
           </GridItem>
 
           <GridItem colSpan={"span-2"}>
-            {isAivenCluster ? null : (
+            {!isAivenCluster && (
               <TextInput
                 name="transactionalId"
                 labelText="Transactional ID"

--- a/coral/src/app/features/topics/acl-request/forms/TopicProducerForm.tsx
+++ b/coral/src/app/features/topics/acl-request/forms/TopicProducerForm.tsx
@@ -87,6 +87,7 @@ const TopicProducerForm = ({
   const hideIpOrPrincipalField =
     aclIpPrincipleType === undefined || clusterInfo === undefined;
   const hideTopicNameOrPrefixField = aclPatternType === undefined;
+  const isAivenCluster = clusterInfo?.aivenCluster === "true";
 
   return (
     <>
@@ -110,6 +111,7 @@ const TopicProducerForm = ({
             <RadioButtonGroup
               name="aclPatternType"
               labelText="Topic pattern type"
+              disabled={isAivenCluster}
               required
             >
               <BaseRadioButton value="LITERAL">Literal</BaseRadioButton>
@@ -128,11 +130,13 @@ const TopicProducerForm = ({
           </GridItem>
 
           <GridItem colSpan={"span-2"}>
-            <TextInput
-              name="transactionalId"
-              labelText="Transactional ID"
-              placeholder="Necessary for exactly-once semantics on producer"
-            />
+            {isAivenCluster ? null : (
+              <TextInput
+                name="transactionalId"
+                labelText="Transactional ID"
+                placeholder="Necessary for exactly-once semantics on producer"
+              />
+            )}
           </GridItem>
 
           <GridItem>


### PR DESCRIPTION
## About this change - What it does

If Environment is an Aiven cluster:
- only allow `LITERAL` pattern type
- do not render Transational ID field and do not send it as part of the request



https://user-images.githubusercontent.com/20607294/215801877-927fa1d8-a1d7-4d09-abc6-557525cda2ad.mov

