### PR TITLE
feat(coral): add data table approve topics request UI only

### DIFF
--- a/coral/src/app/features/approvals/topics/TopicApprovals.tsx
+++ b/coral/src/app/features/approvals/topics/TopicApprovals.tsx
@@ -4,35 +4,31 @@ import { Pagination } from "src/app/components/Pagination";
 import { TopicApprovalsTable } from "src/app/features/approvals/topics/components/TopicApprovalsTable";
 import { TopicRequestTypes, TopicRequestStatus } from "src/domain/topic";
 
-const mockRequests = [
+const mockedRequests = [
   {
     topicname: "test-topic-1",
     environment: "1",
     topicpartitions: 4,
-    teamname: "Ospo",
+    teamname: "NCC1701D",
     remarks: "asap",
     description: "This topic is for test",
     replicationfactor: "2",
-    environmentName: "DEV",
-    topicid: 1034,
+    environmentName: "BRG",
+    topicid: 1000,
     advancedTopicConfigEntries: [
-      {
-        configKey: "compression.type",
-        configValue: "snappy",
-      },
       {
         configKey: "cleanup.policy",
         configValue: "delete",
       },
     ],
     topictype: "Create" as TopicRequestTypes,
-    requestor: "samulisuortti",
-    requesttime: "2023-02-03T13:27:17.252+00:00",
-    requesttimestring: "03-Feb-2023 13:27:17",
+    requestor: "jlpicard",
+    requesttime: "1987-09-28T13:37:00.001+00:00",
+    requesttimestring: "28-Sep-1987 13:37:00",
     topicstatus: "created" as TopicRequestStatus,
     totalNoPages: "1",
     approvingTeamDetails:
-      "Team : Ospo, Users : muralibasani,josepprat,mirjamaulbach,smustafa,amathieu,aindriul,",
+      "Team : NCC1701D, Users : jlpicard, worf, bcrusher, geordilf,",
     teamId: 1003,
     allPageNos: ["1"],
     currentPage: "1",
@@ -41,31 +37,27 @@ const mockRequests = [
     topicname: "test-topic-2",
     environment: "1",
     topicpartitions: 4,
-    teamname: "Ospo",
+    teamname: "MIRRORUNIVERSE",
     remarks: "asap",
     description: "This topic is for test",
     replicationfactor: "2",
-    environmentName: "DEV",
-    topicid: 1034,
+    environmentName: "SBY",
+    topicid: 1001,
     advancedTopicConfigEntries: [
       {
         configKey: "compression.type",
         configValue: "snappy",
       },
-      {
-        configKey: "cleanup.policy",
-        configValue: "delete",
-      },
     ],
 
-    topictype: "Create" as TopicRequestTypes,
-    requestor: "samulisuortti",
-    requesttime: "2023-02-03T13:27:17.252+00:00",
-    requesttimestring: "03-Feb-2023 13:27:17",
-    topicstatus: "created" as TopicRequestStatus,
+    topictype: "Update" as TopicRequestTypes,
+    requestor: "bcrusher",
+    requesttime: "1994-23-05T13:37:00.001+00:00",
+    requesttimestring: "23-May-1994 13:37:00",
+    topicstatus: "approved" as TopicRequestStatus,
     totalNoPages: "1",
     approvingTeamDetails:
-      "Team : Ospo, Users : muralibasani,josepprat,mirjamaulbach,smustafa,amathieu,aindriul,",
+      "Team : NCC1701D, Users : jlpicard, worf, bcrusher, geordilf,",
     teamId: 1003,
     allPageNos: ["1"],
     currentPage: "1",
@@ -112,7 +104,7 @@ function TopicApprovals() {
     </div>,
   ];
 
-  const table = <TopicApprovalsTable requests={mockRequests} />;
+  const table = <TopicApprovalsTable requests={mockedRequests} />;
   const pagination = (
     <Pagination activePage={1} totalPages={2} setActivePage={changePage} />
   );

--- a/coral/src/app/features/approvals/topics/TopicApprovals.tsx
+++ b/coral/src/app/features/approvals/topics/TopicApprovals.tsx
@@ -1,5 +1,125 @@
+import { NativeSelect, SearchInput } from "@aivenio/aquarium";
+import { ApprovalsLayout } from "src/app/features/approvals/components/ApprovalsLayout";
+import { Pagination } from "src/app/components/Pagination";
+import { TopicApprovalsTable } from "src/app/features/approvals/topics/components/TopicApprovalsTable";
+import { TopicRequestTypes, TopicRequestStatus } from "src/domain/topic";
+
+const mockRequests = [
+  {
+    topicname: "test-topic-1",
+    environment: "1",
+    topicpartitions: 4,
+    teamname: "Ospo",
+    remarks: "asap",
+    description: "This topic is for test",
+    replicationfactor: "2",
+    environmentName: "DEV",
+    topicid: 1034,
+    advancedTopicConfigEntries: [
+      {
+        configKey: "compression.type",
+        configValue: "snappy",
+      },
+      {
+        configKey: "cleanup.policy",
+        configValue: "delete",
+      },
+    ],
+    topictype: "Create" as TopicRequestTypes,
+    requestor: "samulisuortti",
+    requesttime: "2023-02-03T13:27:17.252+00:00",
+    requesttimestring: "03-Feb-2023 13:27:17",
+    topicstatus: "created" as TopicRequestStatus,
+    totalNoPages: "1",
+    approvingTeamDetails:
+      "Team : Ospo, Users : muralibasani,josepprat,mirjamaulbach,smustafa,amathieu,aindriul,",
+    teamId: 1003,
+    allPageNos: ["1"],
+    currentPage: "1",
+  },
+  {
+    topicname: "test-topic-2",
+    environment: "1",
+    topicpartitions: 4,
+    teamname: "Ospo",
+    remarks: "asap",
+    description: "This topic is for test",
+    replicationfactor: "2",
+    environmentName: "DEV",
+    topicid: 1034,
+    advancedTopicConfigEntries: [
+      {
+        configKey: "compression.type",
+        configValue: "snappy",
+      },
+      {
+        configKey: "cleanup.policy",
+        configValue: "delete",
+      },
+    ],
+
+    topictype: "Create" as TopicRequestTypes,
+    requestor: "samulisuortti",
+    requesttime: "2023-02-03T13:27:17.252+00:00",
+    requesttimestring: "03-Feb-2023 13:27:17",
+    topicstatus: "created" as TopicRequestStatus,
+    totalNoPages: "1",
+    approvingTeamDetails:
+      "Team : Ospo, Users : muralibasani,josepprat,mirjamaulbach,smustafa,amathieu,aindriul,",
+    teamId: 1003,
+    allPageNos: ["1"],
+    currentPage: "1",
+  },
+];
+
 function TopicApprovals() {
-  return <p>TopicApprovals</p>;
+  function changePage() {
+    console.log("changed page!");
+  }
+
+  const filters = [
+    <NativeSelect labelText={"Filter by teams"} key={"filter-teams"}>
+      <option> one </option>
+      <option> two </option>
+      <option> three </option>
+    </NativeSelect>,
+
+    <NativeSelect
+      labelText={"Filter by environment"}
+      key={"filter-environments"}
+    >
+      <option> one </option>
+      <option> two </option>
+      <option> three </option>
+    </NativeSelect>,
+
+    <NativeSelect labelText={"Filter by status"} key={"filter-status"}>
+      <option> one </option>
+      <option> two </option>
+      <option> three </option>
+    </NativeSelect>,
+    <div key={"search"}>
+      <SearchInput
+        type={"search"}
+        aria-describedby={"search-field-description"}
+        role="search"
+        placeholder={"Search for..."}
+      />
+      <div id={"search-field-description"} className={"visually-hidden"}>
+        Press &quot;Enter&quot; to start your search. Press &quot;Escape&quot;
+        to delete all your input.
+      </div>
+    </div>,
+  ];
+
+  const table = <TopicApprovalsTable requests={mockRequests} />;
+  const pagination = (
+    <Pagination activePage={1} totalPages={2} setActivePage={changePage} />
+  );
+
+  return (
+    <ApprovalsLayout filters={filters} table={table} pagination={pagination} />
+  );
 }
 
 export default TopicApprovals;

--- a/coral/src/app/features/approvals/topics/components/TopicApprovalsTable.test.tsx
+++ b/coral/src/app/features/approvals/topics/components/TopicApprovalsTable.test.tsx
@@ -1,0 +1,215 @@
+import { cleanup, render, screen, within } from "@testing-library/react";
+import { mockIntersectionObserver } from "src/services/test-utils/mock-intersection-observer";
+import { TopicApprovalsTable } from "src/app/features/approvals/topics/components/TopicApprovalsTable";
+import { TopicRequestStatus, TopicRequestTypes } from "src/domain/topic";
+
+const mockedRequests = [
+  {
+    topicname: "test-topic-1",
+    environment: "1",
+    topicpartitions: 4,
+    teamname: "NCC1701D",
+    remarks: "asap",
+    description: "This topic is for test",
+    replicationfactor: "2",
+    environmentName: "BRG",
+    topicid: 1000,
+    advancedTopicConfigEntries: [
+      {
+        configKey: "cleanup.policy",
+        configValue: "delete",
+      },
+    ],
+    topictype: "Create" as TopicRequestTypes,
+    requestor: "jlpicard",
+    requesttime: "1987-09-28T13:37:00.001+00:00",
+    requesttimestring: "28-Sep-1987 13:37:00",
+    topicstatus: "created" as TopicRequestStatus,
+    totalNoPages: "1",
+    approvingTeamDetails:
+      "Team : NCC1701D, Users : jlpicard, worf, bcrusher, geordilf,",
+    teamId: 1003,
+    allPageNos: ["1"],
+    currentPage: "1",
+  },
+  {
+    topicname: "test-topic-2",
+    environment: "1",
+    topicpartitions: 4,
+    teamname: "MIRRORUNIVERSE",
+    remarks: "asap",
+    description: "This topic is for test",
+    replicationfactor: "2",
+    environmentName: "SBY",
+    topicid: 1001,
+    advancedTopicConfigEntries: [
+      {
+        configKey: "compression.type",
+        configValue: "snappy",
+      },
+    ],
+
+    topictype: "Update" as TopicRequestTypes,
+    requestor: "bcrusher",
+    requesttime: "1994-23-05T13:37:00.001+00:00",
+    requesttimestring: "23-May-1994 13:37:00",
+    topicstatus: "approved" as TopicRequestStatus,
+    totalNoPages: "1",
+    approvingTeamDetails:
+      "Team : NCC1701D, Users : jlpicard, worf, bcrusher, geordilf,",
+    teamId: 1003,
+    allPageNos: ["1"],
+    currentPage: "1",
+  },
+];
+
+describe("TopicApprovalsTable", () => {
+  const columnsFieldMap = [
+    { columnHeader: "Topic", relatedField: "topicname" },
+    { columnHeader: "Cluster", relatedField: "environmentName" },
+    { columnHeader: "Type", relatedField: "topictype" },
+    { columnHeader: "Claim by team", relatedField: "teamname" },
+    { columnHeader: "Requested by", relatedField: "requestor" },
+    { columnHeader: "Date requested", relatedField: "requesttimestring" },
+    { columnHeader: "Details", relatedField: null },
+    { columnHeader: "Approve", relatedField: null },
+    { columnHeader: "Decline", relatedField: null },
+  ];
+
+  describe("renders all necessary elements", () => {
+    beforeAll(() => {
+      mockIntersectionObserver();
+      render(<TopicApprovalsTable requests={mockedRequests} />);
+    });
+    afterAll(cleanup);
+
+    it("shows a table with all topic requests", () => {
+      const table = screen.getByRole("table", { name: "Topic requests" });
+
+      expect(table).toBeVisible();
+    });
+
+    it("shows all column headers", () => {
+      const table = screen.getByRole("table", { name: "Topic requests" });
+      const header = within(table).getAllByRole("columnheader");
+
+      expect(header).toHaveLength(columnsFieldMap.length);
+    });
+
+    it("shows a row for each given requests plus header row", () => {
+      const table = screen.getByRole("table", { name: "Topic requests" });
+      const row = within(table).getAllByRole("row");
+
+      expect(row).toHaveLength(mockedRequests.length + 1);
+    });
+
+    it("shows an detail button for every row", () => {
+      const table = screen.getByRole("table", { name: "Topic requests" });
+      const buttons = within(table).getAllByRole("button", {
+        name: /View topic request for /,
+      });
+
+      expect(buttons).toHaveLength(mockedRequests.length);
+    });
+
+    it("shows an approve button for every row", () => {
+      const table = screen.getByRole("table", { name: "Topic requests" });
+      const buttons = within(table).getAllByRole("button", {
+        name: /Approve topic request for /,
+      });
+
+      expect(buttons).toHaveLength(mockedRequests.length);
+    });
+
+    it("shows an decline button for every row", () => {
+      const table = screen.getByRole("table", { name: "Topic requests" });
+      const buttons = within(table).getAllByRole("button", {
+        name: /Decline topic request for /,
+      });
+
+      expect(buttons).toHaveLength(mockedRequests.length);
+    });
+
+    mockedRequests.forEach((request) => {
+      it(`shows a button to show the detailed topic request for topic name ${request.topicname}`, () => {
+        const table = screen.getByRole("table", { name: "Topic requests" });
+        const button = within(table).getByRole("button", {
+          name: `View topic request for ${request.topicname}`,
+        });
+
+        expect(button).toBeEnabled();
+      });
+
+      it(`shows a button to approve topic request for topic name ${request.topicname}`, () => {
+        const table = screen.getByRole("table", { name: "Topic requests" });
+        const button = within(table).getByRole("button", {
+          name: `Approve topic request for ${request.topicname}`,
+        });
+
+        expect(button).toBeEnabled();
+      });
+
+      it(`shows a button to approve topic request for topic name ${request.topicname}`, () => {
+        const table = screen.getByRole("table", { name: "Topic requests" });
+        const button = within(table).getByRole("button", {
+          name: `Decline topic request for ${request.topicname}`,
+        });
+
+        expect(button).toBeEnabled();
+      });
+    });
+  });
+
+  describe("renders all content based on the column definition", () => {
+    beforeAll(() => {
+      mockIntersectionObserver();
+      render(<TopicApprovalsTable requests={mockedRequests} />);
+    });
+
+    afterAll(cleanup);
+
+    it(`renders the right amount of cells`, () => {
+      const table = screen.getByRole("table", {
+        name: "Topic requests",
+      });
+      const cells = within(table).getAllByRole("cell");
+
+      expect(cells).toHaveLength(
+        columnsFieldMap.length * mockedRequests.length
+      );
+    });
+
+    columnsFieldMap.forEach((column) => {
+      it(`shows a column header for ${column.columnHeader}`, () => {
+        const table = screen.getByRole("table", {
+          name: "Topic requests",
+        });
+        const header = within(table).getByRole("columnheader", {
+          name: column.columnHeader,
+        });
+
+        expect(header).toBeVisible();
+      });
+
+      if (column.relatedField) {
+        mockedRequests.forEach((request) => {
+          it(`shows field ${column.relatedField} for topic id ${request.topicid}`, () => {
+            const table = screen.getByRole("table", {
+              name: "Topic requests",
+            });
+
+            // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+            //@ts-ignore
+            const content = `${request[column.relatedField]}`;
+            const isFormattedTime = column.columnHeader === "Date requested";
+
+            const text = `${content}${isFormattedTime ? " UTC" : ""}`;
+            const cell = within(table).getByRole("cell", { name: text });
+
+            expect(cell).toBeVisible();
+          });
+        });
+      }
+    });
+  });
+});

--- a/coral/src/app/features/approvals/topics/components/TopicApprovalsTable.tsx
+++ b/coral/src/app/features/approvals/topics/components/TopicApprovalsTable.tsx
@@ -29,7 +29,7 @@ const columns: Array<DataTableColumn<TopicRequestTableData>> = [
   {
     type: "text",
     field: "requesttimestring",
-    headerName: "Date Requested",
+    headerName: "Date requested",
     formatter: (value) => {
       return `${value} UTC`;
     },

--- a/coral/src/app/features/approvals/topics/components/TopicApprovalsTable.tsx
+++ b/coral/src/app/features/approvals/topics/components/TopicApprovalsTable.tsx
@@ -1,10 +1,4 @@
-import {
-  Box,
-  DataTable,
-  DataTableColumn,
-  GhostButton,
-  Icon,
-} from "@aivenio/aquarium";
+import { DataTable, DataTableColumn, GhostButton } from "@aivenio/aquarium";
 import deleteIcon from "@aivenio/aquarium/dist/src/icons/delete";
 import tickCircle from "@aivenio/aquarium/dist/src/icons/tickCircle";
 import infoSign from "@aivenio/aquarium/dist/src/icons/infoSign";
@@ -45,23 +39,11 @@ const columns: Array<DataTableColumn<TopicRequestTableData>> = [
     width: 30,
     UNSAFE_render: (row) => {
       return (
-        <GhostButton
-          onClick={() => alert("Approve")}
-          title={`View topic request `}
-          dense
-        >
-          <Box
-            component={"span"}
-            display={"flex"}
-            alignItems={"center"}
-            colGap={"2"}
-          >
-            <Icon icon={infoSign} />
-            <span aria-hidden={"true"}>View details</span>
-            <span className={"visually-hidden"}>
-              View topic request for {row.topicname}
-            </span>
-          </Box>
+        <GhostButton onClick={() => alert("Approve")} icon={infoSign} dense>
+          <span aria-hidden={"true"}>View details</span>
+          <span className={"visually-hidden"}>
+            View topic request for {row.topicname}
+          </span>
         </GhostButton>
       );
     },
@@ -79,10 +61,9 @@ const columns: Array<DataTableColumn<TopicRequestTableData>> = [
       return (
         <GhostButton
           onClick={() => alert("Approve")}
-          title={`Approve topic request for ${row.topicname}`}
-        >
-          <Icon color="grey-70" icon={tickCircle} />
-        </GhostButton>
+          aria-label={`Approve topic request for ${row.topicname}`}
+          icon={tickCircle}
+        />
       );
     },
   },
@@ -99,10 +80,9 @@ const columns: Array<DataTableColumn<TopicRequestTableData>> = [
       return (
         <GhostButton
           onClick={() => alert("Decline")}
-          title={`Decline topic request for ${row.topicname}`}
-        >
-          <Icon color="grey-70" icon={deleteIcon} />
-        </GhostButton>
+          aria-label={`Decline topic request for ${row.topicname}`}
+          icon={deleteIcon}
+        />
       );
     },
   },

--- a/coral/src/app/features/approvals/topics/components/TopicApprovalsTable.tsx
+++ b/coral/src/app/features/approvals/topics/components/TopicApprovalsTable.tsx
@@ -1,0 +1,140 @@
+import {
+  Box,
+  DataTable,
+  DataTableColumn,
+  GhostButton,
+  Icon,
+} from "@aivenio/aquarium";
+import deleteIcon from "@aivenio/aquarium/dist/src/icons/delete";
+import tickCircle from "@aivenio/aquarium/dist/src/icons/tickCircle";
+import infoSign from "@aivenio/aquarium/dist/src/icons/infoSign";
+import { TopicRequestNew } from "src/domain/topic/topic-types";
+
+interface TopicRequestTableData {
+  id: number; // unclear
+  topicname: string;
+  environmentName: string;
+  topictype: string;
+  teamname: string; // unclear
+  requestor: string;
+  requesttimestring: string;
+}
+
+const columns: Array<DataTableColumn<TopicRequestTableData>> = [
+  { type: "text", field: "topicname", headerName: "Topic" },
+  { type: "text", field: "environmentName", headerName: "Cluster" },
+  { type: "text", field: "topictype", headerName: "Type" },
+  { type: "text", field: "teamname", headerName: "Claim by team" },
+  { type: "text", field: "requestor", headerName: "Requested by" },
+  {
+    type: "text",
+    field: "requesttimestring",
+    headerName: "Date Requested",
+    formatter: (value) => {
+      return `${value} UTC`;
+    },
+  },
+  {
+    type: "custom",
+    // @TODO PR open in DS to be able to
+    // add an "invisible" header name that
+    // is used as aria-label. That will also
+    // solve the duplicate key warning
+    //https://github.com/aiven/design-system/pull/950
+    headerName: "Details",
+    width: 30,
+    UNSAFE_render: (row) => {
+      return (
+        <GhostButton
+          onClick={() => alert("Approve")}
+          title={`View topic request `}
+          dense
+        >
+          <Box
+            component={"span"}
+            display={"flex"}
+            alignItems={"center"}
+            colGap={"2"}
+          >
+            <Icon icon={infoSign} />
+            <span aria-hidden={"true"}>View details</span>
+            <span className={"visually-hidden"}>
+              View topic request for {row.topicname}
+            </span>
+          </Box>
+        </GhostButton>
+      );
+    },
+  },
+  {
+    type: "custom",
+    // @TODO PR open in DS to be able to
+    // add an "invisible" header name that
+    // is used as aria-label. That will also
+    // solve the duplicate key warning
+    //https://github.com/aiven/design-system/pull/950
+    headerName: "Approve",
+    width: 30,
+    UNSAFE_render: (row) => {
+      return (
+        <GhostButton
+          onClick={() => alert("Approve")}
+          title={`Approve topic request for ${row.topicname}`}
+        >
+          <Icon color="grey-70" icon={tickCircle} />
+        </GhostButton>
+      );
+    },
+  },
+  {
+    type: "custom",
+    // @TODO PR open in DS to be able to
+    // add an "invisible" header name that
+    // is used as aria-label. That will also
+    // solve the duplicate key warning
+    //https://github.com/aiven/design-system/pull/950
+    headerName: "Decline",
+    width: 30,
+    UNSAFE_render: (row) => {
+      return (
+        <GhostButton
+          onClick={() => alert("Decline")}
+          title={`Decline topic request for ${row.topicname}`}
+        >
+          <Icon color="grey-70" icon={deleteIcon} />
+        </GhostButton>
+      );
+    },
+  },
+];
+
+type TopicApprovalsTableProp = {
+  requests: TopicRequestNew[];
+};
+function TopicApprovalsTable(props: TopicApprovalsTableProp) {
+  const { requests } = props;
+
+  const rows: TopicRequestTableData[] = requests.map(
+    (request: TopicRequestNew) => {
+      return {
+        id: request.topicid,
+        topicname: request.topicname,
+        environmentName: request.environmentName,
+        topictype: request.topictype,
+        teamname: request.teamname,
+        requestor: request.requestor,
+        requesttimestring: request.requesttimestring,
+      };
+    }
+  );
+  return (
+    <DataTable
+      ariaLabel={"Topic requests"}
+      columns={columns}
+      rows={rows}
+      noWrap={false}
+    />
+  );
+}
+
+export { TopicApprovalsTable };

--- a/coral/src/domain/topic/index.ts
+++ b/coral/src/domain/topic/index.ts
@@ -3,7 +3,23 @@ import {
   getTopics,
   getTopicTeam,
 } from "src/domain/topic/topic-api";
-import { Topic, TopicNames, TopicTeam } from "src/domain/topic/topic-types";
+import {
+  Topic,
+  TopicNames,
+  TopicRequest,
+  TopicRequestTypes,
+  TopicTeam,
+  TopicRequestStatus,
+  TopicRequestNew,
+} from "src/domain/topic/topic-types";
 
-export type { Topic, TopicNames, TopicTeam };
+export type {
+  Topic,
+  TopicNames,
+  TopicTeam,
+  TopicRequest,
+  TopicRequestNew,
+  TopicRequestTypes,
+  TopicRequestStatus,
+};
 export { getTopics, getTopicNames, getTopicTeam };

--- a/coral/src/domain/topic/topic-types.ts
+++ b/coral/src/domain/topic/topic-types.ts
@@ -1,4 +1,5 @@
-import type { KlawApiModel } from "types/utils";
+import type { KlawApiModel, ResolveIntersectionTypes } from "types/utils";
+import { components } from "types/api";
 
 type Paginated<T> = {
   totalPages: number;
@@ -8,9 +9,11 @@ type Paginated<T> = {
 
 type TopicApiResponse = Paginated<Topic[]>;
 
-type Topic = KlawApiModel<"TopicInfo">;
-type TopicNames = KlawApiModel<"TopicsGetOnlyResponse">;
-type TopicTeam = KlawApiModel<"TopicGetTeamResponse">;
+type Topic = ResolveIntersectionTypes<KlawApiModel<"TopicInfo">>;
+type TopicNames = ResolveIntersectionTypes<
+  KlawApiModel<"TopicsGetOnlyResponse">
+>;
+type TopicTeam = ResolveIntersectionTypes<KlawApiModel<"TopicGetTeamResponse">>;
 
 type TopicAdvancedConfigurationOptions = {
   key: string;
@@ -20,6 +23,26 @@ type TopicAdvancedConfigurationOptions = {
     text: string;
   };
 };
+
+// @TODO add more refined typing when implementation needs are more clear
+type TopicRequestTypes = components["schemas"]["TopicRequestTypes"];
+type TopicRequestStatus = components["schemas"]["RequestStatus"];
+
+type TopicRequestNew = ResolveIntersectionTypes<
+  Required<
+    Pick<
+      KlawApiModel<"TopicRequest">,
+      | "topicid"
+      | "topicname"
+      | "environmentName"
+      | "topictype"
+      | "teamname"
+      | "requestor"
+      | "requesttimestring"
+    >
+  > &
+    KlawApiModel<"TopicRequest">
+>;
 
 // The proper type for this will take shape once we know what data
 // we need in the upcoming features.
@@ -34,4 +57,7 @@ export type {
   TopicApiResponse,
   TopicAdvancedConfigurationOptions,
   TopicRequest,
+  TopicRequestNew,
+  TopicRequestTypes,
+  TopicRequestStatus,
 };


### PR DESCRIPTION
# About this change - What it does

- adds the "Approve schema request page" ui only with:
    - adds table, filter elements, search element and pagination
    - hard coded data for requests
    - placeholder values for selects
    - no functionality behind any buttons or pagination 
    - adds temp type (updated API def for changes endpoint will come later)
   

## Note about the current implementation
- there were api endpoints added already, but they were updated in the meantime, so will update that and connect them in a later PR
- I added types as they are needed right now - when the api endpoints change, already added types and transformer will change, but I'll do that in the other PR

Resolves: #608 

