### PR TITLE
feat(coral): Add /request/acl route

### DIFF
--- a/coral/src/app/layout/main-navigation/MainNavigation.tsx
+++ b/coral/src/app/layout/main-navigation/MainNavigation.tsx
@@ -48,9 +48,9 @@ function MainNavigation() {
                 // This link is only intended to be rendered in dev environment
                 // So the path does not have a coral/ prefix
                 // @TODO: delete when Topic overview / top nac Request dropdown are implemented
-                href={"/topic/aivtopic1/subscribe"}
+                href={"/request/acl"}
                 linkText={"Subscribe"}
-                active={pathname.includes("/subscribe")}
+                active={pathname.includes("/request/acl")}
               />
             ) : (
               <></>

--- a/coral/src/app/router.tsx
+++ b/coral/src/app/router.tsx
@@ -22,6 +22,10 @@ const routes: Array<RouteObject> = [
   //   path: "/login",
   // },
   {
+    path: "/request/acl",
+    element: <AclRequest />,
+  },
+  {
     path: "/topics",
     element: <Topics />,
   },


### PR DESCRIPTION
## About this change - What it does

In alignment with the issue [refactor(coral): Route architecture for request forms](https://github.com/aiven/klaw/issues/452):
- add `/request/acl` route rendering the ACL request form
- redirect to this route from the `Subscribe` Nav link
