### PR TITLE
Adds parameter options for endpoint and rename the ednpoint

### DIFF
--- a/core/src/main/java/io/aiven/klaw/controller/KafkaConnectController.java
+++ b/core/src/main/java/io/aiven/klaw/controller/KafkaConnectController.java
@@ -35,20 +35,27 @@ public class KafkaConnectController {
         kafkaConnectControllerService.createConnectorRequest(addTopicRequest), HttpStatus.OK);
   }
 
-  /*
-     For executing connector requests
-  */
+  /**
+   * @param pageNo Which page would you like returned e.g. 1
+   * @param currentPage Which Page are you currently on e.g. 1
+   * @param requestsType What type of requests are you looking for e.g. 'created' or 'deleted'
+   * @param env The name of the environment you would like returned e.g. '1' or '4'
+   * @param search A wildcard search term that searches topicNames.
+   * @return A List of Kafka Connector Requests filtered by the provided parameters.
+   */
   @RequestMapping(
-      value = "/getCreatedConnectorRequests",
+      value = "/getConnectorRequestsForApproval",
       method = RequestMethod.GET,
       produces = {MediaType.APPLICATION_JSON_VALUE})
   public ResponseEntity<List<KafkaConnectorRequestModel>> getCreatedConnectorRequests(
       @RequestParam("pageNo") String pageNo,
       @RequestParam(value = "currentPage", defaultValue = "") String currentPage,
-      @RequestParam(value = "requestsType", defaultValue = "created") String requestsType) {
+      @RequestParam(value = "requestsType", defaultValue = "created") String requestsType,
+      @RequestParam(value = "env", required = false) String env,
+      @RequestParam(value = "search", required = false) String search) {
     return new ResponseEntity<>(
         kafkaConnectControllerService.getCreatedConnectorRequests(
-            pageNo, currentPage, requestsType),
+            pageNo, currentPage, requestsType, env, search),
         HttpStatus.OK);
   }
 

--- a/core/src/main/java/io/aiven/klaw/helpers/HandleDbRequests.java
+++ b/core/src/main/java/io/aiven/klaw/helpers/HandleDbRequests.java
@@ -87,7 +87,12 @@ public interface HandleDbRequests {
   List<KafkaConnectorRequest> getAllConnectorRequests(String requestor, int tenantId);
 
   List<KafkaConnectorRequest> getCreatedConnectorRequests(
-      String requestor, String status, boolean showRequestsOfAllTeams, int tenantId);
+      String requestor,
+      String status,
+      boolean showRequestsOfAllTeams,
+      int tenantId,
+      String env,
+      String search);
 
   TopicRequest selectTopicRequestsForTopic(int topicId, int tenantId);
 

