### PR TITLE
feat(coral): Add /getAclRequestsForApprover endpoint

### DIFF
--- a/coral/src/domain/acl/acl-api.ts
+++ b/coral/src/domain/acl/acl-api.ts
@@ -17,10 +17,10 @@ const createAclRequest = (
   >("/createAcl", aclParams);
 };
 
-const getCreatedAclRequests = (params: GetCreatedAclRequestParameters) => {
-  return api.get<KlawApiResponse<"getCreatedAclRequests">>(
-    `/getCreatedAclRequests?${new URLSearchParams(params)}`
+const getAclRequestsForApprover = (params: GetCreatedAclRequestParameters) => {
+  return api.get<KlawApiResponse<"getAclRequestsForApprover">>(
+    `/getAclRequestsForApprover?${new URLSearchParams(params)}`
   );
 };
 
-export { createAclRequest, getCreatedAclRequests };
+export { createAclRequest, getAclRequestsForApprover };

--- a/coral/src/domain/acl/acl-api.ts
+++ b/coral/src/domain/acl/acl-api.ts
@@ -1,6 +1,7 @@
 import {
-  CreateAclRequestTopicTypeProducer,
   CreateAclRequestTopicTypeConsumer,
+  CreateAclRequestTopicTypeProducer,
+  GetCreatedAclRequestParameters,
 } from "src/domain/acl/acl-types";
 import api from "src/services/api";
 import { KlawApiRequest, KlawApiResponse } from "types/utils";
@@ -16,4 +17,10 @@ const createAclRequest = (
   >("/createAcl", aclParams);
 };
 
-export { createAclRequest };
+const getCreatedAclRequests = (params: GetCreatedAclRequestParameters) => {
+  return api.get<KlawApiResponse<"getCreatedAclRequests">>(
+    `/getCreatedAclRequests?${new URLSearchParams(params)}`
+  );
+};
+
+export { createAclRequest, getCreatedAclRequests };

--- a/coral/src/domain/acl/acl-types.ts
+++ b/coral/src/domain/acl/acl-types.ts
@@ -38,7 +38,7 @@ type CreateAclRequestTopicTypeConsumer = BaseCreateAclRequest & {
 };
 
 type GetCreatedAclRequestParameters =
-  KlawApiRequestQueryParameters<"getCreatedAclRequests">;
+  KlawApiRequestQueryParameters<"getAclRequestsForApprover">;
 
 type AclRequest = KlawApiModel<"aclRequest">;
 

--- a/coral/src/domain/acl/acl-types.ts
+++ b/coral/src/domain/acl/acl-types.ts
@@ -1,4 +1,8 @@
-import { KlawApiRequest } from "types/utils";
+import {
+  KlawApiRequest,
+  KlawApiRequestQueryParameters,
+  KlawApiModel,
+} from "types/utils";
 
 // Several types are dependent on topictype when it is "Consumer":
 // - aclPatternType can only be "LITERAL"
@@ -33,7 +37,14 @@ type CreateAclRequestTopicTypeConsumer = BaseCreateAclRequest & {
   consumergroup: string;
 };
 
+type GetCreatedAclRequestParameters =
+  KlawApiRequestQueryParameters<"getCreatedAclRequests">;
+
+type AclRequest = KlawApiModel<"aclRequest">;
+
 export type {
   CreateAclRequestTopicTypeProducer,
   CreateAclRequestTopicTypeConsumer,
+  GetCreatedAclRequestParameters,
+  AclRequest,
 };

--- a/coral/types/api.d.ts
+++ b/coral/types/api.d.ts
@@ -36,8 +36,8 @@ export type paths = {
   "/getClusterInfoFromEnv": {
     get: operations["clusterInfoFromEnvironmentGet"];
   };
-  "/getCreatedAclRequests": {
-    get: operations["getCreatedAclRequests"];
+  "/getAclRequestsForApprover": {
+    get: operations["getAclRequestsForApprover"];
   };
   "/createAcl": {
     post: operations["createAclRequest"];
@@ -1155,7 +1155,7 @@ export type operations = {
       };
     };
   };
-  getCreatedAclRequests: {
+  getAclRequestsForApprover: {
     parameters: {
       query: {
         pageNo: string;
@@ -1256,7 +1256,7 @@ export enum ApiPaths {
   environmentsGet = "/getEnvs",
   envsBaseClusterFilteredForTeamGet = "/getEnvsBaseClusterFilteredForTeam",
   clusterInfoFromEnvironmentGet = "/getClusterInfoFromEnv",
-  getCreatedAclRequests = "/getCreatedAclRequests",
+  getAclRequestsForApprover = "/getAclRequestsForApprover",
   createAclRequest = "/createAcl",
   schemaRegEnvsGet = "/getSchemaRegEnvs",
   schemaUpload = "/uploadSchema",

--- a/coral/types/api.d.ts
+++ b/coral/types/api.d.ts
@@ -36,6 +36,9 @@ export type paths = {
   "/getClusterInfoFromEnv": {
     get: operations["clusterInfoFromEnvironmentGet"];
   };
+  "/getCreatedAclRequests": {
+    get: operations["getCreatedAclRequests"];
+  };
   "/createAcl": {
     post: operations["createAclRequest"];
   };
@@ -1152,6 +1155,26 @@ export type operations = {
       };
     };
   };
+  getCreatedAclRequests: {
+    parameters: {
+      query: {
+        pageNo: string;
+        currentPage?: string;
+        requestsType?: "all" | "created" | "approved" | "denied" | "deleted";
+        topic?: string;
+        env?: string;
+        aclType?: "CONSUMER" | "PRODUCER";
+      };
+    };
+    responses: {
+      /** OK */
+      200: {
+        content: {
+          "application/json": components["schemas"]["aclRequest"][];
+        };
+      };
+    };
+  };
   createAclRequest: {
     responses: {
       /** OK */
@@ -1233,6 +1256,7 @@ export enum ApiPaths {
   environmentsGet = "/getEnvs",
   envsBaseClusterFilteredForTeamGet = "/getEnvsBaseClusterFilteredForTeam",
   clusterInfoFromEnvironmentGet = "/getClusterInfoFromEnv",
+  getCreatedAclRequests = "/getCreatedAclRequests",
   createAclRequest = "/createAcl",
   schemaRegEnvsGet = "/getSchemaRegEnvs",
   schemaUpload = "/uploadSchema",

--- a/coral/types/utils.d.ts
+++ b/coral/types/utils.d.ts
@@ -6,5 +6,12 @@ type KlawApiModel<Schema extends keyof components["schemas"]> =
   components["schemas"][Schema];
 type KlawApiRequest<OperationId extends keyof operations> =
   operations[OperationId]["requestBody"]["content"]["application/json"];
+type KlawApiRequestQueryParameters<OperationId extends keyof operations> =
+  operations[OperationId]["parameters"]["query"];
 
-export type { KlawApiResponse, KlawApiModel, KlawApiRequest };
+export type {
+  KlawApiResponse,
+  KlawApiModel,
+  KlawApiRequest,
+  KlawApiRequestQueryParameters,
+};

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -271,6 +271,60 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/environmentGetClusterInfoResponse"
+  /getCreatedAclRequests:
+    get:
+      operationId: getCreatedAclRequests
+      summary: "Get ACL requests with aclstatus: created"
+      tags:
+        - ACL
+      parameters:
+        - name: pageNo
+          in: query
+          required: true
+          schema:
+            type: string
+        - name: currentPage
+          in: query
+          required: false
+          schema:
+            type: string
+        - name: requestsType
+          in: query
+          required: false
+          schema:
+            type: string
+            enum: ["all", "created", "approved", "denied", "deleted"]
+          example: "created"
+          default: "created"
+        - name: topic
+          in: query
+          required: false
+          schema:
+            type: string
+          example: "mytopic"
+        - name: env
+          in: query
+          required: false
+          schema:
+            type: string
+          example: "1"
+        - name: aclType
+          in: query
+          required: false
+          schema:
+            type: string
+            enum: ["CONSUMER", "PRODUCER"]
+          example: "CONSUMER"
+          default: "CONSUMER"
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/aclRequest"
   /createAcl:
     post:
       tags:

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -271,9 +271,9 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/environmentGetClusterInfoResponse"
-  /getCreatedAclRequests:
+  /getAclRequestsForApprover:
     get:
-      operationId: getCreatedAclRequests
+      operationId: getAclRequestsForApprover
       summary: "Get ACL requests with aclstatus: created"
       tags:
         - ACL


### PR DESCRIPTION
## About this change - What it does

- add openapi documentation
- add acl-api function
- ad acl-types for endpoint
- generate types

## Additional changes

- added a `KlawApiRequestQueryParameters` util to pick query params types from the generated types, like for request payloads.

Resolves: #559
