### PR TITLE
feat(coral): Add temporary Modal component

### DIFF
--- a/coral/src/app/components/Modal.module.css
+++ b/coral/src/app/components/Modal.module.css
@@ -1,0 +1,13 @@
+.modal-wrapper {
+  position: fixed;
+  top: 0;
+  height: 100vh;
+  width: 100%;
+  background-color: rgba(48, 55, 94, 0.7);
+  z-index: 2;
+}
+
+.modalTextBlock {
+  overflow: scroll;
+  max-height: 50vh;
+}

--- a/coral/src/app/components/Modal.test.tsx
+++ b/coral/src/app/components/Modal.test.tsx
@@ -1,0 +1,225 @@
+import { cleanup, render, screen } from "@testing-library/react";
+import { Modal } from "src/app/components/Modal";
+import userEvent from "@testing-library/user-event";
+
+describe("Modal.tsx", () => {
+  const testTitle = "Modal title";
+  const mockChildren = <div>This is child content</div>;
+  const mockPrimary = {
+    text: "Primary action 1",
+    onClick: jest.fn(),
+  };
+
+  describe("renders a default modal with all necessary elements", () => {
+    afterEach(jest.clearAllMocks);
+
+    describe("renders all necessary elements", () => {
+      beforeAll(() => {
+        render(
+          <>
+            <div id={"root"}></div>
+            <Modal title={testTitle} primaryAction={mockPrimary}>
+              {mockChildren}
+            </Modal>
+          </>
+        );
+      });
+
+      afterAll(cleanup);
+
+      it("sets the app root to aria hidden true", () => {
+        const root = document.getElementById("root");
+
+        expect(root).toHaveAttribute("aria-hidden", "true");
+      });
+
+      it("sets the tabindex of app root to -1 so users can only access modal", () => {
+        const root = document.getElementById("root");
+
+        expect(root).toHaveAttribute("tabindex", "-1");
+      });
+
+      it("shows a dialog", () => {
+        const dialog = screen.getByRole("dialog");
+
+        expect(dialog).toBeVisible();
+      });
+
+      it("marks the modal as a aria modal to help assistive technology", () => {
+        const dialog = screen.getByRole("dialog");
+
+        expect(dialog).toHaveAttribute("aria-modal", "true");
+      });
+
+      it("shows a given title", () => {
+        const title = screen.getByRole("heading", { name: testTitle });
+
+        expect(title).toBeVisible();
+      });
+
+      it("moves focus to the title in the dialog", () => {
+        const title = screen.getByRole("heading", { name: testTitle });
+
+        expect(title).toHaveFocus();
+      });
+
+      it("shows the given content", () => {
+        const text = screen.getByText("This is child content");
+
+        expect(text).toBeVisible();
+      });
+
+      it("shows a button with a given primary action", () => {
+        const button = screen.getByRole("button", { name: mockPrimary.text });
+
+        expect(button).toBeEnabled();
+      });
+
+      it("shows no other buttons for secondary action or close", () => {
+        const buttons = screen.getAllByRole("button");
+
+        expect(buttons).toHaveLength(1);
+        expect(buttons[0]).toHaveTextContent(mockPrimary.text);
+      });
+    });
+
+    describe("handles user input", () => {
+      beforeEach(() => {
+        render(
+          <>
+            <div id={"root"}></div>
+            <Modal title={testTitle} primaryAction={mockPrimary}>
+              {mockChildren}
+            </Modal>
+          </>
+        );
+      });
+
+      afterEach(cleanup);
+
+      it("enables user to click the secondary action", async () => {
+        const button = screen.getByRole("button", { name: mockPrimary.text });
+
+        await userEvent.click(button);
+        expect(mockPrimary.onClick).toHaveBeenCalled();
+      });
+
+      it("enables user access and trigger the primary action with keyboard", async () => {
+        await userEvent.tab();
+        const button = screen.getByRole("button", { name: mockPrimary.text });
+
+        expect(button).toHaveFocus();
+
+        await userEvent.keyboard("{Enter}");
+        expect(mockPrimary.onClick).toHaveBeenCalled();
+      });
+    });
+  });
+
+  describe("renders additional elements dependent on props", () => {
+    describe("handles a secondary action", () => {
+      const mockSecondary = {
+        text: "this is the secondary action",
+        onClick: jest.fn(),
+      };
+
+      beforeEach(() => {
+        render(
+          <Modal
+            title={testTitle}
+            primaryAction={mockPrimary}
+            secondaryAction={mockSecondary}
+          >
+            {mockChildren}
+          </Modal>
+        );
+      });
+
+      afterEach(cleanup);
+
+      it("shows the secondary action as a button", () => {
+        const button = screen.getByRole("button", { name: mockSecondary.text });
+
+        expect(button).toBeEnabled();
+      });
+
+      it("shows two buttons when secodary and primary action are given", () => {
+        const buttons = screen.getAllByRole("button");
+
+        expect(buttons).toHaveLength(2);
+      });
+
+      it("enables user to click the secondary action", async () => {
+        const button = screen.getByRole("button", { name: mockSecondary.text });
+
+        await userEvent.click(button);
+        expect(mockSecondary.onClick).toHaveBeenCalled();
+      });
+
+      it("enables user access and trigger the secondary action with keyboard", async () => {
+        const buttonPrimary = screen.getByRole("button", {
+          name: mockPrimary.text,
+        });
+        const buttonSecondary = screen.getByRole("button", {
+          name: mockSecondary.text,
+        });
+        await userEvent.tab();
+        expect(buttonSecondary).toHaveFocus();
+        await userEvent.tab();
+        expect(buttonPrimary).toHaveFocus();
+
+        await userEvent.tab({ shift: true });
+        expect(buttonSecondary).toHaveFocus();
+
+        await userEvent.keyboard("{Enter}");
+        expect(mockSecondary.onClick).toHaveBeenCalled();
+      });
+    });
+
+    describe("adds option to close the modal without triggering an action", () => {
+      const mockClose = jest.fn();
+
+      beforeEach(() => {
+        render(
+          <Modal
+            title={testTitle}
+            primaryAction={mockPrimary}
+            close={mockClose}
+          >
+            {mockChildren}
+          </Modal>
+        );
+      });
+
+      afterEach(cleanup);
+
+      it("shows a close button", () => {
+        const button = screen.getByRole("button", { name: "Close modal" });
+
+        expect(button).toBeEnabled();
+      });
+
+      it("enables user to click close the button with the mouse", async () => {
+        const button = screen.getByRole("button", { name: "Close modal" });
+
+        await userEvent.click(button);
+        expect(mockClose).toHaveBeenCalled();
+      });
+
+      it("enables user access and trigger close with the keyboard", async () => {
+        const closeButton = screen.getByRole("button", { name: "Close modal" });
+        await userEvent.tab();
+        expect(closeButton).toHaveFocus();
+
+        await userEvent.click(closeButton);
+        expect(mockClose).toHaveBeenCalled();
+      });
+
+      it("enables user to close the modal with pressing the Escape key", async () => {
+        await userEvent.keyboard("{Escape}");
+
+        expect(mockClose).toHaveBeenCalled();
+      });
+    });
+  });
+});

