### PR TITLE
refactor(coral): Add general mock for DS Icon component

### DIFF
--- a/coral/jest.config.ts
+++ b/coral/jest.config.ts
@@ -12,6 +12,7 @@ export default {
   setupFilesAfterEnv: [
     "<rootDir>/test-setup/setup-files-after-env.ts",
     "<rootDir>/test-setup/mock-monaco-editor.tsx",
+    "<rootDir>/test-setup/mock-ds-icon-component.tsx",
   ],
 
   moduleNameMapper: {

--- a/coral/src/app/components/FileInput.test.tsx
+++ b/coral/src/app/components/FileInput.test.tsx
@@ -2,17 +2,6 @@ import { cleanup, render, screen } from "@testing-library/react";
 import { FileInput } from "src/app/components/FileInput";
 import userEvent from "@testing-library/user-event";
 
-const mockIconRender = jest.fn();
-// mocks out Icon component to avoid clutter
-// Icon is used purely decoratively
-jest.mock("@aivenio/aquarium", () => {
-  return {
-    __esModule: true,
-    ...jest.requireActual("@aivenio/aquarium"),
-    Icon: () => mockIconRender(),
-  };
-});
-
 const testValid = true;
 const testLabelText = "Upload your favorite dog pic!";
 const testButtonText = "Upload picture";

--- a/coral/src/app/components/Pagination.test.tsx
+++ b/coral/src/app/components/Pagination.test.tsx
@@ -2,17 +2,6 @@ import { cleanup, render, within, screen } from "@testing-library/react";
 import { Pagination } from "src/app/components/Pagination";
 import userEvent from "@testing-library/user-event";
 
-const mockIconRender = jest.fn();
-// mocks out Icon component to avoid clutter
-// Icon is used purely decoratively
-jest.mock("@aivenio/aquarium", () => {
-  return {
-    __esModule: true,
-    ...jest.requireActual("@aivenio/aquarium"),
-    Icon: () => mockIconRender(),
-  };
-});
-
 function getNavigationElement() {
   return screen.getByRole("navigation", { name: /Pagination/ });
 }
@@ -113,10 +102,8 @@ describe("Pagination.tsx", () => {
       });
 
       it("renders all icons", () => {
-        // makes sure that the right amount of icons has been used
-        // will break if icons are missing / not used
-        // does NOT check if the right icons are rendered
-        expect(mockIconRender).toHaveBeenCalledTimes(4);
+        const icons = screen.getAllByTestId("ds-icon");
+        expect(icons).toHaveLength(4);
       });
     });
 

--- a/coral/src/app/features/topics/browse/BrowseTopics.test.tsx
+++ b/coral/src/app/features/topics/browse/BrowseTopics.test.tsx
@@ -18,15 +18,6 @@ import { getTeams, Team } from "src/domain/team";
 import { getTopics } from "src/domain/topic";
 import { Environment, getEnvironments } from "src/domain/environment";
 
-// mocks out Icon to reduce clutter
-jest.mock("@aivenio/aquarium", () => {
-  return {
-    __esModule: true,
-    ...jest.requireActual("@aivenio/aquarium"),
-    Icon: jest.fn(),
-  };
-});
-
 jest.mock("src/domain/team/team-api.ts");
 jest.mock("src/domain/topic/topic-api.ts");
 jest.mock("src/domain/environment/environment-api.ts");

--- a/coral/src/app/features/topics/browse/components/search/SearchTopics.test.tsx
+++ b/coral/src/app/features/topics/browse/components/search/SearchTopics.test.tsx
@@ -42,13 +42,10 @@ describe("SearchTopics.tsx", () => {
 
     it("shows an icon in button that is hidden for assistive technology", () => {
       const button = screen.getByRole("button", { name: "Submit search" });
-      const icon = within(button).getByTestId("visually-hidden-search-icon");
+      // ds-icon is aria-hidden by default
+      const icon = within(button).getByTestId("ds-icon");
 
-      // aria-hidden only hides elements from
-      // getByRole, so `toBeVisible` is true in this case
-      // even if element is hidden in the a11y tree
       expect(icon).toBeVisible();
-      expect(icon).toHaveAttribute("aria-hidden", "true");
     });
   });
 

--- a/coral/src/app/layout/Layout.test.tsx
+++ b/coral/src/app/layout/Layout.test.tsx
@@ -2,15 +2,6 @@ import Layout from "src/app/layout/Layout";
 import { cleanup, screen, within } from "@testing-library/react";
 import { customRender } from "src/services/test-utils/render-with-wrappers";
 
