### PR TITLE
Env name size increment from 3 to 10

### DIFF
--- a/core/src/main/java/io/aiven/klaw/model/EnvModel.java
+++ b/core/src/main/java/io/aiven/klaw/model/EnvModel.java
@@ -18,8 +18,8 @@ public class EnvModel implements Serializable {
   private String id;
 
   @NotNull
-  @Size(min = 3, max = 7, message = "Please fill in a valid name")
-  @Pattern(message = "Invalid name", regexp = "^[a-zA-Z0-9_-]{3,}$")
+  @Size(min = 2, max = 10, message = "Please fill in a valid name")
+  @Pattern(message = "Invalid environment name !!", regexp = "^[a-zA-Z0-9_.-]{3,}$")
   private String name;
 
   @NotNull private String type;

--- a/core/src/main/resources/static/js/envs.js
+++ b/core/src/main/resources/static/js/envs.js
@@ -832,9 +832,9 @@ app.controller("envsCtrl", function($scope, $http, $location, $window) {
                     return;
                 }
 
-                if($scope.addNewEnv.envname.length > 3)
+                if($scope.addNewEnv.envname.length < 2 || $scope.addNewEnv.envname.length > 10)
                 {
-                    $scope.alertnote = "Environment name cannot be more than 3 characters.";
+                    $scope.alertnote = "Environment name cannot be less than 2 characters and more than 10 characters";
                     $scope.showAlertToast();
                     return;
                 }
@@ -906,9 +906,9 @@ app.controller("envsCtrl", function($scope, $http, $location, $window) {
                     return;
                 }
 
-                if($scope.addNewSchemaEnv.envname.length > 7)
+                if($scope.addNewSchemaEnv.envname.length > 10)
                 {
-                    $scope.alertnote = "Environment name cannot be more than 7 characters.";
+                    $scope.alertnote = "Environment name cannot be more than 10 characters.";
                     $scope.showAlertToast();
                     return;
                 }
@@ -971,9 +971,9 @@ app.controller("envsCtrl", function($scope, $http, $location, $window) {
                 return;
             }
 
-            if($scope.addNewKafkaConnectEnv.envname.length > 7)
+            if($scope.addNewKafkaConnectEnv.envname.length > 10)
             {
-                $scope.alertnote = "Environment name cannot be more than 7 characters.";
+                $scope.alertnote = "Environment name cannot be more than 10 characters.";
                 $scope.showAlertToast();
                 return;
             }

--- a/core/src/main/resources/static/js/modifyEnvs.js
+++ b/core/src/main/resources/static/js/modifyEnvs.js
@@ -447,9 +447,9 @@ app.controller("modifyEnvsCtrl", function($scope, $http, $location, $window) {
                     return;
                 }
 
-                if($scope.envDetails.name.length > 3)
+                if($scope.envDetails.name.length > 10)
                 {
-                    $scope.alertnote = "Environment name cannot be more than 3 characters.";
+                    $scope.alertnote = "Environment name cannot be more than 10 characters.";
                     $scope.showAlertToast();
                     return;
                 }
@@ -590,9 +590,9 @@ app.controller("modifyEnvsCtrl", function($scope, $http, $location, $window) {
                         return;
                     }
 
-                    if($scope.envDetails.name.length > 7)
+                    if($scope.envDetails.name.length > 10)
                     {
-                        $scope.alertnote = "Environment name cannot be more than 7 characters.";
+                        $scope.alertnote = "Environment name cannot be more than 10 characters.";
                         $scope.showAlertToast();
                         return;
                     }
@@ -649,9 +649,9 @@ app.controller("modifyEnvsCtrl", function($scope, $http, $location, $window) {
                 return;
             }
 
-            if($scope.envDetails.name.length > 7)
+            if($scope.envDetails.name.length > 10)
             {
-                $scope.alertnote = "Environment name cannot be more than 7 characters.";
+                $scope.alertnote = "Environment name cannot be more than 10 characters.";
                 $scope.showAlertToast();
                 return;
             }

--- a/core/src/main/resources/templates/modifyEnv.html
+++ b/core/src/main/resources/templates/modifyEnv.html
@@ -610,7 +610,7 @@
 										<div class="col-md-6">
 											<div class="form-group">
 												<label class="control-label">Environment Name</label>
-												<input type="text" class="form-control" maxlength="7" minlength="3" required ng-model="envDetails.name" placeholder="DEV_SCH"/>
+												<input type="text" class="form-control" maxlength="10" minlength="2" required ng-model="envDetails.name" placeholder="DEV_SCH"/>
 
 											</div>
 										</div>

--- a/core/src/test/java/io/aiven/klaw/controller/UiConfigControllerTest.java
+++ b/core/src/test/java/io/aiven/klaw/controller/UiConfigControllerTest.java
@@ -161,7 +161,7 @@ public class UiConfigControllerTest {
 
   @Test
   @Order(7)
-  public void addNewEnv() throws Exception {
+  public void addNewEnvName3Chars() throws Exception {
     EnvModel env = utilMethods.getEnvList().get(0);
     String jsonReq = OBJECT_MAPPER.writer().writeValueAsString(env);
     ApiResponse apiResponse = ApiResponse.builder().result(ApiResultStatus.SUCCESS.value).build();
@@ -179,6 +179,76 @@ public class UiConfigControllerTest {
 
   @Test
   @Order(8)
+  public void addNewEnvName10charsAllowed() throws Exception {
+    EnvModel env = utilMethods.getEnvList().get(0);
+    env.setName("ABCDEFGHIJ"); // 10 chars allowed
+    String jsonReq = OBJECT_MAPPER.writer().writeValueAsString(env);
+    ApiResponse apiResponse = ApiResponse.builder().result(ApiResultStatus.SUCCESS.value).build();
+    when(envsClustersTenantsControllerService.addNewEnv(any())).thenReturn(apiResponse);
+
+    mvcEnvs
+        .perform(
+            MockMvcRequestBuilders.post("/addNewEnv")
+                .content(jsonReq)
+                .contentType(MediaType.APPLICATION_JSON)
+                .accept(MediaType.APPLICATION_JSON))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.result", is(ApiResultStatus.SUCCESS.value)));
+  }
+
+  @Test
+  @Order(9)
+  public void addNewEnvMoreThan10CharsFailure() throws Exception {
+    EnvModel env = utilMethods.getEnvList().get(0);
+    env.setName("ABCDEFGHIJKL"); // > 10 chars, not allowed
+    String jsonReq = OBJECT_MAPPER.writer().writeValueAsString(env);
+    ApiResponse apiResponse = ApiResponse.builder().result(ApiResultStatus.FAILURE.value).build();
+    when(envsClustersTenantsControllerService.addNewEnv(any())).thenReturn(apiResponse);
+    mvcEnvs
+        .perform(
+            MockMvcRequestBuilders.post("/addNewEnv")
+                .content(jsonReq)
+                .contentType(MediaType.APPLICATION_JSON)
+                .accept(MediaType.APPLICATION_JSON))
+        .andExpect(status().isBadRequest());
+  }
+
+  @Test
+  @Order(10)
+  public void addNewEnvLessThan2CharsFailure() throws Exception {
+    EnvModel env = utilMethods.getEnvList().get(0);
+    env.setName("A"); // < 2 chars, not allowed
+    String jsonReq = OBJECT_MAPPER.writer().writeValueAsString(env);
+    ApiResponse apiResponse = ApiResponse.builder().result(ApiResultStatus.FAILURE.value).build();
+    when(envsClustersTenantsControllerService.addNewEnv(any())).thenReturn(apiResponse);
+    mvcEnvs
+        .perform(
+            MockMvcRequestBuilders.post("/addNewEnv")
+                .content(jsonReq)
+                .contentType(MediaType.APPLICATION_JSON)
+                .accept(MediaType.APPLICATION_JSON))
+        .andExpect(status().isBadRequest());
+  }
+
+  @Test
+  @Order(11)
+  public void addNewEnvNoClusterIdFailure() throws Exception {
+    EnvModel env = utilMethods.getEnvList().get(0);
+    env.setClusterId(null);
+    String jsonReq = OBJECT_MAPPER.writer().writeValueAsString(env);
+    ApiResponse apiResponse = ApiResponse.builder().result(ApiResultStatus.FAILURE.value).build();
+    when(envsClustersTenantsControllerService.addNewEnv(any())).thenReturn(apiResponse);
+    mvcEnvs
+        .perform(
+            MockMvcRequestBuilders.post("/addNewEnv")
+                .content(jsonReq)
+                .contentType(MediaType.APPLICATION_JSON)
+                .accept(MediaType.APPLICATION_JSON))
+        .andExpect(status().isBadRequest());
+  }
+
+  @Test
+  @Order(12)
   public void deleteEnv() throws Exception {
     ApiResponse apiResponse = ApiResponse.builder().result(ApiResultStatus.SUCCESS.value).build();
     when(envsClustersTenantsControllerService.deleteEnvironment(anyString(), anyString()))
@@ -196,7 +266,7 @@ public class UiConfigControllerTest {
   }
 
   @Test
-  @Order(9)
+  @Order(13)
   public void deleteTeam() throws Exception {
     ApiResponse apiResponse = ApiResponse.builder().result(ApiResultStatus.SUCCESS.value).build();
     when(usersTeamsControllerService.deleteTeam(any())).thenReturn(apiResponse);
@@ -212,7 +282,7 @@ public class UiConfigControllerTest {
   }
 
   @Test
-  @Order(10)
+  @Order(14)
   public void deleteUser() throws Exception {
     ApiResponse apiResponse = ApiResponse.builder().result(ApiResultStatus.SUCCESS.value).build();
     when(usersTeamsControllerService.deleteUser(anyString(), anyBoolean())).thenReturn(apiResponse);
@@ -228,7 +298,7 @@ public class UiConfigControllerTest {
   }
 
   @Test
-  @Order(11)
+  @Order(15)
   public void addNewUser() throws Exception {
     ApiResponse apiResponse = ApiResponse.builder().result(ApiResultStatus.SUCCESS.value).build();
     UserInfoModel userInfo = utilMethods.getUserInfoMock();
@@ -246,7 +316,7 @@ public class UiConfigControllerTest {
   }
 
   @Test
-  @Order(12)
+  @Order(16)
   public void addNewTeam() throws Exception {
     Team team = utilMethods.getTeams().get(0);
     String jsonReq = OBJECT_MAPPER.writer().writeValueAsString(team);
@@ -264,7 +334,7 @@ public class UiConfigControllerTest {
   }
 
   @Test
-  @Order(13)
+  @Order(17)
   public void changePwd() throws Exception {
     ApiResponse apiResponse = ApiResponse.builder().result(ApiResultStatus.SUCCESS.value).build();
     when(usersTeamsControllerService.changePwd(any())).thenReturn(apiResponse);
@@ -280,7 +350,7 @@ public class UiConfigControllerTest {
   }
 
   @Test
-  @Order(14)
+  @Order(18)
   public void showUsers() throws Exception {
     List<UserInfoModel> userList = utilMethods.getUserInfoListModel("uiuser", "ADMIN");
     when(usersTeamsControllerService.showUsers(any(), any(), any())).thenReturn(userList);
@@ -297,7 +367,7 @@ public class UiConfigControllerTest {
   }
 
   @Test
-  @Order(15)
+  @Order(19)
   public void getMyProfileInfo() throws Exception {
     UserInfoModel userInfo = utilMethods.getUserInfoMock();
     when(usersTeamsControllerService.getMyProfileInfo()).thenReturn(userInfo);
@@ -312,7 +382,7 @@ public class UiConfigControllerTest {
   }
 
   @Test
-  @Order(16)
+  @Order(20)
   public void showActivityLog() throws Exception {
     List<ActivityLog> activityLogs = utilMethods.getLogs();
     when(uiConfigControllerService.showActivityLog(anyString(), anyString(), anyString()))


### PR DESCRIPTION
Signed-off-by: muralibasani <muralidahr.basani@aiven.io>

About this change - What it does

- Currently there is a restriction on the size of env names, which is now changed to 10
- Update done all new and update envs, for kafka, schema and connect

Resolves: #563
Why this way
There is no change in db. Only code validations are updated.

