### PR TITLE
feat(coral): add `/execAclRequest` endpoint

### DIFF
--- a/coral/src/domain/acl/acl-api.ts
+++ b/coral/src/domain/acl/acl-api.ts
@@ -4,7 +4,11 @@ import {
   GetCreatedAclRequestParameters,
 } from "src/domain/acl/acl-types";
 import api from "src/services/api";
-import { KlawApiRequest, KlawApiResponse } from "types/utils";
+import {
+  KlawApiRequest,
+  KlawApiRequestQueryParameters,
+  KlawApiResponse,
+} from "types/utils";
 
 const createAclRequest = (
   aclParams:
@@ -23,4 +27,12 @@ const getAclRequestsForApprover = (params: GetCreatedAclRequestParameters) => {
   );
 };
 
-export { createAclRequest, getAclRequestsForApprover };
+const approveAclRequest = (
+  params: KlawApiRequestQueryParameters<"approveAclRequests">
+): Promise<KlawApiResponse<"approveAclRequests">> => {
+  return api.post<KlawApiResponse<"approveAclRequests">, never>(
+    `/execAclRequest?${new URLSearchParams(params)}`
+  );
+};
+
+export { createAclRequest, getAclRequestsForApprover, approveAclRequest };

--- a/coral/src/services/api.ts
+++ b/coral/src/services/api.ts
@@ -166,7 +166,7 @@ function withPayload<TBody extends SomeObject | URLSearchParams>(
 }
 
 function withoutPayload(
-  method: HTTPMethod.GET | HTTPMethod.DELETE
+  method: HTTPMethod.GET | HTTPMethod.DELETE | HTTPMethod.POST
 ): Partial<RequestInit> {
   return {
     method,
@@ -281,8 +281,8 @@ function withPayloadAndVerb<
   );
 }
 
-function withoutPayloadandWithVerb<TResponse extends SomeObject>(
-  method: HTTPMethod.GET | HTTPMethod.DELETE,
+function withoutPayloadAndWithVerb<TResponse extends SomeObject>(
+  method: HTTPMethod.GET | HTTPMethod.DELETE | HTTPMethod.POST,
   pathname: AbsolutePathname
 ): Promise<TResponse> {
   return fetch(`${API_BASE_URL}${pathname}`, withoutPayload(method)).then(
@@ -291,15 +291,20 @@ function withoutPayloadandWithVerb<TResponse extends SomeObject>(
 }
 
 const get = <T extends SomeObject>(pathname: AbsolutePathname) =>
-  withoutPayloadandWithVerb<T>(HTTPMethod.GET, pathname);
+  withoutPayloadAndWithVerb<T>(HTTPMethod.GET, pathname);
 
 const post = <
   TResponse extends SomeObject,
-  TBody extends SomeObject | URLSearchParams
+  TBody extends SomeObject | URLSearchParams | never
 >(
   pathname: AbsolutePathname,
-  data: TBody
-): Promise<TResponse> => withPayloadAndVerb(HTTPMethod.POST, pathname, data);
+  data?: TBody
+): Promise<TResponse> => {
+  if (data === undefined) {
+    return withoutPayloadAndWithVerb(HTTPMethod.POST, pathname);
+  }
+  return withPayloadAndVerb(HTTPMethod.POST, pathname, data);
+};
 
 const put = <TBody extends SomeObject | URLSearchParams>(
   pathname: AbsolutePathname,
@@ -312,7 +317,7 @@ const patch = <TBody extends SomeObject | URLSearchParams>(
 ) => withPayloadAndVerb(HTTPMethod.PATCH, pathname, data);
 
 const delete_ = (pathname: AbsolutePathname) =>
-  withoutPayloadandWithVerb(HTTPMethod.DELETE, pathname);
+  withoutPayloadAndWithVerb(HTTPMethod.DELETE, pathname);
 
 // eslint-disable-next-line import/no-anonymous-default-export
 export default {

--- a/coral/types/api.d.ts
+++ b/coral/types/api.d.ts
@@ -39,6 +39,9 @@ export type paths = {
   "/getAclRequestsForApprover": {
     get: operations["getAclRequestsForApprover"];
   };
+  "/execAclRequest": {
+    post: operations["approveAclRequests"];
+  };
   "/createAcl": {
     post: operations["createAclRequest"];
   };
@@ -1175,6 +1178,21 @@ export type operations = {
       };
     };
   };
+  approveAclRequests: {
+    parameters: {
+      query: {
+        req_no: string;
+      };
+    };
+    responses: {
+      /** OK */
+      200: {
+        content: {
+          "application/json": components["schemas"]["GenericApiResponse"];
+        };
+      };
+    };
+  };
   createAclRequest: {
     responses: {
       /** OK */
@@ -1257,6 +1275,7 @@ export enum ApiPaths {
   envsBaseClusterFilteredForTeamGet = "/getEnvsBaseClusterFilteredForTeam",
   clusterInfoFromEnvironmentGet = "/getClusterInfoFromEnv",
   getAclRequestsForApprover = "/getAclRequestsForApprover",
+  approveAclRequests = "/execAclRequest",
   createAclRequest = "/createAcl",
   schemaRegEnvsGet = "/getSchemaRegEnvs",
   schemaUpload = "/uploadSchema",

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -325,6 +325,26 @@ paths:
                 type: array
                 items:
                   $ref: "#/components/schemas/aclRequest"
+  /execAclRequest:
+    post:
+      tags:
+        - ACL
+      operationId: approveAclRequests
+      summary: Approve an ACL request
+      parameters:
+        - name: req_no
+          in: query
+          required: true
+          schema:
+            type: string
+          example: "1008"
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/GenericApiResponse"
   /createAcl:
     post:
       tags:


### PR DESCRIPTION
## About this change - What it does

- add openapi documentation
- add acl-api function
- generate types

## Other changes

- introduces `KlawApiRequestQueryParameters` util to pick query params from the generated types
- modidy `api.post` in `api.ts` to be able to handle `POST` request without payloads

Resolves: #561
