### PR TITLE
feat(coral): Add DataTable and Pagination for ACL approval page

### DIFF
--- a/coral/src/app/features/approvals/SkeletonTable.tsx
+++ b/coral/src/app/features/approvals/SkeletonTable.tsx
@@ -1,0 +1,66 @@
+import { Template, Skeleton } from "@aivenio/aquarium";
+
+const SkeletonTable = () => {
+  return (
+    <div data-testid="skeleton-table">
+      <Template columns={["1", "2", "3", "4", "7", "8"]} gap="4">
+        <Skeleton height={20} width="100%" />
+        <Skeleton height={20} width="100%" />
+        <Skeleton height={20} width="100%" />
+        <Skeleton height={20} width="100%" />
+        <Skeleton height={20} width="100%" />
+        <Skeleton height={20} width="100%" />
+        <Skeleton height={40} width="100%" />
+        <Skeleton height={40} width="100%" />
+        <Skeleton height={40} width="100%" />
+        <Skeleton height={40} width="100%" />
+        <Skeleton height={40} width="100%" />
+        <Skeleton height={40} width="100%" />
+        <Skeleton height={40} width="100%" />
+        <Skeleton height={40} width="100%" />
+        <Skeleton height={40} width="100%" />
+        <Skeleton height={40} width="100%" />
+        <Skeleton height={40} width="100%" />
+        <Skeleton height={40} width="100%" />
+        <Skeleton height={40} width="100%" />
+        <Skeleton height={40} width="100%" />
+        <Skeleton height={40} width="100%" />
+        <Skeleton height={40} width="100%" />
+        <Skeleton height={40} width="100%" />
+        <Skeleton height={40} width="100%" />
+        <Skeleton height={40} width="100%" />
+        <Skeleton height={40} width="100%" />
+        <Skeleton height={40} width="100%" />
+        <Skeleton height={40} width="100%" />
+        <Skeleton height={40} width="100%" />
+        <Skeleton height={40} width="100%" />
+        <Skeleton height={40} width="100%" />
+        <Skeleton height={40} width="100%" />
+        <Skeleton height={40} width="100%" />
+        <Skeleton height={40} width="100%" />
+        <Skeleton height={40} width="100%" />
+        <Skeleton height={40} width="100%" />
+        <Skeleton height={40} width="100%" />
+        <Skeleton height={40} width="100%" />
+        <Skeleton height={40} width="100%" />
+        <Skeleton height={40} width="100%" />
+        <Skeleton height={40} width="100%" />
+        <Skeleton height={40} width="100%" />
+        <Skeleton height={40} width="100%" />
+        <Skeleton height={40} width="100%" />
+        <Skeleton height={40} width="100%" />
+        <Skeleton height={40} width="100%" />
+        <Skeleton height={40} width="100%" />
+        <Skeleton height={40} width="100%" />
+        <Skeleton height={40} width="100%" />
+        <Skeleton height={40} width="100%" />
+        <Skeleton height={40} width="100%" />
+        <Skeleton height={40} width="100%" />
+        <Skeleton height={40} width="100%" />
+        <Skeleton height={40} width="100%" />
+      </Template>
+    </div>
+  );
+};
+
+export default SkeletonTable;

