### PR TITLE
refactor(coral): Update main navigation to show correct active links

### DIFF
--- a/coral/jest.config.ts
+++ b/coral/jest.config.ts
@@ -13,6 +13,7 @@ export default {
     "<rootDir>/test-setup/setup-files-after-env.ts",
     "<rootDir>/test-setup/mock-monaco-editor.tsx",
   ],
+
   moduleNameMapper: {
     ".+\\.(png|jpg|ttf|woff|woff2|svg)$": "jest-transform-stub",
     "\\.css$": "identity-obj-proxy",

--- a/coral/src/app/hooks/useFeatureFlag.ts
+++ b/coral/src/app/hooks/useFeatureFlag.ts
@@ -2,7 +2,6 @@ import { useState, useEffect } from "react";
 
 enum FeatureFlag {
   TOPIC_REQUEST = "FEATURE_FLAG_TOPIC_REQUEST",
-  TOPIC_ACL_REQUEST = "FEATURE_FLAG_TOPIC_ACL_REQUEST",
   APPROVALS = "FEATURE_FLAG_APPROVALS",
 }
 

--- a/coral/src/app/layout/main-navigation/MainNavigation.test.tsx
+++ b/coral/src/app/layout/main-navigation/MainNavigation.test.tsx
@@ -24,6 +24,7 @@ const navLinks = [
     name: "Dashboard",
     linkTo: "/index",
   },
+  { name: "Approval Requests", linkTo: "/approvals" },
   { name: "Audit Log", linkTo: "/activityLog" },
   { name: "Settings", linkTo: "/serverConfig" },
 ];
@@ -39,7 +40,7 @@ const submenuItems = [
 const submenuItemTopics = [
   {
     name: "Topics",
-    links: ["All Topics", "Approval Requests", "My Team's Requests"],
+    links: ["All Topics", "My Team's Requests"],
   },
 ];
 
@@ -51,15 +52,22 @@ const navOrderFirstLevel = [
   { name: "Dashboard", isSubmenu: false },
   { name: "Topics", isSubmenu: true },
   { name: "All Topics", isSubmenu: false },
-  { name: "Approval Requests", isSubmenu: false },
   { name: "My Team's Requests", isSubmenu: false },
   { name: "Kafka Connectors", isSubmenu: true },
   { name: "Users and Teams", isSubmenu: true },
+  { name: "Approval Requests", isSubmenu: false },
   { name: "Audit Log", isSubmenu: false },
   { name: "Settings", isSubmenu: false },
 ];
 
 describe("MainNavigation.tsx", () => {
+  beforeAll(() => {
+    process.env.FEATURE_FLAG_APPROVALS = "true";
+  });
+  afterAll(() => {
+    process.env.FEATURE_FLAG_APPROVALS = "false";
+  });
+
   describe("renders the main navigation in default state", () => {
     beforeAll(() => {
       customRender(<MainNavigation />, { memoryRouter: true });
@@ -301,6 +309,27 @@ describe("MainNavigation.tsx", () => {
           expect(link).toHaveFocus();
         });
       });
+    });
+  });
+
+  describe("renders link dependent on feature flag FEATURE_FLAG_APPROVALS", () => {
+    beforeAll(() => {
+      process.env.FEATURE_FLAG_APPROVALS = "false";
+      customRender(<MainNavigation />, { memoryRouter: true });
+    });
+
+    afterAll(cleanup);
+
+    it("does show link to angular app when feature flag is false", () => {
+      const nav = screen.getByRole("navigation", {
+        name: "Main navigation",
+      });
+
+      const navLink = within(nav).getByRole("link", {
+        name: "Approval Requests",
+      });
+
+      expect(navLink).toHaveAttribute("href", "/execTopics");
     });
   });
 });

