### PR TITLE
Issue575

### DIFF
--- a/core/src/main/java/io/aiven/klaw/helpers/HandleDbRequests.java
+++ b/core/src/main/java/io/aiven/klaw/helpers/HandleDbRequests.java
@@ -72,6 +72,9 @@ public interface HandleDbRequests {
   Map<String, Map<String, Long>> getTopicRequestsCounts(
       int teamId, RequestMode requestMode, int tenantId);
 
+  Map<String, Map<String, Long>> getAclRequestsCounts(
+      int teamId, RequestMode requestMode, int tenantId);
+
   List<TopicRequest> getCreatedTopicRequests(
       String requestor, String status, boolean showRequestsOfAllTeams, int tenantId);
 

--- a/core/src/main/java/io/aiven/klaw/helpers/HandleDbRequests.java
+++ b/core/src/main/java/io/aiven/klaw/helpers/HandleDbRequests.java
@@ -78,6 +78,9 @@ public interface HandleDbRequests {
   Map<String, Map<String, Long>> getSchemaRequestsCounts(
       int teamId, RequestMode requestMode, int tenantId);
 
+  Map<String, Map<String, Long>> getConnectorRequestsCounts(
+      int teamId, RequestMode requestMode, int tenantId);
+
   List<TopicRequest> getCreatedTopicRequests(
       String requestor, String status, boolean showRequestsOfAllTeams, int tenantId);
 

--- a/core/src/main/java/io/aiven/klaw/helpers/HandleDbRequests.java
+++ b/core/src/main/java/io/aiven/klaw/helpers/HandleDbRequests.java
@@ -75,6 +75,9 @@ public interface HandleDbRequests {
   Map<String, Map<String, Long>> getAclRequestsCounts(
       int teamId, RequestMode requestMode, int tenantId);
 
+  Map<String, Map<String, Long>> getSchemaRequestsCounts(
+      int teamId, RequestMode requestMode, int tenantId);
+
   List<TopicRequest> getCreatedTopicRequests(
       String requestor, String status, boolean showRequestsOfAllTeams, int tenantId);
 

--- a/core/src/main/java/io/aiven/klaw/helpers/db/rdbms/HandleDbRequestsJdbc.java
+++ b/core/src/main/java/io/aiven/klaw/helpers/db/rdbms/HandleDbRequestsJdbc.java
@@ -132,6 +132,12 @@ public class HandleDbRequestsJdbc implements HandleDbRequests {
     return jdbcSelectHelper.getTopicRequestsCounts(teamId, requestMode, tenantId);
   }
 
+  @Override
+  public Map<String, Map<String, Long>> getAclRequestsCounts(
+      int teamId, RequestMode requestMode, int tenantId) {
+    return jdbcSelectHelper.getAclRequestsCounts(teamId, requestMode, tenantId);
+  }
+
   public List<TopicRequest> getCreatedTopicRequests(
       String requestor, String status, boolean showRequestsOfAllTeams, int tenantId) {
     return jdbcSelectHelper.selectTopicRequestsByStatus(

--- a/core/src/main/java/io/aiven/klaw/helpers/db/rdbms/HandleDbRequestsJdbc.java
+++ b/core/src/main/java/io/aiven/klaw/helpers/db/rdbms/HandleDbRequestsJdbc.java
@@ -144,6 +144,12 @@ public class HandleDbRequestsJdbc implements HandleDbRequests {
     return jdbcSelectHelper.getSchemaRequestsCounts(teamId, requestMode, tenantId);
   }
 
+  @Override
+  public Map<String, Map<String, Long>> getConnectorRequestsCounts(
+      int teamId, RequestMode requestMode, int tenantId) {
+    return jdbcSelectHelper.getConnectorRequestsCounts(teamId, requestMode, tenantId);
+  }
+
   public List<TopicRequest> getCreatedTopicRequests(
       String requestor, String status, boolean showRequestsOfAllTeams, int tenantId) {
     return jdbcSelectHelper.selectTopicRequestsByStatus(

--- a/core/src/main/java/io/aiven/klaw/helpers/db/rdbms/HandleDbRequestsJdbc.java
+++ b/core/src/main/java/io/aiven/klaw/helpers/db/rdbms/HandleDbRequestsJdbc.java
@@ -138,6 +138,12 @@ public class HandleDbRequestsJdbc implements HandleDbRequests {
     return jdbcSelectHelper.getAclRequestsCounts(teamId, requestMode, tenantId);
   }
 
+  @Override
+  public Map<String, Map<String, Long>> getSchemaRequestsCounts(
+      int teamId, RequestMode requestMode, int tenantId) {
+    return jdbcSelectHelper.getSchemaRequestsCounts(teamId, requestMode, tenantId);
+  }
+
   public List<TopicRequest> getCreatedTopicRequests(
       String requestor, String status, boolean showRequestsOfAllTeams, int tenantId) {
     return jdbcSelectHelper.selectTopicRequestsByStatus(

--- a/core/src/main/java/io/aiven/klaw/helpers/db/rdbms/SelectDataJdbc.java
+++ b/core/src/main/java/io/aiven/klaw/helpers/db/rdbms/SelectDataJdbc.java
@@ -1234,8 +1234,7 @@ public class SelectDataJdbc {
     return allCountsMap;
   }
 
-  // teamId is requestedBy. For 'schemas' all the requests are assigned to the same team, except
-  // claim requests
+  // teamId is requestedBy. For 'schemas' all the requests are assigned to the same team
   public Map<String, Map<String, Long>> getSchemaRequestsCounts(
       int teamId, RequestMode requestMode, int tenantId) {
     Map<String, Map<String, Long>> allCountsMap = new HashMap<>();
@@ -1251,6 +1250,33 @@ public class SelectDataJdbc {
       List<Object[]> schemaRequestsStatusObj =
           schemaRequestRepo.findAllSchemaRequestsGroupByStatus(teamId, tenantId);
       updateMap(statusCountsMap, schemaRequestsStatusObj);
+    }
+
+    // update with 0L if requests don't exist
+    updateCountsForNonExistingRequestTypes(operationTypeCountsMap, statusCountsMap);
+
+    allCountsMap.put("STATUS_COUNTS", statusCountsMap);
+    allCountsMap.put("OPERATION_TYPE_COUNTS", operationTypeCountsMap);
+
+    return allCountsMap;
+  }
+
+  // teamId is requestedBy. For 'connectors' all the requests are assigned to the same team
+  public Map<String, Map<String, Long>> getConnectorRequestsCounts(
+      int teamId, RequestMode requestMode, int tenantId) {
+    Map<String, Map<String, Long>> allCountsMap = new HashMap<>();
+
+    Map<String, Long> operationTypeCountsMap = new HashMap<>();
+    Map<String, Long> statusCountsMap = new HashMap<>();
+
+    if (RequestMode.MY_REQUESTS == requestMode || RequestMode.TO_APPROVE == requestMode) {
+      List<Object[]> connectorRequestsOperationTypObj =
+          kafkaConnectorRequestsRepo.findAllConnectorRequestsGroupByOperationType(teamId, tenantId);
+      updateMap(operationTypeCountsMap, connectorRequestsOperationTypObj);
+
+      List<Object[]> connectorRequestsStatusObj =
+          kafkaConnectorRequestsRepo.findAllConnectorRequestsGroupByStatus(teamId, tenantId);
+      updateMap(statusCountsMap, connectorRequestsStatusObj);
     }
 
     // update with 0L if requests don't exist

--- a/core/src/main/java/io/aiven/klaw/helpers/db/rdbms/SelectDataJdbc.java
+++ b/core/src/main/java/io/aiven/klaw/helpers/db/rdbms/SelectDataJdbc.java
@@ -1234,6 +1234,34 @@ public class SelectDataJdbc {
     return allCountsMap;
   }
 
+  // teamId is requestedBy. For 'schemas' all the requests are assigned to the same team, except
+  // claim requests
+  public Map<String, Map<String, Long>> getSchemaRequestsCounts(
+      int teamId, RequestMode requestMode, int tenantId) {
+    Map<String, Map<String, Long>> allCountsMap = new HashMap<>();
+
+    Map<String, Long> operationTypeCountsMap = new HashMap<>();
+    Map<String, Long> statusCountsMap = new HashMap<>();
+
+    if (RequestMode.MY_REQUESTS == requestMode || RequestMode.TO_APPROVE == requestMode) {
+      List<Object[]> schemaRequestsOperationTypObj =
+          schemaRequestRepo.findAllSchemaRequestsGroupByOperationType(teamId, tenantId);
+      updateMap(operationTypeCountsMap, schemaRequestsOperationTypObj);
+
+      List<Object[]> schemaRequestsStatusObj =
+          schemaRequestRepo.findAllSchemaRequestsGroupByStatus(teamId, tenantId);
+      updateMap(statusCountsMap, schemaRequestsStatusObj);
+    }
+
+    // update with 0L if requests don't exist
+    updateCountsForNonExistingRequestTypes(operationTypeCountsMap, statusCountsMap);
+
+    allCountsMap.put("STATUS_COUNTS", statusCountsMap);
+    allCountsMap.put("OPERATION_TYPE_COUNTS", operationTypeCountsMap);
+
+    return allCountsMap;
+  }
+
   private static void updateCountsForNonExistingRequestTypes(
       Map<String, Long> operationTypeCountsMap, Map<String, Long> statusCountsMap) {
     for (RequestStatus requestStatus : RequestStatus.values()) {

--- a/core/src/main/java/io/aiven/klaw/repository/AclRequestsRepo.java
+++ b/core/src/main/java/io/aiven/klaw/repository/AclRequestsRepo.java
@@ -33,4 +33,40 @@ public interface AclRequestsRepo
   Integer getNextAclRequestId(@Param("tenantId") Integer tenantId);
 
   List<AclRequests> findAllByTenantId(int tenantId);
+
+  // requests raised by my team
+  @Query(
+      value =
+          "select acltype, count(*) from kwaclrequests where tenantid = :tenantId"
+              + " and requestingteam = :requestingTeamId group by acltype",
+      nativeQuery = true)
+  List<Object[]> findAllAclRequestsGroupByOperationTypeMyTeam(
+      @Param("requestingTeamId") Integer requestingTeamId, @Param("tenantId") Integer tenantId);
+
+  // requests raised by my team
+  @Query(
+      value =
+          "select topicstatus, count(*) from kwaclrequests where tenantid = :tenantId"
+              + " and requestingteam = :requestingTeamId group by topicstatus",
+      nativeQuery = true)
+  List<Object[]> findAllAclRequestsGroupByStatusMyTeam(
+      @Param("requestingTeamId") Integer requestingTeamId, @Param("tenantId") Integer tenantId);
+
+  // requests assigned to my team
+  @Query(
+      value =
+          "select acltype, count(*) from kwaclrequests where tenantid = :tenantId"
+              + " and teamid = :assignedToTeamId group by acltype",
+      nativeQuery = true)
+  List<Object[]> findAllAclRequestsGroupByOperationTypeAssignedToTeam(
+      @Param("assignedToTeamId") Integer assignedToTeamId, @Param("tenantId") Integer tenantId);
+
+  // requests assigned to my team
+  @Query(
+      value =
+          "select topicstatus, count(*) from kwaclrequests where tenantid = :tenantId"
+              + " and teamid = :assignedToTeamId group by topicstatus",
+      nativeQuery = true)
+  List<Object[]> findAllAclRequestsGroupByStatusAssignedToTeam(
+      @Param("assignedToTeamId") Integer assignedToTeamId, @Param("tenantId") Integer tenantId);
 }

--- a/core/src/main/java/io/aiven/klaw/repository/KwKafkaConnectorRequestsRepo.java
+++ b/core/src/main/java/io/aiven/klaw/repository/KwKafkaConnectorRequestsRepo.java
@@ -40,4 +40,20 @@ public interface KwKafkaConnectorRequestsRepo
       @Param("teamId") Integer teamId, @Param("tenantId") Integer tenantId);
 
   List<KafkaConnectorRequest> findAllByTenantId(int tenantId);
+
+  @Query(
+      value =
+          "select connectortype, count(*) from kwkafkaconnectorrequests where tenantid = :tenantId"
+              + " and teamid = :teamId group by connectortype",
+      nativeQuery = true)
+  List<Object[]> findAllConnectorRequestsGroupByOperationType(
+      @Param("teamId") Integer teamId, @Param("tenantId") Integer tenantId);
+
+  @Query(
+      value =
+          "select connectorstatus, count(*) from kwkafkaconnectorrequests where tenantid = :tenantId"
+              + " and teamid = :teamId group by connectorstatus",
+      nativeQuery = true)
+  List<Object[]> findAllConnectorRequestsGroupByStatus(
+      @Param("teamId") Integer teamId, @Param("tenantId") Integer tenantId);
 }

--- a/core/src/main/java/io/aiven/klaw/repository/SchemaRequestRepo.java
+++ b/core/src/main/java/io/aiven/klaw/repository/SchemaRequestRepo.java
@@ -33,4 +33,20 @@ public interface SchemaRequestRepo extends CrudRepository<SchemaRequest, SchemaR
       @Param("teamId") Integer teamId, @Param("tenantId") Integer tenantId);
 
   List<SchemaRequest> findAllByTenantId(int tenantId);
+
+  @Query(
+      value =
+          "select requesttype, count(*) from kwschemarequests where tenantid = :tenantId"
+              + " and teamid = :teamId group by requesttype",
+      nativeQuery = true)
+  List<Object[]> findAllSchemaRequestsGroupByOperationType(
+      @Param("teamId") Integer teamId, @Param("tenantId") Integer tenantId);
+
+  @Query(
+      value =
+          "select topicstatus, count(*) from kwschemarequests where tenantid = :tenantId"
+              + " and teamid = :teamId group by topicstatus",
+      nativeQuery = true)
+  List<Object[]> findAllSchemaRequestsGroupByStatus(
+      @Param("teamId") Integer teamId, @Param("tenantId") Integer tenantId);
 }

--- a/core/src/main/java/io/aiven/klaw/service/RequestStatisticsService.java
+++ b/core/src/main/java/io/aiven/klaw/service/RequestStatisticsService.java
@@ -52,6 +52,17 @@ public class RequestStatisticsService {
     updateRequestsCountOverview(
         aclsRequestCountsMap, requestEntityStatusCountSet, RequestEntityType.ACL);
 
+    // get schema reqs count and update requestsCountOverview
+    Map<String, Map<String, Long>> schemasRequestCountsMap =
+        manageDatabase
+            .getHandleDbRequests()
+            .getSchemaRequestsCounts(
+                commonUtilsService.getTeamId(getUserName()),
+                requestMode,
+                commonUtilsService.getTenantId(getUserName()));
+    updateRequestsCountOverview(
+        schemasRequestCountsMap, requestEntityStatusCountSet, RequestEntityType.SCHEMA);
+
     requestsCountOverview.setRequestEntityStatistics(requestEntityStatusCountSet);
     return requestsCountOverview;
   }

--- a/core/src/main/java/io/aiven/klaw/service/RequestStatisticsService.java
+++ b/core/src/main/java/io/aiven/klaw/service/RequestStatisticsService.java
@@ -29,14 +29,8 @@ public class RequestStatisticsService {
   public RequestsCountOverview getRequestsCountOverview(RequestMode requestMode) {
     RequestsCountOverview requestsCountOverview = new RequestsCountOverview();
     Set<RequestEntityStatusCount> requestEntityStatusCountSet = new HashSet<>();
-    updateRequestsCountOverviewForTopics(requestEntityStatusCountSet, requestMode);
 
-    requestsCountOverview.setRequestEntityStatistics(requestEntityStatusCountSet);
-    return requestsCountOverview;
-  }
-
-  private void updateRequestsCountOverviewForTopics(
-      Set<RequestEntityStatusCount> requestEntityStatusCountSet, RequestMode requestMode) {
+    // get topics count and update requestsCountOverview
     Map<String, Map<String, Long>> topicRequestCountsMap =
         manageDatabase
             .getHandleDbRequests()
@@ -44,6 +38,28 @@ public class RequestStatisticsService {
                 commonUtilsService.getTeamId(getUserName()),
                 requestMode,
                 commonUtilsService.getTenantId(getUserName()));
+    updateRequestsCountOverview(
+        topicRequestCountsMap, requestEntityStatusCountSet, RequestEntityType.TOPIC);
+
+    // get acls count and update requestsCountOverview
+    Map<String, Map<String, Long>> aclsRequestCountsMap =
+        manageDatabase
+            .getHandleDbRequests()
+            .getAclRequestsCounts(
+                commonUtilsService.getTeamId(getUserName()),
+                requestMode,
+                commonUtilsService.getTenantId(getUserName()));
+    updateRequestsCountOverview(
+        aclsRequestCountsMap, requestEntityStatusCountSet, RequestEntityType.ACL);
+
+    requestsCountOverview.setRequestEntityStatistics(requestEntityStatusCountSet);
+    return requestsCountOverview;
+  }
+
+  private void updateRequestsCountOverview(
+      Map<String, Map<String, Long>> topicRequestCountsMap,
+      Set<RequestEntityStatusCount> requestEntityStatusCountSet,
+      RequestEntityType requestEntityType) {
     Map<String, Long> opCounts = topicRequestCountsMap.get("OPERATION_TYPE_COUNTS");
     Map<String, Long> stCounts = topicRequestCountsMap.get("STATUS_COUNTS");
 
@@ -69,7 +85,7 @@ public class RequestStatisticsService {
     }
 
     RequestEntityStatusCount requestEntityTopicStatusCount = new RequestEntityStatusCount();
-    requestEntityTopicStatusCount.setRequestEntityType(RequestEntityType.TOPIC);
+    requestEntityTopicStatusCount.setRequestEntityType(requestEntityType);
     requestEntityTopicStatusCount.setRequestStatusCountSet(requestStatusCountSet);
     requestEntityTopicStatusCount.setRequestsOperationTypeCountSet(requestsOperationTypeCountsSet);
     requestEntityStatusCountSet.add(requestEntityTopicStatusCount);

--- a/core/src/main/java/io/aiven/klaw/service/RequestStatisticsService.java
+++ b/core/src/main/java/io/aiven/klaw/service/RequestStatisticsService.java
@@ -63,6 +63,17 @@ public class RequestStatisticsService {
     updateRequestsCountOverview(
         schemasRequestCountsMap, requestEntityStatusCountSet, RequestEntityType.SCHEMA);
 
+    // get connector reqs count and update requestsCountOverview
+    Map<String, Map<String, Long>> connectorRequestCountsMap =
+        manageDatabase
+            .getHandleDbRequests()
+            .getConnectorRequestsCounts(
+                commonUtilsService.getTeamId(getUserName()),
+                requestMode,
+                commonUtilsService.getTenantId(getUserName()));
+    updateRequestsCountOverview(
+        connectorRequestCountsMap, requestEntityStatusCountSet, RequestEntityType.CONNECTOR);
+
     requestsCountOverview.setRequestEntityStatistics(requestEntityStatusCountSet);
     return requestsCountOverview;
   }

--- a/core/src/test/java/io/aiven/klaw/helpers/db/rdbms/ConnectorRequestsIntegrationTest.java
+++ b/core/src/test/java/io/aiven/klaw/helpers/db/rdbms/ConnectorRequestsIntegrationTest.java
@@ -1,0 +1,203 @@
+package io.aiven.klaw.helpers.db.rdbms;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.aiven.klaw.UtilMethods;
+import io.aiven.klaw.dao.KafkaConnectorRequest;
+import io.aiven.klaw.dao.UserInfo;
+import io.aiven.klaw.model.enums.RequestMode;
+import io.aiven.klaw.model.enums.RequestOperationType;
+import io.aiven.klaw.model.enums.RequestStatus;
+import io.aiven.klaw.repository.KwKafkaConnectorRequestsRepo;
+import io.aiven.klaw.repository.UserInfoRepo;
+import java.util.Map;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+@ExtendWith(SpringExtension.class)
+@DataJpaTest
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+public class ConnectorRequestsIntegrationTest {
+
+  @Autowired private KwKafkaConnectorRequestsRepo kafkaConnectorRequestsRepo;
+  @Autowired private UserInfoRepo userInfoRepo;
+
+  @Autowired TestEntityManager entityManager;
+
+  private SelectDataJdbc selectDataJdbc;
+
+  private UtilMethods utilMethods;
+
+  public void loadData() {
+    generateData(
+        5,
+        101,
+        101,
+        "firsttopic1",
+        "dev",
+        RequestStatus.CREATED,
+        RequestOperationType.CREATE,
+        100); // Team1
+    generateData(
+        3,
+        101,
+        101,
+        "firsttopic2",
+        "dev",
+        RequestStatus.APPROVED,
+        RequestOperationType.CREATE,
+        200); // Team1
+    generateData(
+        7,
+        101,
+        101,
+        "firsttopic3",
+        "dev",
+        RequestStatus.DECLINED,
+        RequestOperationType.CREATE,
+        300); // Team1
+    generateData(
+        2,
+        101,
+        101,
+        "firsttopic4",
+        "dev",
+        RequestStatus.DELETED,
+        RequestOperationType.DELETE,
+        400); // Team1
+    generateData(
+        4,
+        103,
+        101,
+        "firsttopic5",
+        "dev",
+        RequestStatus.CREATED,
+        RequestOperationType.DELETE,
+        500); // Team2
+
+    UserInfo user = new UserInfo();
+    user.setTenantId(101);
+    user.setTeamId(101);
+    user.setRole("USER");
+    user.setUsername("James");
+    UserInfo user2 = new UserInfo();
+    user2.setTenantId(103);
+    user2.setTeamId(103);
+    user2.setRole("USER");
+    user2.setUsername("John");
+    entityManager.persistAndFlush(user);
+    entityManager.persistAndFlush(user2);
+  }
+
+  @BeforeEach
+  public void setUp() {
+    selectDataJdbc = new SelectDataJdbc();
+    utilMethods = new UtilMethods();
+    ReflectionTestUtils.setField(
+        selectDataJdbc, "kafkaConnectorRequestsRepo", kafkaConnectorRequestsRepo);
+    ReflectionTestUtils.setField(selectDataJdbc, "userInfoRepo", userInfoRepo);
+    loadData();
+  }
+
+  @Test
+  @Order(1)
+  public void getConnectorRequestsCountsForMyRequestsTeam1() {
+    Map<String, Map<String, Long>> results =
+        selectDataJdbc.getConnectorRequestsCounts(101, RequestMode.MY_REQUESTS, 101);
+
+    Map<String, Long> statsCount = results.get("STATUS_COUNTS");
+    Map<String, Long> operationTypeCount = results.get("OPERATION_TYPE_COUNTS");
+
+    assertThat(results.size()).isEqualTo(2);
+    assertThat(statsCount.get(RequestStatus.CREATED.value)).isEqualTo(5L);
+    assertThat(statsCount.get(RequestStatus.APPROVED.value)).isEqualTo(3L);
+    assertThat(statsCount.get(RequestStatus.DECLINED.value)).isEqualTo(7L);
+    assertThat(statsCount.get(RequestStatus.DELETED.value)).isEqualTo(2L);
+    assertThat(operationTypeCount.get(RequestOperationType.CREATE.value)).isEqualTo(15L);
+  }
+
+  @Test
+  @Order(2)
+  public void getConnectorRequestsCountsForApproveForTeam1() {
+    Map<String, Map<String, Long>> results =
+        selectDataJdbc.getConnectorRequestsCounts(101, RequestMode.TO_APPROVE, 101);
+
+    Map<String, Long> statsCount = results.get("STATUS_COUNTS");
+    Map<String, Long> operationTypeCount = results.get("OPERATION_TYPE_COUNTS");
+
+    assertThat(results.size()).isEqualTo(2);
+    assertThat(statsCount.get(RequestStatus.CREATED.value)).isEqualTo(5L);
+    assertThat(statsCount.get(RequestStatus.APPROVED.value)).isEqualTo(3L);
+    assertThat(statsCount.get(RequestStatus.DECLINED.value)).isEqualTo(7L);
+    assertThat(statsCount.get(RequestStatus.DELETED.value)).isEqualTo(2L);
+    assertThat(operationTypeCount.get(RequestOperationType.CREATE.value)).isEqualTo(15L);
+  }
+
+  @Test
+  @Order(3)
+  public void getConnectorRequestsCountsForApproveForTeam2() {
+    Map<String, Map<String, Long>> results =
+        selectDataJdbc.getConnectorRequestsCounts(103, RequestMode.TO_APPROVE, 101);
+
+    Map<String, Long> statsCount = results.get("STATUS_COUNTS");
+    Map<String, Long> operationTypeCount = results.get("OPERATION_TYPE_COUNTS");
+
+    assertThat(results.size()).isEqualTo(2);
+    assertThat(statsCount.get(RequestStatus.CREATED.value)).isEqualTo(4L);
+    assertThat(statsCount.get(RequestStatus.APPROVED.value)).isEqualTo(0L);
+    assertThat(statsCount.get(RequestStatus.DECLINED.value)).isEqualTo(0L);
+    assertThat(statsCount.get(RequestStatus.DELETED.value)).isEqualTo(0L);
+    assertThat(operationTypeCount.get(RequestOperationType.CREATE.value)).isEqualTo(0L);
+  }
+
+  @Test
+  @Order(3)
+  public void getConnectorRequestsCountsForMyRequestsForTeam2() {
+    Map<String, Map<String, Long>> results =
+        selectDataJdbc.getConnectorRequestsCounts(103, RequestMode.MY_REQUESTS, 101);
+
+    Map<String, Long> statsCount = results.get("STATUS_COUNTS");
+    Map<String, Long> operationTypeCount = results.get("OPERATION_TYPE_COUNTS");
+
+    assertThat(results.size()).isEqualTo(2);
+    assertThat(statsCount.get(RequestStatus.CREATED.value)).isEqualTo(4L);
+    assertThat(statsCount.get(RequestStatus.APPROVED.value)).isEqualTo(0L);
+    assertThat(statsCount.get(RequestStatus.DECLINED.value)).isEqualTo(0L);
+    assertThat(statsCount.get(RequestStatus.DELETED.value)).isEqualTo(0L);
+    assertThat(operationTypeCount.get(RequestOperationType.CREATE.value)).isEqualTo(0L);
+  }
+
+  private void generateData(
+      int number,
+      int teamId,
+      int tenantId,
+      String topicName,
+      String env,
+      RequestStatus requestStatus,
+      RequestOperationType requestOperationType,
+      int topicIdentifier) {
+
+    for (int i = 0; i < number; i++) {
+      KafkaConnectorRequest connectorRequest = new KafkaConnectorRequest();
+      connectorRequest.setTenantId(tenantId);
+      connectorRequest.setConnectorName(topicName);
+      connectorRequest.setTeamId(teamId);
+      connectorRequest.setEnvironment(env);
+      connectorRequest.setConnectorStatus(requestStatus.value);
+      connectorRequest.setConnectortype(requestOperationType.value);
+      connectorRequest.setConnectorId(topicIdentifier + i);
+      connectorRequest.setConnectorConfig("{config}");
+
+      entityManager.persistAndFlush(connectorRequest);
+    }
+  }
+}

--- a/core/src/test/java/io/aiven/klaw/helpers/db/rdbms/SchemaRequestsIntegrationTest.java
+++ b/core/src/test/java/io/aiven/klaw/helpers/db/rdbms/SchemaRequestsIntegrationTest.java
@@ -1,0 +1,203 @@
+package io.aiven.klaw.helpers.db.rdbms;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.aiven.klaw.UtilMethods;
+import io.aiven.klaw.dao.SchemaRequest;
+import io.aiven.klaw.dao.UserInfo;
+import io.aiven.klaw.model.enums.RequestMode;
+import io.aiven.klaw.model.enums.RequestOperationType;
+import io.aiven.klaw.model.enums.RequestStatus;
+import io.aiven.klaw.repository.SchemaRequestRepo;
+import io.aiven.klaw.repository.UserInfoRepo;
+import java.util.Map;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+@ExtendWith(SpringExtension.class)
+@DataJpaTest
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+public class SchemaRequestsIntegrationTest {
+
+  @Autowired private SchemaRequestRepo schemaRequestRepo;
+  @Autowired private UserInfoRepo userInfoRepo;
+
+  @Autowired TestEntityManager entityManager;
+
+  private SelectDataJdbc selectDataJdbc;
+
+  private UtilMethods utilMethods;
+
+  public void loadData() {
+    generateData(
+        5,
+        101,
+        101,
+        "firsttopic1",
+        "dev",
+        RequestStatus.CREATED,
+        RequestOperationType.CREATE,
+        100); // Team1
+    generateData(
+        3,
+        101,
+        101,
+        "firsttopic2",
+        "dev",
+        RequestStatus.APPROVED,
+        RequestOperationType.CREATE,
+        200); // Team1
+    generateData(
+        7,
+        101,
+        101,
+        "firsttopic3",
+        "dev",
+        RequestStatus.DECLINED,
+        RequestOperationType.CREATE,
+        300); // Team1
+    generateData(
+        2,
+        101,
+        101,
+        "firsttopic4",
+        "dev",
+        RequestStatus.DELETED,
+        RequestOperationType.DELETE,
+        400); // Team1
+    generateData(
+        4,
+        103,
+        101,
+        "firsttopic5",
+        "dev",
+        RequestStatus.CREATED,
+        RequestOperationType.DELETE,
+        500); // Team2
+
+    UserInfo user = new UserInfo();
+    user.setTenantId(101);
+    user.setTeamId(101);
+    user.setRole("USER");
+    user.setUsername("James");
+    UserInfo user2 = new UserInfo();
+    user2.setTenantId(103);
+    user2.setTeamId(103);
+    user2.setRole("USER");
+    user2.setUsername("John");
+    entityManager.persistAndFlush(user);
+    entityManager.persistAndFlush(user2);
+  }
+
+  @BeforeEach
+  public void setUp() {
+    selectDataJdbc = new SelectDataJdbc();
+    utilMethods = new UtilMethods();
+    ReflectionTestUtils.setField(selectDataJdbc, "schemaRequestRepo", schemaRequestRepo);
+    ReflectionTestUtils.setField(selectDataJdbc, "userInfoRepo", userInfoRepo);
+    loadData();
+  }
+
+  @Test
+  @Order(1)
+  public void getSchemaRequestsCountsForMyRequestsTeam1() {
+    Map<String, Map<String, Long>> results =
+        selectDataJdbc.getSchemaRequestsCounts(101, RequestMode.MY_REQUESTS, 101);
+
+    Map<String, Long> statsCount = results.get("STATUS_COUNTS");
+    Map<String, Long> operationTypeCount = results.get("OPERATION_TYPE_COUNTS");
+
+    assertThat(results.size()).isEqualTo(2);
+    assertThat(statsCount.get(RequestStatus.CREATED.value)).isEqualTo(5L);
+    assertThat(statsCount.get(RequestStatus.APPROVED.value)).isEqualTo(3L);
+    assertThat(statsCount.get(RequestStatus.DECLINED.value)).isEqualTo(7L);
+    assertThat(statsCount.get(RequestStatus.DELETED.value)).isEqualTo(2L);
+    assertThat(operationTypeCount.get(RequestOperationType.CREATE.value)).isEqualTo(15L);
+  }
+
+  @Test
+  @Order(2)
+  public void getSchemaRequestsCountsForApproveForTeam1() {
+    Map<String, Map<String, Long>> results =
+        selectDataJdbc.getSchemaRequestsCounts(101, RequestMode.TO_APPROVE, 101);
+
+    Map<String, Long> statsCount = results.get("STATUS_COUNTS");
+    Map<String, Long> operationTypeCount = results.get("OPERATION_TYPE_COUNTS");
+
+    assertThat(results.size()).isEqualTo(2);
+    assertThat(statsCount.get(RequestStatus.CREATED.value)).isEqualTo(5L);
+    assertThat(statsCount.get(RequestStatus.APPROVED.value)).isEqualTo(3L);
+    assertThat(statsCount.get(RequestStatus.DECLINED.value)).isEqualTo(7L);
+    assertThat(statsCount.get(RequestStatus.DELETED.value)).isEqualTo(2L);
+    assertThat(operationTypeCount.get(RequestOperationType.CREATE.value)).isEqualTo(15L);
+  }
+
+  @Test
+  @Order(3)
+  public void getSchemaRequestsCountsForApproveForTeam2() {
+    Map<String, Map<String, Long>> results =
+        selectDataJdbc.getSchemaRequestsCounts(103, RequestMode.TO_APPROVE, 101);
+
+    Map<String, Long> statsCount = results.get("STATUS_COUNTS");
+    Map<String, Long> operationTypeCount = results.get("OPERATION_TYPE_COUNTS");
+
+    assertThat(results.size()).isEqualTo(2);
+    assertThat(statsCount.get(RequestStatus.CREATED.value)).isEqualTo(4L);
+    assertThat(statsCount.get(RequestStatus.APPROVED.value)).isEqualTo(0L);
+    assertThat(statsCount.get(RequestStatus.DECLINED.value)).isEqualTo(0L);
+    assertThat(statsCount.get(RequestStatus.DELETED.value)).isEqualTo(0L);
+    assertThat(operationTypeCount.get(RequestOperationType.CREATE.value)).isEqualTo(0L);
+  }
+
+  @Test
+  @Order(3)
+  public void getSchemaRequestsCountsForMyRequestsForTeam2() {
+    Map<String, Map<String, Long>> results =
+        selectDataJdbc.getSchemaRequestsCounts(103, RequestMode.MY_REQUESTS, 101);
+
+    Map<String, Long> statsCount = results.get("STATUS_COUNTS");
+    Map<String, Long> operationTypeCount = results.get("OPERATION_TYPE_COUNTS");
+
+    assertThat(results.size()).isEqualTo(2);
+    assertThat(statsCount.get(RequestStatus.CREATED.value)).isEqualTo(4L);
+    assertThat(statsCount.get(RequestStatus.APPROVED.value)).isEqualTo(0L);
+    assertThat(statsCount.get(RequestStatus.DECLINED.value)).isEqualTo(0L);
+    assertThat(statsCount.get(RequestStatus.DELETED.value)).isEqualTo(0L);
+    assertThat(operationTypeCount.get(RequestOperationType.CREATE.value)).isEqualTo(0L);
+  }
+
+  private void generateData(
+      int number,
+      int teamId,
+      int tenantId,
+      String topicName,
+      String env,
+      RequestStatus requestStatus,
+      RequestOperationType requestOperationType,
+      int topicIdentifier) {
+
+    for (int i = 0; i < number; i++) {
+      SchemaRequest schemaRequest = new SchemaRequest();
+      schemaRequest.setTenantId(tenantId);
+      schemaRequest.setTeamId(teamId);
+      schemaRequest.setTopicname(topicName + "" + i);
+      schemaRequest.setEnvironment(env);
+      schemaRequest.setTopicstatus(requestStatus.value);
+      schemaRequest.setRequesttype(requestOperationType.value);
+      schemaRequest.setReq_no(topicIdentifier + i);
+      schemaRequest.setSchemafull("{schema}");
+      schemaRequest.setForceRegister(false);
+
+      entityManager.persistAndFlush(schemaRequest);
+    }
+  }
+}

--- a/core/src/test/java/io/aiven/klaw/service/RequestStatisticsServiceTest.java
+++ b/core/src/test/java/io/aiven/klaw/service/RequestStatisticsServiceTest.java
@@ -67,6 +67,8 @@ public class RequestStatisticsServiceTest {
         .thenReturn(utilMethods.getRequestCounts());
     when(handleDbRequests.getAclRequestsCounts(anyInt(), eq(RequestMode.MY_REQUESTS), anyInt()))
         .thenReturn(utilMethods.getRequestCounts());
+    when(handleDbRequests.getSchemaRequestsCounts(anyInt(), eq(RequestMode.MY_REQUESTS), anyInt()))
+            .thenReturn(utilMethods.getRequestCounts());
     RequestsCountOverview requestsCountOverview =
         requestStatisticsService.getRequestsCountOverview(RequestMode.MY_REQUESTS);
     Set<RequestEntityStatusCount> requestEntityStatistics =
@@ -74,15 +76,18 @@ public class RequestStatisticsServiceTest {
     List<RequestEntityStatusCount> requestEntityStatusCountArrayList =
         new ArrayList<>(requestEntityStatistics);
 
-    assertThat(requestEntityStatusCountArrayList).hasSize(2);
+    assertThat(requestEntityStatusCountArrayList).hasSize(3);
 
-    boolean topicEntityFound = false, aclEntityFound = false;
+    boolean topicEntityFound = false, aclEntityFound = false, schemaEntityFound = false;
     for (RequestEntityStatusCount requestEntityStatusCount : requestEntityStatusCountArrayList) {
       if (requestEntityStatusCount.getRequestEntityType() == RequestEntityType.TOPIC) {
         topicEntityFound = true;
       }
       if (requestEntityStatusCount.getRequestEntityType() == RequestEntityType.ACL) {
         aclEntityFound = true;
+      }
+      if (requestEntityStatusCount.getRequestEntityType() == RequestEntityType.SCHEMA) {
+        schemaEntityFound = true;
       }
     }
 
@@ -95,6 +100,11 @@ public class RequestStatisticsServiceTest {
     assertThat(requestEntityStatusCountArrayList.get(1).getRequestStatusCountSet()).hasSize(2);
     assertThat(requestEntityStatusCountArrayList.get(1).getRequestsOperationTypeCountSet())
         .hasSize(2);
+
+    assertThat(schemaEntityFound).isTrue();
+    assertThat(requestEntityStatusCountArrayList.get(2).getRequestStatusCountSet()).hasSize(2);
+    assertThat(requestEntityStatusCountArrayList.get(2).getRequestsOperationTypeCountSet())
+            .hasSize(2);
   }
 
   private void loginMock() {

--- a/core/src/test/java/io/aiven/klaw/service/RequestStatisticsServiceTest.java
+++ b/core/src/test/java/io/aiven/klaw/service/RequestStatisticsServiceTest.java
@@ -65,6 +65,8 @@ public class RequestStatisticsServiceTest {
     when(commonUtilsService.getTenantId(userDetails.getUsername())).thenReturn(1);
     when(handleDbRequests.getTopicRequestsCounts(anyInt(), eq(RequestMode.MY_REQUESTS), anyInt()))
         .thenReturn(utilMethods.getRequestCounts());
+    when(handleDbRequests.getAclRequestsCounts(anyInt(), eq(RequestMode.MY_REQUESTS), anyInt()))
+        .thenReturn(utilMethods.getRequestCounts());
     RequestsCountOverview requestsCountOverview =
         requestStatisticsService.getRequestsCountOverview(RequestMode.MY_REQUESTS);
     Set<RequestEntityStatusCount> requestEntityStatistics =
@@ -72,10 +74,26 @@ public class RequestStatisticsServiceTest {
     List<RequestEntityStatusCount> requestEntityStatusCountArrayList =
         new ArrayList<>(requestEntityStatistics);
 
-    assertThat(requestEntityStatusCountArrayList.get(0).getRequestEntityType())
-        .isEqualTo(RequestEntityType.TOPIC);
+    assertThat(requestEntityStatusCountArrayList).hasSize(2);
+
+    boolean topicEntityFound = false, aclEntityFound = false;
+    for (RequestEntityStatusCount requestEntityStatusCount : requestEntityStatusCountArrayList) {
+      if (requestEntityStatusCount.getRequestEntityType() == RequestEntityType.TOPIC) {
+        topicEntityFound = true;
+      }
+      if (requestEntityStatusCount.getRequestEntityType() == RequestEntityType.ACL) {
+        aclEntityFound = true;
+      }
+    }
+
+    assertThat(topicEntityFound).isTrue();
     assertThat(requestEntityStatusCountArrayList.get(0).getRequestStatusCountSet()).hasSize(2);
     assertThat(requestEntityStatusCountArrayList.get(0).getRequestsOperationTypeCountSet())
+        .hasSize(2);
+
+    assertThat(aclEntityFound).isTrue();
+    assertThat(requestEntityStatusCountArrayList.get(1).getRequestStatusCountSet()).hasSize(2);
+    assertThat(requestEntityStatusCountArrayList.get(1).getRequestsOperationTypeCountSet())
         .hasSize(2);
   }
 

--- a/core/src/test/java/io/aiven/klaw/service/RequestStatisticsServiceTest.java
+++ b/core/src/test/java/io/aiven/klaw/service/RequestStatisticsServiceTest.java
@@ -68,7 +68,10 @@ public class RequestStatisticsServiceTest {
     when(handleDbRequests.getAclRequestsCounts(anyInt(), eq(RequestMode.MY_REQUESTS), anyInt()))
         .thenReturn(utilMethods.getRequestCounts());
     when(handleDbRequests.getSchemaRequestsCounts(anyInt(), eq(RequestMode.MY_REQUESTS), anyInt()))
-            .thenReturn(utilMethods.getRequestCounts());
+        .thenReturn(utilMethods.getRequestCounts());
+    when(handleDbRequests.getConnectorRequestsCounts(
+            anyInt(), eq(RequestMode.MY_REQUESTS), anyInt()))
+        .thenReturn(utilMethods.getRequestCounts());
     RequestsCountOverview requestsCountOverview =
         requestStatisticsService.getRequestsCountOverview(RequestMode.MY_REQUESTS);
     Set<RequestEntityStatusCount> requestEntityStatistics =
@@ -76,9 +79,12 @@ public class RequestStatisticsServiceTest {
     List<RequestEntityStatusCount> requestEntityStatusCountArrayList =
         new ArrayList<>(requestEntityStatistics);
 
-    assertThat(requestEntityStatusCountArrayList).hasSize(3);
+    assertThat(requestEntityStatusCountArrayList).hasSize(4);
 
-    boolean topicEntityFound = false, aclEntityFound = false, schemaEntityFound = false;
+    boolean topicEntityFound = false,
+        aclEntityFound = false,
+        schemaEntityFound = false,
+        connectorEntityFound = false;
     for (RequestEntityStatusCount requestEntityStatusCount : requestEntityStatusCountArrayList) {
       if (requestEntityStatusCount.getRequestEntityType() == RequestEntityType.TOPIC) {
         topicEntityFound = true;
@@ -88,6 +94,9 @@ public class RequestStatisticsServiceTest {
       }
       if (requestEntityStatusCount.getRequestEntityType() == RequestEntityType.SCHEMA) {
         schemaEntityFound = true;
+      }
+      if (requestEntityStatusCount.getRequestEntityType() == RequestEntityType.CONNECTOR) {
+        connectorEntityFound = true;
       }
     }
 
@@ -104,7 +113,12 @@ public class RequestStatisticsServiceTest {
     assertThat(schemaEntityFound).isTrue();
     assertThat(requestEntityStatusCountArrayList.get(2).getRequestStatusCountSet()).hasSize(2);
     assertThat(requestEntityStatusCountArrayList.get(2).getRequestsOperationTypeCountSet())
-            .hasSize(2);
+        .hasSize(2);
+
+    assertThat(connectorEntityFound).isTrue();
+    assertThat(requestEntityStatusCountArrayList.get(3).getRequestStatusCountSet()).hasSize(2);
+    assertThat(requestEntityStatusCountArrayList.get(3).getRequestsOperationTypeCountSet())
+        .hasSize(2);
   }
 
   private void loginMock() {


### PR DESCRIPTION
About this change - What it does

Updates /requests/statistics endpoint with counts of acls, schemas and connectors
filters :
  - status
  - operationtype

Resolves: #575 
Why this way
Its better to monitor the counts of all requests with this one end point.