### PR TITLE
Extend schema for approval api with filter parameters

### DIFF
--- a/core/src/main/java/io/aiven/klaw/controller/SchemaRegstryController.java
+++ b/core/src/main/java/io/aiven/klaw/controller/SchemaRegstryController.java
@@ -33,10 +33,10 @@ public class SchemaRegstryController {
   @Autowired SchemaOverviewService schemaOverviewService;
 
   /**
-   * @param pageNo
-   * @param currentPage
-   * @param requestsType
-   * @return A list of
+   * @param pageNo Which page would you like returned e.g. 1
+   * @param currentPage Which Page are you currently on e.g. 1
+   * @param requestsType What type of requests are you looking for e.g. 'all' 'created' or 'deleted'
+   * @return A list of filtered Schema Requests for My (Teams) Requests page
    */
   @RequestMapping(
       value = "/getSchemaRequests",

--- a/core/src/main/java/io/aiven/klaw/controller/SchemaRegstryController.java
+++ b/core/src/main/java/io/aiven/klaw/controller/SchemaRegstryController.java
@@ -32,6 +32,12 @@ public class SchemaRegstryController {
   @Autowired TopicOverviewService topicOverviewService;
   @Autowired SchemaOverviewService schemaOverviewService;
 
+  /**
+   * @param pageNo
+   * @param currentPage
+   * @param requestsType
+   * @return A list of
+   */
   @RequestMapping(
       value = "/getSchemaRequests",
       method = RequestMethod.GET,
@@ -41,20 +47,34 @@ public class SchemaRegstryController {
       @RequestParam(value = "currentPage", defaultValue = "") String currentPage,
       @RequestParam(value = "requestsType", defaultValue = "all") String requestsType) {
     return new ResponseEntity<>(
-        schemaRegstryControllerService.getSchemaRequests(pageNo, currentPage, requestsType),
+        schemaRegstryControllerService.getSchemaRequests(
+            pageNo, currentPage, requestsType, false, null, null, null),
         HttpStatus.OK);
   }
 
+  /**
+   * @param pageNo Which page would you like returned e.g. 1
+   * @param currentPage Which Page are you currently on e.g. 1
+   * @param requestsType What type of requests are you looking for e.g. 'all' 'created' or 'deleted'
+   * @param topic The name of the topic you would like returned
+   * @param env The name of the environment you would like returned e.g. '1'
+   * @param search A wildcard seearch on the topic name allowing
+   * @return A list of filtered Schema Requests for approval
+   */
   @RequestMapping(
-      value = "/getCreatedSchemaRequests",
+      value = "/getSchemaRequestsForApprover",
       method = RequestMethod.GET,
       produces = {MediaType.APPLICATION_JSON_VALUE})
-  public ResponseEntity<List<SchemaRequestModel>> getCreatedSchemaRequests(
+  public ResponseEntity<List<SchemaRequestModel>> getSchemaRequestsForApprover(
       @RequestParam("pageNo") String pageNo,
       @RequestParam(value = "currentPage", defaultValue = "") String currentPage,
-      @RequestParam(value = "requestsType", defaultValue = "created") String requestsType) {
+      @RequestParam(value = "requestsType", defaultValue = "created") String requestsType,
+      @RequestParam(value = "topic", required = false) String topic,
+      @RequestParam(value = "env", required = false) String env,
+      @RequestParam(value = "search", required = false) String search) {
     return new ResponseEntity<>(
-        schemaRegstryControllerService.getSchemaRequests(pageNo, currentPage, requestsType),
+        schemaRegstryControllerService.getSchemaRequests(
+            pageNo, currentPage, requestsType, true, topic, env, search),
         HttpStatus.OK);
   }
 

--- a/core/src/main/java/io/aiven/klaw/helpers/HandleDbRequests.java
+++ b/core/src/main/java/io/aiven/klaw/helpers/HandleDbRequests.java
@@ -133,9 +133,14 @@ public interface HandleDbRequests {
       AclType aclType,
       int tenantId);
 
-  List<SchemaRequest> getAllSchemaRequests(boolean allReqs, String requestor, int tenantId);
-
-  List<SchemaRequest> getCreatedSchemaRequests(String requestor, int tenantId);
+  List<SchemaRequest> getAllSchemaRequests(
+      boolean allReqs,
+      String requestor,
+      int tenantId,
+      String topic,
+      String env,
+      String status,
+      String search);
 
   SchemaRequest selectSchemaRequest(int avroSchemaId, int tenantId);
 

--- a/core/src/main/java/io/aiven/klaw/helpers/db/rdbms/HandleDbRequestsJdbc.java
+++ b/core/src/main/java/io/aiven/klaw/helpers/db/rdbms/HandleDbRequestsJdbc.java
@@ -272,13 +272,16 @@ public class HandleDbRequestsJdbc implements HandleDbRequests {
   }
 
   @Override
-  public List<SchemaRequest> getAllSchemaRequests(boolean allReqs, String requestor, int tenantId) {
-    return jdbcSelectHelper.selectSchemaRequests(allReqs, requestor, tenantId);
-  }
-
-  @Override
-  public List<SchemaRequest> getCreatedSchemaRequests(String requestor, int tenantId) {
-    return jdbcSelectHelper.selectSchemaRequests(true, requestor, tenantId);
+  public List<SchemaRequest> getAllSchemaRequests(
+      boolean allReqs,
+      String requestor,
+      int tenantId,
+      String topic,
+      String env,
+      String status,
+      String search) {
+    return jdbcSelectHelper.selectFilteredSchemaRequests(
+        allReqs, requestor, tenantId, topic, env, status, search);
   }
 
   @Override

--- a/core/src/main/java/io/aiven/klaw/helpers/db/rdbms/SelectDataJdbc.java
+++ b/core/src/main/java/io/aiven/klaw/helpers/db/rdbms/SelectDataJdbc.java
@@ -243,22 +243,17 @@ public class SelectDataJdbc {
               findSchemaRequestsByExample(
                   topic, env, status != null ? status : "created", tenantId));
 
-      log.info("schema List size {}, allReqs {}", schemaListSub.size(), allReqs);
       // Placed here as it should only apply for approvers.
       schemaListSub =
           schemaListSub.stream()
               .filter(request -> !request.getUsername().equals(requestor))
               .collect(Collectors.toList());
-      log.info(
-          "schema List size Remove requestor requests {}, allReqs {}",
-          schemaListSub.size(),
-          allReqs);
+
       if (wildcardSearch != null && !wildcardSearch.isEmpty()) {
         schemaListSub =
             schemaListSub.stream()
-                .filter(request -> !request.getTopicname().contains(wildcardSearch))
+                .filter(request -> request.getTopicname().contains(wildcardSearch))
                 .collect(Collectors.toList());
-        log.info("schema List size wildcardsearch {}, allReqs {}", schemaListSub.size(), allReqs);
       }
 
     } else {

--- a/core/src/main/java/io/aiven/klaw/helpers/db/rdbms/SelectDataJdbc.java
+++ b/core/src/main/java/io/aiven/klaw/helpers/db/rdbms/SelectDataJdbc.java
@@ -274,7 +274,7 @@ public class SelectDataJdbc {
         schemaList.add(row);
       }
     }
-    log.info("schema List size on return {}, allReqs {}", schemaListSub.size(), allReqs);
+
     return schemaList;
   }
 

--- a/core/src/main/java/io/aiven/klaw/repository/SchemaRequestRepo.java
+++ b/core/src/main/java/io/aiven/klaw/repository/SchemaRequestRepo.java
@@ -7,8 +7,10 @@ import java.util.Optional;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.CrudRepository;
 import org.springframework.data.repository.query.Param;
+import org.springframework.data.repository.query.QueryByExampleExecutor;
 
-public interface SchemaRequestRepo extends CrudRepository<SchemaRequest, SchemaRequestID> {
+public interface SchemaRequestRepo
+    extends CrudRepository<SchemaRequest, SchemaRequestID>, QueryByExampleExecutor<SchemaRequest> {
   Optional<SchemaRequest> findById(SchemaRequestID schemaRequestId);
 
   List<SchemaRequest> findAllByTopicstatusAndTenantId(String topicStatus, int tenantId);

--- a/core/src/main/java/io/aiven/klaw/service/SchemaRegstryControllerService.java
+++ b/core/src/main/java/io/aiven/klaw/service/SchemaRegstryControllerService.java
@@ -25,7 +25,6 @@ import java.io.IOException;
 import java.util.*;
 import java.util.stream.Collectors;
 import lombok.extern.slf4j.Slf4j;
-import org.apache.commons.lang3.EnumUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -52,12 +51,20 @@ public class SchemaRegstryControllerService {
   }
 
   public List<SchemaRequestModel> getSchemaRequests(
-      String pageNo, String currentPage, String requestsType) {
+      String pageNo,
+      String currentPage,
+      String requestsType,
+      boolean isApproval,
+      String topic,
+      String env,
+      String search) {
     log.debug("getSchemaRequests page {} requestsType {}", pageNo, requestsType);
     String userName = getUserName();
     int tenantId = commonUtilsService.getTenantId(userName);
     List<SchemaRequest> schemaReqs =
-        manageDatabase.getHandleDbRequests().getAllSchemaRequests(false, userName, tenantId);
+        manageDatabase
+            .getHandleDbRequests()
+            .getAllSchemaRequests(isApproval, userName, tenantId, topic, env, requestsType, search);
 
     // tenant filtering
     final Set<String> allowedEnvIdSet = commonUtilsService.getEnvsFromUserId(userName);
@@ -66,18 +73,6 @@ public class SchemaRegstryControllerService {
           schemaReqs.stream()
               .filter(request -> allowedEnvIdSet.contains(request.getEnvironment()))
               .collect(Collectors.toList());
-    }
-
-    // request status filtering
-    if (!"all".equals(requestsType)
-        && EnumUtils.isValidEnumIgnoreCase(RequestStatus.class, requestsType)) {
-      if (schemaReqs != null) {
-        schemaReqs =
-            schemaReqs.stream()
-                .filter(
-                    schemaRequest -> Objects.equals(schemaRequest.getTopicstatus(), requestsType))
-                .collect(Collectors.toList());
-      }
     }
 
     Integer userTeamId = commonUtilsService.getTeamId(userName);
@@ -393,7 +388,9 @@ public class SchemaRegstryControllerService {
     }
 
     List<SchemaRequest> schemaReqs =
-        manageDatabase.getHandleDbRequests().getAllSchemaRequests(false, userDetails, tenantId);
+        manageDatabase
+            .getHandleDbRequests()
+            .getAllSchemaRequests(false, userDetails, tenantId, null, null, null, null);
 
     // tenant filtering
     final Set<String> allowedEnvIdSet = commonUtilsService.getEnvsFromUserId(getUserName());

--- a/core/src/main/java/io/aiven/klaw/service/UtilControllerService.java
+++ b/core/src/main/java/io/aiven/klaw/service/UtilControllerService.java
@@ -120,7 +120,8 @@ public class UtilControllerService {
         getPrincipal(), PermissionType.REQUEST_CREATE_SUBSCRIPTIONS)) {
       roleToSet = "requestor_subscriptions";
     }
-    List<SchemaRequest> allSchemaReqs = reqsHandle.getAllSchemaRequests(true, requestor, tenantId);
+    List<SchemaRequest> allSchemaReqs =
+        reqsHandle.getAllSchemaRequests(true, requestor, tenantId, null, null, null, null);
 
     List<AclRequests> allAclReqs;
     List<TopicRequest> allTopicReqs;

--- a/core/src/main/resources/static/js/execSchemas.js
+++ b/core/src/main/resources/static/js/execSchemas.js
@@ -78,7 +78,7 @@ app.controller("execSchemasCtrl", function($scope, $http, $location, $window) {
 
             $http({
                 method: "GET",
-                url: "getCreatedSchemaRequests",
+                url: "getSchemaRequestsForApprover",
                 headers : { 'Content-Type' : 'application/json' },
                 params: {'pageNo' : pageNoSelected,
                  'currentPage' : $scope.currentPageSelected,

--- a/core/src/main/resources/swagger_spec.json
+++ b/core/src/main/resources/swagger_spec.json
@@ -1507,40 +1507,6 @@
         }
       }
     },
-    "/getCreatedSchemaRequests" : {
-      "get" : {
-        "operationId" : "getCreatedSchemaRequests",
-        "produces" : [ "application/json" ],
-        "parameters" : [ {
-          "name" : "pageNo",
-          "in" : "query",
-          "required" : true,
-          "type" : "string"
-        }, {
-          "name" : "currentPage",
-          "in" : "query",
-          "required" : false,
-          "type" : "string"
-        }, {
-          "name" : "requestsType",
-          "in" : "query",
-          "required" : false,
-          "type" : "string",
-          "default" : "created"
-        } ],
-        "responses" : {
-          "200" : {
-            "description" : "successful operation",
-            "schema" : {
-              "type" : "array",
-              "items" : {
-                "$ref" : "#/definitions/SchemaRequestModel"
-              }
-            }
-          }
-        }
-      }
-    },
     "/getDashboardStats" : {
       "get" : {
         "operationId" : "getDashboardStats",
@@ -2013,6 +1979,55 @@
           "required" : false,
           "type" : "string",
           "default" : "all"
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "schema" : {
+              "type" : "array",
+              "items" : {
+                "$ref" : "#/definitions/SchemaRequestModel"
+              }
+            }
+          }
+        }
+      }
+    },
+    "/getSchemaRequestsForApprover" : {
+      "get" : {
+        "operationId" : "getSchemaRequestsForApprover",
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "pageNo",
+          "in" : "query",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "currentPage",
+          "in" : "query",
+          "required" : false,
+          "type" : "string"
+        }, {
+          "name" : "requestsType",
+          "in" : "query",
+          "required" : false,
+          "type" : "string",
+          "default" : "created"
+        }, {
+          "name" : "topic",
+          "in" : "query",
+          "required" : false,
+          "type" : "string"
+        }, {
+          "name" : "env",
+          "in" : "query",
+          "required" : false,
+          "type" : "string"
+        }, {
+          "name" : "search",
+          "in" : "query",
+          "required" : false,
+          "type" : "string"
         } ],
         "responses" : {
           "200" : {

--- a/core/src/test/java/io/aiven/klaw/controller/SchemaRegstryControllerTest.java
+++ b/core/src/test/java/io/aiven/klaw/controller/SchemaRegstryControllerTest.java
@@ -2,7 +2,9 @@ package io.aiven.klaw.controller;
 
 import static org.hamcrest.Matchers.*;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
@@ -55,7 +57,8 @@ public class SchemaRegstryControllerTest {
   public void getSchemaRequests() throws Exception {
     List<SchemaRequestModel> schRequests = utilMethods.getSchemaRequests();
 
-    when(schemaRegstryControllerService.getSchemaRequests(anyString(), anyString(), anyString()))
+    when(schemaRegstryControllerService.getSchemaRequests(
+            anyString(), anyString(), anyString(), anyBoolean(), eq(null), eq(null), eq(null)))
         .thenReturn(schRequests);
 
     mvc.perform(

--- a/core/src/test/java/io/aiven/klaw/helpers/db/rdbms/SelectDataJdbcTest.java
+++ b/core/src/test/java/io/aiven/klaw/helpers/db/rdbms/SelectDataJdbcTest.java
@@ -109,7 +109,8 @@ public class SelectDataJdbcTest {
     when(userInfoRepo.findByUsernameIgnoreCase(requestor))
         .thenReturn(java.util.Optional.of(userInfo));
 
-    List<SchemaRequest> schemaRequestsActual = selectData.selectSchemaRequests(false, requestor, 1);
+    List<SchemaRequest> schemaRequestsActual =
+        selectData.selectFilteredSchemaRequests(false, requestor, 1, null, null, null, null);
     assertThat(schemaRequestsActual).isEmpty();
   }
 

--- a/core/src/test/java/io/aiven/klaw/service/SchemaRegistryControllerServiceTest.java
+++ b/core/src/test/java/io/aiven/klaw/service/SchemaRegistryControllerServiceTest.java
@@ -117,7 +117,8 @@ public class SchemaRegistryControllerServiceTest {
   public void getSchemaRequests() {
     stubUserInfo();
     when(commonUtilsService.getTenantId(anyString())).thenReturn(101);
-    when(handleDbRequests.getAllSchemaRequests(anyBoolean(), anyString(), anyInt()))
+    when(handleDbRequests.getAllSchemaRequests(
+            anyBoolean(), anyString(), anyInt(), eq(null), eq(null), eq("all"), eq(null)))
         .thenReturn(getSchemasReqs());
     when(rolesPermissionsControllerService.getApproverRoles(anyString(), anyInt()))
         .thenReturn(List.of(""));
@@ -130,7 +131,7 @@ public class SchemaRegistryControllerServiceTest {
     when(manageDatabase.getTeamNameFromTeamId(anyInt(), anyInt())).thenReturn("teamname");
 
     List<SchemaRequestModel> listReqs =
-        schemaRegstryControllerService.getSchemaRequests("1", "", "all");
+        schemaRegstryControllerService.getSchemaRequests("1", "", "all", true, null, null, null);
     assertThat(listReqs).hasSize(2);
   }
 


### PR DESCRIPTION
About this change - What it does
This change adds topic, env and search parameters available on the GetCreatedSchemaRequests API.
It also renames the API to getSchemaRequestsForApproval to match other Approval endpoints.

Resolves: #586 
Why this way
This supports the React UI and its new design to allow filtering and pagination.
It also updates the requests to follow the same pattern as previously updated requests to make them consistent and uniform in their implementation.