### PR TITLE
feat(coral): Add RequestDetailsModal and RequestDeclineModal

### DIFF
--- a/coral/src/app/components/Modal.module.css
+++ b/coral/src/app/components/Modal.module.css
@@ -4,7 +4,6 @@
   height: 100vh;
   width: 100%;
   background-color: rgba(48, 55, 94, 0.7);
-  z-index: 2;
 }
 
 .modalTextBlock {

--- a/coral/src/app/components/Modal.test.tsx
+++ b/coral/src/app/components/Modal.test.tsx
@@ -256,14 +256,14 @@ describe("Modal.tsx", () => {
       const mockSecondary = {
         text: "this is the secondary action",
         onClick: jest.fn(),
-        isLoading: true,
+        loading: true,
       };
 
       beforeEach(() => {
         render(
           <Modal
             title={testTitle}
-            primaryAction={{ ...mockPrimary, isLoading: true }}
+            primaryAction={{ ...mockPrimary, loading: true }}
             secondaryAction={mockSecondary}
             close={mockClose}
           >

--- a/coral/src/app/components/Modal.test.tsx
+++ b/coral/src/app/components/Modal.test.tsx
@@ -251,21 +251,21 @@ describe("Modal.tsx", () => {
       });
     });
 
-    describe("handles isLoading state", () => {
+    describe("handles Modal actions isLoading state", () => {
       const mockClose = jest.fn();
       const mockSecondary = {
         text: "this is the secondary action",
         onClick: jest.fn(),
+        isLoading: true,
       };
 
       beforeEach(() => {
         render(
           <Modal
             title={testTitle}
-            primaryAction={mockPrimary}
+            primaryAction={{ ...mockPrimary, isLoading: true }}
             secondaryAction={mockSecondary}
             close={mockClose}
-            isLoading
           >
             {mockChildren}
           </Modal>
@@ -287,21 +287,21 @@ describe("Modal.tsx", () => {
       });
     });
 
-    describe("handles disabled state", () => {
+    describe("handles Modal actions disabled state", () => {
       const mockClose = jest.fn();
       const mockSecondary = {
         text: "this is the secondary action",
         onClick: jest.fn(),
+        disabled: true,
       };
 
       beforeEach(() => {
         render(
           <Modal
             title={testTitle}
-            primaryAction={mockPrimary}
+            primaryAction={{ ...mockPrimary, disabled: true }}
             secondaryAction={mockSecondary}
             close={mockClose}
-            disabled
           >
             {mockChildren}
           </Modal>
@@ -310,7 +310,7 @@ describe("Modal.tsx", () => {
 
       afterEach(cleanup);
 
-      it("disables primary action button", () => {
+      it("disables primary and secondary action button", () => {
         const buttonPrimary = screen.getByRole("button", {
           name: mockPrimary.text,
         });
@@ -319,7 +319,7 @@ describe("Modal.tsx", () => {
         });
 
         expect(buttonPrimary).toBeDisabled();
-        expect(buttonSecondary).toBeEnabled();
+        expect(buttonSecondary).toBeDisabled();
       });
     });
   });

--- a/coral/src/app/components/Modal.test.tsx
+++ b/coral/src/app/components/Modal.test.tsx
@@ -1,6 +1,6 @@
 import { cleanup, render, RenderResult, screen } from "@testing-library/react";
-import { Modal } from "src/app/components/Modal";
 import userEvent from "@testing-library/user-event";
+import { Modal } from "src/app/components/Modal";
 
 describe("Modal.tsx", () => {
   const testTitle = "Modal title";
@@ -248,6 +248,78 @@ describe("Modal.tsx", () => {
         await userEvent.keyboard("{Escape}");
 
         expect(mockClose).toHaveBeenCalled();
+      });
+    });
+
+    describe("handles isLoading state", () => {
+      const mockClose = jest.fn();
+      const mockSecondary = {
+        text: "this is the secondary action",
+        onClick: jest.fn(),
+      };
+
+      beforeEach(() => {
+        render(
+          <Modal
+            title={testTitle}
+            primaryAction={mockPrimary}
+            secondaryAction={mockSecondary}
+            close={mockClose}
+            isLoading
+          >
+            {mockChildren}
+          </Modal>
+        );
+      });
+
+      afterEach(cleanup);
+
+      it("disables primary and secondary action button", () => {
+        const buttonPrimary = screen.getByRole("button", {
+          name: mockPrimary.text,
+        });
+        const buttonSecondary = screen.getByRole("button", {
+          name: mockSecondary.text,
+        });
+
+        expect(buttonPrimary).toBeDisabled();
+        expect(buttonSecondary).toBeDisabled();
+      });
+    });
+
+    describe("handles disabled state", () => {
+      const mockClose = jest.fn();
+      const mockSecondary = {
+        text: "this is the secondary action",
+        onClick: jest.fn(),
+      };
+
+      beforeEach(() => {
+        render(
+          <Modal
+            title={testTitle}
+            primaryAction={mockPrimary}
+            secondaryAction={mockSecondary}
+            close={mockClose}
+            disabled
+          >
+            {mockChildren}
+          </Modal>
+        );
+      });
+
+      afterEach(cleanup);
+
+      it("disables primary action button", () => {
+        const buttonPrimary = screen.getByRole("button", {
+          name: mockPrimary.text,
+        });
+        const buttonSecondary = screen.getByRole("button", {
+          name: mockSecondary.text,
+        });
+
+        expect(buttonPrimary).toBeDisabled();
+        expect(buttonSecondary).toBeEnabled();
       });
     });
   });

--- a/coral/src/app/components/Modal.tsx
+++ b/coral/src/app/components/Modal.tsx
@@ -171,7 +171,7 @@ function Modal(props: ModalProps) {
                   data-focusable
                   // Secondary action is highly unlikely to be an async process
                   // So we disable it when isLoading, and don't show loading state for it
-                  disabled={disabled || isLoading}
+                  disabled={isLoading}
                 >
                   {secondaryAction.text}
                 </Button>

--- a/coral/src/app/components/Modal.tsx
+++ b/coral/src/app/components/Modal.tsx
@@ -162,8 +162,6 @@ function Modal(props: ModalProps) {
                   kind={"secondary"}
                   onClick={secondaryAction.onClick}
                   data-focusable
-                  // Secondary action is highly unlikely to be an async process
-                  // So we disable it when isLoading, and don't show loading state for it
                   disabled={secondaryAction.disabled}
                   loading={secondaryAction.isLoading}
                 >

--- a/coral/src/app/components/Modal.tsx
+++ b/coral/src/app/components/Modal.tsx
@@ -15,11 +15,21 @@ type ModalProps = {
   primaryAction: ModalAction;
   secondaryAction?: ModalAction;
   children: ReactElement;
+  disabled?: boolean;
+  isLoading?: boolean;
 };
 
 function Modal(props: ModalProps) {
-  const { close, primaryAction, secondaryAction, children, title, subtitle } =
-    props;
+  const {
+    close,
+    primaryAction,
+    secondaryAction,
+    children,
+    title,
+    subtitle,
+    disabled = false,
+    isLoading = false,
+  } = props;
 
   function setFocus(appRoot: HTMLElement, modal: HTMLElement) {
     appRoot.setAttribute("aria-hidden", "true");
@@ -159,6 +169,9 @@ function Modal(props: ModalProps) {
                   kind={"secondary"}
                   onClick={secondaryAction.onClick}
                   data-focusable
+                  // Secondary action is highly unlikely to be an async process
+                  // So we disable it when isLoading, and don't show loading state for it
+                  disabled={disabled || isLoading}
                 >
                   {secondaryAction.text}
                 </Button>
@@ -167,6 +180,8 @@ function Modal(props: ModalProps) {
                 kind={"primary"}
                 onClick={primaryAction.onClick}
                 data-focusable
+                disabled={disabled}
+                loading={isLoading}
               >
                 {primaryAction.text}
               </Button>

--- a/coral/src/app/components/Modal.tsx
+++ b/coral/src/app/components/Modal.tsx
@@ -7,7 +7,10 @@ import classes from "src/app/components/Modal.module.css";
 type ModalAction = {
   text: string;
   onClick: () => void;
+  isLoading?: boolean;
+  disabled?: boolean;
 };
+
 type ModalProps = {
   title: string;
   subtitle?: string;
@@ -15,21 +18,11 @@ type ModalProps = {
   primaryAction: ModalAction;
   secondaryAction?: ModalAction;
   children: ReactElement;
-  disabled?: boolean;
-  isLoading?: boolean;
 };
 
 function Modal(props: ModalProps) {
-  const {
-    close,
-    primaryAction,
-    secondaryAction,
-    children,
-    title,
-    subtitle,
-    disabled = false,
-    isLoading = false,
-  } = props;
+  const { close, primaryAction, secondaryAction, children, title, subtitle } =
+    props;
 
   function setFocus(appRoot: HTMLElement, modal: HTMLElement) {
     appRoot.setAttribute("aria-hidden", "true");
@@ -171,7 +164,8 @@ function Modal(props: ModalProps) {
                   data-focusable
                   // Secondary action is highly unlikely to be an async process
                   // So we disable it when isLoading, and don't show loading state for it
-                  disabled={isLoading}
+                  disabled={secondaryAction.disabled}
+                  loading={secondaryAction.isLoading}
                 >
                   {secondaryAction.text}
                 </Button>
@@ -180,8 +174,8 @@ function Modal(props: ModalProps) {
                 kind={"primary"}
                 onClick={primaryAction.onClick}
                 data-focusable
-                disabled={disabled}
-                loading={isLoading}
+                disabled={primaryAction.disabled}
+                loading={primaryAction.isLoading}
               >
                 {primaryAction.text}
               </Button>

--- a/coral/src/app/components/Modal.tsx
+++ b/coral/src/app/components/Modal.tsx
@@ -1,13 +1,13 @@
-import { createPortal } from "react-dom";
-import { ReactElement, useEffect } from "react";
 import { Box, Button, IconButton, Typography } from "@aivenio/aquarium";
 import cross from "@aivenio/aquarium/icons/cross";
+import { ReactElement, useEffect } from "react";
+import { createPortal } from "react-dom";
 import classes from "src/app/components/Modal.module.css";
 
 type ModalAction = {
   text: string;
   onClick: () => void;
-  isLoading?: boolean;
+  loading?: boolean;
   disabled?: boolean;
 };
 
@@ -163,7 +163,7 @@ function Modal(props: ModalProps) {
                   onClick={secondaryAction.onClick}
                   data-focusable
                   disabled={secondaryAction.disabled}
-                  loading={secondaryAction.isLoading}
+                  loading={secondaryAction.loading}
                 >
                   {secondaryAction.text}
                 </Button>
@@ -173,7 +173,7 @@ function Modal(props: ModalProps) {
                 onClick={primaryAction.onClick}
                 data-focusable
                 disabled={primaryAction.disabled}
-                loading={primaryAction.isLoading}
+                loading={primaryAction.loading}
               >
                 {primaryAction.text}
               </Button>

--- a/coral/src/app/components/Modal.tsx
+++ b/coral/src/app/components/Modal.tsx
@@ -147,6 +147,7 @@ function Modal(props: ModalProps) {
                   icon={cross}
                   onClick={close}
                   data-focusable
+                  disabled={secondaryAction?.loading || primaryAction.loading}
                 />
               )}
             </Box>

--- a/coral/src/app/features/approvals/components/RequestDetailsModal.test.tsx
+++ b/coral/src/app/features/approvals/components/RequestDetailsModal.test.tsx
@@ -1,0 +1,74 @@
+import { cleanup, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import RequestDetailsModal from "src/app/features/approvals/components/RequestDetailsModal";
+
+const baseProps = {
+  onClose: jest.fn(),
+  onApprove: jest.fn(),
+  onReject: jest.fn(),
+};
+
+describe.only("RequestDetailsModal.test", () => {
+  afterEach(cleanup);
+
+  it("renders a Modal with correct elements (isLoading false)", () => {
+    render(
+      <RequestDetailsModal {...baseProps} isLoading={false}>
+        <div>content</div>
+      </RequestDetailsModal>
+    );
+
+    expect(
+      screen.getByRole("heading", { name: "Request details" })
+    ).toBeVisible();
+    expect(screen.getByText("content")).toBeVisible();
+    expect(screen.getByRole("button", { name: "Close modal" })).toBeVisible();
+    expect(screen.getByRole("button", { name: "Close modal" })).toBeVisible();
+    expect(screen.getByRole("button", { name: "Approve" })).toBeEnabled();
+    expect(screen.getByRole("button", { name: "Approve" })).toBeEnabled();
+    expect(screen.getByRole("button", { name: "Reject" })).toBeVisible();
+    expect(screen.getByRole("button", { name: "Reject" })).toBeEnabled();
+  });
+
+  it("renders a Modal with correct elements (isLoading true)", () => {
+    render(
+      <RequestDetailsModal {...baseProps} isLoading={true}>
+        <div>content</div>
+      </RequestDetailsModal>
+    );
+
+    expect(
+      screen.getByRole("heading", { name: "Request details" })
+    ).toBeVisible();
+    expect(screen.getByText("content")).toBeVisible();
+    expect(screen.getByRole("button", { name: "Close modal" })).toBeVisible();
+    expect(screen.getByRole("button", { name: "Close modal" })).toBeVisible();
+    expect(screen.getByRole("button", { name: "Approve" })).toBeVisible();
+    expect(screen.getByRole("button", { name: "Approve" })).toBeDisabled();
+    expect(screen.getByRole("button", { name: "Reject" })).toBeVisible();
+    expect(screen.getByRole("button", { name: "Reject" })).toBeDisabled();
+  });
+
+  it("calls correct functions when clicking buttons", async () => {
+    render(
+      <RequestDetailsModal {...baseProps} isLoading={false}>
+        <div>content</div>
+      </RequestDetailsModal>
+    );
+
+    const { onClose, onApprove, onReject } = baseProps;
+
+    const closeButton = screen.getByRole("button", { name: "Close modal" });
+    const approveButton = screen.getByRole("button", { name: "Approve" });
+    const rejectButton = screen.getByRole("button", { name: "Reject" });
+
+    await userEvent.click(closeButton);
+    expect(onClose).toHaveBeenCalledTimes(1);
+
+    await userEvent.click(approveButton);
+    expect(onApprove).toHaveBeenCalledTimes(1);
+
+    await userEvent.click(rejectButton);
+    expect(onReject).toHaveBeenCalledTimes(1);
+  });
+});

--- a/coral/src/app/features/approvals/components/RequestDetailsModal.test.tsx
+++ b/coral/src/app/features/approvals/components/RequestDetailsModal.test.tsx
@@ -9,60 +9,105 @@ const baseProps = {
 };
 
 describe("RequestDetailsModal.test", () => {
-  afterEach(cleanup);
+  describe("renders a Modal with correct elements when isLoading is false (before interaction)", () => {
+    beforeAll(() => {
+      render(
+        <RequestDetailsModal {...baseProps} isLoading={false}>
+          <div>content</div>
+        </RequestDetailsModal>
+      );
+    });
+    afterAll(cleanup);
 
-  it("renders a Modal with correct elements (isLoading false)", () => {
-    render(
-      <RequestDetailsModal {...baseProps} isLoading={false}>
-        <div>content</div>
-      </RequestDetailsModal>
-    );
+    it("renders a Modal", () => {
+      expect(screen.getByRole("dialog")).toBeVisible();
+    });
 
-    expect(
-      screen.getByRole("heading", { name: "Request details" })
-    ).toBeVisible();
-    expect(screen.getByText("content")).toBeVisible();
-    expect(screen.getByRole("button", { name: "Close modal" })).toBeEnabled();
-    expect(screen.getByRole("button", { name: "Approve" })).toBeEnabled();
-    expect(screen.getByRole("button", { name: "Reject" })).toBeEnabled();
+    it("renders correct heading", () => {
+      expect(
+        screen.getByRole("heading", { name: "Request details" })
+      ).toBeVisible();
+    });
+
+    it("renders enabled Close button", () => {
+      expect(screen.getByRole("button", { name: "Close modal" })).toBeEnabled();
+    });
+
+    it("renders enabled Approve button", () => {
+      expect(screen.getByRole("button", { name: "Approve" })).toBeEnabled();
+    });
+
+    it("renders enabled Reject request button", () => {
+      expect(screen.getByRole("button", { name: "Reject" })).toBeEnabled();
+    });
   });
 
-  it("renders a Modal with correct elements (isLoading true)", () => {
-    render(
-      <RequestDetailsModal {...baseProps} isLoading={true}>
-        <div>content</div>
-      </RequestDetailsModal>
-    );
+  describe("renders a Modal with correct elements when isLoading is true", () => {
+    beforeAll(() => {
+      render(
+        <RequestDetailsModal {...baseProps} isLoading={true}>
+          <div>content</div>
+        </RequestDetailsModal>
+      );
+    });
+    afterAll(cleanup);
 
-    expect(
-      screen.getByRole("heading", { name: "Request details" })
-    ).toBeVisible();
-    expect(screen.getByText("content")).toBeVisible();
-    expect(screen.getByRole("button", { name: "Close modal" })).toBeEnabled();
-    expect(screen.getByRole("button", { name: "Approve" })).toBeDisabled();
-    expect(screen.getByRole("button", { name: "Reject" })).toBeDisabled();
+    it("renders correct heading", () => {
+      expect(
+        screen.getByRole("heading", { name: "Request details" })
+      ).toBeVisible();
+    });
+
+    it("renders disabled Close button", () => {
+      expect(
+        screen.getByRole("button", { name: "Close modal" })
+      ).toBeDisabled();
+    });
+
+    it("renders disabled Approve button", () => {
+      expect(screen.getByRole("button", { name: "Approve" })).toBeDisabled();
+    });
+
+    it("renders disabled Reject request button", () => {
+      expect(screen.getByRole("button", { name: "Reject" })).toBeDisabled();
+    });
   });
 
-  it("calls correct functions when clicking buttons", async () => {
-    render(
-      <RequestDetailsModal {...baseProps} isLoading={false}>
-        <div>content</div>
-      </RequestDetailsModal>
-    );
+  describe("handles user interaction", () => {
+    beforeAll(() => {
+      render(
+        <RequestDetailsModal {...baseProps} isLoading={false}>
+          <div>content</div>
+        </RequestDetailsModal>
+      );
+    });
+    afterAll(cleanup);
 
-    const { onClose, onApprove, onReject } = baseProps;
+    it("user can close Modal", async () => {
+      const { onClose } = baseProps;
+      const closeButton = screen.getByRole("button", { name: "Close modal" });
 
-    const closeButton = screen.getByRole("button", { name: "Close modal" });
-    const approveButton = screen.getByRole("button", { name: "Approve" });
-    const rejectButton = screen.getByRole("button", { name: "Reject" });
+      await userEvent.click(closeButton);
+      expect(onClose).toHaveBeenCalledTimes(1);
+    });
 
-    await userEvent.click(closeButton);
-    expect(onClose).toHaveBeenCalledTimes(1);
+    it("user can approve", async () => {
+      const { onApprove } = baseProps;
+      const approveButton = screen.getByRole("button", { name: "Approve" });
 
-    await userEvent.click(approveButton);
-    expect(onApprove).toHaveBeenCalledTimes(1);
+      await userEvent.click(approveButton);
+      expect(onApprove).toHaveBeenCalledTimes(1);
+    });
 
-    await userEvent.click(rejectButton);
-    expect(onReject).toHaveBeenCalledTimes(1);
+    it("user can reject", async () => {
+      const { onReject } = baseProps;
+
+      const rejectButton = screen.getByRole("button", {
+        name: "Reject",
+      });
+
+      await userEvent.click(rejectButton);
+      expect(onReject).toHaveBeenCalledTimes(1);
+    });
   });
 });

--- a/coral/src/app/features/approvals/components/RequestDetailsModal.test.tsx
+++ b/coral/src/app/features/approvals/components/RequestDetailsModal.test.tsx
@@ -8,7 +8,7 @@ const baseProps = {
   onReject: jest.fn(),
 };
 
-describe.only("RequestDetailsModal.test", () => {
+describe("RequestDetailsModal.test", () => {
   afterEach(cleanup);
 
   it("renders a Modal with correct elements (isLoading false)", () => {

--- a/coral/src/app/features/approvals/components/RequestDetailsModal.test.tsx
+++ b/coral/src/app/features/approvals/components/RequestDetailsModal.test.tsx
@@ -22,11 +22,8 @@ describe("RequestDetailsModal.test", () => {
       screen.getByRole("heading", { name: "Request details" })
     ).toBeVisible();
     expect(screen.getByText("content")).toBeVisible();
-    expect(screen.getByRole("button", { name: "Close modal" })).toBeVisible();
-    expect(screen.getByRole("button", { name: "Close modal" })).toBeVisible();
+    expect(screen.getByRole("button", { name: "Close modal" })).toBeEnabled();
     expect(screen.getByRole("button", { name: "Approve" })).toBeEnabled();
-    expect(screen.getByRole("button", { name: "Approve" })).toBeEnabled();
-    expect(screen.getByRole("button", { name: "Reject" })).toBeVisible();
     expect(screen.getByRole("button", { name: "Reject" })).toBeEnabled();
   });
 
@@ -41,11 +38,8 @@ describe("RequestDetailsModal.test", () => {
       screen.getByRole("heading", { name: "Request details" })
     ).toBeVisible();
     expect(screen.getByText("content")).toBeVisible();
-    expect(screen.getByRole("button", { name: "Close modal" })).toBeVisible();
-    expect(screen.getByRole("button", { name: "Close modal" })).toBeVisible();
-    expect(screen.getByRole("button", { name: "Approve" })).toBeVisible();
+    expect(screen.getByRole("button", { name: "Close modal" })).toBeEnabled();
     expect(screen.getByRole("button", { name: "Approve" })).toBeDisabled();
-    expect(screen.getByRole("button", { name: "Reject" })).toBeVisible();
     expect(screen.getByRole("button", { name: "Reject" })).toBeDisabled();
   });
 

--- a/coral/src/app/features/approvals/components/RequestDetailsModal.tsx
+++ b/coral/src/app/features/approvals/components/RequestDetailsModal.tsx
@@ -20,9 +20,12 @@ const RequestDetailsModal = ({
     <Modal
       title={"Request details"}
       close={onClose}
-      primaryAction={{ text: "Approve", onClick: onApprove }}
-      secondaryAction={{ text: "Reject", onClick: onReject }}
-      isLoading={isLoading}
+      primaryAction={{ text: "Approve", onClick: onApprove, isLoading }}
+      secondaryAction={{
+        text: "Reject",
+        onClick: onReject,
+        disabled: isLoading,
+      }}
     >
       {children}
     </Modal>

--- a/coral/src/app/features/approvals/components/RequestDetailsModal.tsx
+++ b/coral/src/app/features/approvals/components/RequestDetailsModal.tsx
@@ -1,0 +1,32 @@
+import { ReactElement } from "react";
+import { Modal } from "src/app/components/Modal";
+
+interface RequestDetailsModalProps {
+  onClose: () => void;
+  onApprove: () => void;
+  onReject: () => void;
+  children: ReactElement;
+  isLoading: boolean;
+}
+
+const RequestDetailsModal = ({
+  children,
+  onClose,
+  onApprove,
+  onReject,
+  isLoading,
+}: RequestDetailsModalProps) => {
+  return (
+    <Modal
+      title={"Request details"}
+      close={onClose}
+      primaryAction={{ text: "Approve", onClick: onApprove }}
+      secondaryAction={{ text: "Reject", onClick: onReject }}
+      isLoading={isLoading}
+    >
+      {children}
+    </Modal>
+  );
+};
+
+export default RequestDetailsModal;

--- a/coral/src/app/features/approvals/components/RequestDetailsModal.tsx
+++ b/coral/src/app/features/approvals/components/RequestDetailsModal.tsx
@@ -20,7 +20,11 @@ const RequestDetailsModal = ({
     <Modal
       title={"Request details"}
       close={onClose}
-      primaryAction={{ text: "Approve", onClick: onApprove, isLoading }}
+      primaryAction={{
+        text: "Approve",
+        onClick: onApprove,
+        loading: isLoading,
+      }}
       secondaryAction={{
         text: "Reject",
         onClick: onReject,

--- a/coral/src/app/features/approvals/components/RequestRejectModal.test.tsx
+++ b/coral/src/app/features/approvals/components/RequestRejectModal.test.tsx
@@ -9,86 +9,134 @@ const baseProps = {
 };
 
 describe("RequestRejectModal.test", () => {
-  afterEach(cleanup);
+  describe("renders a Modal with correct elements when isLoading is false (before interaction)", () => {
+    beforeAll(() => {
+      render(<RequestRejectModal {...baseProps} isLoading={false} />);
+    });
+    afterAll(cleanup);
 
-  it("renders a Modal with correct elements on first load (isLoading false)", () => {
-    render(<RequestRejectModal {...baseProps} isLoading={false} />);
-
-    expect(
-      screen.getByRole("heading", { name: "Reject request" })
-    ).toBeVisible();
-    expect(
-      screen.getByRole("textbox", {
-        name: "Submit a reason to decline the request *",
-      })
-    ).toBeEnabled();
-    expect(screen.getByRole("button", { name: "Close modal" })).toBeEnabled();
-    expect(screen.getByRole("button", { name: "Cancel" })).toBeEnabled();
-    expect(
-      screen.getByRole("button", { name: "Reject request" })
-    ).toBeDisabled();
-  });
-
-  it("renders a Modal with correct elements (isLoading true)", () => {
-    render(<RequestRejectModal {...baseProps} isLoading={true} />);
-
-    expect(
-      screen.getByRole("heading", { name: "Reject request" })
-    ).toBeVisible();
-    expect(
-      screen.getByRole("textbox", {
-        name: "Submit a reason to decline the request *",
-      })
-    ).toBeDisabled();
-    expect(screen.getByRole("button", { name: "Close modal" })).toBeEnabled();
-    expect(screen.getByRole("button", { name: "Cancel" })).toBeDisabled();
-    expect(
-      screen.getByRole("button", { name: "Reject request" })
-    ).toBeDisabled();
-  });
-
-  it("calls correct functions when clicking close and cancel buttons", async () => {
-    render(<RequestRejectModal {...baseProps} isLoading={false} />);
-
-    const { onClose, onCancel } = baseProps;
-
-    const closeButton = screen.getByRole("button", { name: "Close modal" });
-    const cancelButton = screen.getByRole("button", { name: "Cancel" });
-
-    await userEvent.click(closeButton);
-    expect(onClose).toHaveBeenCalledTimes(1);
-
-    await userEvent.click(cancelButton);
-    expect(onCancel).toHaveBeenCalledTimes(1);
-  });
-
-  it("calls correct function when clicking reject request button", async () => {
-    render(<RequestRejectModal {...baseProps} isLoading={false} />);
-
-    const { onSubmit } = baseProps;
-
-    const rejectButton = screen.getByRole("button", { name: "Reject request" });
-    const textArea = screen.getByRole("textbox", {
-      name: "Submit a reason to decline the request *",
+    it("renders a Modal", () => {
+      expect(screen.getByRole("dialog")).toBeVisible();
     });
 
-    await userEvent.type(textArea, "reason");
-    await userEvent.click(rejectButton);
-    expect(onSubmit).toHaveBeenCalledWith("reason");
-  });
-
-  it("shows error when entering a too long message", async () => {
-    render(<RequestRejectModal {...baseProps} isLoading={false} />);
-    const tooLong =
-      "Quisque commodo aliquam tristique. Class aptent taciti sociosqu ad litora torquent per conubia nostra, per inceptos himenaeos. Sed ornare turpis ac cursus vulputate. Morbi auctor sodales porttitor. Mauris placerat ante id facilisis vehicula. Pellentesque ornare quis massa elementum auctor. Suspendisse potenti. Phasellus dignissim sit amet risus vitae aliquet. Vivamus at dolor vehicula, placerat odio sit amet, imperdiet enim. Donec scelerisque pretium metus ut dignissim. Morbi posuere tortor in cursus porttitor. Maecenas a diam ut urna mattis convallis a vel ligula.";
-
-    const rejectButton = screen.getByRole("button", { name: "Reject request" });
-    const textArea = screen.getByRole("textbox", {
-      name: "Submit a reason to decline the request *",
+    it("renders correct heading", () => {
+      expect(
+        screen.getByRole("heading", { name: "Reject request" })
+      ).toBeVisible();
     });
 
-    await userEvent.type(textArea, tooLong);
-    expect(rejectButton).toBeDisabled();
-    expect(textArea).toBeInvalid();
+    it("renders enabled Reason too decline field", () => {
+      expect(
+        screen.getByRole("textbox", {
+          name: "Submit a reason to decline the request *",
+        })
+      ).toBeEnabled();
+    });
+
+    it("renders enabled Close button", () => {
+      expect(screen.getByRole("button", { name: "Close modal" })).toBeEnabled();
+    });
+
+    it("renders enabled Cancel button", () => {
+      expect(screen.getByRole("button", { name: "Cancel" })).toBeEnabled();
+    });
+
+    it("renders disabled Reject request button", () => {
+      expect(
+        screen.getByRole("button", { name: "Reject request" })
+      ).toBeDisabled();
+    });
+  });
+
+  describe("renders a Modal with correct elements when isLoading is true", () => {
+    beforeAll(() => {
+      render(<RequestRejectModal {...baseProps} isLoading={true} />);
+    });
+    afterAll(cleanup);
+
+    it("renders correct heading", () => {
+      expect(
+        screen.getByRole("heading", { name: "Reject request" })
+      ).toBeVisible();
+    });
+
+    it("renders disabled Reason too decline field", () => {
+      expect(
+        screen.getByRole("textbox", {
+          name: "Submit a reason to decline the request *",
+        })
+      ).toBeDisabled();
+    });
+
+    it("renders enabled Close button", () => {
+      expect(
+        screen.getByRole("button", { name: "Close modal" })
+      ).toBeDisabled();
+    });
+
+    it("renders disabled Cancel button", () => {
+      expect(screen.getByRole("button", { name: "Cancel" })).toBeDisabled();
+    });
+
+    it("renders disabled Reject request button", () => {
+      expect(
+        screen.getByRole("button", { name: "Reject request" })
+      ).toBeDisabled();
+    });
+  });
+
+  describe("handles user interaction", () => {
+    beforeAll(() => {
+      render(<RequestRejectModal {...baseProps} isLoading={false} />);
+    });
+    afterAll(cleanup);
+
+    it("user can close Modal", async () => {
+      const { onClose } = baseProps;
+      const closeButton = screen.getByRole("button", { name: "Close modal" });
+
+      await userEvent.click(closeButton);
+      expect(onClose).toHaveBeenCalledTimes(1);
+    });
+
+    it("user can cancel", async () => {
+      const { onCancel } = baseProps;
+
+      const cancelButton = screen.getByRole("button", { name: "Cancel" });
+
+      await userEvent.click(cancelButton);
+      expect(onCancel).toHaveBeenCalledTimes(1);
+    });
+
+    it("user can reject", async () => {
+      const { onSubmit } = baseProps;
+
+      const rejectButton = screen.getByRole("button", {
+        name: "Reject request",
+      });
+      const textArea = screen.getByRole("textbox", {
+        name: "Submit a reason to decline the request *",
+      });
+
+      await userEvent.type(textArea, "reason");
+      await userEvent.click(rejectButton);
+      expect(onSubmit).toHaveBeenCalledWith("reason");
+    });
+
+    it("shows error when entering a too long message", async () => {
+      const tooLong =
+        "Quisque commodo aliquam tristique. Class aptent taciti sociosqu ad litora torquent per conubia nostra, per inceptos himenaeos. Sed ornare turpis ac cursus vulputate. Morbi auctor sodales porttitor. Mauris placerat ante id facilisis vehicula. Pellentesque ornare quis massa elementum auctor. Suspendisse potenti. Phasellus dignissim sit amet risus vitae aliquet. Vivamus at dolor vehicula, placerat odio sit amet, imperdiet enim. Donec scelerisque pretium metus ut dignissim. Morbi posuere tortor in cursus porttitor. Maecenas a diam ut urna mattis convallis a vel ligula.";
+
+      const rejectButton = screen.getByRole("button", {
+        name: "Reject request",
+      });
+      const textArea = screen.getByRole("textbox", {
+        name: "Submit a reason to decline the request *",
+      });
+
+      await userEvent.type(textArea, tooLong);
+      expect(rejectButton).toBeDisabled();
+      expect(textArea).toBeInvalid();
+    });
   });
 });

--- a/coral/src/app/features/approvals/components/RequestRejectModal.test.tsx
+++ b/coral/src/app/features/approvals/components/RequestRejectModal.test.tsx
@@ -21,19 +21,9 @@ describe("RequestRejectModal.test", () => {
       screen.getByRole("textbox", {
         name: "Submit a reason to decline the request *",
       })
-    ).toBeVisible();
-    expect(
-      screen.getByRole("textbox", {
-        name: "Submit a reason to decline the request *",
-      })
     ).toBeEnabled();
-    expect(screen.getByRole("button", { name: "Close modal" })).toBeVisible();
     expect(screen.getByRole("button", { name: "Close modal" })).toBeEnabled();
-    expect(screen.getByRole("button", { name: "Cancel" })).toBeVisible();
     expect(screen.getByRole("button", { name: "Cancel" })).toBeEnabled();
-    expect(
-      screen.getByRole("button", { name: "Reject request" })
-    ).toBeVisible();
     expect(
       screen.getByRole("button", { name: "Reject request" })
     ).toBeDisabled();
@@ -49,19 +39,9 @@ describe("RequestRejectModal.test", () => {
       screen.getByRole("textbox", {
         name: "Submit a reason to decline the request *",
       })
-    ).toBeVisible();
-    expect(
-      screen.getByRole("textbox", {
-        name: "Submit a reason to decline the request *",
-      })
     ).toBeDisabled();
-    expect(screen.getByRole("button", { name: "Close modal" })).toBeVisible();
     expect(screen.getByRole("button", { name: "Close modal" })).toBeEnabled();
-    expect(screen.getByRole("button", { name: "Cancel" })).toBeVisible();
     expect(screen.getByRole("button", { name: "Cancel" })).toBeDisabled();
-    expect(
-      screen.getByRole("button", { name: "Reject request" })
-    ).toBeVisible();
     expect(
       screen.getByRole("button", { name: "Reject request" })
     ).toBeDisabled();
@@ -110,6 +90,5 @@ describe("RequestRejectModal.test", () => {
     await userEvent.type(textArea, tooLong);
     expect(rejectButton).toBeDisabled();
     expect(textArea).toBeInvalid();
-    expect(screen.getByText("Rejection message is too long.")).toBeVisible();
   });
 });

--- a/coral/src/app/features/approvals/components/RequestRejectModal.test.tsx
+++ b/coral/src/app/features/approvals/components/RequestRejectModal.test.tsx
@@ -1,0 +1,115 @@
+import { cleanup, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import RequestRejectModal from "src/app/features/approvals/components/RequestRejectModal";
+
+const baseProps = {
+  onClose: jest.fn(),
+  onSubmit: jest.fn(),
+  onCancel: jest.fn(),
+};
+
+describe.only("RequestRejectModal.test", () => {
+  afterEach(cleanup);
+
+  it("renders a Modal with correct elements on first load (isLoading false)", () => {
+    render(<RequestRejectModal {...baseProps} isLoading={false} />);
+
+    expect(
+      screen.getByRole("heading", { name: "Reject request" })
+    ).toBeVisible();
+    expect(
+      screen.getByRole("textbox", {
+        name: "Submit a reason to decline the request *",
+      })
+    ).toBeVisible();
+    expect(
+      screen.getByRole("textbox", {
+        name: "Submit a reason to decline the request *",
+      })
+    ).toBeEnabled();
+    expect(screen.getByRole("button", { name: "Close modal" })).toBeVisible();
+    expect(screen.getByRole("button", { name: "Close modal" })).toBeEnabled();
+    expect(screen.getByRole("button", { name: "Cancel" })).toBeVisible();
+    expect(screen.getByRole("button", { name: "Cancel" })).toBeEnabled();
+    expect(
+      screen.getByRole("button", { name: "Reject request" })
+    ).toBeVisible();
+    expect(
+      screen.getByRole("button", { name: "Reject request" })
+    ).toBeDisabled();
+  });
+
+  it("renders a Modal with correct elements (isLoading true)", () => {
+    render(<RequestRejectModal {...baseProps} isLoading={true} />);
+
+    expect(
+      screen.getByRole("heading", { name: "Reject request" })
+    ).toBeVisible();
+    expect(
+      screen.getByRole("textbox", {
+        name: "Submit a reason to decline the request *",
+      })
+    ).toBeVisible();
+    expect(
+      screen.getByRole("textbox", {
+        name: "Submit a reason to decline the request *",
+      })
+    ).toBeDisabled();
+    expect(screen.getByRole("button", { name: "Close modal" })).toBeVisible();
+    expect(screen.getByRole("button", { name: "Close modal" })).toBeEnabled();
+    expect(screen.getByRole("button", { name: "Cancel" })).toBeVisible();
+    expect(screen.getByRole("button", { name: "Cancel" })).toBeDisabled();
+    expect(
+      screen.getByRole("button", { name: "Reject request" })
+    ).toBeVisible();
+    expect(
+      screen.getByRole("button", { name: "Reject request" })
+    ).toBeDisabled();
+  });
+
+  it("calls correct functions when clicking close and cancel buttons", async () => {
+    render(<RequestRejectModal {...baseProps} isLoading={false} />);
+
+    const { onClose, onCancel } = baseProps;
+
+    const closeButton = screen.getByRole("button", { name: "Close modal" });
+    const cancelButton = screen.getByRole("button", { name: "Cancel" });
+
+    await userEvent.click(closeButton);
+    expect(onClose).toHaveBeenCalledTimes(1);
+
+    await userEvent.click(cancelButton);
+    expect(onCancel).toHaveBeenCalledTimes(1);
+  });
+
+  it("calls correct function when clicking reject request button", async () => {
+    render(<RequestRejectModal {...baseProps} isLoading={false} />);
+
+    const { onSubmit } = baseProps;
+
+    const rejectButton = screen.getByRole("button", { name: "Reject request" });
+    const textArea = screen.getByRole("textbox", {
+      name: "Submit a reason to decline the request *",
+    });
+
+    await userEvent.type(textArea, "reason");
+    await userEvent.click(rejectButton);
+    expect(onSubmit).toHaveBeenCalledWith("reason");
+  });
+
+  it("shows error when entering a too long message", async () => {
+    render(<RequestRejectModal {...baseProps} isLoading={false} />);
+    const tooLong =
+      "Quisque commodo aliquam tristique. Class aptent taciti sociosqu ad litora torquent per conubia nostra, per inceptos himenaeos. Sed ornare turpis ac cursus vulputate. Morbi auctor sodales porttitor. Mauris placerat ante id facilisis vehicula. Pellentesque ornare quis massa elementum auctor. Suspendisse potenti. Phasellus dignissim sit amet risus vitae aliquet. Vivamus at dolor vehicula, placerat odio sit amet, imperdiet enim. Donec scelerisque pretium metus ut dignissim. Morbi posuere tortor in cursus porttitor. Maecenas a diam ut urna mattis convallis a vel ligula.";
+
+    const rejectButton = screen.getByRole("button", { name: "Reject request" });
+    const textArea = screen.getByRole("textbox", {
+      name: "Submit a reason to decline the request *",
+    });
+
+    await userEvent.type(textArea, tooLong);
+    expect(rejectButton).toBeDisabled();
+    expect(textArea).toBeInvalid();
+    expect(screen.getByText("Rejection message is too long.")).toBeVisible();
+  });
+});

--- a/coral/src/app/features/approvals/components/RequestRejectModal.test.tsx
+++ b/coral/src/app/features/approvals/components/RequestRejectModal.test.tsx
@@ -8,7 +8,7 @@ const baseProps = {
   onCancel: jest.fn(),
 };
 
-describe.only("RequestRejectModal.test", () => {
+describe("RequestRejectModal.test", () => {
   afterEach(cleanup);
 
   it("renders a Modal with correct elements on first load (isLoading false)", () => {

--- a/coral/src/app/features/approvals/components/RequestRejectModal.tsx
+++ b/coral/src/app/features/approvals/components/RequestRejectModal.tsx
@@ -25,10 +25,14 @@ const RequestRejectModal = ({
       primaryAction={{
         text: "Reject request",
         onClick: () => onSubmit(rejectionMessage),
+        disabled: !isValid || rejectionMessage.length === 0,
+        isLoading: isLoading,
       }}
-      secondaryAction={{ text: "Cancel", onClick: onCancel }}
-      disabled={rejectionMessage === "" || !isValid}
-      isLoading={isLoading}
+      secondaryAction={{
+        text: "Cancel",
+        onClick: onCancel,
+        disabled: isLoading,
+      }}
     >
       <Textarea
         labelText="Submit a reason to decline the request"

--- a/coral/src/app/features/approvals/components/RequestRejectModal.tsx
+++ b/coral/src/app/features/approvals/components/RequestRejectModal.tsx
@@ -1,0 +1,46 @@
+import { Textarea } from "@aivenio/aquarium";
+import { useState } from "react";
+import { Modal } from "src/app/components/Modal";
+
+interface RequestRejectModalProps {
+  onClose: () => void;
+  onCancel: () => void;
+  onSubmit: (message: string) => void;
+  isLoading: boolean;
+}
+
+const RequestRejectModal = ({
+  onClose,
+  onSubmit,
+  onCancel,
+  isLoading,
+}: RequestRejectModalProps) => {
+  const [rejectionMessage, setRejectionMessage] = useState("");
+  const isValid = rejectionMessage.length < 300;
+
+  return (
+    <Modal
+      title={"Reject request"}
+      close={onClose}
+      primaryAction={{
+        text: "Reject request",
+        onClick: () => onSubmit(rejectionMessage),
+      }}
+      secondaryAction={{ text: "Cancel", onClick: onCancel }}
+      disabled={rejectionMessage === "" || !isValid}
+      isLoading={isLoading}
+    >
+      <Textarea
+        labelText="Submit a reason to decline the request"
+        name="rejection-reason"
+        placeholder="Write a message ..."
+        onChange={(e) => setRejectionMessage(e.target.value)}
+        helperText={!isValid ? "Rejection message is too long." : undefined}
+        valid={isValid}
+        required
+      />
+    </Modal>
+  );
+};
+
+export default RequestRejectModal;

--- a/coral/src/app/features/approvals/components/RequestRejectModal.tsx
+++ b/coral/src/app/features/approvals/components/RequestRejectModal.tsx
@@ -37,6 +37,7 @@ const RequestRejectModal = ({
         onChange={(e) => setRejectionMessage(e.target.value)}
         helperText={!isValid ? "Rejection message is too long." : undefined}
         valid={isValid}
+        disabled={isLoading}
         required
       />
     </Modal>

--- a/coral/src/app/features/approvals/components/RequestRejectModal.tsx
+++ b/coral/src/app/features/approvals/components/RequestRejectModal.tsx
@@ -26,7 +26,7 @@ const RequestRejectModal = ({
         text: "Reject request",
         onClick: () => onSubmit(rejectionMessage),
         disabled: !isValid || rejectionMessage.length === 0,
-        isLoading: isLoading,
+        loading: isLoading,
       }}
       secondaryAction={{
         text: "Cancel",

--- a/coral/src/app/layout/Layout.tsx
+++ b/coral/src/app/layout/Layout.tsx
@@ -15,6 +15,7 @@ function Layout({ children }: { children: ReactNode }) {
         style={{
           gridTemplateColumns: "240px 1fr",
           gridTemplateRows: "auto 1fr",
+          isolation: "isolate",
         }}
       >
         <GridItem


### PR DESCRIPTION
## About this change - What it does

For merge message
```
- add `RequestDetailsModal` component
- add `RequestDeclineModal` component
- add `isLoading` and `disabled` props to `Modal` component
```

This enables sharing this Modal UI across approval tables :

https://user-images.githubusercontent.com/20607294/218511007-73439f20-374e-4d97-adba-08974de7d159.mov

Resolves: #587

## Possible follow up

Use these new modal components in a generic `RequestApprovalTable` component: https://github.com/aiven/klaw/issues/617