--- a/core/src/main/java/io/aiven/klaw/helpers/db/rdbms/HandleDbRequestsJdbc.java
+++ b/core/src/main/java/io/aiven/klaw/helpers/db/rdbms/HandleDbRequestsJdbc.java
@@ -169,14 +169,19 @@ public class HandleDbRequestsJdbc implements HandleDbRequests {
   }
 
   public List<KafkaConnectorRequest> getAllConnectorRequests(String requestor, int tenantId) {
-    return jdbcSelectHelper.selectConnectorRequestsByStatus(
-        false, requestor, RequestStatus.CREATED.value, false, tenantId);
+    return jdbcSelectHelper.getFilteredKafkaConnectorRequests(
+        false, requestor, RequestStatus.CREATED.value, false, tenantId, null, null);
   }
 
   public List<KafkaConnectorRequest> getCreatedConnectorRequests(
-      String requestor, String status, boolean showRequestsOfAllTeams, int tenantId) {
-    return jdbcSelectHelper.selectConnectorRequestsByStatus(
-        true, requestor, status, showRequestsOfAllTeams, tenantId);
+      String requestor,
+      String status,
+      boolean showRequestsOfAllTeams,
+      int tenantId,
+      String env,
+      String search) {
+    return jdbcSelectHelper.getFilteredKafkaConnectorRequests(
+        true, requestor, status, showRequestsOfAllTeams, tenantId, env, search);
   }
 
   public TopicRequest selectTopicRequestsForTopic(int topicId, int tenantId) {

--- a/core/src/main/java/io/aiven/klaw/helpers/db/rdbms/SelectDataJdbc.java
+++ b/core/src/main/java/io/aiven/klaw/helpers/db/rdbms/SelectDataJdbc.java
@@ -655,6 +655,12 @@ public class SelectDataJdbc {
           topicRequestListSub.stream()
               .filter(topicRequest -> !topicRequest.getRequestor().equals(requestor))
               .collect(Collectors.toList());
+      if (search != null && !search.isEmpty()) {
+        topicRequestListSub =
+            topicRequestListSub.stream()
+                .filter(topicRequest -> topicRequest.getConnectorName().contains(search))
+                .collect(Collectors.toList());
+      }
 
     } else {
       // show my teams requests

--- a/core/src/main/java/io/aiven/klaw/helpers/db/rdbms/SelectDataJdbc.java
+++ b/core/src/main/java/io/aiven/klaw/helpers/db/rdbms/SelectDataJdbc.java
@@ -607,12 +607,14 @@ public class SelectDataJdbc {
     return topicRequestsRepo.findAll(Example.of(request));
   }
 
-  public List<KafkaConnectorRequest> selectConnectorRequestsByStatus(
+  public List<KafkaConnectorRequest> getFilteredKafkaConnectorRequests(
       boolean allReqs,
       String requestor,
       String status,
       boolean showRequestsOfAllTeams,
-      int tenantId) {
+      int tenantId,
+      String env,
+      String search) {
     log.debug("selectConnectorRequestsByStatus {} {}", requestor, status);
     List<KafkaConnectorRequest> topicRequestList = new ArrayList<>();
 
@@ -620,49 +622,46 @@ public class SelectDataJdbc {
     Integer teamSelected = selectUserInfo(requestor).getTeamId();
 
     if (allReqs) { // approvers
+
+      // Team Name is null here as it is the team who created the requested
+      // Description includes the teamId as that is how Claim topics know who is the owning team.
       List<KafkaConnectorRequest> claimTopicReqs =
-          kafkaConnectorRequestsRepo.findAllByConnectortypeAndTenantId(
-              RequestOperationType.CLAIM.value, tenantId);
+          Lists.newArrayList(
+              findKafkaConnectorRequestsByExample(
+                  RequestOperationType.CLAIM.value,
+                  null,
+                  env,
+                  status,
+                  tenantId,
+                  String.valueOf(teamSelected)));
 
-      if ("all".equals(status)) {
-        topicRequestListSub =
-            Lists.newArrayList(kafkaConnectorRequestsRepo.findAllByTenantId(tenantId));
-        topicRequestListSub =
-            topicRequestListSub.stream()
-                .filter(
-                    topicRequest ->
-                        !RequestOperationType.CLAIM.value.equals(topicRequest.getConnectortype()))
-                .collect(Collectors.toList());
+      topicRequestListSub =
+          Lists.newArrayList(
+              findKafkaConnectorRequestsByExample(
+                  null, showRequestsOfAllTeams ? null : teamSelected, env, status, tenantId, null));
 
-        claimTopicReqs =
-            claimTopicReqs.stream()
-                .filter(
-                    claimTopicReq ->
-                        Objects.equals(claimTopicReq.getDescription(), "" + teamSelected))
-                .collect(Collectors.toList());
-      } else {
-        topicRequestListSub =
-            kafkaConnectorRequestsRepo.findAllByConnectorStatusAndTenantId(status, tenantId);
-        topicRequestListSub =
-            topicRequestListSub.stream()
-                .filter(
-                    topicRequest ->
-                        !RequestOperationType.CLAIM.value.equals(topicRequest.getConnectortype()))
-                .collect(Collectors.toList());
-
-        claimTopicReqs =
-            claimTopicReqs.stream()
-                .filter(
-                    claimTopicReq ->
-                        Objects.equals(claimTopicReq.getDescription(), "" + teamSelected)
-                            && Objects.equals(claimTopicReq.getConnectorStatus(), status))
-                .collect(Collectors.toList());
-      }
+      // Only execute just before adding the separate claim list as this will make sure only the
+      // claim topics this team is able to approve will be returned.
+      topicRequestListSub =
+          topicRequestListSub.stream()
+              .filter(
+                  request -> !RequestOperationType.CLAIM.value.equals(request.getConnectortype()))
+              .collect(Collectors.toList());
 
       topicRequestListSub.addAll(claimTopicReqs);
-    } else {
+      // remove users own requests to approve/show in the list
+      // Placed here as it should only apply for approvers.
       topicRequestListSub =
-          Lists.newArrayList(kafkaConnectorRequestsRepo.findAllByTenantId(tenantId));
+          topicRequestListSub.stream()
+              .filter(topicRequest -> !topicRequest.getRequestor().equals(requestor))
+              .collect(Collectors.toList());
+
+    } else {
+      // show my teams requests
+      topicRequestListSub =
+          Lists.newArrayList(
+              findKafkaConnectorRequestsByExample(
+                  null, showRequestsOfAllTeams ? null : teamSelected, null, null, tenantId, null));
     }
 
     for (KafkaConnectorRequest row : topicRequestListSub) {
@@ -674,16 +673,60 @@ public class SelectDataJdbc {
       } catch (Exception ignored) {
       }
 
-      if (showRequestsOfAllTeams) {
-        topicRequestList.add(row); // no team filter
-      } else if (teamSelected != null
-          && (Objects.equals(teamSelected, teamId)
-              || Objects.equals("" + teamSelected, row.getDescription()))) {
-        topicRequestList.add(row);
-      }
+      topicRequestList.add(row); // no team filter
     }
 
     return topicRequestList;
+  }
+
+  /**
+   * Query the KafkaConnectorRequestsRepo by supplying optional search parameters any given search
+   * parameters will be utilised in the search.
+   *
+   * @param requestType The type of topic request Create/claim etc
+   * @param teamId The identifier of the team
+   * @param environment the environment
+   * @param status created/declined/approved
+   * @param tenantId The tenantId
+   * @return An Iterable of all TopicRequests that match the parameters that have been supplied
+   */
+  private Iterable<KafkaConnectorRequest> findKafkaConnectorRequestsByExample(
+      String requestType,
+      Integer teamId,
+      String environment,
+      String status,
+      int tenantId,
+      String description) {
+
+    KafkaConnectorRequest request = new KafkaConnectorRequest();
+    request.setTenantId(tenantId);
+
+    if (requestType != null) {
+      request.setConnectortype(requestType);
+    }
+    if (environment != null) {
+      request.setEnvironment(environment);
+    }
+    if (teamId != null) {
+      request.setTeamId(teamId);
+    }
+
+    if (description != null && !description.isEmpty()) {
+      request.setDescription(description);
+    }
+
+    if (status != null && !status.equalsIgnoreCase("all")) {
+      request.setConnectorStatus(status);
+    }
+
+    // check if debug is enabled so the logger doesn't waste resources converting object request to
+    // a
+    // string
+    if (log.isDebugEnabled()) {
+      log.debug("find By topic etc example {}", request);
+    }
+
+    return kafkaConnectorRequestsRepo.findAll(Example.of(request));
   }
 
   public TopicRequest selectTopicRequestsForTopic(int topicId, int tenantId) {

--- a/core/src/main/java/io/aiven/klaw/repository/KwKafkaConnectorRequestsRepo.java
+++ b/core/src/main/java/io/aiven/klaw/repository/KwKafkaConnectorRequestsRepo.java
@@ -7,9 +7,11 @@ import java.util.Optional;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.CrudRepository;
 import org.springframework.data.repository.query.Param;
+import org.springframework.data.repository.query.QueryByExampleExecutor;
 
 public interface KwKafkaConnectorRequestsRepo
-    extends CrudRepository<KafkaConnectorRequest, KafkaConnectorRequestID> {
+    extends CrudRepository<KafkaConnectorRequest, KafkaConnectorRequestID>,
+        QueryByExampleExecutor<KafkaConnectorRequest> {
   Optional<KafkaConnectorRequest> findById(KafkaConnectorRequestID connectorRequestId);
 
   List<KafkaConnectorRequest> findAllByConnectorStatusAndTenantId(

--- a/core/src/main/java/io/aiven/klaw/service/KafkaConnectControllerService.java
+++ b/core/src/main/java/io/aiven/klaw/service/KafkaConnectControllerService.java
@@ -449,7 +449,7 @@ public class KafkaConnectControllerService {
   }
 
   public List<KafkaConnectorRequestModel> getCreatedConnectorRequests(
-      String pageNo, String currentPage, String requestsType) {
+      String pageNo, String currentPage, String requestsType, String env, String search) {
     log.debug("getCreatedTopicRequests {} {}", pageNo, requestsType);
     String userDetails = getUserName();
     List<KafkaConnectorRequest> createdTopicReqList;
@@ -461,12 +461,12 @@ public class KafkaConnectControllerService {
       createdTopicReqList =
           manageDatabase
               .getHandleDbRequests()
-              .getCreatedConnectorRequests(userDetails, requestsType, false, tenantId);
+              .getCreatedConnectorRequests(userDetails, requestsType, false, tenantId, env, search);
     else
       createdTopicReqList =
           manageDatabase
               .getHandleDbRequests()
-              .getCreatedConnectorRequests(userDetails, requestsType, true, tenantId);
+              .getCreatedConnectorRequests(userDetails, requestsType, true, tenantId, env, search);
 
     createdTopicReqList = getConnectorRequestsFilteredForTenant(createdTopicReqList);
 

--- a/core/src/main/java/io/aiven/klaw/service/UtilControllerService.java
+++ b/core/src/main/java/io/aiven/klaw/service/UtilControllerService.java
@@ -137,7 +137,7 @@ public class UtilControllerService {
               requestor, RequestStatus.CREATED.value, false, tenantId);
       allConnectorReqs =
           reqsHandle.getCreatedConnectorRequests(
-              requestor, RequestStatus.CREATED.value, false, tenantId);
+              requestor, RequestStatus.CREATED.value, false, tenantId, null, null);
     } else {
       allAclReqs =
           reqsHandle.getAllAclRequests(
@@ -147,7 +147,7 @@ public class UtilControllerService {
               requestor, RequestStatus.CREATED.value, true, tenantId);
       allConnectorReqs =
           reqsHandle.getCreatedConnectorRequests(
-              requestor, RequestStatus.CREATED.value, true, tenantId);
+              requestor, RequestStatus.CREATED.value, true, tenantId, null, null);
     }
 
     try {

--- a/core/src/main/resources/static/js/execConnectors.js
+++ b/core/src/main/resources/static/js/execConnectors.js
@@ -63,7 +63,7 @@ app.controller("execConnectorsCtrl", function($scope, $http, $location, $window)
 
             $http({
                 method: "GET",
-                url: "getCreatedConnectorRequests",
+                url: "getConnectorRequestsForApproval",
                 headers : { 'Content-Type' : 'application/json' },
                 params: {'pageNo' : pageNoSelected,
                  'currentPage' : $scope.currentPageSelected,

--- a/core/src/main/resources/swagger_spec.json
+++ b/core/src/main/resources/swagger_spec.json
@@ -1391,6 +1391,50 @@
         }
       }
     },
+    "/getConnectorRequestsForApproval" : {
+      "get" : {
+        "operationId" : "getCreatedConnectorRequests",
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "pageNo",
+          "in" : "query",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "currentPage",
+          "in" : "query",
+          "required" : false,
+          "type" : "string"
+        }, {
+          "name" : "requestsType",
+          "in" : "query",
+          "required" : false,
+          "type" : "string",
+          "default" : "created"
+        }, {
+          "name" : "env",
+          "in" : "query",
+          "required" : false,
+          "type" : "string"
+        }, {
+          "name" : "search",
+          "in" : "query",
+          "required" : false,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "schema" : {
+              "type" : "array",
+              "items" : {
+                "$ref" : "#/definitions/KafkaConnectorRequestModel"
+              }
+            }
+          }
+        }
+      }
+    },
     "/getConnectors" : {
       "get" : {
         "operationId" : "getTopics",
@@ -1467,40 +1511,6 @@
                 "additionalProperties" : {
                   "type" : "string"
                 }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/getCreatedConnectorRequests" : {
-      "get" : {
-        "operationId" : "getCreatedConnectorRequests",
-        "produces" : [ "application/json" ],
-        "parameters" : [ {
-          "name" : "pageNo",
-          "in" : "query",
-          "required" : true,
-          "type" : "string"
-        }, {
-          "name" : "currentPage",
-          "in" : "query",
-          "required" : false,
-          "type" : "string"
-        }, {
-          "name" : "requestsType",
-          "in" : "query",
-          "required" : false,
-          "type" : "string",
-          "default" : "created"
-        } ],
-        "responses" : {
-          "200" : {
-            "description" : "successful operation",
-            "schema" : {
-              "type" : "array",
-              "items" : {
-                "$ref" : "#/definitions/KafkaConnectorRequestModel"
               }
             }
           }

--- a/core/src/test/java/io/aiven/klaw/helpers/db/rdbms/KafkaConnectorsIntegrationTest.java
+++ b/core/src/test/java/io/aiven/klaw/helpers/db/rdbms/KafkaConnectorsIntegrationTest.java
@@ -544,6 +544,35 @@ public class KafkaConnectorsIntegrationTest {
     }
   }
 
+  @Test
+  @Order(24)
+  public void getAllCRequestsForApprovalFilteredByWildcardSearch() {
+
+    List<KafkaConnectorRequest> resultSet =
+        selectDataJdbc.getFilteredKafkaConnectorRequests(
+            true, "James", RequestStatus.ALL.value, false, 101, null, "first");
+
+    assertThat(resultSet.size()).isEqualTo(10);
+
+    // MyTeamsRequests only
+    for (KafkaConnectorRequest req : resultSet) {
+      assertThat(req.getTenantId()).isEqualTo(101);
+      assertThat(req.getUsername()).isNotEqualTo("James");
+      assertThat(req.getTeamId()).isEqualTo(101);
+      assertThat(req.getConnectorName()).isEqualTo("firstconn");
+    }
+  }
+
+  @Test
+  @Order(25)
+  public void getAllCRequestsForApprovalFilteredByWildcardSearchNoMatching() {
+
+    List<KafkaConnectorRequest> resultSet =
+        selectDataJdbc.getFilteredKafkaConnectorRequests(
+            true, "James", RequestStatus.ALL.value, false, 103, null, "lots");
+    assertThat(resultSet.size()).isEqualTo(0);
+  }
+
   private void generateData(
       int number,
       int tenantId,


### PR DESCRIPTION
Signed-off-by: Aindriu Lavelle <aindriu.lavelle@aiven.io>

About this change - What it does
This change renames the endpoint inline with how the other approvers endpoints have been renamed.
It also adds the ability to search by environment and by a wildcard topic search name.
Resolves: #592 
Why this way
This follows the same pattern as the other updates we have made and make them all consistent with each other.