### PR TITLE
fix(coral): Make consumergroup value -na- only for Aiven clusters

### DIFF
--- a/coral/src/app/features/topics/acl-request/TopicAclRequest.test.tsx
+++ b/coral/src/app/features/topics/acl-request/TopicAclRequest.test.tsx
@@ -1024,6 +1024,13 @@ describe("<TopicAclRequest />", () => {
         await userEvent.type(principalsField, "Alice");
         await userEvent.tab();
 
+        const consumerGroupField = await screen.findByRole("textbox", {
+          name: "Consumer group *",
+        });
+
+        await userEvent.type(consumerGroupField, "group");
+        userEvent.tab();
+
         await waitFor(() => expect(submitButton).toBeEnabled());
         await userEvent.click(submitButton);
 
@@ -1041,7 +1048,7 @@ describe("<TopicAclRequest />", () => {
           environment: "1",
           topictype: "Consumer",
           teamname: "Ospo",
-          consumergroup: "-na-",
+          consumergroup: "group",
         });
 
         const alert = await screen.findByRole("alert");
@@ -1090,6 +1097,13 @@ describe("<TopicAclRequest />", () => {
         await userEvent.type(principalsField, "Alice");
         await userEvent.tab();
 
+        const consumerGroupField = await screen.findByRole("textbox", {
+          name: "Consumer group *",
+        });
+
+        await userEvent.type(consumerGroupField, "group");
+        userEvent.tab();
+
         await waitFor(() => expect(submitButton).toBeEnabled());
         await userEvent.click(submitButton);
 
@@ -1107,7 +1121,7 @@ describe("<TopicAclRequest />", () => {
           environment: "1",
           topictype: "Consumer",
           teamname: "Ospo",
-          consumergroup: "-na-",
+          consumergroup: "group",
         });
 
         // @TODO use when Klaw migration is completed and redirect is handling with react-router

--- a/coral/src/app/features/topics/acl-request/TopicAclRequest.tsx
+++ b/coral/src/app/features/topics/acl-request/TopicAclRequest.tsx
@@ -37,7 +37,7 @@ const TopicAclRequest = () => {
       topicname: topicName,
       environment: ENVIRONMENT_NOT_INITIALIZED,
       topictype: "Consumer",
-      consumergroup: "-na-",
+      consumergroup: "",
     },
   });
 

--- a/coral/src/app/features/topics/acl-request/forms/TopicConsumerForm.tsx
+++ b/coral/src/app/features/topics/acl-request/forms/TopicConsumerForm.tsx
@@ -75,6 +75,14 @@ const TopicConsumerForm = ({
   const hideIpOrPrincipalField =
     aclIpPrincipleType === undefined || isAivenCluster === undefined;
 
+  useEffect(() => {
+    if (hideConsumerGroupField) {
+      topicConsumerForm.setValue("consumergroup", "-na-");
+    } else {
+      topicConsumerForm.setValue("consumergroup", "");
+    }
+  }, [hideConsumerGroupField]);
+
   return (
     <>
       {isError && (

--- a/coral/src/app/features/topics/acl-request/forms/TopicConsumerForm.tsx
+++ b/coral/src/app/features/topics/acl-request/forms/TopicConsumerForm.tsx
@@ -71,14 +71,22 @@ const TopicConsumerForm = ({
     mutate(formData);
   };
 
+  // The consumer group field is irrelevant if the Environment is an Aiven cluster
+  // So we hide it when:
+  // - we don't know if the Environment is an Aiven cluster (user has not selected an environment yet)
+  // - the selected Environment is an Aiven cluster
   const hideConsumerGroupField = isAivenCluster === undefined || isAivenCluster;
   const hideIpOrPrincipalField =
     aclIpPrincipleType === undefined || isAivenCluster === undefined;
 
+  // Because the consumergroup field is *still* a required field in the form schema,
+  // we need to pass it a value even when the field is hidden.
+  // This value needs to be "-na-" so that the backend can process it correctly
   useEffect(() => {
     if (hideConsumerGroupField) {
       topicConsumerForm.setValue("consumergroup", "-na-");
     } else {
+      // Reset field to e empty value so that the "-na-" value does not persist between switching environments
       topicConsumerForm.setValue("consumergroup", "");
     }
   }, [hideConsumerGroupField]);


### PR DESCRIPTION
## About this change - What it does

Consumer group value should be:
- Aiven cluster: `"-na-"`
- not Aiven cluster: `""`

To achieve this:
- set default value of `consumergroup` to `""`
- when an environment is selected:
  - if field is hidden (Aiven cluster), set its value to `"-na-"`
  - if field is rendered (noy Aiven cluster). set its value to `""`
  
  

https://user-images.githubusercontent.com/20607294/216052807-9b20d294-b194-4820-8b06-75dea3bf4aa0.mov