--- a/coral/src/app/layout/main-navigation/MainNavigation.tsx
+++ b/coral/src/app/layout/main-navigation/MainNavigation.tsx
@@ -29,7 +29,7 @@ function MainNavigation() {
         <li>
           <MainNavigationLink
             icon={database}
-            href={`/index`}
+            to={`/index`}
             linkText={"Dashboard"}
           />
         </li>
@@ -41,15 +41,14 @@ function MainNavigation() {
           >
             <MainNavigationLink
               linkText={"All Topics"}
-              href={Routes.TOPICS}
+              to={Routes.TOPICS}
               active={
                 pathname.startsWith(Routes.TOPICS) ||
                 pathname.startsWith("/topic")
               }
-              useRouter={true}
             />
             <MainNavigationLink
-              href={`/myTopicRequests`}
+              to={`/myTopicRequests`}
               linkText={"My Team's Requests"}
             />
           </MainNavigationSubmenuList>
@@ -60,38 +59,34 @@ function MainNavigation() {
             text={"Kafka Connectors"}
           >
             <MainNavigationLink
-              href={`/kafkaConnectors`}
+              to={`/kafkaConnectors`}
               linkText={"All Connectors"}
             />
             <MainNavigationLink
-              href={`/execConnectors`}
+              to={`/execConnectors`}
               linkText={"Connector Requests"}
             />
           </MainNavigationSubmenuList>
         </li>
         <li>
           <MainNavigationSubmenuList icon={people} text={"Users and Teams"}>
-            <MainNavigationLink href={`/users`} linkText={"Users"} />
-            <MainNavigationLink href={`/teams`} linkText={"Teams"} />
-            <MainNavigationLink
-              href={`/execUsers`}
-              linkText={"User Requests"}
-            />
+            <MainNavigationLink to={`/users`} linkText={"Users"} />
+            <MainNavigationLink to={`/teams`} linkText={"Teams"} />
+            <MainNavigationLink to={`/execUsers`} linkText={"User Requests"} />
           </MainNavigationSubmenuList>
         </li>
         <li>
           {approvalsEnabled ? (
             <MainNavigationLink
               icon={tickCircle}
-              href={Routes.APPROVALS}
+              to={Routes.APPROVALS}
               linkText={"Approval Requests"}
               active={pathname.startsWith(Routes.APPROVALS)}
-              useRouter={true}
             />
           ) : (
             <MainNavigationLink
               icon={tickCircle}
-              href={`/execTopics`}
+              to={`/execTopics`}
               linkText={"Approval Requests"}
             />
           )}
@@ -99,7 +94,7 @@ function MainNavigation() {
         <li>
           <MainNavigationLink
             icon={list}
-            href={`/activityLog`}
+            to={`/activityLog`}
             linkText={"Audit Log"}
           />
         </li>
@@ -109,7 +104,7 @@ function MainNavigation() {
           </Box>
           <MainNavigationLink
             icon={cog}
-            href={`/serverConfig`}
+            to={`/serverConfig`}
             linkText={"Settings"}
           />
         </li>

--- a/coral/src/app/layout/main-navigation/MainNavigation.tsx
+++ b/coral/src/app/layout/main-navigation/MainNavigation.tsx
@@ -5,13 +5,14 @@ import layoutGroupBy from "@aivenio/aquarium/dist/src/icons/layoutGroupBy";
 import people from "@aivenio/aquarium/dist/src/icons/people";
 import list from "@aivenio/aquarium/dist/src/icons/list";
 import cog from "@aivenio/aquarium/dist/src/icons/cog";
+import tickCircle from "@aivenio/aquarium/dist/src/icons/tickCircle";
 import MainNavigationLink from "src/app/layout/main-navigation/MainNavigationLink";
 import MainNavigationSubmenuList from "src/app/layout/main-navigation/MainNavigationSubmenuList";
 import useFeatureFlag, { FeatureFlag } from "src/app/hooks/useFeatureFlag";
 import { useLocation } from "react-router-dom";
+import { Routes } from "src/app/router_utils";
 
 function MainNavigation() {
-  const topicAclRequestEnabled = useFeatureFlag(FeatureFlag.TOPIC_ACL_REQUEST);
   const approvalsEnabled = useFeatureFlag(FeatureFlag.APPROVALS);
   const { pathname } = useLocation();
 
@@ -39,36 +40,14 @@ function MainNavigation() {
             text={"Topics"}
           >
             <MainNavigationLink
-              href={"/coral/topics"}
               linkText={"All Topics"}
-              active={pathname === "/coral/topics"}
+              href={Routes.TOPICS}
+              active={
+                pathname.startsWith(Routes.TOPICS) ||
+                pathname.startsWith("/topic")
+              }
+              useRouter={true}
             />
-            {topicAclRequestEnabled ? (
-              <MainNavigationLink
-                // This link is only intended to be rendered in dev environment
-                // So the path does not have a coral/ prefix
-                // @TODO: delete when Topic overview / top nac Request dropdown are implemented
-                href={"/topic/aivtopic1/subscribe"}
-                linkText={"Subscribe"}
-                active={pathname.includes("/subscribe")}
-              />
-            ) : (
-              <></>
-            )}
-
-            {approvalsEnabled ? (
-              <MainNavigationLink
-                href={`/approvals/topics`}
-                linkText={"Approval Requests"}
-                useRouter={true}
-              />
-            ) : (
-              <MainNavigationLink
-                href={`/execTopics`}
-                linkText={"Approval Requests"}
-              />
-            )}
-
             <MainNavigationLink
               href={`/myTopicRequests`}
               linkText={"My Team's Requests"}
@@ -99,6 +78,23 @@ function MainNavigation() {
               linkText={"User Requests"}
             />
           </MainNavigationSubmenuList>
+        </li>
+        <li>
+          {approvalsEnabled ? (
+            <MainNavigationLink
+              icon={tickCircle}
+              href={Routes.APPROVALS}
+              linkText={"Approval Requests"}
+              active={pathname.startsWith(Routes.APPROVALS)}
+              useRouter={true}
+            />
+          ) : (
+            <MainNavigationLink
+              icon={tickCircle}
+              href={`/execTopics`}
+              linkText={"Approval Requests"}
+            />
+          )}
         </li>
         <li>
           <MainNavigationLink

--- a/coral/src/app/layout/main-navigation/MainNavigationLink.test.tsx
+++ b/coral/src/app/layout/main-navigation/MainNavigationLink.test.tsx
@@ -1,7 +1,8 @@
 import MainNavigationLink from "src/app/layout/main-navigation/MainNavigationLink";
-import { cleanup, screen, render } from "@testing-library/react";
+import { cleanup, render, screen } from "@testing-library/react";
 import data from "@aivenio/aquarium/dist/src/icons/console";
 import { MemoryRouter } from "react-router-dom";
+import { Routes } from "src/app/router_utils";
 
 // mock out svgs to avoid clutter
 jest.mock("@aivenio/aquarium", () => {
@@ -19,13 +20,13 @@ describe("MainNavigationLink.tsx", () => {
   // (icon is not needed for the test, Icon component mocked out)
   const mockIcon = "fake-icon" as unknown as typeof data;
 
-  describe("renders a default link with required props", () => {
+  describe("renders a default link with required props with a string as `to`", () => {
     beforeAll(() => {
       render(
         <MainNavigationLink
           icon={mockIcon}
-          href={"/topics"}
-          linkText={"Topics"}
+          to={"/some-klaw-link"}
+          linkText={"Link back to Klaw"}
         />
       );
     });
@@ -33,14 +34,14 @@ describe("MainNavigationLink.tsx", () => {
     afterAll(cleanup);
 
     it(`renders a link with text dependent on a given property`, () => {
-      const navLink = screen.getByRole("link", { name: "Topics" });
+      const navLink = screen.getByRole("link", { name: "Link back to Klaw" });
 
       expect(navLink).toBeVisible();
     });
 
     it(`renders a href for that link dependent on a given  property`, () => {
-      const navLink = screen.getByRole("link", { name: "Topics" });
-      expect(navLink).toHaveAttribute("href", "/topics");
+      const navLink = screen.getByRole("link", { name: "Link back to Klaw" });
+      expect(navLink).toHaveAttribute("href", "/some-klaw-link");
     });
 
     it(`renders a given icon for that is hidden from assistive technology`, () => {
@@ -56,12 +57,12 @@ describe("MainNavigationLink.tsx", () => {
       render(
         <MainNavigationLink
           icon={mockIcon}
-          href={"/topics"}
-          linkText={"Topics"}
+          to={"/some-klaw-link"}
+          linkText={"Link back to Klaw"}
         />
       );
 
-      const navLink = screen.getByRole("link", { name: "Topics" });
+      const navLink = screen.getByRole("link", { name: "Link back to Klaw" });
 
       expect(navLink).not.toHaveAttribute("aria-current", "page");
     });
@@ -70,12 +71,12 @@ describe("MainNavigationLink.tsx", () => {
       render(
         <MainNavigationLink
           icon={mockIcon}
-          href={"/topics"}
-          linkText={"Topics"}
+          to={"/some-klaw-link"}
+          linkText={"Link back to Klaw"}
         />
       );
 
-      const navLink = screen.getByRole("link", { name: "Topics" });
+      const navLink = screen.getByRole("link", { name: "Link back to Klaw" });
 
       expect(navLink.parentNode).not.toHaveClass("mainNavigationLinkActive");
     });
@@ -84,13 +85,13 @@ describe("MainNavigationLink.tsx", () => {
       render(
         <MainNavigationLink
           icon={mockIcon}
-          href={"/topics"}
-          linkText={"Topics"}
+          to={"/some-klaw-link"}
+          linkText={"Link back to Klaw"}
           active={true}
         />
       );
 
-      const navLink = screen.getByRole("link", { name: "Topics" });
+      const navLink = screen.getByRole("link", { name: "Link back to Klaw" });
 
       expect(navLink).toHaveAttribute("aria-current", "page");
     });
@@ -99,27 +100,28 @@ describe("MainNavigationLink.tsx", () => {
       render(
         <MainNavigationLink
           icon={mockIcon}
-          href={"/topics"}
-          linkText={"Topics"}
+          to={"/some-klaw-link"}
+          linkText={"Link back to Klaw"}
           active={true}
         />
       );
 
-      const navLink = screen.getByRole("link", { name: "Topics" });
+      const navLink = screen.getByRole("link", { name: "Link back to Klaw" });
 
       expect(navLink.parentNode).toHaveClass("mainNavigationLinkActive");
     });
   });
-  describe("Link rendered with React Routers <Link>", () => {
+
+  describe("renders a react router <Link> when `to` belongs to `Routes`", () => {
+    afterAll(cleanup);
     it("renders correct link content", () => {
       render(
         <MemoryRouter initialEntries={["/users/mjackson"]}>
           <MainNavigationLink
             icon={mockIcon}
-            href={"/topics"}
+            to={Routes.TOPICS}
             linkText={"Topics"}
             active={true}
-            useRouter={true}
           />
         </MemoryRouter>
       );

--- a/coral/src/app/layout/main-navigation/MainNavigationLink.tsx
+++ b/coral/src/app/layout/main-navigation/MainNavigationLink.tsx
@@ -1,7 +1,8 @@
 import { Box, Icon } from "@aivenio/aquarium";
 import data from "@aivenio/aquarium/dist/src/icons/console";
-import { Link } from "react-router-dom";
 import classes from "src/app/layout/main-navigation/MainNavigationLink.module.css";
+import { Routes } from "src/app/router_utils";
+import { Link } from "react-router-dom";
 
 function LinkContent({
   linkText,
@@ -23,13 +24,20 @@ function LinkContent({
 
 type MainNavigationLinkProps = {
   icon?: typeof data;
-  href: string;
-  useRouter?: boolean;
+  // only use a string if the link
+  // should go into the Klaw Angular app!
+  to: Routes | string;
   linkText: string;
   active?: boolean;
 };
 function MainNavigationLink(props: MainNavigationLinkProps) {
-  const { icon, href, linkText, active, useRouter = false } = props;
+  const { icon, to, linkText, active = false } = props;
+
+  function isRouterLink() {
+    const allRoutes: string[] = Object.values(Routes);
+    return allRoutes.includes(to);
+  }
+
   return (
     <Box
       className={
@@ -43,12 +51,12 @@ function MainNavigationLink(props: MainNavigationLinkProps) {
       marginBottom={"3"}
       paddingBottom={"3"}
     >
-      {useRouter ? (
-        <Link to={href} aria-current={active && "page"}>
+      {isRouterLink() ? (
+        <Link to={to} aria-current={active && "page"}>
           <LinkContent icon={icon} linkText={linkText} />
         </Link>
       ) : (
-        <a href={href} aria-current={active && "page"}>
+        <a href={to} aria-current={active && "page"}>
           <LinkContent icon={icon} linkText={linkText} />
         </a>
       )}

--- a/coral/src/app/main.tsx
+++ b/coral/src/app/main.tsx
@@ -9,7 +9,6 @@ import router from "src/app/router";
 import { isUnauthorizedError } from "src/services/api";
 import "/src/app/accessibility.module.css";
 import "/src/app/main.module.css";
-
 // https://github.com/microsoft/monaco-editor/tree/main/samples/browser-esm-vite-react
 import "/src/services/configure-monaco-editor";
 

--- a/coral/src/app/router.tsx
+++ b/coral/src/app/router.tsx
@@ -11,8 +11,9 @@ import { getRouterBasename } from "src/config";
 import RequestTopic from "src/app/pages/topics/request";
 import SchemaRequest from "src/app/pages/topics/schema-request";
 import {
-  ApprovalsTabEnum,
   APPROVALS_TAB_ID_INTO_PATH,
+  ApprovalsTabEnum,
+  Routes,
 } from "src/app/router_utils";
 
 const routes: Array<RouteObject> = [
@@ -22,23 +23,23 @@ const routes: Array<RouteObject> = [
   //   path: "/login",
   // },
   {
-    path: "/topics",
+    path: Routes.TOPICS,
     element: <Topics />,
   },
   {
-    path: "/topics/request",
+    path: Routes.TOPIC_REQUEST,
     element: <RequestTopic />,
   },
   {
-    path: "/topic/:topicName/subscribe",
+    path: Routes.TOPIC_ALC_REQUEST,
     element: <AclRequest />,
   },
   {
-    path: "/topic/:topicName/request-schema",
+    path: Routes.TOPIC_SCHEMA_REQUEST,
     element: <SchemaRequest />,
   },
   {
-    path: "/approvals/",
+    path: Routes.APPROVALS,
     element: <ApprovalsPage />,
     children: [
       {

--- a/coral/src/app/router.tsx
+++ b/coral/src/app/router.tsx
@@ -31,7 +31,7 @@ const routes: Array<RouteObject> = [
     element: <RequestTopic />,
   },
   {
-    path: Routes.TOPIC_ALC_REQUEST,
+    path: Routes.TOPIC_ACL_REQUEST,
     element: <AclRequest />,
   },
   {

--- a/coral/src/app/router_utils.ts
+++ b/coral/src/app/router_utils.ts
@@ -1,5 +1,13 @@
 import isString from "lodash/isString";
 
+enum Routes {
+  TOPICS = "/topics",
+  TOPIC_REQUEST = "/topics/request",
+  TOPIC_ALC_REQUEST = "/topic/:topicName/subscribe",
+  TOPIC_SCHEMA_REQUEST = "/topic/:topicName/request-schema",
+  APPROVALS = "/approvals",
+}
+
 enum ApprovalsTabEnum {
   TOPICS = "APPROVALS_TAB_ENUM_topics",
   ACLS = "APPROVALS_TAB_ENUM_acls",
@@ -24,4 +32,9 @@ function isApprovalsTabEnum(value: unknown): value is ApprovalsTabEnum {
   return false;
 }
 
-export { ApprovalsTabEnum, APPROVALS_TAB_ID_INTO_PATH, isApprovalsTabEnum };
+export {
+  ApprovalsTabEnum,
+  Routes,
+  APPROVALS_TAB_ID_INTO_PATH,
+  isApprovalsTabEnum,
+};

--- a/coral/src/app/router_utils.ts
+++ b/coral/src/app/router_utils.ts
@@ -3,7 +3,7 @@ import isString from "lodash/isString";
 enum Routes {
   TOPICS = "/topics",
   TOPIC_REQUEST = "/topics/request",
-  TOPIC_ALC_REQUEST = "/topic/:topicName/subscribe",
+  TOPIC_ACL_REQUEST = "/topic/:topicName/subscribe",
   TOPIC_SCHEMA_REQUEST = "/topic/:topicName/request-schema",
   APPROVALS = "/approvals",
 }

--- a/coral/test-setup/setup-files-after-env.ts
+++ b/coral/test-setup/setup-files-after-env.ts
@@ -1,5 +1,7 @@
 import "@testing-library/jest-dom";
 import "whatwg-fetch";
+import * as process from "process";
+//eslint-disable-next-line no-relative-import-paths/no-relative-import-paths
 
 process.env.API_BASE_URL = "http://localhost:8080";
 process.env.FEATURE_FLAG_TOPIC_REQUEST = "true";

--- a/coral/vite.config.ts
+++ b/coral/vite.config.ts
@@ -134,9 +134,6 @@ export default defineConfig(({ mode }) => {
       "process.env": {
         ROUTER_BASENAME: getRouterBasename(environment),
         API_BASE_URL: getApiBaseUrl(environment),
-        FEATURE_FLAG_TOPIC_ACL_REQUEST: ["development", "remote-api"]
-          .includes(mode)
-          .toString(),
         FEATURE_FLAG_APPROVALS: ["development", "remote-api"]
           .includes(mode)
           .toString(),


### PR DESCRIPTION
# Description 
(can also be the commit body)

- add `Routes` enum for a bit more type safety
- add `active` props to all links in coral so they are styled and marked correctly based on route
- remove general acl request feature flag and link (dev need only)
- remove `useRouter` prop from `MainNavigationLink`, component determines which link to dependent wether the path is part of `Routes`