--- a/coral/src/app/features/approvals/acls/AclApprovals.test.tsx
+++ b/coral/src/app/features/approvals/acls/AclApprovals.test.tsx
@@ -1,0 +1,207 @@
+import * as ReactQuery from "@tanstack/react-query";
+import {
+  cleanup,
+  screen,
+  waitForElementToBeRemoved,
+} from "@testing-library/react";
+import AclApprovals from "src/app/features/approvals/acls/AclApprovals";
+import { getAclRequestsForApprover } from "src/domain/acl/acl-api";
+import transformAclRequestApiResponse from "src/domain/acl/acl-transformer";
+import { AclRequest } from "src/domain/acl/acl-types";
+import { customRender } from "src/services/test-utils/render-with-wrappers";
+import { mockIntersectionObserver } from "src/services/test-utils/mock-intersection-observer";
+
+jest.mock("src/domain/acl/acl-api.ts");
+
+const mockGetAclRequestsForApprover =
+  getAclRequestsForApprover as jest.MockedFunction<
+    typeof getAclRequestsForApprover
+  >;
+
+const useQuerySpy = jest.spyOn(ReactQuery, "useQuery");
+
+const mockedAclRequestsForApproverApiResponse: AclRequest[] = [
+  {
+    remarks: undefined,
+    consumergroup: "-na-",
+    acl_ip: undefined,
+    acl_ssl: ["mbasani", "maulbach"],
+    aclPatternType: "LITERAL",
+    transactionalId: undefined,
+    req_no: 1014,
+    topicname: "aivtopic1",
+    environment: "1",
+    teamname: "Ospo",
+    topictype: "Consumer",
+    aclIpPrincipleType: "PRINCIPAL",
+    environmentName: "DEV",
+    teamId: 1003,
+    requestingteam: 1003,
+    appname: "App",
+    username: "amathieu",
+    requesttime: "2023-01-06T14:50:37.912+00:00",
+    requesttimestring: "06-Jan-2023 14:50:37",
+    aclstatus: "created",
+    approver: undefined,
+    approvingtime: undefined,
+    aclType: "Consumer",
+    aclResourceType: undefined,
+    currentPage: "1",
+    otherParams: undefined,
+    totalNoPages: "1",
+    allPageNos: ["1", ">", ">>"],
+    approvingTeamDetails:
+      "Team : Ospo, Users : muralibasani,josepprat,samulisuortti,mirjamaulbach,smustafa,aindriul,",
+  },
+  {
+    remarks: "hello",
+    consumergroup: undefined,
+    acl_ip: ["3.3.3.32", "3.3.3.33"],
+    acl_ssl: ["User:*"],
+    aclPatternType: "PREFIXED",
+    transactionalId: undefined,
+    req_no: 1015,
+    topicname: "newaudittopic",
+    environment: "2",
+    teamname: "Ospo",
+    topictype: "Producer",
+    aclIpPrincipleType: "IP_ADDRESS",
+    environmentName: "TST",
+    teamId: 1003,
+    requestingteam: 1003,
+    appname: "App",
+    username: "amathieu",
+    requesttime: "2023-01-10T13:19:10.757+00:00",
+    requesttimestring: "10-Jan-2023 13:19:10",
+    aclstatus: "created",
+    approver: undefined,
+    approvingtime: undefined,
+    aclType: "Producer",
+    aclResourceType: undefined,
+    currentPage: "1",
+    otherParams: undefined,
+    totalNoPages: "1",
+    allPageNos: ["1", ">", ">>"],
+    approvingTeamDetails:
+      "Team : Ospo, Users : muralibasani,josepprat,samulisuortti,mirjamaulbach,smustafa,aindriul,",
+  },
+];
+
+const mockGetAclRequestsForApproverResponse = transformAclRequestApiResponse(
+  mockedAclRequestsForApproverApiResponse
+);
+
+describe("AclApprovals", () => {
+  beforeAll(() => {
+    mockIntersectionObserver();
+  });
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+
+  describe("Skeleton", () => {
+    beforeAll(() => {
+      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+      //@ts-ignore
+      useQuerySpy.mockReturnValue({ data: [], isLoading: true });
+
+      customRender(<AclApprovals />, {
+        queryClient: true,
+        memoryRouter: true,
+      });
+    });
+
+    afterAll(() => {
+      cleanup();
+      useQuerySpy.mockRestore();
+    });
+
+    it("shows a skeleton table", () => {
+      const skeleton = screen.getByTestId("skeleton-table");
+
+      expect(skeleton).toBeVisible();
+    });
+  });
+
+  describe("DataTable", () => {
+    beforeAll(async () => {
+      mockGetAclRequestsForApprover.mockResolvedValue(
+        mockGetAclRequestsForApproverResponse
+      );
+      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+      //@ts-ignore
+      customRender(<AclApprovals />, {
+        queryClient: true,
+        memoryRouter: true,
+      });
+
+      await waitForElementToBeRemoved(screen.getByTestId("skeleton-table"));
+    });
+
+    afterAll(() => {
+      cleanup();
+    });
+
+    it("shows one header row and two data rows", async () => {
+      const rows = screen.getAllByRole("row");
+
+      expect(rows).toHaveLength(3);
+      expect(rows[0]).toHaveTextContent("Principals/Usernames");
+      expect(rows[1]).toHaveTextContent("mbasani");
+      expect(rows[2]).toHaveTextContent("User:*");
+    });
+
+    it("renders (prefixed) in Topic cell when appropriate", async () => {
+      const prefixedCells = screen.getAllByText("(prefixed)");
+      const notPrefixedCells = screen.getAllByText("aivtopic1");
+
+      expect(prefixedCells).toHaveLength(1);
+      expect(notPrefixedCells).toHaveLength(1);
+    });
+
+    it("renders all values for cells who can have multiple values", async () => {
+      const cells = screen.getAllByRole("cell");
+
+      expect(
+        cells.filter((cell) => {
+          return cell.textContent === "mbasanimaulbach";
+        })
+      ).toHaveLength(1);
+      expect(
+        cells.filter((cell) => cell.textContent === "3.3.3.323.3.3.33")
+      ).toHaveLength(1);
+    });
+  });
+
+  describe("Pagination", () => {
+    beforeAll(async () => {
+      mockGetAclRequestsForApprover.mockResolvedValue(
+        mockGetAclRequestsForApproverResponse
+      );
+      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+      //@ts-ignore
+      customRender(<AclApprovals />, {
+        queryClient: true,
+        memoryRouter: true,
+      });
+
+      await waitForElementToBeRemoved(screen.getByTestId("skeleton-table"));
+    });
+
+    afterAll(() => {
+      cleanup();
+    });
+
+    it("render a Pagination component", async () => {
+      const pagination = screen.getByRole("navigation");
+
+      expect(pagination).toBeInTheDocument();
+      expect(pagination).toBeEnabled();
+    });
+
+    it("render Pagination on page 1 on load", async () => {
+      const pagination = screen.getByRole("navigation");
+      expect(pagination).toHaveTextContent("Page 1 of 1");
+    });
+  });
+});

--- a/coral/src/app/features/approvals/acls/AclApprovals.test.tsx
+++ b/coral/src/app/features/approvals/acls/AclApprovals.test.tsx
@@ -8,8 +8,8 @@ import AclApprovals from "src/app/features/approvals/acls/AclApprovals";
 import { getAclRequestsForApprover } from "src/domain/acl/acl-api";
 import transformAclRequestApiResponse from "src/domain/acl/acl-transformer";
 import { AclRequest } from "src/domain/acl/acl-types";
-import { customRender } from "src/services/test-utils/render-with-wrappers";
 import { mockIntersectionObserver } from "src/services/test-utils/mock-intersection-observer";
+import { customRender } from "src/services/test-utils/render-with-wrappers";
 
 jest.mock("src/domain/acl/acl-api.ts");
 
