### PR TITLE
Refactor(coral): Add type helper Prettify

### DIFF
--- a/coral/src/app/components/ComplexNativeSelect.tsx
+++ b/coral/src/app/components/ComplexNativeSelect.tsx
@@ -1,14 +1,18 @@
 import { NativeSelect, NativeSelectProps } from "@aivenio/aquarium";
 import omit from "lodash/omit";
 import { ChangeEvent, useState } from "react";
+import { ResolveIntersectionTypes } from "types/utils";
 
-type ComplexNativeSelectProps<T> = NativeSelectProps & {
-  options: Array<T>;
-  identifierValue: keyof T;
-  identifierName: keyof T;
-  onBlur: (option: T | undefined) => void;
-  activeOption?: T;
-};
+type ComplexNativeSelectProps<T> = ResolveIntersectionTypes<
+  NativeSelectProps & {
+    options: Array<T>;
+    identifierValue: keyof T;
+    identifierName: keyof T;
+    onBlur: (option: T | undefined) => void;
+
+    activeOption?: T;
+  }
+>;
 
 function ComplexNativeSelect<T>(props: ComplexNativeSelectProps<T>) {
   const { options, onBlur, identifierValue, identifierName, activeOption } =

--- a/coral/src/app/components/FileInput.tsx
+++ b/coral/src/app/components/FileInput.tsx
@@ -4,18 +4,21 @@ import uniqueId from "lodash/uniqueId";
 import { InputHTMLAttributes, useRef } from "react";
 import classes from "src/app/components/FileInput.module.css";
 import cloudUpload from "@aivenio/aquarium/dist/src/icons/cloudUpload";
+import { ResolveIntersectionTypes } from "types/utils";
 
-type FileInputProps = InputHTMLAttributes<HTMLInputElement> & {
-  valid: boolean;
-  // labelText is where the important information for
-  // visual and AT users is transported!
-  labelText: string;
-  // buttonText is not conveyed to e.g. screen reader
-  // users, treat is as more decorative text
-  buttonText: string;
-  helperText: string;
-  noFileText: string;
-};
+type FileInputProps = ResolveIntersectionTypes<
+  InputHTMLAttributes<HTMLInputElement> & {
+    valid: boolean;
+    // labelText is where the important information for
+    // visual and AT users is transported!
+    labelText: string;
+    // buttonText is not conveyed to e.g. screen reader
+    // users, treat is as more decorative text
+    buttonText: string;
+    helperText: string;
+    noFileText: string;
+  }
+>;
 
 function FileInput(props: FileInputProps) {
   const { valid, labelText, buttonText, helperText, noFileText } = props;

--- a/coral/src/domain/acl/acl-types.ts
+++ b/coral/src/domain/acl/acl-types.ts
@@ -2,6 +2,7 @@ import {
   KlawApiRequest,
   KlawApiRequestQueryParameters,
   KlawApiModel,
+  Prettify,
 } from "types/utils";
 
 // Several types are dependent on topictype when it is "Consumer":
@@ -26,16 +27,22 @@ type BaseCreateAclRequest = Pick<
   | "acl_ip"
 >;
 
-type CreateAclRequestTopicTypeProducer = BaseCreateAclRequest & {
-  topictype: "Producer";
-};
+// type CreateAclRequestTopicTypeProducerIntersected = ;
 
-type CreateAclRequestTopicTypeConsumer = BaseCreateAclRequest & {
-  transactionalId?: string;
-  topictype: "Consumer";
-  aclPatternType: "LITERAL";
-  consumergroup: string;
-};
+type CreateAclRequestTopicTypeProducer = Prettify<
+  BaseCreateAclRequest & {
+    topictype: "Producer";
+  }
+>;
+
+type CreateAclRequestTopicTypeConsumer = Prettify<
+  BaseCreateAclRequest & {
+    transactionalId?: string;
+    topictype: "Consumer";
+    aclPatternType: "LITERAL";
+    consumergroup: string;
+  }
+>;
 
 type GetCreatedAclRequestParameters =
   KlawApiRequestQueryParameters<"getAclRequestsForApprover">;

--- a/coral/src/domain/acl/acl-types.ts
+++ b/coral/src/domain/acl/acl-types.ts
@@ -2,7 +2,7 @@ import {
   KlawApiRequest,
   KlawApiRequestQueryParameters,
   KlawApiModel,
-  Prettify,
+  ResolveIntersectionTypes,
 } from "types/utils";
 
 // Several types are dependent on topictype when it is "Consumer":
@@ -27,13 +27,13 @@ type BaseCreateAclRequest = Pick<
   | "acl_ip"
 >;
 
-type CreateAclRequestTopicTypeProducer = Prettify<
+type CreateAclRequestTopicTypeProducer = ResolveIntersectionTypes<
   BaseCreateAclRequest & {
     topictype: "Producer";
   }
 >;
 
-type CreateAclRequestTopicTypeConsumer = Prettify<
+type CreateAclRequestTopicTypeConsumer = ResolveIntersectionTypes<
   BaseCreateAclRequest & {
     transactionalId?: string;
     topictype: "Consumer";

--- a/coral/src/domain/acl/acl-types.ts
+++ b/coral/src/domain/acl/acl-types.ts
@@ -27,8 +27,6 @@ type BaseCreateAclRequest = Pick<
   | "acl_ip"
 >;
 
-// type CreateAclRequestTopicTypeProducerIntersected = ;
-
 type CreateAclRequestTopicTypeProducer = Prettify<
   BaseCreateAclRequest & {
     topictype: "Producer";

--- a/coral/src/domain/schema-request/schema-request-types.ts
+++ b/coral/src/domain/schema-request/schema-request-types.ts
@@ -1,18 +1,22 @@
-import { KlawApiModel } from "types/utils";
+import { KlawApiModel, Prettify } from "types/utils";
 
-type SchemaRequest = Required<
-  Pick<
-    KlawApiModel<"SchemaRequest">,
-    "environment" | "schemafull" | "topicname"
-  >
-> &
-  Pick<KlawApiModel<"SchemaRequest">, "remarks">;
+type SchemaRequest = Prettify<
+  Required<
+    Pick<
+      KlawApiModel<"SchemaRequest">,
+      "environment" | "schemafull" | "topicname"
+    >
+  > &
+    Pick<KlawApiModel<"SchemaRequest">, "remarks">
+>;
 
-type SchemaRequestPayload = SchemaRequest & {
-  // schemaversion and appname
-  // should be hard coded at the moment
-  schemaversion: "1.0";
-  appname: "App";
-};
+type SchemaRequestPayload = Prettify<
+  SchemaRequest & {
+    // schemaversion and appname
+    // should be hard coded at the moment
+    schemaversion: "1.0";
+    appname: "App";
+  }
+>;
 
 export type { SchemaRequest, SchemaRequestPayload };

--- a/coral/src/domain/schema-request/schema-request-types.ts
+++ b/coral/src/domain/schema-request/schema-request-types.ts
@@ -1,6 +1,6 @@
-import { KlawApiModel, Prettify } from "types/utils";
+import { KlawApiModel, ResolveIntersectionTypes } from "types/utils";
 
-type SchemaRequest = Prettify<
+type SchemaRequest = ResolveIntersectionTypes<
   Required<
     Pick<
       KlawApiModel<"SchemaRequest">,
@@ -10,7 +10,7 @@ type SchemaRequest = Prettify<
     Pick<KlawApiModel<"SchemaRequest">, "remarks">
 >;
 
-type SchemaRequestPayload = Prettify<
+type SchemaRequestPayload = ResolveIntersectionTypes<
   SchemaRequest & {
     // schemaversion and appname
     // should be hard coded at the moment

--- a/coral/src/services/api.ts
+++ b/coral/src/services/api.ts
@@ -2,6 +2,7 @@ import { getHTTPBaseAPIUrl } from "src/config";
 import isPlainObject from "lodash/isPlainObject";
 import { components } from "types/api";
 import { objectHasProperty } from "src/services/type-utils";
+import { ResolveIntersectionTypes } from "types/utils";
 
 type GenericApiResponse = components["schemas"]["GenericApiResponse"];
 
@@ -12,11 +13,14 @@ enum HTTPMethod {
   PATCH = "PATCH",
   DELETE = "DELETE",
 }
+
 type SomeObject =
   | Record<string, unknown>
   | Record<string, never>
   | Array<unknown>;
+
 type AbsolutePathname = `/${string}`;
+
 const CONTENT_TYPE_JSON = "application/json" as const;
 
 const API_BASE_URL = getHTTPBaseAPIUrl();
@@ -28,42 +32,59 @@ type HTTPError = {
   headers: Headers;
 };
 
-type UnauthorizedError = HTTPError & { status: 401 };
-type ClientError = HTTPError & {
-  status:
-    | 400
-    | 402
-    | 403
-    | 404
-    | 405
-    | 406
-    | 407
-    | 408
-    | 409
-    | 410
-    | 411
-    | 412
-    | 413
-    | 414
-    | 415
-    | 416
-    | 417
-    | 418
-    | 421
-    | 422
-    | 423
-    | 424
-    | 426
-    | 428
-    | 429
-    | 431
-    | 444
-    | 451
-    | 499;
-};
-type ServerError = HTTPError & {
-  status: 500 | 501 | 502 | 503 | 504 | 505 | 506 | 507 | 508 | 510 | 511 | 599;
-};
+type UnauthorizedError = ResolveIntersectionTypes<HTTPError & { status: 401 }>;
+type ClientError = ResolveIntersectionTypes<
+  HTTPError & {
+    status:
+      | 400
+      | 402
+      | 403
+      | 404
+      | 405
+      | 406
+      | 407
+      | 408
+      | 409
+      | 410
+      | 411
+      | 412
+      | 413
+      | 414
+      | 415
+      | 416
+      | 417
+      | 418
+      | 421
+      | 422
+      | 423
+      | 424
+      | 426
+      | 428
+      | 429
+      | 431
+      | 444
+      | 451
+      | 499;
+  }
+>;
+
+type ServerError = ResolveIntersectionTypes<
+  HTTPError & {
+    status:
+      | 500
+      | 501
+      | 502
+      | 503
+      | 504
+      | 505
+      | 506
+      | 507
+      | 508
+      | 510
+      | 511
+      | 599;
+  }
+>;
 
 function hasHTTPErrorProperties(
   value: Record<string, unknown>

--- a/coral/types/utils.d.ts
+++ b/coral/types/utils.d.ts
@@ -1,8 +1,9 @@
 import type { operations, components } from "types/api.d";
 
-type KlawApiResponse<OperationId extends keyof operations> = Prettify<
-  operations[OperationId]["responses"][200]["content"]["application/json"]
->;
+type KlawApiResponse<OperationId extends keyof operations> =
+  ResolveIntersectionTypes<
+    operations[OperationId]["responses"][200]["content"]["application/json"]
+  >;
 type KlawApiModel<Schema extends keyof components["schemas"]> =
   components["schemas"][Schema];
 type KlawApiRequest<OperationId extends keyof operations> =
@@ -10,7 +11,7 @@ type KlawApiRequest<OperationId extends keyof operations> =
 type KlawApiRequestQueryParameters<OperationId extends keyof operations> =
   operations[OperationId]["parameters"]["query"];
 
-type Prettify<T> = {
+type ResolveIntersectionTypes<T> = {
   [K in keyof T]: T[K];
   // eslint-disable-next-line @typescript-eslint/ban-types
 } & {};
@@ -20,5 +21,5 @@ export type {
   KlawApiModel,
   KlawApiRequest,
   KlawApiRequestQueryParameters,
-  Prettify,
+  ResolveIntersectionTypes,
 };

--- a/coral/types/utils.d.ts
+++ b/coral/types/utils.d.ts
@@ -1,7 +1,8 @@
 import type { operations, components } from "types/api.d";
 
-type KlawApiResponse<OperationId extends keyof operations> =
-  operations[OperationId]["responses"][200]["content"]["application/json"];
+type KlawApiResponse<OperationId extends keyof operations> = Prettify<
+  operations[OperationId]["responses"][200]["content"]["application/json"]
+>;
 type KlawApiModel<Schema extends keyof components["schemas"]> =
   components["schemas"][Schema];
 type KlawApiRequest<OperationId extends keyof operations> =
@@ -9,9 +10,15 @@ type KlawApiRequest<OperationId extends keyof operations> =
 type KlawApiRequestQueryParameters<OperationId extends keyof operations> =
   operations[OperationId]["parameters"]["query"];
 
+type Prettify<T> = {
+  [K in keyof T]: T[K];
+  // eslint-disable-next-line @typescript-eslint/ban-types
+} & {};
+
 export type {
   KlawApiResponse,
   KlawApiModel,
   KlawApiRequest,
   KlawApiRequestQueryParameters,
+  Prettify,
 };


### PR DESCRIPTION
# About this change - What it does

- Adds type helper `Prettify`
- Adds changes to types exposed for `acl` and `schema-request` as showcase (and because I felt it's most useful for these)

## About this change - Thy

Found this neat little util on [Twitter ](https://twitter.com/mattpocockuk/status/1622730173446557697) 😅  and it solves an annoyance I had quite often already. 

### Looking at my type `SchemaRequest` before 🙎‍♀️ 

<img width="302" alt="Screenshot 2023-02-07 at 14 39 43" src="https://user-images.githubusercontent.com/943800/217274066-93c4aff4-73a3-4948-8c3d-0c5b3904b952.png">

### Looking at my type `SchemaRequest` after 🦄 

<img width="326" alt="Screenshot 2023-02-07 at 15 17 25" src="https://user-images.githubusercontent.com/943800/217274315-8ffe419b-3233-4745-9948-5bace72d5817.png">