-// mock out svgs to avoid clutter
-jest.mock("@aivenio/aquarium", () => {
-  return {
-    __esModule: true,
-    ...jest.requireActual("@aivenio/aquarium"),
-    Icon: () => null,
-  };
-});
-
 describe("Layout.tsx", () => {
   const testChildren = <div data-testid={"test-children"}></div>;
   beforeAll(() => {

--- a/coral/src/app/layout/header/Header.test.tsx
+++ b/coral/src/app/layout/header/Header.test.tsx
@@ -5,18 +5,6 @@ import {
   tabThroughForward,
 } from "src/services/test-utils/tabbing";
 
-// mock out svgs to avoid clutter
-jest.mock("@aivenio/aquarium", () => {
-  return {
-    __esModule: true,
-    ...jest.requireActual("@aivenio/aquarium"),
-
-    Icon: () => {
-      return <div data-testid={"ds-icon"}></div>;
-    },
-  };
-});
-
 const quickLinksNavItems = [
   { name: "Go to approval requests", linkTo: "/execTopics" },
   {

--- a/coral/src/app/layout/header/HeaderMenuLink.test.tsx
+++ b/coral/src/app/layout/header/HeaderMenuLink.test.tsx
@@ -4,18 +4,6 @@ import userEvent from "@testing-library/user-event";
 import HeaderMenuLink from "src/app/layout/header/HeaderMenuLink";
 import { tabNavigateTo } from "src/services/test-utils/tabbing";
 
-// mock out svgs to avoid clutter
-jest.mock("@aivenio/aquarium", () => {
-  return {
-    __esModule: true,
-    ...jest.requireActual("@aivenio/aquarium"),
-
-    Icon: () => {
-      return <div data-testid={"ds-icon"}></div>;
-    },
-  };
-});
-
 const linkText = "Go to your profile page";
 
 describe("HeaderMenuLink.tsx", () => {

--- a/coral/src/app/layout/main-navigation/MainNavigation.test.tsx
+++ b/coral/src/app/layout/main-navigation/MainNavigation.test.tsx
@@ -7,18 +7,6 @@ import {
   tabThroughForward,
 } from "src/services/test-utils/tabbing";
 
-// mock out svgs to avoid clutter
-jest.mock("@aivenio/aquarium", () => {
-  return {
-    __esModule: true,
-    ...jest.requireActual("@aivenio/aquarium"),
-
-    Icon: () => {
-      return <div data-testid={"ds-icon"}></div>;
-    },
-  };
-});
-
 const navLinks = [
   {
     name: "Dashboard",

--- a/coral/src/app/layout/main-navigation/MainNavigationLink.test.tsx
+++ b/coral/src/app/layout/main-navigation/MainNavigationLink.test.tsx
@@ -4,18 +4,6 @@ import data from "@aivenio/aquarium/dist/src/icons/console";
 import { MemoryRouter } from "react-router-dom";
 import { Routes } from "src/app/router_utils";
 
-// mock out svgs to avoid clutter
-jest.mock("@aivenio/aquarium", () => {
-  return {
-    __esModule: true,
-    ...jest.requireActual("@aivenio/aquarium"),
-
-    Icon: () => {
-      return <div data-testid={"ds-icon"}></div>;
-    },
-  };
-});
-
 describe("MainNavigationLink.tsx", () => {
   // (icon is not needed for the test, Icon component mocked out)
   const mockIcon = "fake-icon" as unknown as typeof data;

--- a/coral/src/app/layout/main-navigation/MainNavigationSubmenuList.test.tsx
+++ b/coral/src/app/layout/main-navigation/MainNavigationSubmenuList.test.tsx
@@ -3,18 +3,6 @@ import { cleanup, screen, render, within } from "@testing-library/react";
 import data from "@aivenio/aquarium/dist/src/icons/console";
 import userEvent from "@testing-library/user-event";
 
-// mock out svgs to avoid clutter
-jest.mock("@aivenio/aquarium", () => {
-  return {
-    __esModule: true,
-    ...jest.requireActual("@aivenio/aquarium"),
-
-    Icon: () => {
-      return <div data-testid={"ds-icon"}></div>;
-    },
-  };
-});
-
 const textButtonSubmenuClosed = "Topics submenu, closed. Click to open.";
 const textButtonSubmenuOpened = "Topics submenu, open. Click to close.";
 const textSubmenuList = "Topics submenu";

--- a/coral/src/app/pages/topics/schema-request.test.tsx
+++ b/coral/src/app/pages/topics/schema-request.test.tsx
@@ -7,15 +7,6 @@ import { MemoryRouter, Routes, Route } from "react-router-dom";
 import { getSchemaRegistryEnvironments } from "src/domain/environment";
 import { createSchemaRequest } from "src/domain/schema-request";
 
-// mock out svgs to avoid clutter
-jest.mock("@aivenio/aquarium", () => {
-  return {
-    __esModule: true,
-    ...jest.requireActual("@aivenio/aquarium"),
-    Icon: () => null,
-  };
-});
-
 jest.mock("src/domain/schema-request/schema-request-api.ts");
 jest.mock("src/domain/environment/environment-api.ts");
 

--- a/coral/test-setup/mock-ds-icon-component.tsx
+++ b/coral/test-setup/mock-ds-icon-component.tsx
@@ -1,0 +1,16 @@
+// The Icon component is creating a lot of clutter in test output if not mocked out.
+// If you want to check for an Icon to be rendered, use: `screen.[x]byTestId("ds-icon").`
+// There should not be a need to check that the right icon element is passed,
+// but in case you want to do that:
+// the element queried with by test id can be checked for the icon with:
+// expect(element).toHaveAttribute("data-icon", [ICON-IMPORTED-FROM-@aivenio/aquarium/dist/src/icons].body);
+
+jest.mock("@aivenio/aquarium", () => {
+  return {
+    __esModule: true,
+    ...jest.requireActual("@aivenio/aquarium"),
+    Icon: jest.fn((props) => {
+      return <div data-testid={"ds-icon"} data-icon={props.icon.body} />;
+    }),
+  };
+});


### PR DESCRIPTION
# About this change - What it does

- adds a mock the `Icon` component in `setupAfterEnv`, so we don't have to mock it out in component tests to reduce clutter in test output (e.g. `screen.debug()` or in output for failing tests. 
- the mock enables us to still assert that the icon is rendered (based on test-id) and even if the right icon is rendered -> there should not really be a need for that, but there may be edge cases where it's valuable to be able to do it. 
- removes mocks in test files and updates test where needed

Resolves: #282

