### PR TITLE
fix(coral): Fix typo in PreviewBanner url

### DIFF
--- a/coral/src/app/pages/topics/acl-request.tsx
+++ b/coral/src/app/pages/topics/acl-request.tsx
@@ -12,7 +12,7 @@ const AclRequest = () => {
     <AuthenticationRequiredBoundary>
       <Layout>
         <PreviewBanner
-          linkTarget={`/requestAcl${
+          linkTarget={`/requestAcls${
             topicName !== undefined ? `?topicName=${topicName}` : ""
           }`}
         />


### PR DESCRIPTION
## About this change - What it does

Path should be `requestAcls?topicname=${topicName}` (notice the `s`)

It was `requestAcl?topicName=${topicName}`