### PR TITLE
Add Parameter Options to getCreatedAclRequests

### DIFF
--- a/core/src/main/java/io/aiven/klaw/controller/AclController.java
+++ b/core/src/main/java/io/aiven/klaw/controller/AclController.java
@@ -50,11 +50,11 @@ public class AclController {
   }
 
   /**
-   * @param pageNo Which page would you like returned
-   * @param currentPage Which Page are you currently on
+   * @param pageNo Which page would you like returned e.g. 1
+   * @param currentPage Which Page are you currently on e.g. 1
    * @param requestsType What type of requests are you looking for e.g. 'created' or 'deleted'
    * @param topic The name of the topic you would like returned
-   * @param environment The name of the environment you would like returned
+   * @param env The name of the environment you would like returned e.g. 'DEV'
    * @param aclType The Type of acl Consumer/Producer
    * @return An array of AclRequests that met the criteria of the inputted values.
    */
@@ -70,11 +70,11 @@ public class AclController {
       @RequestParam(value = "currentPage", defaultValue = "") String currentPage,
       @RequestParam(value = "requestsType", defaultValue = "created") String requestsType,
       @RequestParam(value = "topic", required = false) String topic,
-      @RequestParam(value = "environment", required = false) String environment,
+      @RequestParam(value = "env", required = false) String env,
       @RequestParam(value = "aclType", required = false) AclType aclType) {
     return new ResponseEntity<>(
         aclControllerService.getCreatedAclRequests(
-            pageNo, currentPage, requestsType, topic, environment, aclType),
+            pageNo, currentPage, requestsType, topic, env, aclType),
         HttpStatus.OK);
   }
 