--- a/coral/src/app/components/Modal.tsx
+++ b/coral/src/app/components/Modal.tsx
@@ -1,0 +1,181 @@
+import { createPortal } from "react-dom";
+import { ReactElement, useEffect } from "react";
+import { Box, Button, IconButton, Typography } from "@aivenio/aquarium";
+import cross from "@aivenio/aquarium/icons/cross";
+import classes from "src/app/components/Modal.module.css";
+
+type ModalAction = {
+  text: string;
+  onClick: () => void;
+};
+type ModalProps = {
+  title: string;
+  subtitle?: string;
+  close?: () => void;
+  primaryAction: ModalAction;
+  secondaryAction?: ModalAction;
+  children: ReactElement;
+};
+
+function Modal(props: ModalProps) {
+  const { close, primaryAction, secondaryAction, children, title, subtitle } =
+    props;
+
+  function setFocus(appRoot: HTMLElement, modal: HTMLElement) {
+    appRoot.setAttribute("aria-hidden", "true");
+    appRoot.setAttribute("tabindex", "-1");
+    appRoot.setAttribute("inert", "true");
+    modal.setAttribute("tabindex", "0");
+    modal.focus();
+  }
+
+  function removeFocus(appRoot: HTMLElement, modal: HTMLElement) {
+    appRoot.removeAttribute("aria-hidden");
+    appRoot.removeAttribute("tabindex");
+    modal.removeAttribute("tabindex");
+  }
+
+  useEffect(() => {
+    const appRoot = document.getElementById("root");
+    const modalFocus = document.getElementById("modal-focus");
+    if (appRoot && modalFocus) {
+      setFocus(appRoot, modalFocus);
+      return () => {
+        removeFocus(appRoot, modalFocus);
+      };
+    }
+  }, []);
+
+  useEffect(() => {
+    if (close) {
+      const handleEscape = (event: KeyboardEvent) => {
+        if (event.key !== "Escape") return;
+        close();
+      };
+
+      window.addEventListener("keydown", handleEscape);
+
+      return () => {
+        window.removeEventListener("keydown", handleEscape);
+      };
+    }
+  }, []);
+
+  useEffect(() => {
+    const isFirefox = window.navigator.userAgent.includes("Firefox");
+
+    if (isFirefox) {
+      const focusableElements =
+        document.querySelectorAll<HTMLElement>("[data-focusable]");
+      const firstElement = focusableElements[0];
+      const lastElement = focusableElements[focusableElements.length - 1];
+
+      const handleTab = (event: KeyboardEvent) => {
+        if (event.key !== "Tab") return;
+
+        if (!event.shiftKey && document.activeElement === lastElement) {
+          event.preventDefault();
+          firstElement.focus();
+        }
+
+        if (event.shiftKey && document.activeElement === firstElement) {
+          event.preventDefault();
+          lastElement.focus();
+        }
+      };
+
+      window.addEventListener("keydown", handleTab);
+
+      return () => {
+        window.removeEventListener("keydown", handleTab);
+      };
+    }
+  }, []);
+
+  return (
+    <>
+      {createPortal(
+        <Box
+          display={"flex"}
+          alignItems={"center"}
+          justifyContent={"center"}
+          className={classes.modalWrapper}
+        >
+          <Box
+            component={"dialog"}
+            aria-modal={"true"}
+            paddingX={"l3"}
+            paddingY={"l2"}
+            display={"flex"}
+            flexDirection={"column"}
+            borderRadius={"4px"}
+            backgroundColor={"white"}
+            width={"6/12"}
+            // value is arbitrary, it should prevent buttons overflowing
+            // the modal in a very small screen
+            //eslint-disable-next-line @typescript-eslint/ban-ts-comment
+            //@ts-ignore*
+            minWidth={"600px"}
+          >
+            <Box
+              display={"flex"}
+              justifyContent={"space-between"}
+              alignItems={"start"}
+              paddingBottom={"l2"}
+            >
+              <div>
+                <Typography.Subheading
+                  htmlTag={"h1"}
+                  id={"modal-focus"}
+                  data-focusable
+                >
+                  {title}
+                </Typography.Subheading>
+                {subtitle && (
+                  <Typography.SmallText htmlTag={"h2"} color={"grey-60"}>
+                    {subtitle}
+                  </Typography.SmallText>
+                )}
+              </div>
+              {close && (
+                <IconButton
+                  aria-label="Close modal"
+                  icon={cross}
+                  onClick={close}
+                  data-focusable
+                />
+              )}
+            </Box>
+            <Box className={classes.modalTextBlock}>{children}</Box>
+            <Box
+              paddingTop={"l2"}
+              display={"flex"}
+              justifyContent={"end"}
+              colGap={"l1"}
+            >
+              {secondaryAction && (
+                <Button
+                  kind={"secondary"}
+                  onClick={secondaryAction.onClick}
+                  data-focusable
+                >
+                  {secondaryAction.text}
+                </Button>
+              )}
+              <Button
+                kind={"primary"}
+                onClick={primaryAction.onClick}
+                data-focusable
+              >
+                {primaryAction.text}
+              </Button>
+            </Box>
+          </Box>
+        </Box>,
+        document.body
+      )}
+    </>
+  );
+}
+
+export { Modal };


