### PR TITLE
Version Numbers and Uglify fixes

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -31,6 +31,8 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version: ${{ env.NODE_VERSION }}
+      - name: Install node.js uglify packages
+        run: npm install uglify-js -g && npm install uglifycss -g
       - name: Set up JDK ${{ matrix.java-version }}
         uses: actions/setup-java@v3
         with:

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -141,6 +141,56 @@
     </dependencies>
 
     <build>
+        <!--
+Using filtering means we have to explicitly control Resources for Test and production..
+ -->
+        <resources>
+            <resource>
+                <directory>src/main/resources</directory>
+                <includes>
+                    <include>application.properties</include>
+                </includes>
+                    <excludes>
+                        <exclude>static</exclude>
+                        <exclude>template</exclude>
+                        <exclude>**/*.sql</exclude>
+                        <exclude>**/*.yaml</exclude>
+                    </excludes>
+                <filtering>true</filtering>
+            </resource>
+            <resource>
+                <directory>src/main/resources</directory>
+                <excludes>
+                    <exclude>application.properties</exclude>
+                </excludes>
+                <includes>
+                    <include>**</include>
+                </includes>
+                <filtering>false</filtering>
+            </resource>
+        </resources>
+        <testResources>
+            <testResource>
+                <directory>src/test/resources</directory>
+                <includes>
+                    <include>*</include>
+                </includes>
+                <filtering>true</filtering>
+            </testResource>
+            <testResource>
+                <directory>src/main/resources/</directory>
+                <includes>
+                    <include>application.properties</include>
+                </includes>
+                <excludes>
+                    <exclude>static</exclude>
+                    <exclude>template</exclude>
+                    <exclude>**/*.sql</exclude>
+                    <exclude>**/*.yaml</exclude>
+                </excludes>
+                <filtering>true</filtering>
+            </testResource>
+        </testResources>
         <plugins>
             <!-- Install node and npm for React components -->
 <!--            <plugin>-->

--- a/core/src/main/java/io/aiven/klaw/uglify/UglifyFiles.java
+++ b/core/src/main/java/io/aiven/klaw/uglify/UglifyFiles.java
@@ -23,11 +23,23 @@ public class UglifyFiles {
   private void uglifyCssFiles(String osName, Runtime rt) {
     String styleCssFile = cssDir + "style.css";
     String styleBlueDarkCssFile = cssDir + "colors/blue-dark.css";
+    File style = new File(styleCssFile);
+    File bluedark = new File(styleBlueDarkCssFile);
 
-    String commandToExec = "uglifycss " + styleCssFile + " --output " + styleCssFile;
+    if (!style.exists()) {
+      style = new File("./core/" + styleCssFile);
+    }
+
+    if (!bluedark.exists()) {
+      bluedark = new File("./core/" + styleBlueDarkCssFile);
+    }
+
+    String commandToExec =
+        "uglifycss " + style.getAbsolutePath() + " --output " + style.getAbsolutePath();
     executeCommand(rt, commandToExec, osName);
 
-    commandToExec = "uglifycss " + styleBlueDarkCssFile + " --output " + styleBlueDarkCssFile;
+    commandToExec =
+        "uglifycss " + bluedark.getAbsolutePath() + " --output " + bluedark.getAbsolutePath();
     executeCommand(rt, commandToExec, osName);
   }
 
@@ -35,6 +47,10 @@ public class UglifyFiles {
 
     File f = new File(sourceDirJsFiles);
     File[] filesInDir = f.listFiles();
+    if (filesInDir == null) {
+      File file = new File("./core/" + sourceDirJsFiles);
+      filesInDir = file.listFiles();
+    }
     if (filesInDir != null) {
 
       for (File file : filesInDir) {

--- a/core/src/main/resources/application.properties
+++ b/core/src/main/resources/application.properties
@@ -132,7 +132,7 @@ klaw.db.storetype=rdbms
 klaw.installation.type=onpremise
 
 # current version of klaw
-klaw.version=2.0.0
+klaw.version=@project.version@
 
 # Database settings
 spring.liquibase.enabled=true

--- a/core/src/test/resources/test-application-rdbms-ad-authorization.properties
+++ b/core/src/test/resources/test-application-rdbms-ad-authorization.properties
@@ -23,7 +23,7 @@ klaw.login.authentication.type=ad
 spring.liquibase.enabled=true
 spring.liquibase.change-log=classpath:db/changelog/changelog.yaml
 
-klaw.version=2.0.0
+klaw.version=@project.version@
 
 # Spring JPA properties mysql
 # Spring JPA properties filedb

--- a/core/src/test/resources/test-application-rdbms-sso-ad.properties
+++ b/core/src/test/resources/test-application-rdbms-sso-ad.properties
@@ -23,7 +23,7 @@ klaw.login.authentication.type=ad
 spring.liquibase.enabled=true
 spring.liquibase.change-log=classpath:db/changelog/changelog.yaml
 
-klaw.version=2.0.0
+klaw.version=@project.version@
 
 # Spring JPA properties mysql
 # Spring JPA properties filedb

--- a/core/src/test/resources/test-application-rdbms-windows-ad.properties
+++ b/core/src/test/resources/test-application-rdbms-windows-ad.properties
@@ -126,7 +126,7 @@ klaw.db.storetype=rdbms
 klaw.installation.type=onpremise
 
 # current version of klaw
-klaw.version=2.0.0
+klaw.version=@project.version@
 
 # Database settings
 spring.liquibase.enabled=true

--- a/core/src/test/resources/test-application-rdbms.properties
+++ b/core/src/test/resources/test-application-rdbms.properties
@@ -23,7 +23,7 @@ klaw.login.authentication.type=db
 spring.liquibase.enabled=true
 spring.liquibase.change-log=classpath:db/changelog/changelog.yaml
 
-klaw.version=2.0.0
+klaw.version=@project.version@
 
 # Spring JPA properties mysql
 # Spring JPA properties filedb

--- a/core/src/test/resources/test-application-rdbms1.properties
+++ b/core/src/test/resources/test-application-rdbms1.properties
@@ -23,7 +23,7 @@ klaw.login.authentication.type=db
 spring.liquibase.enabled=true
 spring.liquibase.change-log=classpath:db/changelog/changelog.yaml
 
-klaw.version=2.0.0
+klaw.version=@project.version@
 
 # Spring JPA properties mysql
 # Spring JPA properties filedb


### PR DESCRIPTION
Signed-off-by: Aindriu Lavelle <aindriu.lavelle@aiven.io>

About this change - What it does
Auto updates the version number from the project version in property files. 
Also enables uglify from the parent directory if that is where the maven build is being run from.

Why this way
Reduces the need on releases to manually update files and have some files forgotten.
Also properly uglifies the files.
Updating a project now only requires one command from the klaw parent project and all version numbers will be updated.
example: mvn versions:set -DnewVersion=2.0.1