### PR TITLE
Acl Requests with Filters

### DIFF
--- a/core/src/main/java/io/aiven/klaw/controller/AclController.java
+++ b/core/src/main/java/io/aiven/klaw/controller/AclController.java
@@ -37,6 +37,16 @@ public class AclController {
     return new ResponseEntity<>(aclControllerService.createAcl(addAclRequest), HttpStatus.OK);
   }
 
+  /**
+   * @param pageNo Which page would you like returned e.g. 1
+   * @param currentPage Which Page are you currently on e.g. 1
+   * @param requestsType What type of requests are you looking for e.g. 'created' or 'deleted'
+   * @param topic The name of the topic you would like returned
+   * @param env The name of the environment you would like returned e.g. '1' or '4'
+   * @param aclType The Type of acl Consumer/Producer
+   * @param isMyRequest filter requests to ony return your own requests
+   * @return An array of AclRequests that met the criteria of the inputted values.
+   */
   @RequestMapping(
       value = "/getAclRequests",
       method = RequestMethod.GET,
@@ -44,9 +54,16 @@ public class AclController {
   public ResponseEntity<List<AclRequestsModel>> getAclRequests(
       @RequestParam("pageNo") String pageNo,
       @RequestParam(value = "currentPage", defaultValue = "") String currentPage,
-      @RequestParam(value = "requestsType", defaultValue = "all") String requestsType) {
+      @RequestParam(value = "requestsType", defaultValue = "all") String requestsType,
+      @RequestParam(value = "topic", required = false) String topic,
+      @RequestParam(value = "env", required = false) String env,
+      @RequestParam(value = "aclType", required = false) AclType aclType,
+      @RequestParam(value = "isMyRequest", required = false, defaultValue = "false")
+          boolean isMyRequest) {
     return new ResponseEntity<>(
-        aclControllerService.getAclRequests(pageNo, currentPage, requestsType), HttpStatus.OK);
+        aclControllerService.getAclRequests(
+            pageNo, currentPage, requestsType, topic, env, aclType, isMyRequest),
+        HttpStatus.OK);
   }
 
   /**

--- a/core/src/main/java/io/aiven/klaw/helpers/HandleDbRequests.java
+++ b/core/src/main/java/io/aiven/klaw/helpers/HandleDbRequests.java
@@ -136,6 +136,10 @@ public interface HandleDbRequests {
       String role,
       String status,
       boolean showRequestsOfAllTeams,
+      String topic,
+      String environment,
+      AclType aclType,
+      boolean isMyRequest,
       int tenantId);
 
   List<AclRequests> getCreatedAclRequestsByStatus(

--- a/core/src/main/java/io/aiven/klaw/helpers/db/rdbms/HandleDbRequestsJdbc.java
+++ b/core/src/main/java/io/aiven/klaw/helpers/db/rdbms/HandleDbRequestsJdbc.java
@@ -276,9 +276,22 @@ public class HandleDbRequestsJdbc implements HandleDbRequests {
       String role,
       String status,
       boolean showRequestsOfAllTeams,
+      String topic,
+      String environment,
+      AclType aclType,
+      boolean isMyRequest,
       int tenantId) {
     return jdbcSelectHelper.selectAclRequests(
-        allReqs, requestor, role, status, showRequestsOfAllTeams, tenantId);
+        allReqs,
+        requestor,
+        role,
+        status,
+        showRequestsOfAllTeams,
+        topic,
+        environment,
+        aclType,
+        isMyRequest,
+        tenantId);
   }
 
   @Override
@@ -291,7 +304,16 @@ public class HandleDbRequestsJdbc implements HandleDbRequests {
       AclType aclType,
       int tenantId) {
     return jdbcSelectHelper.selectAclRequests(
-        true, requestor, "", status, showRequestsOfAllTeams, topic, environment, aclType, tenantId);
+        true,
+        requestor,
+        "",
+        status,
+        showRequestsOfAllTeams,
+        topic,
+        environment,
+        aclType,
+        false,
+        tenantId);
   }
 
   @Override

--- a/core/src/main/java/io/aiven/klaw/helpers/db/rdbms/SelectDataJdbc.java
+++ b/core/src/main/java/io/aiven/klaw/helpers/db/rdbms/SelectDataJdbc.java
@@ -112,27 +112,19 @@ public class SelectDataJdbc {
       String role,
       String status,
       boolean showRequestsOfAllTeams,
-      int tenantId) {
-    return selectAclRequests(
-        allReqs, requestor, role, status, showRequestsOfAllTeams, null, null, null, tenantId);
-  }
-
-  public List<AclRequests> selectAclRequests(
-      boolean allReqs,
-      String requestor,
-      String role,
-      String status,
-      boolean showRequestsOfAllTeams,
       String topic,
       String environment,
       AclType aclType,
+      boolean isMyRequest,
       int tenantId) {
     log.debug("selectAclRequests {}", requestor);
     List<AclRequests> aclList = new ArrayList<>();
     List<AclRequests> aclListSub;
 
     aclListSub =
-        Lists.newArrayList(findAclRequestsByExample(topic, environment, aclType, status, tenantId));
+        Lists.newArrayList(
+            findAclRequestsByExample(
+                topic, environment, aclType, status, isMyRequest ? requestor : null, tenantId));
     if (allReqs) {
       // Only filter when returning to approvers view.
       // in the acl request the username is mapped to the requestor column in the database.
@@ -186,11 +178,17 @@ public class SelectDataJdbc {
    * @param environment the environment
    * @param aclType Producer or consumer
    * @param status created/declined/approved
+   * @param requestor the name of the user who created the request in klaw
    * @param tenantId The tenantId
    * @return
    */
   public Iterable<AclRequests> findAclRequestsByExample(
-      String topic, String environment, AclType aclType, String status, int tenantId) {
+      String topic,
+      String environment,
+      AclType aclType,
+      String status,
+      String requestor,
+      int tenantId) {
 
     AclRequests request = new AclRequests();
 
@@ -206,6 +204,10 @@ public class SelectDataJdbc {
     }
     if (status != null && !status.equalsIgnoreCase("all")) {
       request.setAclstatus(status);
+    }
+
+    if (requestor != null && !requestor.isEmpty()) {
+      request.setUsername(requestor);
     }
     // check if debug is enabled so the logger doesnt waste resources converting object request to a
     // string

--- a/core/src/main/java/io/aiven/klaw/model/AclRequestsModel.java
+++ b/core/src/main/java/io/aiven/klaw/model/AclRequestsModel.java
@@ -87,4 +87,8 @@ public class AclRequestsModel implements Serializable {
   private List<String> allPageNos;
 
   private String approvingTeamDetails;
+
+  boolean isEditable;
+
+  boolean isDeletable;
 }

--- a/core/src/main/java/io/aiven/klaw/service/UtilControllerService.java
+++ b/core/src/main/java/io/aiven/klaw/service/UtilControllerService.java
@@ -131,7 +131,16 @@ public class UtilControllerService {
         getPrincipal(), PermissionType.APPROVE_ALL_REQUESTS_TEAMS)) {
       allAclReqs =
           reqsHandle.getAllAclRequests(
-              true, requestor, roleToSet, RequestStatus.CREATED.value, false, tenantId);
+              true,
+              requestor,
+              roleToSet,
+              RequestStatus.CREATED.value,
+              false,
+              null,
+              null,
+              null,
+              false,
+              tenantId);
       allTopicReqs =
           reqsHandle.getCreatedTopicRequests(
               requestor, RequestStatus.CREATED.value, false, tenantId);
@@ -141,7 +150,16 @@ public class UtilControllerService {
     } else {
       allAclReqs =
           reqsHandle.getAllAclRequests(
-              true, requestor, roleToSet, RequestStatus.CREATED.value, true, tenantId);
+              true,
+              requestor,
+              roleToSet,
+              RequestStatus.CREATED.value,
+              true,
+              null,
+              null,
+              null,
+              false,
+              tenantId);
       allTopicReqs =
           reqsHandle.getCreatedTopicRequests(
               requestor, RequestStatus.CREATED.value, true, tenantId);

--- a/core/src/main/resources/swagger_spec.json
+++ b/core/src/main/resources/swagger_spec.json
@@ -781,6 +781,28 @@
           "required" : false,
           "type" : "string",
           "default" : "all"
+        }, {
+          "name" : "topic",
+          "in" : "query",
+          "required" : false,
+          "type" : "string"
+        }, {
+          "name" : "env",
+          "in" : "query",
+          "required" : false,
+          "type" : "string"
+        }, {
+          "name" : "aclType",
+          "in" : "query",
+          "required" : false,
+          "type" : "string",
+          "enum" : [ "PRODUCER", "CONSUMER" ]
+        }, {
+          "name" : "isMyRequest",
+          "in" : "query",
+          "required" : false,
+          "type" : "boolean",
+          "default" : false
         } ],
         "responses" : {
           "200" : {
@@ -3574,6 +3596,12 @@
         },
         "approvingTeamDetails" : {
           "type" : "string"
+        },
+        "editable" : {
+          "type" : "boolean"
+        },
+        "deletable" : {
+          "type" : "boolean"
         }
       }
     },