--- a/core/src/main/java/io/aiven/klaw/controller/AclController.java
+++ b/core/src/main/java/io/aiven/klaw/controller/AclController.java
@@ -69,7 +69,7 @@ public class AclController {
       @RequestParam("pageNo") String pageNo,
       @RequestParam(value = "currentPage", defaultValue = "") String currentPage,
       @RequestParam(value = "requestsType", defaultValue = "created") String requestsType,
-      @RequestParam(value = "topic", required = false ) String topic,
+      @RequestParam(value = "topic", required = false) String topic,
       @RequestParam(value = "environment", required = false) String environment,
       @RequestParam(value = "aclType", required = false) AclType aclType) {
     return new ResponseEntity<>(

--- a/core/src/main/java/io/aiven/klaw/controller/AclController.java
+++ b/core/src/main/java/io/aiven/klaw/controller/AclController.java
@@ -49,6 +49,15 @@ public class AclController {
         aclControllerService.getAclRequests(pageNo, currentPage, requestsType), HttpStatus.OK);
   }
 
+  /**
+   * @param pageNo Which page would you like returned
+   * @param currentPage Which Page are you currently on
+   * @param requestsType What type of requests are you looking for e.g. 'created' or 'deleted'
+   * @param topic The name of the topic you would like returned
+   * @param environment The name of the environment you would like returned
+   * @param aclType The Type of acl Consumer/Producer
+   * @return An array of AclRequests that met the criteria of the inputted values.
+   */
   /*
      For executing acl requests
   */
@@ -60,7 +69,7 @@ public class AclController {
       @RequestParam("pageNo") String pageNo,
       @RequestParam(value = "currentPage", defaultValue = "") String currentPage,
       @RequestParam(value = "requestsType", defaultValue = "created") String requestsType,
-      @RequestParam(value = "topic", required = false) String topic,
+      @RequestParam(value = "topic", required = false ) String topic,
       @RequestParam(value = "environment", required = false) String environment,
       @RequestParam(value = "aclType", required = false) AclType aclType) {
     return new ResponseEntity<>(

--- a/core/src/main/java/io/aiven/klaw/controller/AclController.java
+++ b/core/src/main/java/io/aiven/klaw/controller/AclController.java
@@ -4,6 +4,7 @@ import io.aiven.klaw.error.KlawException;
 import io.aiven.klaw.model.AclRequestsModel;
 import io.aiven.klaw.model.ApiResponse;
 import io.aiven.klaw.model.TopicOverview;
+import io.aiven.klaw.model.enums.AclType;
 import io.aiven.klaw.service.AclControllerService;
 import io.aiven.klaw.service.TopicOverviewService;
 import jakarta.validation.Valid;
@@ -58,9 +59,13 @@ public class AclController {
   public ResponseEntity<List<AclRequestsModel>> getCreatedAclRequests(
       @RequestParam("pageNo") String pageNo,
       @RequestParam(value = "currentPage", defaultValue = "") String currentPage,
-      @RequestParam(value = "requestsType", defaultValue = "created") String requestsType) {
+      @RequestParam(value = "requestsType", defaultValue = "created") String requestsType,
+      @RequestParam(value = "topic", required = false) String topic,
+      @RequestParam(value = "environment", required = false) String environment,
+      @RequestParam(value = "aclType", required = false) AclType aclType) {
     return new ResponseEntity<>(
-        aclControllerService.getCreatedAclRequests(pageNo, currentPage, requestsType),
+        aclControllerService.getCreatedAclRequests(
+            pageNo, currentPage, requestsType, topic, environment, aclType),
         HttpStatus.OK);
   }
 

--- a/core/src/main/java/io/aiven/klaw/helpers/HandleDbRequests.java
+++ b/core/src/main/java/io/aiven/klaw/helpers/HandleDbRequests.java
@@ -18,6 +18,7 @@ import io.aiven.klaw.dao.Team;
 import io.aiven.klaw.dao.Topic;
 import io.aiven.klaw.dao.TopicRequest;
 import io.aiven.klaw.dao.UserInfo;
+import io.aiven.klaw.model.enums.AclType;
 import io.aiven.klaw.model.enums.KafkaClustersType;
 import java.util.List;
 import java.util.Map;
@@ -119,8 +120,28 @@ public interface HandleDbRequests {
       boolean showRequestsOfAllTeams,
       int tenantId);
 
+  List<AclRequests> getAllAclRequestsFiltered(
+      boolean allReqs,
+      String requestor,
+      String role,
+      String status,
+      boolean showRequestsOfAllTeams,
+      String topic,
+      String environment,
+      AclType aclType,
+      int tenantId);
+
   List<AclRequests> getCreatedAclRequestsByStatus(
       String requestor, String status, boolean showRequestsOfAllTeams, int tenantId);
+
+  List<AclRequests> getCreatedAclRequestsByStatus(
+      String requestor,
+      String status,
+      boolean showRequestsOfAllTeams,
+      String topic,
+      String environment,
+      AclType aclType,
+      int tenantId);
 
   List<SchemaRequest> getAllSchemaRequests(boolean allReqs, String requestor, int tenantId);
 

--- a/core/src/main/java/io/aiven/klaw/helpers/HandleDbRequests.java
+++ b/core/src/main/java/io/aiven/klaw/helpers/HandleDbRequests.java
@@ -120,20 +120,6 @@ public interface HandleDbRequests {
       boolean showRequestsOfAllTeams,
       int tenantId);
 
-  List<AclRequests> getAllAclRequestsFiltered(
-      boolean allReqs,
-      String requestor,
-      String role,
-      String status,
-      boolean showRequestsOfAllTeams,
-      String topic,
-      String environment,
-      AclType aclType,
-      int tenantId);
-
-  List<AclRequests> getCreatedAclRequestsByStatus(
-      String requestor, String status, boolean showRequestsOfAllTeams, int tenantId);
-
   List<AclRequests> getCreatedAclRequestsByStatus(
       String requestor,
       String status,

--- a/core/src/main/java/io/aiven/klaw/helpers/db/rdbms/HandleDbRequestsJdbc.java
+++ b/core/src/main/java/io/aiven/klaw/helpers/db/rdbms/HandleDbRequestsJdbc.java
@@ -240,36 +240,6 @@ public class HandleDbRequestsJdbc implements HandleDbRequests {
   }
 
   @Override
-  public List<AclRequests> getAllAclRequestsFiltered(
-      boolean allReqs,
-      String requestor,
-      String role,
-      String status,
-      boolean showRequestsOfAllTeams,
-      String topic,
-      String environment,
-      AclType aclType,
-      int tenantId) {
-    return jdbcSelectHelper.selectAclRequests(
-        allReqs,
-        requestor,
-        role,
-        status,
-        showRequestsOfAllTeams,
-        topic,
-        environment,
-        aclType,
-        tenantId);
-  }
-
-  @Override
-  public List<AclRequests> getCreatedAclRequestsByStatus(
-      String requestor, String status, boolean showRequestsOfAllTeams, int tenantId) {
-    return jdbcSelectHelper.selectAclRequests(
-        true, requestor, "", status, showRequestsOfAllTeams, tenantId);
-  }
-
-  @Override
   public List<AclRequests> getCreatedAclRequestsByStatus(
       String requestor,
       String status,

--- a/core/src/main/java/io/aiven/klaw/helpers/db/rdbms/HandleDbRequestsJdbc.java
+++ b/core/src/main/java/io/aiven/klaw/helpers/db/rdbms/HandleDbRequestsJdbc.java
@@ -19,6 +19,7 @@ import io.aiven.klaw.dao.Topic;
 import io.aiven.klaw.dao.TopicRequest;
 import io.aiven.klaw.dao.UserInfo;
 import io.aiven.klaw.helpers.HandleDbRequests;
+import io.aiven.klaw.model.enums.AclType;
 import io.aiven.klaw.model.enums.KafkaClustersType;
 import io.aiven.klaw.model.enums.RequestStatus;
 import java.util.List;
@@ -239,10 +240,46 @@ public class HandleDbRequestsJdbc implements HandleDbRequests {
   }
 
   @Override
+  public List<AclRequests> getAllAclRequestsFiltered(
+      boolean allReqs,
+      String requestor,
+      String role,
+      String status,
+      boolean showRequestsOfAllTeams,
+      String topic,
+      String environment,
+      AclType aclType,
+      int tenantId) {
+    return jdbcSelectHelper.selectAclRequests(
+        allReqs,
+        requestor,
+        role,
+        status,
+        showRequestsOfAllTeams,
+        topic,
+        environment,
+        aclType,
+        tenantId);
+  }
+
+  @Override
   public List<AclRequests> getCreatedAclRequestsByStatus(
       String requestor, String status, boolean showRequestsOfAllTeams, int tenantId) {
     return jdbcSelectHelper.selectAclRequests(
         true, requestor, "", status, showRequestsOfAllTeams, tenantId);
+  }
+
+  @Override
+  public List<AclRequests> getCreatedAclRequestsByStatus(
+      String requestor,
+      String status,
+      boolean showRequestsOfAllTeams,
+      String topic,
+      String environment,
+      AclType aclType,
+      int tenantId) {
+    return jdbcSelectHelper.selectAclRequests(
+        true, requestor, "", status, showRequestsOfAllTeams, topic, environment, aclType, tenantId);
   }
 
   @Override

--- a/core/src/main/java/io/aiven/klaw/helpers/db/rdbms/SelectDataJdbc.java
+++ b/core/src/main/java/io/aiven/klaw/helpers/db/rdbms/SelectDataJdbc.java
@@ -198,7 +198,11 @@ public class SelectDataJdbc {
     if (status != null && !status.equalsIgnoreCase("all")) {
       request.setAclstatus(status);
     }
-    log.info("find By topic etc example {}", request);
+    // check if debug is enabled so the logger doesnt waste resources converting object request to a
+    // string
+    if (log.isDebugEnabled()) {
+      log.debug("find By topic etc example {}", request);
+    }
     return aclRequestsRepo.findAll(Example.of(request));
   }
 

--- a/core/src/main/java/io/aiven/klaw/helpers/db/rdbms/SelectDataJdbc.java
+++ b/core/src/main/java/io/aiven/klaw/helpers/db/rdbms/SelectDataJdbc.java
@@ -132,7 +132,7 @@ public class SelectDataJdbc {
 
     aclListSub =
         Lists.newArrayList(
-            findByTopicByClusterByAclTypeByTenantId(topic, environment, aclType, status, tenantId));
+            findAclRequestsByExample(topic, environment, aclType, status, tenantId));
 
     Integer teamSelected = selectUserInfo(requestor).getTeamId();
 
@@ -170,7 +170,17 @@ public class SelectDataJdbc {
     return aclList;
   }
 
-  public Iterable<AclRequests> findByTopicByClusterByAclTypeByTenantId(
+  /**
+   * Query the AclRequestsRepo by supplying optional search parameters any given search parameters will be utilised in the search.
+   *
+   * @param topic The topic Name
+   * @param environment the environment
+   * @param aclType Producer or consumer
+   * @param status created/declined/approved
+   * @param tenantId The tenantId
+   * @return
+   */
+  public Iterable<AclRequests> findAclRequestsByExample(
       String topic, String environment, AclType aclType, String status, int tenantId) {
 
     AclRequests request = new AclRequests();

--- a/core/src/main/java/io/aiven/klaw/helpers/db/rdbms/SelectDataJdbc.java
+++ b/core/src/main/java/io/aiven/klaw/helpers/db/rdbms/SelectDataJdbc.java
@@ -131,8 +131,7 @@ public class SelectDataJdbc {
     List<AclRequests> aclListSub;
 
     aclListSub =
-        Lists.newArrayList(
-            findAclRequestsByExample(topic, environment, aclType, status, tenantId));
+        Lists.newArrayList(findAclRequestsByExample(topic, environment, aclType, status, tenantId));
 
     Integer teamSelected = selectUserInfo(requestor).getTeamId();
 
@@ -171,7 +170,8 @@ public class SelectDataJdbc {
   }
 
   /**
-   * Query the AclRequestsRepo by supplying optional search parameters any given search parameters will be utilised in the search.
+   * Query the AclRequestsRepo by supplying optional search parameters any given search parameters
+   * will be utilised in the search.
    *
    * @param topic The topic Name
    * @param environment the environment

--- a/core/src/main/java/io/aiven/klaw/repository/AclRequestsRepo.java
+++ b/core/src/main/java/io/aiven/klaw/repository/AclRequestsRepo.java
@@ -7,8 +7,10 @@ import java.util.Optional;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.CrudRepository;
 import org.springframework.data.repository.query.Param;
+import org.springframework.data.repository.query.QueryByExampleExecutor;
 
-public interface AclRequestsRepo extends CrudRepository<AclRequests, AclRequestID> {
+public interface AclRequestsRepo
+    extends CrudRepository<AclRequests, AclRequestID>, QueryByExampleExecutor<AclRequests> {
   Optional<AclRequests> findById(AclRequestID aclRequestID);
 
   List<AclRequests> findAllByAclstatusAndTenantId(String topicStatus, int tenantId);

--- a/core/src/main/java/io/aiven/klaw/repository/AclRequestsRepo.java
+++ b/core/src/main/java/io/aiven/klaw/repository/AclRequestsRepo.java
@@ -13,8 +13,6 @@ public interface AclRequestsRepo
     extends CrudRepository<AclRequests, AclRequestID>, QueryByExampleExecutor<AclRequests> {
   Optional<AclRequests> findById(AclRequestID aclRequestID);
 
-  List<AclRequests> findAllByAclstatusAndTenantId(String topicStatus, int tenantId);
-
   @Query(
       value =
           "select count(*) from kwaclrequests where env = :envId and tenantid = :tenantId and topicstatus='created'",

--- a/core/src/main/java/io/aiven/klaw/service/AclControllerService.java
+++ b/core/src/main/java/io/aiven/klaw/service/AclControllerService.java
@@ -358,7 +358,12 @@ public class AclControllerService {
   }
 
   public List<AclRequestsModel> getCreatedAclRequests(
-      String pageNo, String currentPage, String requestsType) {
+      String pageNo,
+      String currentPage,
+      String requestsType,
+      String topic,
+      String environment,
+      AclType aclType) {
     log.debug("getCreatedAclRequests {} {}", pageNo, requestsType);
     String userDetails = getCurrentUserName();
     List<AclRequests> createdAclReqs;
@@ -370,12 +375,14 @@ public class AclControllerService {
       createdAclReqs =
           manageDatabase
               .getHandleDbRequests()
-              .getCreatedAclRequestsByStatus(userDetails, requestsType, false, tenantId);
+              .getCreatedAclRequestsByStatus(
+                  userDetails, requestsType, false, topic, environment, aclType, tenantId);
     } else {
       createdAclReqs =
           manageDatabase
               .getHandleDbRequests()
-              .getCreatedAclRequestsByStatus(userDetails, requestsType, true, tenantId);
+              .getCreatedAclRequestsByStatus(
+                  userDetails, requestsType, true, topic, environment, aclType, tenantId);
     }
 
     // tenant filtering

--- a/core/src/main/resources/swagger_spec.json
+++ b/core/src/main/resources/swagger_spec.json
@@ -1443,6 +1443,22 @@
           "required" : false,
           "type" : "string",
           "default" : "created"
+        }, {
+          "name" : "topic",
+          "in" : "query",
+          "required" : false,
+          "type" : "string"
+        }, {
+          "name" : "environment",
+          "in" : "query",
+          "required" : false,
+          "type" : "string"
+        }, {
+          "name" : "aclType",
+          "in" : "query",
+          "required" : false,
+          "type" : "string",
+          "enum" : [ "PRODUCER", "CONSUMER" ]
         } ],
         "responses" : {
           "200" : {

--- a/core/src/main/resources/swagger_spec.json
+++ b/core/src/main/resources/swagger_spec.json
@@ -1449,7 +1449,7 @@
           "required" : false,
           "type" : "string"
         }, {
-          "name" : "environment",
+          "name" : "env",
           "in" : "query",
           "required" : false,
           "type" : "string"

--- a/core/src/test/java/io/aiven/klaw/controller/AclControllerTest.java
+++ b/core/src/test/java/io/aiven/klaw/controller/AclControllerTest.java
@@ -120,7 +120,8 @@ public class AclControllerTest {
 
     List<AclRequestsModel> aclRequests = utilMethods.getAclRequestsList();
 
-    when(aclControllerService.getCreatedAclRequests("1", "", "created")).thenReturn(aclRequests);
+    when(aclControllerService.getCreatedAclRequests("1", "", "created", null, null, null))
+        .thenReturn(aclRequests);
 
     mvcAcls
         .perform(

--- a/core/src/test/java/io/aiven/klaw/helpers/db/rdbms/AclRequestsIntegrationTest.java
+++ b/core/src/test/java/io/aiven/klaw/helpers/db/rdbms/AclRequestsIntegrationTest.java
@@ -1,0 +1,220 @@
+package io.aiven.klaw.helpers.db.rdbms;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.google.common.collect.Lists;
+import io.aiven.klaw.UtilMethods;
+import io.aiven.klaw.dao.AclRequests;
+import io.aiven.klaw.dao.UserInfo;
+import io.aiven.klaw.model.enums.AclType;
+import io.aiven.klaw.repository.AclRequestsRepo;
+import io.aiven.klaw.repository.UserInfoRepo;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+@ExtendWith(SpringExtension.class)
+@DataJpaTest
+public class AclRequestsIntegrationTest {
+
+  @Autowired private AclRequestsRepo repo;
+  @Autowired private UserInfoRepo userInfoRepo;
+
+  @Autowired TestEntityManager entityManager;
+
+  private SelectDataJdbc selectDataJdbc;
+
+  private UtilMethods utilMethods;
+
+  public void loadData() {
+    generateData(10, 101, "firsttopic", "dev", AclType.CONSUMER, "created", 1);
+    generateData(10, 103, "firsttopic", "dev", AclType.CONSUMER, "created", 11);
+    generateData(10, 101, "secondtopic", "dev", AclType.CONSUMER, "created", 21);
+    generateData(10, 101, "secondtopic", "test", AclType.CONSUMER, "declined", 31);
+    generateData(1, 101, "secondtopic", "test", AclType.PRODUCER, "created", 41);
+    UserInfo user = new UserInfo();
+    user.setTenantId(101);
+    user.setTeamId(101);
+    user.setRole("USER");
+    user.setUsername("James");
+    UserInfo user2 = new UserInfo();
+    user2.setTenantId(103);
+    user2.setTeamId(103);
+    user2.setRole("USER");
+    user2.setUsername("John");
+    entityManager.persistAndFlush(user);
+    entityManager.persistAndFlush(user2);
+  }
+
+  @BeforeEach
+  public void setUp() {
+    selectDataJdbc = new SelectDataJdbc();
+    utilMethods = new UtilMethods();
+    ReflectionTestUtils.setField(selectDataJdbc, "aclRequestsRepo", repo);
+    ReflectionTestUtils.setField(selectDataJdbc, "userInfoRepo", userInfoRepo);
+    loadData();
+  }
+
+  @Test
+  @Order(1)
+  public void givenNewQueryMethodAssertThatOldAndNewQueriesReturnTheSameResultSet() {
+    // Old way of getting all requests
+    List<AclRequests> aclListSub = Lists.newArrayList(repo.findAllByTenantId(101));
+
+    List<AclRequests> results =
+        selectDataJdbc.selectAclRequests(true, "James", "USER", "ALL", true, 101);
+
+    assertThat(aclListSub.size()).isEqualTo(results.size());
+    assertThat(aclListSub).isEqualTo(results);
+  }
+
+  @Test
+  @Order(2)
+  public void getAllRequestsFilteredByTenantId() {
+
+    List<AclRequests> james =
+        selectDataJdbc.selectAclRequests(true, "James", "USER", "ALL", true, null, null, null, 101);
+    List<AclRequests> john =
+        selectDataJdbc.selectAclRequests(true, "John", "USER", "ALL", true, null, null, null, 103);
+
+    assertThat(james.size()).isEqualTo(31);
+    for (AclRequests req : james) {
+      assertThat(req.getTenantId()).isEqualTo(101);
+    }
+    assertThat(john.size()).isEqualTo(10);
+    for (AclRequests req : john) {
+      assertThat(req.getTenantId()).isEqualTo(103);
+    }
+  }
+
+  @Test
+  @Order(3)
+  public void getAllRequestsFilteredByEnvironment() {
+
+    List<AclRequests> james =
+        selectDataJdbc.selectAclRequests(
+            true, "James", "USER", "created", true, null, "dev", null, 101);
+    List<AclRequests> john =
+        selectDataJdbc.selectAclRequests(
+            true, "John", "USER", "declined", true, null, "dev", null, 103);
+
+    assertThat(james.size()).isEqualTo(20);
+    for (AclRequests req : james) {
+      assertThat(req.getAclstatus()).isEqualTo("created");
+      assertThat(req.getTenantId()).isEqualTo(101);
+      assertThat(req.getEnvironment()).isEqualTo("dev");
+    }
+    assertThat(john.size()).isEqualTo(0);
+  }
+
+  @Test
+  @Order(4)
+  public void getAllRequestsFilteredByAclType() {
+
+    List<AclRequests> james =
+        selectDataJdbc.selectAclRequests(
+            true, "James", "USER", "ALL", true, null, null, AclType.PRODUCER, 101);
+    List<AclRequests> james2 =
+        selectDataJdbc.selectAclRequests(
+            true, "James", "USER", "ALL", true, null, null, AclType.CONSUMER, 101);
+    List<AclRequests> john =
+        selectDataJdbc.selectAclRequests(
+            true, "John", "USER", "ALL", true, null, null, AclType.CONSUMER, 103);
+
+    assertThat(james.size()).isEqualTo(1);
+    for (AclRequests req : james) {
+      assertThat(req.getTenantId()).isEqualTo(101);
+      assertThat(req.getAclType()).isEqualTo(AclType.PRODUCER.value);
+    }
+    assertThat(john.size()).isEqualTo(10);
+    assertThat(james2.size()).isEqualTo(30);
+    for (AclRequests req : james2) {
+      assertThat(req.getTenantId()).isEqualTo(101);
+      assertThat(req.getAclType()).isEqualTo(AclType.CONSUMER.value);
+    }
+  }
+
+  @Test
+  @Order(5)
+  public void getAllRequestsFilteredByTopic() {
+
+    List<AclRequests> james =
+        selectDataJdbc.selectAclRequests(
+            true, "James", "USER", "ALL", true, "firsttopic", null, null, 101);
+
+    assertThat(james.size()).isEqualTo(10);
+    for (AclRequests req : james) {
+      assertThat(req.getTenantId()).isEqualTo(101);
+    }
+  }
+
+  @Test
+  @Order(6)
+  public void getAllRequestsFilteredByTopicbyEnvironment() {
+
+    List<AclRequests> james =
+        selectDataJdbc.selectAclRequests(
+            true, "James", "USER", "ALL", true, "secondtopic", "test", null, 101);
+
+    assertThat(james.size()).isEqualTo(11);
+    for (AclRequests req : james) {
+      assertThat(req.getTenantId()).isEqualTo(101);
+    }
+  }
+
+  @Test
+  @Order(7)
+  public void getAllRequestsFilteredByTopicbyEnvironmentByAclType() {
+
+    List<AclRequests> james =
+        selectDataJdbc.selectAclRequests(
+            true, "James", "USER", "ALL", true, "secondtopic", "test", AclType.CONSUMER, 101);
+
+    assertThat(james.size()).isEqualTo(10);
+    for (AclRequests req : james) {
+      assertThat(req.getTenantId()).isEqualTo(101);
+    }
+  }
+
+  @Test
+  @Order(8)
+  public void getAllRequestsFilteredByMisSpeltTopicbyEnvironmentByAclType_ReturnNothing() {
+    // topic name is case sensitive.
+    List<AclRequests> james =
+        selectDataJdbc.selectAclRequests(
+            true, "James", "USER", "ALL", true, "Secondtopic", "test", AclType.CONSUMER, 101);
+    assertThat(james.size()).isEqualTo(0);
+  }
+
+  private void generateData(
+      int number,
+      int tenantId,
+      String topicName,
+      String env,
+      AclType aclType,
+      String status,
+      int requestNumber) {
+
+    for (int i = 0; i < number; i++) {
+      AclRequests acl = new AclRequests();
+      acl.setTenantId(tenantId);
+      acl.setTeamId(tenantId);
+      acl.setRequestingteam(tenantId);
+      acl.setReq_no(requestNumber++);
+      acl.setTopicname(topicName);
+      acl.setEnvironment(env);
+      acl.setAclType(aclType.value);
+      if (status != null) {
+        acl.setAclstatus(status);
+      }
+      entityManager.persistAndFlush(acl);
+    }
+  }
+}

--- a/core/src/test/java/io/aiven/klaw/service/AclControllerServiceTest.java
+++ b/core/src/test/java/io/aiven/klaw/service/AclControllerServiceTest.java
@@ -308,7 +308,7 @@ public class AclControllerServiceTest {
     stubUserInfo();
     when(manageDatabase.getKafkaEnvList(anyInt())).thenReturn(utilMethods.getEnvLists());
     when(handleDbRequests.getCreatedAclRequestsByStatus(
-            anyString(), anyString(), anyBoolean(), anyInt()))
+            anyString(), anyString(), anyBoolean(), any(), any(), any(), anyInt()))
         .thenReturn(getAclRequests("testtopic", 16));
     when(commonUtilsService.getEnvsFromUserId(anyString()))
         .thenReturn(new HashSet<>(Collections.singletonList("1")));
@@ -316,7 +316,8 @@ public class AclControllerServiceTest {
         .thenReturn("1", "2");
     when(manageDatabase.getTeamNameFromTeamId(anyInt(), anyInt())).thenReturn(teamName);
 
-    List<AclRequestsModel> listReqs = aclControllerService.getCreatedAclRequests("", "", "");
+    List<AclRequestsModel> listReqs =
+        aclControllerService.getCreatedAclRequests("", "", "", null, null, null);
     assertThat(listReqs.size()).isEqualTo(10);
   }
 
@@ -327,7 +328,7 @@ public class AclControllerServiceTest {
     stubUserInfo();
     when(manageDatabase.getKafkaEnvList(anyInt())).thenReturn(utilMethods.getEnvLists());
     when(handleDbRequests.getCreatedAclRequestsByStatus(
-            anyString(), anyString(), anyBoolean(), anyInt()))
+            anyString(), anyString(), anyBoolean(), any(), any(), any(), anyInt()))
         .thenReturn(getAclRequests("testtopic", 16));
     when(commonUtilsService.isNotAuthorizedUser(any(), any())).thenReturn(true);
     when(commonUtilsService.getEnvsFromUserId(anyString()))
@@ -336,7 +337,8 @@ public class AclControllerServiceTest {
         .thenReturn("1", "2");
     when(manageDatabase.getTeamNameFromTeamId(anyInt(), anyInt())).thenReturn(teamName);
 
-    List<AclRequestsModel> listReqs = aclControllerService.getCreatedAclRequests("", "", "");
+    List<AclRequestsModel> listReqs =
+        aclControllerService.getCreatedAclRequests("", "", "", null, null, null);
     assertThat(listReqs.size()).isEqualTo(10);
   }
 


### PR DESCRIPTION
Signed-off-by: Aindriu Lavelle <aindriu.lavelle@aiven.io>

About this change - What it does
This change adds three optional paramters to the getCreatedAclRequest.
1) topic the topicName
2) environment DEV/TST/UAT/PRD
3) AclType PRODUCER/CONSuMER
Resolves: #xxxxx
Why this way
The use of the example repo allows for further extension without writing custom queries for a multitude of options.
It also allows a reuse of existing code without the addition of a lot of new code.