### PR TITLE
refactor(coral): Remove custom implementation for placeholder NativeSelect

### DIFF
--- a/coral/src/app/components/ComplexNativeSelect.test.tsx
+++ b/coral/src/app/components/ComplexNativeSelect.test.tsx
@@ -35,7 +35,6 @@ describe("ComplexNativeSelect.tsx", () => {
     identifierValue: "id" as keyof TestOption,
     identifierName: "name" as keyof TestOption,
     onBlur: onBlurMock,
-    placeholder,
     labelText,
     helperText,
   };
@@ -54,27 +53,18 @@ describe("ComplexNativeSelect.tsx", () => {
       expect(select).not.toBeRequired();
     });
 
-    it("shows a given placeholder text as displayed value", () => {
+    it("shows the value of the first option as displayed value", () => {
       const select = screen.getByRole("combobox", { name: labelText });
 
-      expect(select).toHaveDisplayValue(placeholder);
+      expect(select).toHaveDisplayValue(testOptions[0].name);
+      expect(select).toHaveValue(testOptions[0].id);
     });
 
-    it("renders a list of given options including a disabled placeholder options", () => {
+    it("renders a list of given options", () => {
       const select = screen.getByRole("combobox", { name: labelText });
       const options = within(select).getAllByRole("option");
 
-      expect(options).toHaveLength(testOptions.length + 1);
-    });
-
-    it("sets the option related to the placeholder as selected, but disabled", () => {
-      const select = screen.getByRole("combobox", { name: labelText });
-      const selectedOption = within(select).getByRole("option", {
-        name: placeholder,
-      });
-
-      expect(selectedOption).toHaveAttribute("selected");
-      expect(selectedOption).toBeDisabled();
+      expect(options).toHaveLength(testOptions.length);
     });
 
     testOptions.forEach((option) => {
@@ -84,7 +74,6 @@ describe("ComplexNativeSelect.tsx", () => {
           name: option.name,
         });
 
-        expect(currOption).not.toHaveAttribute("selected");
         expect(currOption).toHaveValue(option.id);
         expect(currOption).toBeEnabled();
       });
@@ -146,22 +135,15 @@ describe("ComplexNativeSelect.tsx", () => {
     });
   });
 
-  describe("renders a given option as the active one when set by prop", () => {
+  describe("renders a given option as the active one when value is set as defaultValue", () => {
     const selectedOption = testOptions[0];
-
-    const requiredProps = {
-      options: testOptions,
-      identifierValue: "id" as keyof TestOption,
-      identifierName: "name" as keyof TestOption,
-      onBlur: onBlurMock,
-      placeholder,
-      labelText,
-      helperText,
-    };
 
     beforeEach(() => {
       render(
-        <ComplexNativeSelect {...requiredProps} activeOption={selectedOption} />
+        <ComplexNativeSelect
+          {...requiredProps}
+          defaultValue={selectedOption.name}
+        />
       );
     });
 
@@ -191,9 +173,14 @@ describe("ComplexNativeSelect.tsx", () => {
     });
   });
 
-  describe("handles user choosing an option an optional select", () => {
+  describe("handles user choosing an option an optional select with placeholder", () => {
     beforeEach(() => {
-      render(<ComplexNativeSelect<TestOption> {...requiredProps} />);
+      render(
+        <ComplexNativeSelect<TestOption>
+          {...requiredProps}
+          placeholder={placeholder}
+        />
+      );
     });
 
     afterEach(() => {
@@ -212,12 +199,13 @@ describe("ComplexNativeSelect.tsx", () => {
       expect(onBlurMock).toHaveBeenCalledWith(testOptions[0]);
     });
 
-    it("does not set an value and call onBlur if user didn't select an option", async () => {
+    it("does not set an value onBlur if user didn't select an option", async () => {
       const select = screen.getByRole("combobox", { name: labelText });
+      select.focus();
       await userEvent.tab();
 
       expect(select).toHaveDisplayValue(placeholder);
-      expect(onBlurMock).not.toHaveBeenCalled();
+      expect(onBlurMock).toHaveBeenCalledWith(undefined);
     });
   });
 });

--- a/coral/src/app/components/ComplexNativeSelect.tsx
+++ b/coral/src/app/components/ComplexNativeSelect.tsx
@@ -7,19 +7,12 @@ type ComplexNativeSelectProps<T> = NativeSelectProps & {
   identifierValue: keyof T;
   identifierName: keyof T;
   onBlur: (option: T | undefined) => void;
-  placeholder: string;
   activeOption?: T;
 };
 
 function ComplexNativeSelect<T>(props: ComplexNativeSelectProps<T>) {
-  const {
-    options,
-    onBlur,
-    identifierValue,
-    identifierName,
-    placeholder,
-    activeOption,
-  } = props;
+  const { options, onBlur, identifierValue, identifierName, activeOption } =
+    props;
 
   const [activeValue, setActiveValue] = useState<T | undefined>(
     activeOption || undefined
@@ -33,24 +26,21 @@ function ComplexNativeSelect<T>(props: ComplexNativeSelectProps<T>) {
     return String((option as T)[identifierName]);
   }
 
-  // the placeholder behavior will be covered by DS NativeSelect
-  // soon, this is a temp solution
-  const placeholderValue = "055d87f2-8cd4-11ed-a1eb-0242ac120002";
   function setNewOption({ target: { value } }: ChangeEvent<HTMLSelectElement>) {
-    if (value === placeholderValue) {
-      onBlur(undefined);
+    const newOption = options.find((option) => getValue(option) === value);
+    if (newOption) {
+      setActiveValue(newOption);
+      onBlur(newOption);
     } else {
-      const newOption = options.find((option) => getValue(option) === value);
-      if (newOption) {
-        setActiveValue(newOption);
-        onBlur(newOption);
-      }
+      // trigger onBlur with undefined so a required field
+      // is marked invalid in case no value (or placeholder)
+      // is choosen.
+      onBlur(undefined);
     }
   }
 
   const nativeSelectProps = omit(
     props,
-    "placeholder",
     "options",
     "identifierValue",
     "identifierName",
@@ -63,13 +53,7 @@ function ComplexNativeSelect<T>(props: ComplexNativeSelectProps<T>) {
       value={activeValue && getValue(activeValue)}
       onBlur={setNewOption}
       onChange={setNewOption}
-      {...(!activeOption && { defaultValue: placeholderValue })}
     >
-      {!activeOption && (
-        <option key={placeholderValue} value={placeholderValue} disabled={true}>
-          {placeholder}
-        </option>
-      )}
       {options.map((option) => {
         const value = getValue(option);
         return (

--- a/coral/src/app/components/Form.test.tsx
+++ b/coral/src/app/components/Form.test.tsx
@@ -235,15 +235,7 @@ describe("Form", () => {
       screen.getByRole("combobox", { name: "NativeSelect" });
     });
 
-    it("should default to first available option", async () => {
-      expect(screen.getByLabelText("NativeSelect")).toHaveDisplayValue(
-        "Helsinki"
-      );
-      await submit();
-      assertSubmitted({ formFieldsCustomName: "helsinki" });
-    });
-
-    it("should sync value to form state when choosing another option", async () => {
+    it("should sync value to form state when choosing option", async () => {
       await user.selectOptions(screen.getByLabelText("NativeSelect"), "berlin");
       expect(screen.getByLabelText("NativeSelect")).toHaveDisplayValue(
         "Berlin"
@@ -258,11 +250,8 @@ describe("Form", () => {
         <NativeSelect<Schema>
           name="formFieldsCustomName"
           labelText="NativeSelect"
-          defaultValue={"placeholdervalue"}
+          placeholder={"placeholder value"}
         >
-          <option value="placeholdervalue" disabled={true}>
-            placeholder
-          </option>
           <option value="helsinki">Helsinki</option>
           <option value="berlin">Berlin</option>
           <option value="london">London</option>
@@ -271,17 +260,39 @@ describe("Form", () => {
       );
 
       const select = screen.getByRole("combobox", { name: "NativeSelect" });
-      expect(select).toHaveValue("placeholdervalue");
 
       await userEvent.click(select);
-      await userEvent.keyboard("{Enter}");
+      await userEvent.keyboard("{Escape}");
       await userEvent.tab();
 
       const errorMessage = await screen.findByText(
-        "Invalid enum value. Expected 'helsinki' | 'berlin' | 'london', received 'placeholdervalue'"
+        "Invalid enum value. Expected 'helsinki' | 'berlin' | 'london', received ''"
       );
       expect(errorMessage).toBeVisible();
-      expect(true).toBeTruthy();
+    });
+
+    it("defaults to the first option if no placeholder is set", async () => {
+      cleanup();
+      renderForm(
+        <NativeSelect<Schema>
+          name="formFieldsCustomName"
+          labelText="NativeSelect"
+        >
+          <option value="helsinki">Helsinki</option>
+          <option value="berlin">Berlin</option>
+          <option value="london">London</option>
+        </NativeSelect>,
+        { schema, onSubmit, onError }
+      );
+
+      const select = screen.getByRole("combobox", { name: "NativeSelect" });
+
+      await userEvent.click(select);
+      await userEvent.keyboard("{Escape}");
+      await userEvent.tab();
+
+      await submit();
+      assertSubmitted({ formFieldsCustomName: "helsinki" });
     });
   });
 

--- a/coral/src/app/components/Form.tsx
+++ b/coral/src/app/components/Form.tsx
@@ -42,6 +42,8 @@ import {
   FileInputProps as BaseFileInputProps,
 } from "src/app/components/FileInput";
 import { ZodSchema } from "zod";
+import placeholder from "lodash/fp/placeholder";
+import omit from "lodash/omit";
 
 type FormInputProps<T extends FieldValues = FieldValues> = {
   name: FieldPath<T>;
@@ -339,25 +341,48 @@ MultiInput.Skeleton = BaseMultiInput.Skeleton;
 function _NativeSelect<T extends FieldValues>({
   name,
   formContext: form,
-  onChange,
-  onBlur,
   disabled,
   ...props
 }: BaseNativeSelectProps & FormInputProps<T> & FormRegisterProps<T>) {
-  const { isSubmitting } = form.formState;
-  const error = parseFieldErrorMessage(form.formState, name);
-
   return (
-    <BaseNativeSelect
-      {...props}
-      {...form.register(name, {
-        disabled: disabled || isSubmitting,
-        onChange,
-        onBlur,
-      })}
+    <_Controller
       name={name}
-      valid={error === undefined}
-      error={error}
+      control={form.control}
+      render={({ field: { name }, fieldState: { error } }) => {
+        const { isSubmitting } = form.formState;
+        const value = form.getValues(name);
+
+        // makes sure NativeSelect in Form works without logging warning
+        // about use of value and defaultValue when:
+        // - it has placeholder AND defaultValue (which is not a usual case),
+        // - value is updated not through user input
+        const baseNativeProps = !value
+          ? props
+          : { ...omit(props, "placeholder"), value: value };
+        return (
+          <BaseNativeSelect
+            {...baseNativeProps}
+            name={name}
+            disabled={disabled || isSubmitting}
+            onBlur={(option) => {
+              // eslint-disable-next-line @typescript-eslint/no-explicit-any
+              form.setValue(name, option.target.value as any, {
+                shouldValidate: true,
+                shouldDirty: true,
+              });
+            }}
+            onChange={(option) => {
+              // eslint-disable-next-line @typescript-eslint/no-explicit-any
+              form.setValue(name, option.target.value as any, {
+                shouldValidate: true,
+                shouldDirty: true,
+              });
+            }}
+            valid={error === undefined}
+            helperText={error?.message}
+          />
+        );
+      }}
     />
   );
 }

--- a/coral/src/app/components/Form.tsx
+++ b/coral/src/app/components/Form.tsx
@@ -42,7 +42,6 @@ import {
   FileInputProps as BaseFileInputProps,
 } from "src/app/components/FileInput";
 import { ZodSchema } from "zod";
-import placeholder from "lodash/fp/placeholder";
 import omit from "lodash/omit";
 
 type FormInputProps<T extends FieldValues = FieldValues> = {

--- a/coral/src/app/components/__snapshots__/Form.test.tsx.snap
+++ b/coral/src/app/components/__snapshots__/Form.test.tsx.snap
@@ -8,8 +8,8 @@ exports[`Form <PasswordInput> should render <PasswordInput> 1`] = `
     >
       <label
         class="w-full"
-        for="input-1144"
-        id="input-1144-label"
+        for="input-1162"
+        id="input-1162-label"
       >
         <span
           class="inline-block mb-2 typography-small-strong text-grey-60"
@@ -21,7 +21,7 @@ exports[`Form <PasswordInput> should render <PasswordInput> 1`] = `
         >
           <input
             class="block w-full rounded-sm disabled:cursor-not-allowed disabled:border-grey-20 disabled:bg-grey-5 typography-small text-grey-70 disabled:text-grey-40 placeholder:text-grey-40 focus:outline-none px-3 py-3 border border-grey-20 hover:border-grey-50 focus:border-info-70"
-            id="input-1144"
+            id="input-1162"
             name="password"
             type="password"
           />

--- a/coral/src/app/components/__snapshots__/Form.test.tsx.snap
+++ b/coral/src/app/components/__snapshots__/Form.test.tsx.snap
@@ -8,8 +8,8 @@ exports[`Form <PasswordInput> should render <PasswordInput> 1`] = `
     >
       <label
         class="w-full"
-        for="input-1162"
-        id="input-1162-label"
+        for="input-1171"
+        id="input-1171-label"
       >
         <span
           class="inline-block mb-2 typography-small-strong text-grey-60"
@@ -21,7 +21,7 @@ exports[`Form <PasswordInput> should render <PasswordInput> 1`] = `
         >
           <input
             class="block w-full rounded-sm disabled:cursor-not-allowed disabled:border-grey-20 disabled:bg-grey-5 typography-small text-grey-70 disabled:text-grey-40 placeholder:text-grey-40 focus:outline-none px-3 py-3 border border-grey-20 hover:border-grey-50 focus:border-info-70"
-            id="input-1162"
+            id="input-1171"
             name="password"
             type="password"
           />

--- a/coral/src/app/features/topics/acl-request/TopicAclRequest.tsx
+++ b/coral/src/app/features/topics/acl-request/TopicAclRequest.tsx
@@ -14,7 +14,6 @@ import topicConsumerFormSchema, {
 import topicProducerFormSchema, {
   TopicProducerFormSchema,
 } from "src/app/features/topics/acl-request/schemas/topic-acl-request-producer";
-import { ENVIRONMENT_NOT_INITIALIZED } from "src/domain/environment/environment-types";
 import { getTopicTeam, TopicTeam } from "src/domain/topic";
 
 const TopicAclRequest = () => {
@@ -25,7 +24,6 @@ const TopicAclRequest = () => {
     schema: topicProducerFormSchema,
     defaultValues: {
       topicname: topicName,
-      environment: ENVIRONMENT_NOT_INITIALIZED,
       topictype: "Producer",
     },
   });
@@ -35,7 +33,7 @@ const TopicAclRequest = () => {
     defaultValues: {
       aclPatternType: "LITERAL",
       topicname: topicName,
-      environment: ENVIRONMENT_NOT_INITIALIZED,
+      environment: "1",
       topictype: "Consumer",
       consumergroup: "",
     },

--- a/coral/src/app/features/topics/acl-request/TopicAclRequest.tsx
+++ b/coral/src/app/features/topics/acl-request/TopicAclRequest.tsx
@@ -33,7 +33,6 @@ const TopicAclRequest = () => {
     defaultValues: {
       aclPatternType: "LITERAL",
       topicname: topicName,
-      environment: "1",
       topictype: "Consumer",
       consumergroup: "",
     },

--- a/coral/src/app/features/topics/acl-request/fields/EnvironmentField.test.tsx
+++ b/coral/src/app/features/topics/acl-request/fields/EnvironmentField.test.tsx
@@ -1,4 +1,4 @@
-import { cleanup } from "@testing-library/react";
+import { cleanup, screen, within } from "@testing-library/react";
 import EnvironmentField from "src/app/features/topics/acl-request/fields/EnvironmentField";
 import { environment } from "src/app/features/topics/acl-request/schemas/topic-acl-request-shared-fields";
 import { createEnvironment } from "src/domain/environment/environment-test-helper";
@@ -31,37 +31,32 @@ describe("EnvironmentField", () => {
   });
 
   it("renders NativeSelect component", () => {
-    const result = renderForm(
-      <EnvironmentField environments={mockedEnvironments} />,
-      {
-        schema,
-        onSubmit,
-        onError,
-        defaultValues: {
-          environment: undefined,
-        },
-      }
-    );
-    const select = result.getByRole("combobox");
+    renderForm(<EnvironmentField environments={mockedEnvironments} />, {
+      schema,
+      onSubmit,
+      onError,
+    });
+    const select = screen.getByRole("combobox", {
+      name: "Select Environment *",
+    });
 
     expect(select).toBeVisible();
     expect(select).toBeEnabled();
+    expect(select).toBeRequired();
   });
 
   it("renders NativeSelect with a placeholder option", () => {
-    const result = renderForm(
-      <EnvironmentField environments={mockedEnvironments} />,
-      {
-        schema,
-        onSubmit,
-        onError,
-        defaultValues: {
-          environment: undefined,
-        },
-      }
-    );
-    const options = result.getAllByRole("option");
+    renderForm(<EnvironmentField environments={mockedEnvironments} />, {
+      schema,
+      onSubmit,
+      onError,
+    });
+    const select = screen.getByRole("combobox", {
+      name: "Select Environment *",
+    });
+    const options = within(select).getAllByRole("option");
 
+    expect(select).toHaveDisplayValue("-- Select Environment --");
     expect(options).toHaveLength(mockedEnvironments.length + 1);
   });
 });

--- a/coral/src/app/features/topics/acl-request/fields/EnvironmentField.tsx
+++ b/coral/src/app/features/topics/acl-request/fields/EnvironmentField.tsx
@@ -1,7 +1,6 @@
 import { Option } from "@aivenio/aquarium";
 import { NativeSelect } from "src/app/components/Form";
 import { Environment } from "src/domain/environment";
-import { ENVIRONMENT_NOT_INITIALIZED } from "src/domain/environment/environment-types";
 
 interface EnvironmentFieldProps {
   environments: Environment[];
@@ -9,14 +8,12 @@ interface EnvironmentFieldProps {
 
 const EnvironmentField = ({ environments }: EnvironmentFieldProps) => {
   return (
-    <NativeSelect name="environment" labelText="Select Environment" required>
-      <Option
-        key={ENVIRONMENT_NOT_INITIALIZED}
-        value={ENVIRONMENT_NOT_INITIALIZED}
-        disabled
-      >
-        -- Select Environment --
-      </Option>
+    <NativeSelect
+      name="environment"
+      labelText="Select Environment"
+      placeholder={"-- Select Environment --"}
+      required
+    >
       {environments.map((env) => (
         <Option key={env.id} value={env.id}>
           {env.name}

--- a/coral/src/app/features/topics/acl-request/fields/TopicNameField.tsx
+++ b/coral/src/app/features/topics/acl-request/fields/TopicNameField.tsx
@@ -10,10 +10,10 @@ const TopicNameField = ({ topicNames }: TopicNameFieldProps) => {
     <NativeSelect
       name="topicname"
       labelText="Topic name"
+      placeholder={"-- Select Topic --"}
       disabled={topicNames.length === 0}
       required
     >
-      <Option disabled>-- Select Topic --</Option>
       {topicNames.map((name) => (
         <Option key={name} value={name}>
           {name}

--- a/coral/src/app/features/topics/acl-request/forms/TopicConsumerForm.test.tsx
+++ b/coral/src/app/features/topics/acl-request/forms/TopicConsumerForm.test.tsx
@@ -9,7 +9,6 @@ import topicConsumerFormSchema, {
   TopicConsumerFormSchema,
 } from "src/app/features/topics/acl-request/schemas/topic-acl-request-consumer";
 import { createEnvironment } from "src/domain/environment/environment-test-helper";
-import { ENVIRONMENT_NOT_INITIALIZED } from "src/domain/environment/environment-types";
 import { customRender } from "src/services/test-utils/render-with-wrappers";
 
 const baseProps = {
@@ -47,7 +46,6 @@ describe("<TopicConsumerForm />", () => {
           schema: topicConsumerFormSchema,
           defaultValues: {
             topicname: "aiventopic1",
-            environment: ENVIRONMENT_NOT_INITIALIZED,
             topictype: "Consumer",
           },
         })

--- a/coral/src/app/features/topics/acl-request/schemas/topic-acl-request-shared-fields.ts
+++ b/coral/src/app/features/topics/acl-request/schemas/topic-acl-request-shared-fields.ts
@@ -28,7 +28,7 @@ const aclPatternType = z.union([z.literal("LITERAL"), z.literal("PREFIXED")]);
 const topicname = z.string().min(1, { message: "Please enter a prefix." });
 const environment = z
   .string()
-  .refine((value) => value !== "placeholder", "Please select an environment");
+  .min(1, { message: "Please select an environment" });
 const teamname = z.string();
 
 export {

--- a/coral/src/app/features/topics/request/TopicRequest.test.tsx
+++ b/coral/src/app/features/topics/request/TopicRequest.test.tsx
@@ -64,19 +64,17 @@ describe("<TopicRequest />", () => {
         expect(select).toBeEnabled();
       });
 
-      it("shows an empty value with placeholder text", async () => {
-        const prodSelectOption: HTMLOptionElement = await screen.findByRole(
-          "option",
-          {
-            name: "-- Select Environment --",
-          }
-        );
+      it("shows an placeholder text for the select", async () => {
+        const select = await screen.findByRole("combobox", {
+          name: "Environment",
+        });
 
-        expect(prodSelectOption.selected).toBe(true);
+        expect(select).toHaveDisplayValue("-- Select Environment --");
       });
 
       it("shows all environment names as options", () => {
         const options = screen.getAllByRole("option");
+        // 3 environments + option for placeholder
         expect(options.length).toBe(4);
         expect(options.map((o) => o.textContent)).toEqual([
           "-- Select Environment --",
@@ -113,7 +111,7 @@ describe("<TopicRequest />", () => {
       });
 
       describe("when 'PROD' option is clicked", () => {
-        it("selects 'PROD' value when user choses the option", async () => {
+        it("selects 'PROD' value when user chooses the option", async () => {
           const select = await screen.findByRole("combobox", {
             name: "Environment",
           });

--- a/coral/src/app/features/topics/request/TopicRequest.test.tsx
+++ b/coral/src/app/features/topics/request/TopicRequest.test.tsx
@@ -1,4 +1,10 @@
-import { cleanup, screen, waitFor, within } from "@testing-library/react";
+import {
+  cleanup,
+  screen,
+  waitFor,
+  within,
+  waitForElementToBeRemoved,
+} from "@testing-library/react";
 import { Context as AquariumContext } from "@aivenio/aquarium";
 import { customRender } from "src/services/test-utils/render-with-wrappers";
 import userEvent from "@testing-library/user-event";
@@ -11,7 +17,6 @@ import {
   mockgetTopicAdvancedConfigOptions,
   mockRequestTopic,
 } from "src/domain/topic/topic-api.msw";
-import { waitForElementToBeRemoved } from "@testing-library/react/pure";
 import api from "src/services/api";
 
 describe("<TopicRequest />", () => {
@@ -423,7 +428,9 @@ describe("<TopicRequest />", () => {
           }
         );
 
-        expect(inputReplicationFactorSelect).toHaveDisplayValue("2");
+        await waitFor(() => {
+          expect(inputReplicationFactorSelect).toHaveDisplayValue("2");
+        });
       });
 
       it('keeps topic replication factor value if not default and value does not exceeded "maxPartitions"', async () => {
@@ -597,7 +604,10 @@ describe("<TopicRequest />", () => {
       const topicPartitionsSelect = screen.getByRole("combobox", {
         name: "Topic partitions *",
       });
-      expect(topicPartitionsSelect).toHaveDisplayValue("8");
+
+      await waitFor(() => {
+        expect(topicPartitionsSelect).toHaveDisplayValue("8");
+      });
     });
 
     it('keeps topic partitions value if not default and value does not exceeded "maxPartitions"', async () => {

--- a/coral/src/app/features/topics/request/TopicRequest.tsx
+++ b/coral/src/app/features/topics/request/TopicRequest.tsx
@@ -27,6 +27,7 @@ function TopicRequest() {
     ["environments-for-team"],
     getEnvironmentsForTeam
   );
+
   const defaultValues = Array.isArray(environments)
     ? {
         environment: undefined,

--- a/coral/src/app/features/topics/schema-request/TopicSchemaRequest.test.tsx
+++ b/coral/src/app/features/topics/schema-request/TopicSchemaRequest.test.tsx
@@ -292,24 +292,23 @@ describe("TopicSchemaRequest", () => {
       cleanup();
     });
 
-    // The new placeholder behaviour is to select the first option when no placeholder is provided
-    // So this situation will never happen, as there always be a value selected in this context
-    // @TODO https://github.com/aiven/klaw/issues/495
-    // it("shows error when user does not fill out environment select", async () => {
-    //   const form = getForm();
-    //   const select = within(form).getByRole("combobox", {
-    //     name: /Select environment/i,
-    //   });
+    it("shows error when user does not fill out environment select", async () => {
+      const form = getForm();
+      const select = within(form).getByRole("combobox", {
+        name: /Select environment/i,
+      });
 
-    //   select.focus();
-    //   await userEvent.keyboard("{ArrowDown}");
-    //   await userEvent.keyboard("{ESC}");
-    //   await userEvent.tab();
+      select.focus();
+      await userEvent.keyboard("{ArrowDown}");
+      await userEvent.keyboard("{ESC}");
+      await userEvent.tab();
 
-    //   const error = await screen.findByText("The environment is required.");
-    //   expect(error).toBeVisible();
-    //   expect(select).toBeInvalid();
-    // });
+      const error = await screen.findByText(
+        "Selection Error: Please select an environment"
+      );
+      expect(error).toBeVisible();
+      expect(select).toBeInvalid();
+    });
 
     it("shows error when user does not upload a file", async () => {
       const form = getForm();
@@ -555,10 +554,7 @@ describe("TopicSchemaRequest", () => {
         name: mockedEnvironments[1].name,
       });
 
-      // The new placeholder behaviour is to select the first option when no placeholder is provided
-      // So this situation will never happen, as there always be a value selected in this context
-      // @TODO https://github.com/aiven/klaw/issues/495
-      expect(select).toHaveValue("1");
+      expect(select).toHaveDisplayValue("-- Please select --");
 
       await userEvent.selectOptions(select, option);
 

--- a/coral/src/app/features/topics/schema-request/TopicSchemaRequest.tsx
+++ b/coral/src/app/features/topics/schema-request/TopicSchemaRequest.tsx
@@ -98,7 +98,6 @@ function TopicSchemaRequest(props: TopicSchemaRequestProps) {
         <NativeSelect<TopicRequestFormSchema>
           name={"topicname"}
           labelText={"Topic name"}
-          defaultValue={topicName}
           readOnly={true}
           aria-readonly={true}
         >
@@ -115,12 +114,9 @@ function TopicSchemaRequest(props: TopicSchemaRequestProps) {
           <NativeSelect<TopicRequestFormSchema>
             name={"environment"}
             labelText={"Select environment"}
-            defaultValue={""}
+            placeholder={"-- Please select --"}
             required={true}
           >
-            <option disabled value={""}>
-              Please select
-            </option>
             {environments.map((env) => {
               return (
                 <option key={env.id} value={env.id}>


### PR DESCRIPTION
# About this change - What it does

`NativeSelect` implemented new behaviour in the last DS release how to show accessible placeholder. This PR removes the custom implementations we did to get an accessible placeholder on our site now. 

Background: The native `placeholder` for `select` does nothing, it does not show up or is useful for assistive technology. The implementation in DS adds this. Since it's not based on native behaviour, when using `NativeSelect` as a base component in `Form` (or `ComplexNativeSelect`) we have to account for that.

## Details
- removing custom placeholder implementation in  `ComplexNativeSelect` and making sure we get the wanted behaviour for required/optional select (mainly making sure we do an `onBlur` with `undefined` when needed. 
- adapt usage in `Form`: 
    -  make `NativeSelect` controlled, otherwise the originally `onBlur` is overwritten and this is where `NativeSelect` takes care about passing the right values.
    - since a `value` might be added by form while a `defaultValue` for placeholder is present, I took care of what props to pass in which cases, so we avoid the warning logged
- update `TopicRequest` test to be stable with new behaviour (can take a moment more until value is updated right here)
- update `ACLRequest` form(s) 
- update `TopicSchemaRequest` form

### Side note
Holy 🐮 all the tests we have in place where _SUPER_ helpful to update the `Form` usage of `NativeSelect` (which was the hardest part) 🤯  The test did not only helped me with turning green/red, but also the descriptions made it very easy to understand what was supposed to happen when, so I could do manual testing, too. 

Tests are ✨🎉🪄 AWESOME!

![](https://media.tenor.com/50lPCpLt_vkAAAAC/will-ferrell-evil-boss.gif)

Resolves: #495 and #410


