### PR TITLE
Topic promotion flow change

### DIFF
--- a/core/src/main/java/io/aiven/klaw/config/ManageDatabase.java
+++ b/core/src/main/java/io/aiven/klaw/config/ManageDatabase.java
@@ -618,7 +618,6 @@ public class ManageDatabase implements ApplicationContextAware, InitializingBean
 
   private void loadRequestTypeStatuses() {
     reqStatusList = new ArrayList<>();
-    reqStatusList.add("all");
     for (RequestStatus requestStatus : RequestStatus.values()) {
       reqStatusList.add(requestStatus.value);
     }

--- a/core/src/main/java/io/aiven/klaw/model/enums/RequestOperationType.java
+++ b/core/src/main/java/io/aiven/klaw/model/enums/RequestOperationType.java
@@ -7,6 +7,7 @@ import org.checkerframework.checker.nullness.qual.Nullable;
 public enum RequestOperationType {
   CREATE("Create"),
   UPDATE("Update"),
+  PROMOTE("Promote"),
   CLAIM("Claim"),
   DELETE("Delete");
 

--- a/core/src/main/java/io/aiven/klaw/service/ClusterApiService.java
+++ b/core/src/main/java/io/aiven/klaw/service/ClusterApiService.java
@@ -427,7 +427,8 @@ public class ClusterApiService {
               .build();
 
       String uri;
-      if (RequestOperationType.CREATE.value.equals(topicRequestType)) {
+      if (RequestOperationType.CREATE.value.equals(topicRequestType)
+          || RequestOperationType.PROMOTE.value.equals(topicRequestType)) {
         uri = clusterConnUrl + URI_CREATE_TOPICS;
         clusterTopicRequest =
             clusterTopicRequest.toBuilder()

--- a/core/src/main/java/io/aiven/klaw/validation/TopicRequestValidatorImpl.java
+++ b/core/src/main/java/io/aiven/klaw/validation/TopicRequestValidatorImpl.java
@@ -44,11 +44,12 @@ public class TopicRequestValidatorImpl
     }
 
     if (permissionType.equals(PermissionType.REQUEST_CREATE_TOPICS)) {
-      // Verify if topic request type is Create
-      if (!RequestOperationType.CREATE.value.equals(topicRequestModel.getTopictype())) {
+      // Verify if topic request type is Create/Promote
+      if (!RequestOperationType.CREATE.value.equals(topicRequestModel.getTopictype())
+          && !RequestOperationType.PROMOTE.value.equals(topicRequestModel.getTopictype())) {
         updateConstraint(
             constraintValidatorContext,
-            "Failure. Invalid Topic request type. Possible Value : Create");
+            "Failure. Invalid Topic request type. Possible Value : Create/Promote");
         return false;
       }
     } else if (permissionType.equals(PermissionType.REQUEST_EDIT_TOPICS)) {
@@ -64,9 +65,8 @@ public class TopicRequestValidatorImpl
     }
 
     // tenant filtering
-    if (!commonUtilsService
-        .getEnvsFromUserId(userName)
-        .contains(topicRequestModel.getEnvironment())) {
+    if (!commonUtilsService.getEnvsFromUserId(userName).contains(topicRequestModel.getEnvironment())
+        && !RequestOperationType.PROMOTE.value.equals(topicRequestModel.getTopictype())) {
       updateConstraint(
           constraintValidatorContext,
           "Failure. Not authorized to request topic for this environment.");

--- a/core/src/main/resources/static/js/modifyEnvs.js
+++ b/core/src/main/resources/static/js/modifyEnvs.js
@@ -489,14 +489,14 @@ app.controller("modifyEnvsCtrl", function($scope, $http, $location, $window) {
                     return;
                 }
 
-                if($scope.envDetails.defaultPartitions > $scope.envDetails.maxPartitions){
+                if(parseInt($scope.envDetails.defaultPartitions) > parseInt($scope.envDetails.maxPartitions)){
                     $scope.alertnote = "Default partitions should be less than Maximum partitions";
                     $scope.showAlertToast();
                     return;
                 }
 
                 // Replication factor validation
-                if($scope.envDetails.defaultReplicationFactor.length<=0 || $scope.envDetails.defaultReplicationFactor<=0)
+                if(parseInt($scope.envDetails.defaultReplicationFactor.length) <= 0 || parseInt($scope.envDetails.defaultReplicationFactor) <= 0)
                 {
                     $scope.alertnote = "Default replication factor should not be empty and should be greater than 0";
                     $scope.showAlertToast();

--- a/core/src/main/resources/swagger_spec.json
+++ b/core/src/main/resources/swagger_spec.json
@@ -3668,10 +3668,10 @@
         "titleForReport" : {
           "type" : "string"
         },
-        "yaxisLabel" : {
+        "xaxisLabel" : {
           "type" : "string"
         },
-        "xaxisLabel" : {
+        "yaxisLabel" : {
           "type" : "string"
         }
       }
@@ -4208,7 +4208,7 @@
       "properties" : {
         "requestOperationType" : {
           "type" : "string",
-          "enum" : [ "CREATE", "UPDATE", "CLAIM", "DELETE" ]
+          "enum" : [ "CREATE", "UPDATE", "PROMOTE", "CLAIM", "DELETE" ]
         },
         "count" : {
           "type" : "integer",

--- a/core/src/main/resources/templates/browseAcls.html
+++ b/core/src/main/resources/templates/browseAcls.html
@@ -493,7 +493,7 @@
 										<td width="5%"></td>
 										<td align="right" width="10%">
 											<div class="p-2" style="width:5%">
-												<a href="requestTopics?topicname={{topicSelectedParam}}&env={{resultB.clusterId}}">
+												<a href="requestTopics?topicname={{topicSelectedParam}}&env={{resultB.clusterId}}&requestType=edit">
 													<button ng-show="resultB.showEditTopic == true"
 															type="button" class="btn btn-sm btn-outline-secondary btn-circle"><i class="fas fa-edit"></i>
 													</button>
@@ -543,18 +543,13 @@
 										</td>
 										<td width="5%"></td>
 										<td width="20%" align="right">
-												<button ng-show="topicPromotionDetails.status =='success' && firstPromote == 'false'"
-														type="button"
-														ng-click="onFirstPromote(topicPromotionDetails.targetEnvId)"
-														class="btn btn-rounded btn-block btn-outline-info">
-													Promote to {{topicPromotionDetails.targetEnv}}
-												</button>
-												<button ng-show="topicPromotionDetails.status =='success' && firstPromote == 'true'"
-														type="button"
-														ng-click="onFinalPromote(topicPromotionDetails.targetEnvId)"
-														class="btn btn-rounded btn-block btn-outline-info">
-													Submit Promotion to {{topicPromotionDetails.targetEnv}}
-												</button>
+												<a href="requestTopics?topicname={{topicSelectedParam}}&env={{topicPromotionDetails.targetEnvId}}&envName={{topicPromotionDetails.targetEnv}}&requestType=promote">
+													<button ng-show="topicPromotionDetails.status =='success' && firstPromote == 'false'"
+																type="button"
+																class="btn btn-rounded btn-block btn-outline-info">
+															Promote to {{topicPromotionDetails.targetEnv}}
+													</button>
+												</a>
 										</td>
 									</tr>
 								</table>

--- a/core/src/main/resources/templates/execTopics.html
+++ b/core/src/main/resources/templates/execTopics.html
@@ -533,6 +533,10 @@
 											<h6 class="text-primary">Request Type</h6><b>
 											<span class="badge badge-info">{{ topicRequest.topictype }} Topic</span></b>
 										</div>
+										<div ng-show="topicRequest.topictype == 'Promote'" class="p-2 border-right" style="width:15%">
+											<h6 class="text-primary">Request Type</h6><b>
+											<span class="badge badge-info">{{ topicRequest.topictype }} Topic</span></b>
+										</div>
 										<div ng-show="topicRequest.topictype == 'Update'" class="p-2 border-right" style="width:15%">
 											<h6 class="text-primary">Request Type</h6><b>
 											<span class="badge badge-primary">{{ topicRequest.topictype }} Topic</span></b>

--- a/core/src/main/resources/templates/myTopicRequests.html
+++ b/core/src/main/resources/templates/myTopicRequests.html
@@ -516,6 +516,10 @@
 										<h6 class="text-primary">Request Type</h6><b>
 										<span class="badge badge-info">{{ topicRequest.topictype }} Topic</span></b>
 									</div>
+									<div ng-show="topicRequest.topictype == 'Promote'" class="p-2 border-right" style="width:12%">
+										<h6 class="text-primary">Request Type</h6><b>
+										<span class="badge badge-info">{{ topicRequest.topictype }} Topic</span></b>
+									</div>
 									<div ng-show="topicRequest.topictype == 'Update'" class="p-2 border-right" style="width:12%">
 										<h6 class="text-primary">Request Type</h6><b>
 										<span class="badge badge-primary">{{ topicRequest.topictype }} Topic</span></b>

--- a/core/src/main/resources/templates/requestTopics.html
+++ b/core/src/main/resources/templates/requestTopics.html
@@ -479,6 +479,9 @@
 													<option value="" selected="selected">
 														Select Environment</option>
 												</select>
+
+												<input disabled ng-show="requestType == 'PromoteTopic'"  name="addTopic.envName"
+													   type="text" value="{{addTopic.envNameToDisplay}}" class="form-control">
 											</div>
 										</div>
 										<!--/span-->
@@ -486,7 +489,7 @@
 											<div class="form-group">
 												<label>Topic name</label>
 												<input ng-show="requestType == 'CreateTopic'" type="text" class="form-control" ng-model="addTopic.topicname" required>
-												<input ng-show="requestType == 'EditTopic'" disabled type="text" class="form-control" ng-model="addTopic.topicname" required>
+												<input ng-show="requestType == 'EditTopic' || requestType == 'PromoteTopic'" disabled type="text" class="form-control" ng-model="addTopic.topicname" required>
 												<small ng-show="topicPrefix != null && topicPrefix != ''" class="form-control-feedback">Ex: <b>{{topicPrefix}}</b>mortgagetopic  (With prefix)</small>
 												<small ng-show="topicSuffix != null && topicSuffix != ''" class="form-control-feedback">Ex: mortgagetopic<b>{{topicSuffix}}</b>  (With suffix)</small>
 												<small ng-show="(topicPrefix == null || topicPrefix == '') && (topicSuffix == null || topicSuffix == '')" class="form-control-feedback">Ex: mortgagetopic </small>
@@ -573,7 +576,7 @@
 
 											</div>
 										</div>
-										<div class="col-md-6">
+										<div class="col-md-6" ng-show="requestType == 'CreateTopic'">
 											<div class="form-group">
 												<label class="control-label">Topic Description</label>
 												<input class="form-control" maxlength="75" placeholder="This topic is for .."

--- a/core/src/test/java/io/aiven/klaw/TopicRequestValidatorImplIT.java
+++ b/core/src/test/java/io/aiven/klaw/TopicRequestValidatorImplIT.java
@@ -14,6 +14,7 @@ import io.aiven.klaw.model.TopicCreateRequestModel;
 import io.aiven.klaw.model.TopicUpdateRequestModel;
 import io.aiven.klaw.model.enums.ApiResultStatus;
 import io.aiven.klaw.model.enums.PermissionType;
+import io.aiven.klaw.model.enums.RequestOperationType;
 import io.aiven.klaw.service.CommonUtilsService;
 import io.aiven.klaw.service.MailUtils;
 import io.aiven.klaw.service.TopicControllerService;
@@ -167,6 +168,7 @@ public class TopicRequestValidatorImplIT {
     Env env = utilMethods.getEnvLists().get(0);
 
     TopicCreateRequestModel addTopicRequest = utilMethods.getTopicCreateRequestModel(1001);
+    addTopicRequest.setTopictype(RequestOperationType.PROMOTE.value);
     addTopicRequest.setEnvironment("2");
     when(commonUtilsService.isNotAuthorizedUser(any(), any())).thenReturn(false);
     when(topicControllerService.getUserName()).thenReturn("superadmin");

--- a/core/src/test/java/io/aiven/klaw/helpers/db/rdbms/TopicRequestsIntegrationTest.java
+++ b/core/src/test/java/io/aiven/klaw/helpers/db/rdbms/TopicRequestsIntegrationTest.java
@@ -55,6 +55,16 @@ public class TopicRequestsIntegrationTest {
         100,
         null); // Team1
     generateData(
+        8,
+        101,
+        101,
+        "firsttopic1",
+        "dev",
+        RequestStatus.CREATED,
+        RequestOperationType.PROMOTE,
+        150,
+        null); // Team1
+    generateData(
         3,
         101,
         101,
@@ -234,12 +244,13 @@ public class TopicRequestsIntegrationTest {
     Map<String, Long> operationTypeCount = results.get("OPERATION_TYPE_COUNTS");
 
     assertThat(results.size()).isEqualTo(2);
-    assertThat(statsCount.get(RequestStatus.CREATED.value)).isEqualTo(5L);
-    assertThat(operationTypeCount.get(RequestOperationType.CREATE.value)).isEqualTo(8L);
-    assertThat(operationTypeCount.get(RequestOperationType.CLAIM.value)).isEqualTo(7L);
+    assertThat(statsCount.get(RequestStatus.CREATED.value)).isEqualTo(13L);
     assertThat(statsCount.get(RequestStatus.APPROVED.value)).isEqualTo(3L);
     assertThat(statsCount.get(RequestStatus.DECLINED.value)).isEqualTo(17L);
     assertThat(statsCount.get(RequestStatus.DELETED.value)).isEqualTo(2L);
+    assertThat(operationTypeCount.get(RequestOperationType.CREATE.value)).isEqualTo(8L);
+    assertThat(operationTypeCount.get(RequestOperationType.PROMOTE.value)).isEqualTo(8L);
+    assertThat(operationTypeCount.get(RequestOperationType.CLAIM.value)).isEqualTo(7L);
     assertThat(operationTypeCount.get(RequestOperationType.UPDATE.value)).isEqualTo(2L);
   }
 
@@ -253,7 +264,7 @@ public class TopicRequestsIntegrationTest {
     Map<String, Long> operationTypeCount = results.get("OPERATION_TYPE_COUNTS");
 
     assertThat(results.size()).isEqualTo(2);
-    assertThat(statsCount.get(RequestStatus.CREATED.value)).isEqualTo(5L);
+    assertThat(statsCount.get(RequestStatus.CREATED.value)).isEqualTo(13L);
     assertThat(operationTypeCount.get(RequestOperationType.CREATE.value)).isEqualTo(8L);
     assertThat(operationTypeCount.get(RequestOperationType.CLAIM.value)).isEqualTo(4L);
     assertThat(statsCount.get(RequestStatus.APPROVED.value)).isEqualTo(3L);
@@ -345,14 +356,14 @@ public class TopicRequestsIntegrationTest {
         selectDataJdbc.getFilteredTopicRequests(
             true, "James", "ALL", true, 101, null, null, "topic");
 
-    assertThat(james.size()).isEqualTo(14);
+    assertThat(james.size()).isEqualTo(22);
     for (TopicRequest req : james) {
       assertThat(req.getTenantId()).isEqualTo(101);
     }
 
     assertThat(john.size()).isEqualTo(10);
 
-    assertThat(all.size()).isEqualTo(24);
+    assertThat(all.size()).isEqualTo(32);
   }
 
   @Test
@@ -382,7 +393,7 @@ public class TopicRequestsIntegrationTest {
         selectDataJdbc.getFilteredTopicRequests(
             true, "John", "ALL", true, 103, Integer.valueOf(103), null, null);
 
-    assertThat(james.size()).isEqualTo(24);
+    assertThat(james.size()).isEqualTo(32);
     for (TopicRequest req : james) {
       assertThat(req.getTenantId()).isEqualTo(101);
       if (!req.getTopictype().equals(RequestOperationType.CLAIM.value)) {
@@ -419,7 +430,7 @@ public class TopicRequestsIntegrationTest {
     List<TopicRequest> tenant2 =
         selectDataJdbc.getFilteredTopicRequests(false, "John", null, true, 103, null, null, null);
 
-    assertThat(tenant1.size()).isEqualTo(31);
+    assertThat(tenant1.size()).isEqualTo(39);
     for (TopicRequest req : tenant1) {
       assertThat(req.getTenantId()).isEqualTo(101);
     }
@@ -442,7 +453,7 @@ public class TopicRequestsIntegrationTest {
         selectDataJdbc.getFilteredTopicRequests(
             false, "John", "declined", true, 103, null, "test", null);
 
-    assertThat(tenant1.size()).isEqualTo(31);
+    assertThat(tenant1.size()).isEqualTo(39);
     for (TopicRequest req : tenant1) {
       assertThat(req.getTenantId()).isEqualTo(101);
     }
@@ -465,7 +476,7 @@ public class TopicRequestsIntegrationTest {
         selectDataJdbc.getFilteredTopicRequests(
             false, "John", "created", true, 103, null, null, "two");
 
-    assertThat(tenant1.size()).isEqualTo(31);
+    assertThat(tenant1.size()).isEqualTo(39);
 
     assertThat(tenant2.size()).isEqualTo(1);
   }
@@ -504,7 +515,7 @@ public class TopicRequestsIntegrationTest {
     List<TopicRequest> john =
         selectDataJdbc.getFilteredTopicRequests(true, "John", null, true, 103, null, null, null);
 
-    assertThat(james.size()).isEqualTo(24);
+    assertThat(james.size()).isEqualTo(32);
     for (TopicRequest req : james) {
       assertThat(req.getTenantId()).isEqualTo(101);
     }
@@ -525,7 +536,7 @@ public class TopicRequestsIntegrationTest {
         selectDataJdbc.getFilteredTopicRequests(
             true, "John", "declined", true, 103, null, "test", null);
 
-    assertThat(james.size()).isEqualTo(9);
+    assertThat(james.size()).isEqualTo(17);
     for (TopicRequest req : james) {
       assertThat(req.getTopicstatus()).isEqualTo("created");
       assertThat(req.getTenantId()).isEqualTo(101);
@@ -552,7 +563,7 @@ public class TopicRequestsIntegrationTest {
         selectDataJdbc.getFilteredTopicRequests(
             false, "Jackie", "all", true, 101, null, null, null);
 
-    assertThat(jackie.size()).isEqualTo(31);
+    assertThat(jackie.size()).isEqualTo(39);
   }
 
   @Test
@@ -595,7 +606,7 @@ public class TopicRequestsIntegrationTest {
         selectDataJdbc.getFilteredTopicRequests(
             true, "James", RequestStatus.ALL.value, true, 101, null, null, null);
 
-    assertThat(resultSet.size()).isEqualTo(24);
+    assertThat(resultSet.size()).isEqualTo(32);
     for (TopicRequest req : resultSet) {
       assertThat(req.getTenantId()).isEqualTo(101);
       assertThat(req.getUsername()).isNotEqualTo("James");
@@ -616,7 +627,7 @@ public class TopicRequestsIntegrationTest {
         selectDataJdbc.getFilteredTopicRequests(
             false, "James", RequestStatus.ALL.value, false, 101, null, null, null);
 
-    assertThat(resultSet.size()).isEqualTo(27);
+    assertThat(resultSet.size()).isEqualTo(35);
     for (TopicRequest req : resultSet) {
       assertThat(req.getTenantId()).isEqualTo(101);
       assertThat(req.getUsername()).isNotEqualTo("James");
@@ -634,7 +645,7 @@ public class TopicRequestsIntegrationTest {
         selectDataJdbc.getFilteredTopicRequests(
             true, "John", RequestStatus.ALL.value, true, 101, null, null, null);
 
-    assertThat(resultSet.size()).isEqualTo(27);
+    assertThat(resultSet.size()).isEqualTo(35);
     for (TopicRequest req : resultSet) {
       assertThat(req.getTenantId()).isEqualTo(101);
       assertThat(req.getUsername()).isNotEqualTo("James");


### PR DESCRIPTION
Signed-off-by: muralibasani <muralidahr.basani@aiven.io>

About this change - What it does

- With this change to topic promotion flow, user is routed to normal topic request flow, with non editable field for env and topic name
- New operation type introduced - 'Promote'
- Update my requests page and approve requests page to display this new type
- for cluster api, its still a create topic, so updated condition
- Validations updated to handle this request type

Resolves: #532
Why this way

It is more visible for users, and can clearly distinguish between create and promote request types
