### PR TITLE
Add primary key to dbchangelog

### DIFF
--- a/core/src/main/java/io/aiven/klaw/config/ManageDatabase.java
+++ b/core/src/main/java/io/aiven/klaw/config/ManageDatabase.java
@@ -235,6 +235,7 @@ public class ManageDatabase implements ApplicationContextAware, InitializingBean
               KwConstants.DEFAULT_TENANT_ID, true, kwInstallationType));
     }
 
+    log.info("Klaw Version : {}", kwVersion);
     // product details
     String productName = "Klaw";
     Optional<ProductDetails> productDetails = handleDbRequests.selectProductDetails(productName);

--- a/core/src/main/resources/db/changelog/changelog.yaml
+++ b/core/src/main/resources/db/changelog/changelog.yaml
@@ -932,3 +932,11 @@ databaseChangeLog:
                     defaultValue: false
                     name: forceregister
                     type: BOOLEAN
+    - changeSet:
+        id: 2023-02-02 Adding primary key to databasechangelog table
+        author: muralibasani
+        changes:
+          - addPrimaryKey:
+              columnNames: id
+              constraintName: pk_db_changelog
+              tableName: databasechangelog


### PR DESCRIPTION
Signed-off-by: muralibasani <muralidahr.basani@aiven.io>

About this change - What it does

Few databases require all tables to have primary keys. Adds primary key to databasechangelog table.

Resolves: #533
Why this way

Adding to changelog ensures pk is added to the db table