--- a/core/src/test/java/io/aiven/klaw/controller/AclControllerTest.java
+++ b/core/src/test/java/io/aiven/klaw/controller/AclControllerTest.java
@@ -103,7 +103,8 @@ public class AclControllerTest {
 
     List<AclRequestsModel> aclRequests = utilMethods.getAclRequestsModel();
 
-    when(aclControllerService.getAclRequests("1", "", "all")).thenReturn(aclRequests);
+    when(aclControllerService.getAclRequests("1", "", "all", null, null, null, false))
+        .thenReturn(aclRequests);
 
     mvcAcls
         .perform(

--- a/core/src/test/java/io/aiven/klaw/helpers/db/rdbms/AclRequestsIntegrationTest.java
+++ b/core/src/test/java/io/aiven/klaw/helpers/db/rdbms/AclRequestsIntegrationTest.java
@@ -132,7 +132,8 @@ public class AclRequestsIntegrationTest {
     List<AclRequests> aclListSub = Lists.newArrayList(repo.findAllByTenantId(101));
 
     List<AclRequests> results =
-        selectDataJdbc.selectAclRequests(true, "James", "USER", "ALL", true, 101);
+        selectDataJdbc.selectAclRequests(
+            true, "James", "USER", "ALL", true, null, null, null, false, 101);
 
     assertThat(aclListSub.size()).isEqualTo(results.size());
     assertThat(aclListSub).isEqualTo(results);
@@ -143,9 +144,11 @@ public class AclRequestsIntegrationTest {
   public void getAllRequestsFilteredByTenantId() {
 
     List<AclRequests> james =
-        selectDataJdbc.selectAclRequests(true, "James", "USER", "ALL", true, null, null, null, 101);
+        selectDataJdbc.selectAclRequests(
+            true, "James", "USER", "ALL", true, null, null, null, false, 101);
     List<AclRequests> john =
-        selectDataJdbc.selectAclRequests(true, "John", "USER", "ALL", true, null, null, null, 103);
+        selectDataJdbc.selectAclRequests(
+            true, "John", "USER", "ALL", true, null, null, null, false, 103);
 
     assertThat(james.size()).isEqualTo(31);
     for (AclRequests req : james) {
@@ -163,10 +166,10 @@ public class AclRequestsIntegrationTest {
 
     List<AclRequests> james =
         selectDataJdbc.selectAclRequests(
-            true, "James", "USER", "created", true, null, "dev", null, 101);
+            true, "James", "USER", "created", true, null, "dev", null, false, 101);
     List<AclRequests> john =
         selectDataJdbc.selectAclRequests(
-            true, "John", "USER", "declined", true, null, "dev", null, 103);
+            true, "John", "USER", "declined", true, null, "dev", null, false, 103);
 
     assertThat(james.size()).isEqualTo(20);
     for (AclRequests req : james) {
@@ -183,13 +186,13 @@ public class AclRequestsIntegrationTest {
 
     List<AclRequests> james =
         selectDataJdbc.selectAclRequests(
-            true, "James", "USER", "ALL", true, null, null, AclType.PRODUCER, 101);
+            true, "James", "USER", "ALL", true, null, null, AclType.PRODUCER, false, 101);
     List<AclRequests> james2 =
         selectDataJdbc.selectAclRequests(
-            true, "James", "USER", "ALL", true, null, null, AclType.CONSUMER, 101);
+            true, "James", "USER", "ALL", true, null, null, AclType.CONSUMER, false, 101);
     List<AclRequests> john =
         selectDataJdbc.selectAclRequests(
-            true, "John", "USER", "ALL", true, null, null, AclType.CONSUMER, 103);
+            true, "John", "USER", "ALL", true, null, null, AclType.CONSUMER, false, 103);
 
     assertThat(james.size()).isEqualTo(1);
     for (AclRequests req : james) {
@@ -210,7 +213,7 @@ public class AclRequestsIntegrationTest {
 
     List<AclRequests> james =
         selectDataJdbc.selectAclRequests(
-            true, "James", "USER", "ALL", true, "firsttopic", null, null, 101);
+            true, "James", "USER", "ALL", true, "firsttopic", null, null, false, 101);
 
     assertThat(james.size()).isEqualTo(10);
     for (AclRequests req : james) {
@@ -224,7 +227,7 @@ public class AclRequestsIntegrationTest {
 
     List<AclRequests> james =
         selectDataJdbc.selectAclRequests(
-            true, "James", "USER", "ALL", true, "secondtopic", "test", null, 101);
+            true, "James", "USER", "ALL", true, "secondtopic", "test", null, false, 101);
 
     assertThat(james.size()).isEqualTo(11);
     for (AclRequests req : james) {
@@ -238,7 +241,16 @@ public class AclRequestsIntegrationTest {
 
     List<AclRequests> james =
         selectDataJdbc.selectAclRequests(
-            true, "James", "USER", "ALL", true, "secondtopic", "test", AclType.CONSUMER, 101);
+            true,
+            "James",
+            "USER",
+            "ALL",
+            true,
+            "secondtopic",
+            "test",
+            AclType.CONSUMER,
+            false,
+            101);
 
     assertThat(james.size()).isEqualTo(10);
     for (AclRequests req : james) {
@@ -252,7 +264,16 @@ public class AclRequestsIntegrationTest {
     // topic name is case sensitive.
     List<AclRequests> james =
         selectDataJdbc.selectAclRequests(
-            true, "James", "USER", "ALL", true, "Secondtopic", "test", AclType.CONSUMER, 101);
+            true,
+            "James",
+            "USER",
+            "ALL",
+            true,
+            "Secondtopic",
+            "test",
+            AclType.CONSUMER,
+            false,
+            101);
     assertThat(james.size()).isEqualTo(0);
   }
 
@@ -261,7 +282,7 @@ public class AclRequestsIntegrationTest {
   public void getAllRequestsDontReturnOwnRequestsForApproval() {
     List<AclRequests> jackie =
         selectDataJdbc.selectAclRequests(
-            true, "Jackie", "USER", "ALL", true, null, null, null, 101);
+            true, "Jackie", "USER", "ALL", true, null, null, null, false, 101);
     assertThat(jackie.size()).isEqualTo(0);
   }
 
@@ -270,7 +291,7 @@ public class AclRequestsIntegrationTest {
   public void getAllRequestsAndReturnOwnRequests() {
     List<AclRequests> jackie =
         selectDataJdbc.selectAclRequests(
-            false, "Jackie", "USER", "ALL", true, null, null, null, 101);
+            false, "Jackie", "USER", "ALL", true, null, null, null, false, 101);
     assertThat(jackie.size()).isEqualTo(31);
   }
 
@@ -366,6 +387,96 @@ public class AclRequestsIntegrationTest {
     assertThat(statsCount.get(RequestStatus.DELETED.value)).isEqualTo(0L);
     assertThat(operationTypeCount.get(RequestOperationType.CREATE.value)).isEqualTo(10L);
     assertThat(operationTypeCount.get(RequestOperationType.DELETE.value)).isEqualTo(0L);
+  }
+
+  @Test
+  @Order(16)
+  public void getAllRequestsOnlyReturnMyRequests() {
+    List<AclRequests> jackie =
+        selectDataJdbc.selectAclRequests(
+            false, "Jackie", "USER", "ALL", true, null, null, null, true, 101);
+    assertThat(jackie.size()).isEqualTo(31);
+    for (AclRequests req : jackie) {
+      assertThat(req.getUsername()).isEqualTo("Jackie");
+    }
+  }
+
+  @Test
+  @Order(17)
+  public void getAllRequestsOnlyReturnMyRequestsFromDevEnv() {
+    List<AclRequests> jackie =
+        selectDataJdbc.selectAclRequests(
+            false, "Jackie", "USER", "ALL", true, null, "dev", null, true, 101);
+    assertThat(jackie.size()).isEqualTo(20);
+    for (AclRequests req : jackie) {
+      assertThat(req.getUsername()).isEqualTo("Jackie");
+      assertThat(req.getEnvironment()).isEqualTo("dev");
+    }
+  }
+
+  @Test
+  @Order(18)
+  public void getAllRequestsOnlyReturnMyRequestsOfProducerAclType() {
+    List<AclRequests> jackie =
+        selectDataJdbc.selectAclRequests(
+            false, "Jackie", "USER", "ALL", true, null, null, AclType.PRODUCER, true, 101);
+    assertThat(jackie.size()).isEqualTo(1);
+    for (AclRequests req : jackie) {
+      assertThat(req.getUsername()).isEqualTo("Jackie");
+      assertThat(req.getTopictype()).isEqualTo("Producer");
+    }
+  }
+
+  @Test
+  @Order(19)
+  public void getAllRequestsOnlyReturnMyRequestsOfTopicFirstTopic() {
+    List<AclRequests> jackie =
+        selectDataJdbc.selectAclRequests(
+            false, "Jackie", "USER", "ALL", true, "firsttopic", null, null, true, 101);
+    assertThat(jackie.size()).isEqualTo(10);
+    for (AclRequests req : jackie) {
+      assertThat(req.getUsername()).isEqualTo("Jackie");
+      assertThat(req.getTopicname()).isEqualTo("firsttopic");
+    }
+  }
+
+  @Test
+  @Order(20)
+  public void getAllRequestsOnlyReturnWhereEnvisTestMyRequestsOfTopicFirstTopic() {
+    List<AclRequests> jackie =
+        selectDataJdbc.selectAclRequests(
+            false, "Jackie", "USER", "ALL", true, null, "test", null, true, 101);
+    assertThat(jackie.size()).isEqualTo(11);
+    for (AclRequests req : jackie) {
+      assertThat(req.getUsername()).isEqualTo("Jackie");
+      assertThat(req.getTopicname()).isEqualTo("secondtopic");
+      assertThat(req.getEnvironment()).isEqualTo("test");
+    }
+  }
+
+  @Test
+  @Order(21)
+  public void
+      getAllRequestsOnlyReturnWhereEnvisTestAndAclTypeConsumerMyRequestsOfTopicFirstTopic() {
+    List<AclRequests> jackie =
+        selectDataJdbc.selectAclRequests(
+            false, "Jackie", "USER", "ALL", true, null, "test", AclType.CONSUMER, true, 101);
+    assertThat(jackie.size()).isEqualTo(10);
+    for (AclRequests req : jackie) {
+      assertThat(req.getUsername()).isEqualTo("Jackie");
+      assertThat(req.getTopicname()).isEqualTo("secondtopic");
+      assertThat(req.getEnvironment()).isEqualTo("test");
+      assertThat(req.getTopictype()).isEqualTo("Consumer");
+    }
+  }
+
+  @Test
+  @Order(21)
+  public void getAllRequestsReturnAllRequests() {
+    List<AclRequests> jackie =
+        selectDataJdbc.selectAclRequests(
+            false, "Jackie", "USER", "ALL", true, null, null, null, false, 101);
+    assertThat(jackie.size()).isEqualTo(31);
   }
 
   private void generateData(

--- a/core/src/test/java/io/aiven/klaw/helpers/db/rdbms/SelectDataJdbcTest.java
+++ b/core/src/test/java/io/aiven/klaw/helpers/db/rdbms/SelectDataJdbcTest.java
@@ -93,7 +93,8 @@ public class SelectDataJdbcTest {
         .thenReturn(java.util.Optional.of(userInfo));
 
     List<AclRequests> aclRequestsActual =
-        selectData.selectAclRequests(false, requestor, "", "all", false, 1);
+        selectData.selectAclRequests(
+            false, requestor, "", "all", false, null, null, null, false, 1);
     assertThat(aclRequestsActual).isEmpty();
   }
 

--- a/core/src/test/java/io/aiven/klaw/service/AclControllerServiceTest.java
+++ b/core/src/test/java/io/aiven/klaw/service/AclControllerServiceTest.java
@@ -5,6 +5,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.when;
 import static org.springframework.beans.BeanUtils.copyProperties;
 
@@ -281,7 +282,16 @@ public class AclControllerServiceTest {
     when(commonUtilsService.getEnvsFromUserId(anyString()))
         .thenReturn(new HashSet<>(Collections.singletonList("1")));
     when(handleDbRequests.getAllAclRequests(
-            anyBoolean(), anyString(), anyString(), anyString(), anyBoolean(), anyInt()))
+            anyBoolean(),
+            anyString(),
+            anyString(),
+            anyString(),
+            anyBoolean(),
+            eq(null),
+            eq(null),
+            eq(null),
+            eq(false),
+            anyInt()))
         .thenReturn(getAclRequests("testtopic", 15));
     when(rolesPermissionsControllerService.getApproverRoles(anyString(), anyInt()))
         .thenReturn(Collections.singletonList("USER"));
@@ -290,12 +300,13 @@ public class AclControllerServiceTest {
     when(commonUtilsService.getFilteredTopicsForTenant(any())).thenReturn(topicList);
     when(handleDbRequests.selectAllUsersInfoForTeam(anyInt(), anyInt())).thenReturn(userList);
 
-    List<AclRequestsModel> aclReqs = aclControllerService.getAclRequests("1", "", "all");
+    List<AclRequestsModel> aclReqs =
+        aclControllerService.getAclRequests("1", "", "all", null, null, null, false);
     assertThat(aclReqs.size()).isEqualTo(10);
     assertThat(aclReqs.get(0).getAcl_ip().size()).isEqualTo(3);
     assertThat(aclReqs.get(0).getTeamname()).isEqualTo(teamName);
 
-    aclReqs = aclControllerService.getAclRequests("2", "", "all");
+    aclReqs = aclControllerService.getAclRequests("2", "", "all", null, null, null, false);
     assertThat(aclReqs.size()).isEqualTo(5);
     assertThat(aclReqs.get(0).getApprovingTeamDetails()).contains(userList.get(0).getUsername());
     assertThat(aclReqs.get(0).getApprovingTeamDetails()).contains(userList.get(1).getUsername());


### PR DESCRIPTION
Adds filter options to get the ACL reequests api and adds is editable… and isdeleteable to api response

Signed-off-by: Aindriu Lavelle <aindriu.lavelle@aiven.io>

About this change - What it does

Resolves: #xxxxx
Why this way