@@ -48,7 +48,7 @@ const mockedAclRequestsForApproverApiResponse: AclRequest[] = [
     aclResourceType: undefined,
     currentPage: "1",
     otherParams: undefined,
-    totalNoPages: "1",
+    totalNoPages: "2",
     allPageNos: ["1", ">", ">>"],
     approvingTeamDetails:
       "Team : Ospo, Users : muralibasani,josepprat,samulisuortti,mirjamaulbach,smustafa,aindriul,",
@@ -80,7 +80,7 @@ const mockedAclRequestsForApproverApiResponse: AclRequest[] = [
     aclResourceType: undefined,
     currentPage: "1",
     otherParams: undefined,
-    totalNoPages: "1",
+    totalNoPages: "2",
     allPageNos: ["1", ">", ">>"],
     approvingTeamDetails:
       "Team : Ospo, Users : muralibasani,josepprat,samulisuortti,mirjamaulbach,smustafa,aindriul,",
@@ -140,6 +140,7 @@ describe("AclApprovals", () => {
 
     afterAll(() => {
       cleanup();
+      jest.resetAllMocks();
     });
 
     it("shows one header row and two data rows", async () => {
@@ -164,22 +165,21 @@ describe("AclApprovals", () => {
 
       expect(
         cells.filter((cell) => {
-          return cell.textContent === "mbasanimaulbach";
+          return cell.textContent === "mbasani maulbach ";
         })
       ).toHaveLength(1);
       expect(
-        cells.filter((cell) => cell.textContent === "3.3.3.323.3.3.33")
+        cells.filter((cell) => cell.textContent === "3.3.3.32 3.3.3.33 ")
       ).toHaveLength(1);
     });
   });
 
-  describe("Pagination", () => {
+  describe("handles paginated data", () => {
     beforeAll(async () => {
       mockGetAclRequestsForApprover.mockResolvedValue(
         mockGetAclRequestsForApproverResponse
       );
-      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-      //@ts-ignore
+
       customRender(<AclApprovals />, {
         queryClient: true,
         memoryRouter: true,
@@ -190,18 +190,17 @@ describe("AclApprovals", () => {
 
     afterAll(() => {
       cleanup();
+      jest.resetAllMocks();
     });
 
     it("render a Pagination component", async () => {
       const pagination = screen.getByRole("navigation");
-
-      expect(pagination).toBeInTheDocument();
-      expect(pagination).toBeEnabled();
+      expect(pagination).toBeVisible();
     });
 
     it("render Pagination on page 1 on load", async () => {
       const pagination = screen.getByRole("navigation");
-      expect(pagination).toHaveTextContent("Page 1 of 1");
+      expect(pagination).toHaveTextContent("Page 1 of 2");
     });
   });
 });

--- a/coral/src/app/features/approvals/acls/AclApprovals.tsx
+++ b/coral/src/app/features/approvals/acls/AclApprovals.tsx
@@ -97,33 +97,29 @@ const columns: Array<DataTableColumn<AclRequestTableData>> = [
   },
   {
     width: 30,
-    headerName: "Approve",
+    headerName: "",
     type: "custom",
     UNSAFE_render: () => {
       return (
-        <Flexbox justifyContent={"center"}>
-          <GhostButton onClick={() => alert("Approve")} title={"Approve"}>
-            <Icon color="grey-70" icon={tickCircle} />
-          </GhostButton>
-        </Flexbox>
+        <GhostButton onClick={() => alert("Approve")} title={"Approve"}>
+          <Icon color="grey-70" icon={tickCircle} />
+        </GhostButton>
       );
     },
   },
   {
     width: 30,
-    headerName: "Decline",
+    headerName: "",
     type: "custom",
     UNSAFE_render: () => {
       return (
-        <Flexbox justifyContent={"center"}>
-          <GhostButton
-            onClick={() => alert("Decline")}
-            title={"Decline"}
-            style={{ textAlign: "center" }}
-          >
-            <Icon color="grey-70" icon={deleteIcon} />
-          </GhostButton>
-        </Flexbox>
+        <GhostButton
+          onClick={() => alert("Decline")}
+          title={"Decline"}
+          style={{ textAlign: "center" }}
+        >
+          <Icon color="grey-70" icon={deleteIcon} />
+        </GhostButton>
       );
     },
   },

--- a/coral/src/app/features/approvals/acls/AclApprovals.tsx
+++ b/coral/src/app/features/approvals/acls/AclApprovals.tsx
@@ -244,7 +244,7 @@ function AclApprovals() {
 
   const [activePage, setActivePage] = useState(initialPage || 1);
 
-  const { data, isPreviousData } = useQuery<AclRequestsForApprover, Error>({
+  const { data } = useQuery<AclRequestsForApprover, Error>({
     queryKey: ["aclRequests", activePage],
     queryFn: () => getAclRequestsForApprover({ pageNo: String(activePage) }),
     keepPreviousData: true,
@@ -285,7 +285,7 @@ function AclApprovals() {
   };
 
   return (
-    <div style={{ opacity: isPreviousData ? "0.7" : "1" }}>
+    <>
       <DataTable
         ariaLabel={"Acl requests"}
         columns={columns}
@@ -297,7 +297,7 @@ function AclApprovals() {
         totalPages={data.totalPages}
         setActivePage={handleChangePage}
       />
-    </div>
+    </>
   );
 }
 

--- a/coral/src/app/features/approvals/acls/AclApprovals.tsx
+++ b/coral/src/app/features/approvals/acls/AclApprovals.tsx
@@ -25,7 +25,7 @@ interface AclRequestTableData {
   teamname: AclRequest["teamname"];
   topictype: AclRequest["topictype"];
   username: string;
-  requesttime: string;
+  requesttimestring: string;
 }
 
 const columns: Array<DataTableColumn<AclRequestTableData>> = [
@@ -92,25 +92,8 @@ const columns: Array<DataTableColumn<AclRequestTableData>> = [
   },
   {
     type: "text",
-    field: "requesttime",
+    field: "requesttimestring",
     headerName: "Date requested",
-    formatter: (value) => {
-      const date = new Date(value);
-
-      const dateTimeString = Intl.DateTimeFormat("en", {
-        dateStyle: "medium",
-        timeStyle: "medium",
-        hourCycle: "h24",
-      }).format(date);
-
-      const timezoneString = Intl.DateTimeFormat("en", {
-        timeZoneName: "short",
-      })
-        .format(date)
-        .split(",")[1];
-
-      return `${dateTimeString} ${timezoneString}`;
-    },
   },
   {
     width: 30,
@@ -285,7 +268,7 @@ function AclApprovals() {
       teamname,
       topictype,
       username,
-      requesttime,
+      requesttimestring,
     }) => ({
       id: Number(req_no),
       acl_ssl: acl_ssl ?? [],
@@ -295,7 +278,7 @@ function AclApprovals() {
       teamname,
       topictype,
       username: username ?? "-",
-      requesttime: requesttime ?? "-",
+      requesttimestring: requesttimestring ?? "-",
     })
   );
 

--- a/coral/src/app/features/approvals/acls/AclApprovals.tsx
+++ b/coral/src/app/features/approvals/acls/AclApprovals.tsx
@@ -7,6 +7,7 @@ import {
   StatusChip,
 } from "@aivenio/aquarium";
 import deleteIcon from "@aivenio/aquarium/dist/src/icons/delete";
+import infoSign from "@aivenio/aquarium/dist/src/icons/infoSign";
 import tickCircle from "@aivenio/aquarium/dist/src/icons/tickCircle";
 import { useQuery } from "@tanstack/react-query";
 import { useState } from "react";
@@ -104,6 +105,27 @@ const columns: Array<DataTableColumn<AclRequestTableData>> = [
     headerName: "Date requested",
   },
   {
+    // Not having a headerName triggers React error:
+    // Warning: Encountered two children with the same key, ``.
+    headerName: "",
+    type: "custom",
+    UNSAFE_render: () => {
+      return (
+        <Flexbox justifyContent={"center"}>
+          <GhostButton
+            icon={infoSign}
+            onClick={() =>
+              alert("Details modal with approve and reject buttons")
+            }
+            title={"View request details"}
+          >
+            View details
+          </GhostButton>
+        </Flexbox>
+      );
+    },
+  },
+  {
     width: 30,
     // Not having a headerName triggers React error:
     // Warning: Encountered two children with the same key, ``.
@@ -111,8 +133,15 @@ const columns: Array<DataTableColumn<AclRequestTableData>> = [
     type: "custom",
     UNSAFE_render: () => {
       return (
-        <GhostButton onClick={() => alert("Approve")} title={"Approve"}>
-          <Icon color="grey-70" icon={tickCircle} />
+        <GhostButton
+          onClick={() => alert("Approve request right away")}
+          title={"Approve request"}
+        >
+          <Icon
+            style={{ fontSize: "20px" }}
+            color="grey-70"
+            icon={tickCircle}
+          />
         </GhostButton>
       );
     },
@@ -125,8 +154,15 @@ const columns: Array<DataTableColumn<AclRequestTableData>> = [
     type: "custom",
     UNSAFE_render: () => {
       return (
-        <GhostButton onClick={() => alert("Decline")} title={"Decline"}>
-          <Icon color="grey-70" icon={deleteIcon} />
+        <GhostButton
+          onClick={() => alert("Reject modal with form for reason")}
+          title={"Reject request"}
+        >
+          <Icon
+            style={{ fontSize: "20px" }}
+            color="grey-70"
+            icon={deleteIcon}
+          />
         </GhostButton>
       );
     },
@@ -136,6 +172,8 @@ const columns: Array<DataTableColumn<AclRequestTableData>> = [
 function AclApprovals() {
   const [searchParams, setSearchParams] = useSearchParams();
   const initialPage = Number(searchParams.get("page"));
+
+  console.log("search", searchParams);
 
   const [activePage, setActivePage] = useState(initialPage || 1);
 

--- a/coral/src/app/features/approvals/acls/AclApprovals.tsx
+++ b/coral/src/app/features/approvals/acls/AclApprovals.tsx
@@ -10,7 +10,6 @@ import deleteIcon from "@aivenio/aquarium/dist/src/icons/delete";
 import infoSign from "@aivenio/aquarium/dist/src/icons/infoSign";
 import tickCircle from "@aivenio/aquarium/dist/src/icons/tickCircle";
 import { useQuery } from "@tanstack/react-query";
-import { type } from "@testing-library/user-event/dist/types/utility";
 import { useState } from "react";
 import { useSearchParams } from "react-router-dom";
 import { Pagination } from "src/app/components/Pagination";
@@ -81,7 +80,8 @@ const columns: Array<DataTableColumn<AclRequestTableData>> = [
     UNSAFE_render({ topicname, prefixed }: AclRequestTableData) {
       return (
         <>
-          {prefixed && <code>(prefixed)</code>} {topicname}
+          {topicname}
+          {prefixed && <code>(prefixed)</code>}
         </>
       );
     },

--- a/coral/src/app/features/approvals/acls/AclApprovals.tsx
+++ b/coral/src/app/features/approvals/acls/AclApprovals.tsx
@@ -105,6 +105,8 @@ const columns: Array<DataTableColumn<AclRequestTableData>> = [
   },
   {
     width: 30,
+    // Not having a headerName triggers React error:
+    // Warning: Encountered two children with the same key, ``.
     headerName: "",
     type: "custom",
     UNSAFE_render: () => {
@@ -117,15 +119,13 @@ const columns: Array<DataTableColumn<AclRequestTableData>> = [
   },
   {
     width: 30,
+    // Not having a headerName triggers React error:
+    // Warning: Encountered two children with the same key, ``.
     headerName: "",
     type: "custom",
     UNSAFE_render: () => {
       return (
-        <GhostButton
-          onClick={() => alert("Decline")}
-          title={"Decline"}
-          style={{ textAlign: "center" }}
-        >
+        <GhostButton onClick={() => alert("Decline")} title={"Decline"}>
           <Icon color="grey-70" icon={deleteIcon} />
         </GhostButton>
       );
@@ -139,13 +139,13 @@ function AclApprovals() {
 
   const [activePage, setActivePage] = useState(initialPage || 1);
 
-  const { data } = useQuery<AclRequestsForApprover, Error>({
+  const { data, isLoading } = useQuery<AclRequestsForApprover, Error>({
     queryKey: ["aclRequests", activePage],
     queryFn: () => getAclRequestsForApprover({ pageNo: String(activePage) }),
     keepPreviousData: true,
   });
 
-  if (data === undefined) {
+  if (data === undefined || isLoading) {
     return <SkeletonTable />;
   }
 

--- a/coral/src/app/features/approvals/acls/AclApprovals.tsx
+++ b/coral/src/app/features/approvals/acls/AclApprovals.tsx
@@ -1,5 +1,327 @@
+import {
+  DataTable,
+  DataTableColumn,
+  Flexbox,
+  GhostButton,
+  Icon,
+  Pagination,
+  StatusChip,
+} from "@aivenio/aquarium";
+import deleteIcon from "@aivenio/aquarium/dist/src/icons/delete";
+import tickCircle from "@aivenio/aquarium/dist/src/icons/tickCircle";
+import { useQuery } from "@tanstack/react-query";
+import { useState } from "react";
+import { useSearchParams } from "react-router-dom";
+import SkeletonTable from "src/app/features/approvals/SkeletonTable";
+import { getAclRequestsForApprover } from "src/domain/acl/acl-api";
+import { AclRequest, AclRequestsForApprover } from "src/domain/acl/acl-types";
+
+interface AclRequestTableData {
+  id: number;
+  acl_ssl: string[];
+  acl_ip: string[];
+  topicname: AclRequest["topicname"];
+  environmentName: string;
+  teamname: AclRequest["teamname"];
+  topictype: AclRequest["topictype"];
+  username: string;
+  requesttime: string;
+}
+
+const columns: Array<DataTableColumn<AclRequestTableData>> = [
+  {
+    type: "custom",
+    field: "acl_ssl",
+    headerName: "Principals/Usernames",
+    UNSAFE_render: ({ acl_ssl }: AclRequestTableData) => {
+      return (
+        <Flexbox wrap={"wrap"} gap={"2"}>
+          {acl_ssl.map((ssl, index) => (
+            <StatusChip status="neutral" key={`${ssl}-${index}`} text={ssl} />
+          ))}
+        </Flexbox>
+      );
+    },
+  },
+  {
+    type: "custom",
+    field: "acl_ip",
+    headerName: "IP addresses",
+    UNSAFE_render: ({ acl_ip }: AclRequestTableData) => {
+      return (
+        <Flexbox wrap={"wrap"} gap={"2"}>
+          {acl_ip.map((ip, index) => (
+            <StatusChip status="neutral" key={`${ip}-${index}`} text={ip} />
+          ))}
+        </Flexbox>
+      );
+    },
+  },
+  {
+    type: "text",
+    field: "topicname",
+    headerName: "Topic",
+  },
+  {
+    type: "status",
+    field: "environmentName",
+    headerName: "Cluster",
+    status: ({ environmentName }) => ({
+      status: "neutral",
+      text: environmentName,
+    }),
+  },
+  {
+    type: "text",
+    field: "teamname",
+    headerName: "Team",
+  },
+  {
+    type: "status",
+    field: "topictype",
+    headerName: "ACL type",
+    status: ({ topictype }) => ({
+      status: topictype === "Consumer" ? "success" : "info",
+      text: topictype,
+    }),
+  },
+  {
+    type: "text",
+    field: "username",
+    headerName: "Requested by",
+  },
+  {
+    type: "text",
+    field: "requesttime",
+    headerName: "Date requested",
+    formatter: (value) => {
+      const date = new Date(value);
+
+      const dateTimeString = Intl.DateTimeFormat("en", {
+        dateStyle: "medium",
+        timeStyle: "medium",
+        hourCycle: "h24",
+      }).format(date);
+
+      const timezoneString = Intl.DateTimeFormat("en", {
+        timeZoneName: "short",
+      })
+        .format(date)
+        .split(",")[1];
+
+      return `${dateTimeString} ${timezoneString}`;
+    },
+  },
+  {
+    width: 30,
+    headerName: "Approve",
+    type: "custom",
+    UNSAFE_render: () => {
+      return (
+        <Flexbox justifyContent={"center"}>
+          <GhostButton onClick={() => alert("Approve")} title={"Approve"}>
+            <Icon color="grey-70" icon={tickCircle} />
+          </GhostButton>
+        </Flexbox>
+      );
+    },
+  },
+  {
+    width: 30,
+    headerName: "Decline",
+    type: "custom",
+    UNSAFE_render: () => {
+      return (
+        <Flexbox justifyContent={"center"}>
+          <GhostButton
+            onClick={() => alert("Decline")}
+            title={"Decline"}
+            style={{ textAlign: "center" }}
+          >
+            <Icon color="grey-70" icon={deleteIcon} />
+          </GhostButton>
+        </Flexbox>
+      );
+    },
+  },
+];
+
+// const placeholderData: AclRequestTableData[] = [
+//   {
+//     id: 0,
+//     acl_ssl: ["..."],
+//     acl_ip: ["..."],
+//     topicname: "...",
+//     environmentName: "...",
+//     teamname: "...",
+//     topictype: "Consumer",
+//     username: "...",
+//     requesttime: "2022-12-20T13:01:47.409+00:00",
+//   },
+//   {
+//     id: 1,
+//     acl_ssl: ["..."],
+//     acl_ip: ["..."],
+//     topicname: "...",
+//     environmentName: "...",
+//     teamname: "...",
+//     topictype: "Consumer",
+//     username: "...",
+//     requesttime: "2022-12-20T13:01:47.409+00:00",
+//   },
+//   {
+//     id: 2,
+//     acl_ssl: ["..."],
+//     acl_ip: ["..."],
+//     topicname: "...",
+//     environmentName: "...",
+//     teamname: "...",
+//     topictype: "Consumer",
+//     username: "...",
+//     requesttime: "2022-12-20T13:01:47.409+00:00",
+//   },
+//   {
+//     id: 3,
+//     acl_ssl: ["..."],
+//     acl_ip: ["..."],
+//     topicname: "...",
+//     environmentName: "...",
+//     teamname: "...",
+//     topictype: "Consumer",
+//     username: "...",
+//     requesttime: "2022-12-20T13:01:47.409+00:00",
+//   },
+//   {
+//     id: 4,
+//     acl_ssl: ["..."],
+//     acl_ip: ["..."],
+//     topicname: "...",
+//     environmentName: "...",
+//     teamname: "...",
+//     topictype: "Consumer",
+//     username: "...",
+//     requesttime: "2022-12-20T13:01:47.409+00:00",
+//   },
+//   {
+//     id: 5,
+//     acl_ssl: ["..."],
+//     acl_ip: ["..."],
+//     topicname: "...",
+//     environmentName: "...",
+//     teamname: "...",
+//     topictype: "Consumer",
+//     username: "...",
+//     requesttime: "2022-12-20T13:01:47.409+00:00",
+//   },
+//   {
+//     id: 6,
+//     acl_ssl: ["..."],
+//     acl_ip: ["..."],
+//     topicname: "...",
+//     environmentName: "...",
+//     teamname: "...",
+//     topictype: "Consumer",
+//     username: "...",
+//     requesttime: "2022-12-20T13:01:47.409+00:00",
+//   },
+//   {
+//     id: 7,
+//     acl_ssl: ["..."],
+//     acl_ip: ["..."],
+//     topicname: "...",
+//     environmentName: "...",
+//     teamname: "...",
+//     topictype: "Consumer",
+//     username: "...",
+//     requesttime: "2022-12-20T13:01:47.409+00:00",
+//   },
+//   {
+//     id: 8,
+//     acl_ssl: ["..."],
+//     acl_ip: ["..."],
+//     topicname: "...",
+//     environmentName: "...",
+//     teamname: "...",
+//     topictype: "Consumer",
+//     username: "...",
+//     requesttime: "2022-12-20T13:01:47.409+00:00",
+//   },
+//   {
+//     id: 9,
+//     acl_ssl: ["..."],
+//     acl_ip: ["..."],
+//     topicname: "...",
+//     environmentName: "...",
+//     teamname: "...",
+//     topictype: "Consumer",
+//     username: "...",
+//     requesttime: "2022-12-20T13:01:47.409+00:00",
+//   },
+// ];
+
 function AclApprovals() {
-  return <p>AclApprovals</p>;
+  const [searchParams, setSearchParams] = useSearchParams();
+  const initialPage = Number(searchParams.get("page"));
+
+  const [activePage, setActivePage] = useState(initialPage || 1);
+
+  const { data, isPreviousData } = useQuery<AclRequestsForApprover, Error>({
+    queryKey: ["aclRequests", activePage],
+    queryFn: () => getAclRequestsForApprover({ pageNo: String(activePage) }),
+    keepPreviousData: true,
+  });
+
+  if (data === undefined) {
+    return <SkeletonTable />;
+  }
+
+  const tableData: AclRequestTableData[] = data.entries.map(
+    ({
+      req_no,
+      acl_ssl,
+      acl_ip,
+      topicname,
+      environmentName,
+      teamname,
+      topictype,
+      username,
+      requesttime,
+    }) => ({
+      id: Number(req_no),
+      acl_ssl: acl_ssl ?? [],
+      acl_ip: acl_ip ?? [],
+      topicname: topicname,
+      environmentName: environmentName ?? "-",
+      teamname,
+      topictype,
+      username: username ?? "-",
+      requesttime: requesttime ?? "-",
+    })
+  );
+
+  const handleChangePage = (activePage: number) => {
+    setActivePage(activePage);
+    searchParams.set("page", activePage.toString());
+    setSearchParams(searchParams);
+  };
+
+  return (
+    <div style={{ opacity: isPreviousData ? "0.7" : "1" }}>
+      <DataTable
+        ariaLabel={"Acl requests"}
+        columns={columns}
+        rows={tableData}
+        noWrap={false}
+      />
+      <Pagination
+        currentPage={data.currentPage}
+        totalPages={data.totalPages}
+        hasNextPage={activePage < data.totalPages}
+        hasPreviousPage={data.currentPage !== 1}
+        onPageChange={handleChangePage}
+      />
+    </div>
+  );
 }
 
 export default AclApprovals;

--- a/coral/src/app/features/approvals/acls/AclApprovals.tsx
+++ b/coral/src/app/features/approvals/acls/AclApprovals.tsx
@@ -39,7 +39,14 @@ const columns: Array<DataTableColumn<AclRequestTableData>> = [
       return (
         <Flexbox wrap={"wrap"} gap={"2"}>
           {acl_ssl.map((ssl, index) => (
-            <StatusChip status="neutral" key={`${ssl}-${index}`} text={ssl} />
+            <StatusChip
+              status="neutral"
+              key={`${ssl}-${index}`}
+              // We need to add a space after text value
+              // Otherwise a list of values would be rendered as value1value2value3 for screen readers
+              // Instead of value1 value2 value3
+              text={`${ssl} `}
+            />
           ))}
         </Flexbox>
       );
@@ -53,7 +60,14 @@ const columns: Array<DataTableColumn<AclRequestTableData>> = [
       return (
         <Flexbox wrap={"wrap"} gap={"2"}>
           {acl_ip.map((ip, index) => (
-            <StatusChip status="neutral" key={`${ip}-${index}`} text={ip} />
+            <StatusChip
+              status="neutral"
+              key={`${ip}-${index}`}
+              // We need to add a space after text value
+              // Otherwise a list of values would be rendered as value1value2value3 for screen readers
+              // Instead of value1 value2 value3
+              text={`${ip} `}
+            />
           ))}
         </Flexbox>
       );
@@ -172,8 +186,6 @@ const columns: Array<DataTableColumn<AclRequestTableData>> = [
 function AclApprovals() {
   const [searchParams, setSearchParams] = useSearchParams();
   const initialPage = Number(searchParams.get("page"));
-
-  console.log("search", searchParams);
 
   const [activePage, setActivePage] = useState(initialPage || 1);
 

--- a/coral/src/app/features/approvals/acls/AclApprovals.tsx
+++ b/coral/src/app/features/approvals/acls/AclApprovals.tsx
@@ -21,6 +21,7 @@ interface AclRequestTableData {
   acl_ssl: string[];
   acl_ip: string[];
   topicname: AclRequest["topicname"];
+  prefixed: boolean;
   environmentName: string;
   teamname: AclRequest["teamname"];
   topictype: AclRequest["topictype"];
@@ -58,9 +59,16 @@ const columns: Array<DataTableColumn<AclRequestTableData>> = [
     },
   },
   {
-    type: "text",
+    type: "custom",
     field: "topicname",
     headerName: "Topic",
+    UNSAFE_render({ topicname, prefixed }: AclRequestTableData) {
+      return (
+        <>
+          {prefixed && <code>(prefixed)</code>} {topicname}
+        </>
+      );
+    },
   },
   {
     type: "status",
@@ -125,119 +133,6 @@ const columns: Array<DataTableColumn<AclRequestTableData>> = [
   },
 ];
 
-// const placeholderData: AclRequestTableData[] = [
-//   {
-//     id: 0,
-//     acl_ssl: ["..."],
-//     acl_ip: ["..."],
-//     topicname: "...",
-//     environmentName: "...",
-//     teamname: "...",
-//     topictype: "Consumer",
-//     username: "...",
-//     requesttime: "2022-12-20T13:01:47.409+00:00",
-//   },
-//   {
-//     id: 1,
-//     acl_ssl: ["..."],
-//     acl_ip: ["..."],
-//     topicname: "...",
-//     environmentName: "...",
-//     teamname: "...",
-//     topictype: "Consumer",
-//     username: "...",
-//     requesttime: "2022-12-20T13:01:47.409+00:00",
-//   },
-//   {
-//     id: 2,
-//     acl_ssl: ["..."],
-//     acl_ip: ["..."],
-//     topicname: "...",
-//     environmentName: "...",
-//     teamname: "...",
-//     topictype: "Consumer",
-//     username: "...",
-//     requesttime: "2022-12-20T13:01:47.409+00:00",
-//   },
-//   {
-//     id: 3,
-//     acl_ssl: ["..."],
-//     acl_ip: ["..."],
-//     topicname: "...",
-//     environmentName: "...",
-//     teamname: "...",
-//     topictype: "Consumer",
-//     username: "...",
-//     requesttime: "2022-12-20T13:01:47.409+00:00",
-//   },
-//   {
-//     id: 4,
-//     acl_ssl: ["..."],
-//     acl_ip: ["..."],
-//     topicname: "...",
-//     environmentName: "...",
-//     teamname: "...",
-//     topictype: "Consumer",
-//     username: "...",
-//     requesttime: "2022-12-20T13:01:47.409+00:00",
-//   },
-//   {
-//     id: 5,
-//     acl_ssl: ["..."],
-//     acl_ip: ["..."],
-//     topicname: "...",
-//     environmentName: "...",
-//     teamname: "...",
-//     topictype: "Consumer",
-//     username: "...",
-//     requesttime: "2022-12-20T13:01:47.409+00:00",
-//   },
-//   {
-//     id: 6,
-//     acl_ssl: ["..."],
-//     acl_ip: ["..."],
-//     topicname: "...",
-//     environmentName: "...",
-//     teamname: "...",
-//     topictype: "Consumer",
-//     username: "...",
-//     requesttime: "2022-12-20T13:01:47.409+00:00",
-//   },
-//   {
-//     id: 7,
-//     acl_ssl: ["..."],
-//     acl_ip: ["..."],
-//     topicname: "...",
-//     environmentName: "...",
-//     teamname: "...",
-//     topictype: "Consumer",
-//     username: "...",
-//     requesttime: "2022-12-20T13:01:47.409+00:00",
-//   },
-//   {
-//     id: 8,
-//     acl_ssl: ["..."],
-//     acl_ip: ["..."],
-//     topicname: "...",
-//     environmentName: "...",
-//     teamname: "...",
-//     topictype: "Consumer",
-//     username: "...",
-//     requesttime: "2022-12-20T13:01:47.409+00:00",
-//   },
-//   {
-//     id: 9,
-//     acl_ssl: ["..."],
-//     acl_ip: ["..."],
-//     topicname: "...",
-//     environmentName: "...",
-//     teamname: "...",
-//     topictype: "Consumer",
-//     username: "...",
-//     requesttime: "2022-12-20T13:01:47.409+00:00",
-//   },
-// ];
-
 function AclApprovals() {
   const [searchParams, setSearchParams] = useSearchParams();
   const initialPage = Number(searchParams.get("page"));
@@ -260,6 +155,7 @@ function AclApprovals() {
       acl_ssl,
       acl_ip,
       topicname,
+      aclPatternType,
       environmentName,
       teamname,
       topictype,
@@ -270,6 +166,7 @@ function AclApprovals() {
       acl_ssl: acl_ssl ?? [],
       acl_ip: acl_ip ?? [],
       topicname: topicname,
+      prefixed: aclPatternType === "PREFIXED",
       environmentName: environmentName ?? "-",
       teamname,
       topictype,

--- a/coral/src/app/features/approvals/acls/AclApprovals.tsx
+++ b/coral/src/app/features/approvals/acls/AclApprovals.tsx
@@ -10,6 +10,7 @@ import deleteIcon from "@aivenio/aquarium/dist/src/icons/delete";
 import infoSign from "@aivenio/aquarium/dist/src/icons/infoSign";
 import tickCircle from "@aivenio/aquarium/dist/src/icons/tickCircle";
 import { useQuery } from "@tanstack/react-query";
+import { type } from "@testing-library/user-event/dist/types/utility";
 import { useState } from "react";
 import { useSearchParams } from "react-router-dom";
 import { Pagination } from "src/app/components/Pagination";
@@ -125,17 +126,14 @@ const columns: Array<DataTableColumn<AclRequestTableData>> = [
     type: "custom",
     UNSAFE_render: () => {
       return (
-        <Flexbox justifyContent={"center"}>
-          <GhostButton
-            icon={infoSign}
-            onClick={() =>
-              alert("Details modal with approve and reject buttons")
-            }
-            title={"View request details"}
-          >
-            View details
-          </GhostButton>
-        </Flexbox>
+        <GhostButton
+          icon={infoSign}
+          onClick={() => alert("Details modal with approve and reject buttons")}
+          title={"View request details"}
+          dense
+        >
+          View details
+        </GhostButton>
       );
     },
   },
@@ -151,11 +149,7 @@ const columns: Array<DataTableColumn<AclRequestTableData>> = [
           onClick={() => alert("Approve request right away")}
           title={"Approve request"}
         >
-          <Icon
-            style={{ fontSize: "20px" }}
-            color="grey-70"
-            icon={tickCircle}
-          />
+          <Icon color="grey-70" icon={tickCircle} />
         </GhostButton>
       );
     },
@@ -172,11 +166,7 @@ const columns: Array<DataTableColumn<AclRequestTableData>> = [
           onClick={() => alert("Reject modal with form for reason")}
           title={"Reject request"}
         >
-          <Icon
-            style={{ fontSize: "20px" }}
-            color="grey-70"
-            icon={deleteIcon}
-          />
+          <Icon color="grey-70" icon={deleteIcon} />
         </GhostButton>
       );
     },

--- a/coral/src/app/features/approvals/acls/AclApprovals.tsx
+++ b/coral/src/app/features/approvals/acls/AclApprovals.tsx
@@ -4,7 +4,6 @@ import {
   Flexbox,
   GhostButton,
   Icon,
-  Pagination,
   StatusChip,
 } from "@aivenio/aquarium";
 import deleteIcon from "@aivenio/aquarium/dist/src/icons/delete";
@@ -12,6 +11,7 @@ import tickCircle from "@aivenio/aquarium/dist/src/icons/tickCircle";
 import { useQuery } from "@tanstack/react-query";
 import { useState } from "react";
 import { useSearchParams } from "react-router-dom";
+import { Pagination } from "src/app/components/Pagination";
 import SkeletonTable from "src/app/features/approvals/SkeletonTable";
 import { getAclRequestsForApprover } from "src/domain/acl/acl-api";
 import { AclRequest, AclRequestsForApprover } from "src/domain/acl/acl-types";
@@ -314,11 +314,9 @@ function AclApprovals() {
         noWrap={false}
       />
       <Pagination
-        currentPage={data.currentPage}
+        activePage={data.currentPage}
         totalPages={data.totalPages}
-        hasNextPage={activePage < data.totalPages}
-        hasPreviousPage={data.currentPage !== 1}
-        onPageChange={handleChangePage}
+        setActivePage={handleChangePage}
       />
     </div>
   );

--- a/coral/src/domain/acl/acl-api.ts
+++ b/coral/src/domain/acl/acl-api.ts
@@ -1,3 +1,4 @@
+import transformAclRequestApiResponse from "src/domain/acl/acl-transformer";
 import {
   CreateAclRequestTopicTypeConsumer,
   CreateAclRequestTopicTypeProducer,
@@ -22,9 +23,11 @@ const createAclRequest = (
 };
 
 const getAclRequestsForApprover = (params: GetCreatedAclRequestParameters) => {
-  return api.get<KlawApiResponse<"getAclRequestsForApprover">>(
-    `/getAclRequestsForApprover?${new URLSearchParams(params)}`
-  );
+  return api
+    .get<KlawApiResponse<"getAclRequestsForApprover">>(
+      `/getAclRequestsForApprover?${new URLSearchParams(params)}`
+    )
+    .then(transformAclRequestApiResponse);
 };
 
 const approveAclRequest = (

--- a/coral/src/domain/acl/acl-transformer.ts
+++ b/coral/src/domain/acl/acl-transformer.ts
@@ -1,0 +1,21 @@
+import { AclRequestsForApprover } from "src/domain/acl/acl-types";
+import { KlawApiResponse } from "types/utils";
+
+const transformAclRequestApiResponse = (
+  data: KlawApiResponse<"getAclRequestsForApprover">
+): AclRequestsForApprover => {
+  if (data.length === 0) {
+    return {
+      totalPages: 0,
+      currentPage: 0,
+      entries: [],
+    };
+  }
+  return {
+    totalPages: Number(data[0].totalNoPages),
+    currentPage: Number(data[0].currentPage),
+    entries: data,
+  };
+};
+
+export default transformAclRequestApiResponse;

--- a/coral/src/domain/acl/acl-types.ts
+++ b/coral/src/domain/acl/acl-types.ts
@@ -47,9 +47,18 @@ type GetCreatedAclRequestParameters =
 
 type AclRequest = KlawApiModel<"aclRequest">;
 
+type Paginated<T> = {
+  totalPages: number;
+  currentPage: number;
+  entries: T;
+};
+
+type AclRequestsForApprover = Paginated<AclRequest[]>;
+
 export type {
   CreateAclRequestTopicTypeProducer,
   CreateAclRequestTopicTypeConsumer,
   GetCreatedAclRequestParameters,
   AclRequest,
+  AclRequestsForApprover,
 };


### PR DESCRIPTION
## About this change - What it does

https://user-images.githubusercontent.com/20607294/218109160-c3da654f-a304-4dfc-807b-9f6b913e0ef9.mov



- add content to `AclApprovals` component: `DataTable` populated with data from `getAclRequestsForApprover`, `Pagination` component (not from `aquarium`, cf "Follow-ups")
- to be able to implement this, added `acl-transformer` to parse the data from the API in a `Paginated` format.
- implement sync between pagination and search parameters with `?page={number}` search param


## Next tasks

- add data filters
- add approve and delete modal behaviour on relevant buttons (cf https://github.com/aiven/klaw/issues/587)

## Follow-ups

- `Pagination` from `aquarium has a bug that prevents gracefully syncing and pagination and search parameters, so will be implemented once it is fixed
- When there are several columns without `headerName` in `DataTable`, React throws a "duplicate key" error. This may be addressed once `ariaLabel` is added -> https://github.com/aiven/design-system/pull/950
- Testing is sparse, will be reinforced in later Prs


Resolves: #574