### PR DESCRIPTION
# About this change - Why

- We now have multiple user journeys where user can cancel or submit forms and get redirected to a different page without warning / information why this is happening. 
- The `Modal` from Aquarium design system uses `react-aria`, which currently [does not work](https://github.com/adobe/react-spectrum/issues/779#issuecomment-1353734729) in React18 `StrictMode`.
- I added a temporary implementation to create a better usability for our users, especially since we're going to add more forms now. This gives us time to see if the mentioned issue is getting fixed or to decide how we want to continue with this. 

## About this change - What
- uses `dialog` and `aria-modal` to support assistive technology
- `setFocus` in `Modal` is removing focus and focusability from `#root` while setting focus on the `h1` element (it's sometimes recommended to set the focus on the first / primary action, but that leads to confusing information for screen reader users as I think, so I oped for this)
    - Firefox is the only browser that does not support the `inert` attribute, so in case the user agent is FF there's a special handling to trap user in modal
    - setting it on `h1` enables screen reader user (tested with VO) to access content in dialog easily
- adds a event listener to enable user to close modal with ESC (when it's closable)


## Screen recordings

### Chrome (keyboard) 

https://user-images.githubusercontent.com/943800/217295633-29c9005b-4d1f-41dc-9377-99ec7c82be68.mov


### Chrome (voice over) 

https://user-images.githubusercontent.com/943800/217295598-e78c9553-8525-415d-9748-b88ff88a6622.mov


### Firefox (keyboard)

https://user-images.githubusercontent.com/943800/217295555-525ae71b-df08-4e42-a9f9-d5d9ac021e7b.mov


### Notes about potential optimisation
- the `Modal` css uses a `z-index`, since one element (`FileInput`) uses one already. It would be good to add defined variables and values for z-index, otherwise this could get messy in the future
- the `minWidth` for the modal dialog element is an arbitrary value to prevent layout breaks. It does not use a valid TW value here, but I could not find a fitting one. 
- it would be ideal to test this with different screen reader, since they support the elements / aria attributes differently and it's possible that we could improve this for the other SR more. 


