### PR TITLE
[WIP] RequestApprovalTable

### DIFF
--- a/coral/src/app/components/Modal.tsx
+++ b/coral/src/app/components/Modal.tsx
@@ -15,11 +15,21 @@ type ModalProps = {
   primaryAction: ModalAction;
   secondaryAction?: ModalAction;
   children: ReactElement;
+  disabled?: boolean;
+  isLoading?: boolean;
 };
 
 function Modal(props: ModalProps) {
-  const { close, primaryAction, secondaryAction, children, title, subtitle } =
-    props;
+  const {
+    close,
+    primaryAction,
+    secondaryAction,
+    children,
+    title,
+    subtitle,
+    disabled = false,
+    isLoading,
+  } = props;
 
   function setFocus(appRoot: HTMLElement, modal: HTMLElement) {
     appRoot.setAttribute("aria-hidden", "true");
@@ -159,6 +169,8 @@ function Modal(props: ModalProps) {
                   kind={"secondary"}
                   onClick={secondaryAction.onClick}
                   data-focusable
+                  disabled={disabled}
+                  loading={isLoading}
                 >
                   {secondaryAction.text}
                 </Button>
@@ -167,6 +179,8 @@ function Modal(props: ModalProps) {
                 kind={"primary"}
                 onClick={primaryAction.onClick}
                 data-focusable
+                disabled={disabled}
+                loading={isLoading}
               >
                 {primaryAction.text}
               </Button>

--- a/coral/src/app/features/approvals/acls/AclApprovals.tsx
+++ b/coral/src/app/features/approvals/acls/AclApprovals.tsx
@@ -1,20 +1,15 @@
-import {
-  DataTable,
-  DataTableColumn,
-  Flexbox,
-  GhostButton,
-  Icon,
-  StatusChip,
-} from "@aivenio/aquarium";
-import deleteIcon from "@aivenio/aquarium/dist/src/icons/delete";
-import infoSign from "@aivenio/aquarium/dist/src/icons/infoSign";
-import tickCircle from "@aivenio/aquarium/dist/src/icons/tickCircle";
+import { DataTableColumn, Flexbox, StatusChip } from "@aivenio/aquarium";
 import { useQuery } from "@tanstack/react-query";
 import { useState } from "react";
 import { useSearchParams } from "react-router-dom";
 import { Pagination } from "src/app/components/Pagination";
+import RequestApprovalTable from "src/app/features/approvals/components/RequestApprovalTable";
 import SkeletonTable from "src/app/features/approvals/SkeletonTable";
-import { getAclRequestsForApprover } from "src/domain/acl/acl-api";
+import {
+  approveAclRequest,
+  declineAclRequest,
+  getAclRequestsForApprover,
+} from "src/domain/acl/acl-api";
 import { AclRequest, AclRequestsForApprover } from "src/domain/acl/acl-types";
 
 interface AclRequestTableData {
@@ -30,153 +25,9 @@ interface AclRequestTableData {
   requesttimestring: string;
 }
 
-const columns: Array<DataTableColumn<AclRequestTableData>> = [
-  {
-    type: "custom",
-    field: "acl_ssl",
-    headerName: "Principals/Usernames",
-    UNSAFE_render: ({ acl_ssl }: AclRequestTableData) => {
-      return (
-        <Flexbox wrap={"wrap"} gap={"2"}>
-          {acl_ssl.map((ssl, index) => (
-            <StatusChip
-              status="neutral"
-              key={`${ssl}-${index}`}
-              // We need to add a space after text value
-              // Otherwise a list of values would be rendered as value1value2value3 for screen readers
-              // Instead of value1 value2 value3
-              text={`${ssl} `}
-            />
-          ))}
-        </Flexbox>
-      );
-    },
-  },
-  {
-    type: "custom",
-    field: "acl_ip",
-    headerName: "IP addresses",
-    UNSAFE_render: ({ acl_ip }: AclRequestTableData) => {
-      return (
-        <Flexbox wrap={"wrap"} gap={"2"}>
-          {acl_ip.map((ip, index) => (
-            <StatusChip
-              status="neutral"
-              key={`${ip}-${index}`}
-              // We need to add a space after text value
-              // Otherwise a list of values would be rendered as value1value2value3 for screen readers
-              // Instead of value1 value2 value3
-              text={`${ip} `}
-            />
-          ))}
-        </Flexbox>
-      );
-    },
-  },
-  {
-    type: "custom",
-    field: "topicname",
-    headerName: "Topic",
-    UNSAFE_render({ topicname, prefixed }: AclRequestTableData) {
-      return (
-        <>
-          {topicname}
-          {prefixed && <code>(prefixed)</code>}
-        </>
-      );
-    },
-  },
-  {
-    type: "status",
-    field: "environmentName",
-    headerName: "Cluster",
-    status: ({ environmentName }) => ({
-      status: "neutral",
-      text: environmentName,
-    }),
-  },
-  {
-    type: "text",
-    field: "teamname",
-    headerName: "Team",
-  },
-  {
-    type: "status",
-    field: "topictype",
-    headerName: "ACL type",
-    status: ({ topictype }) => ({
-      status: topictype === "Consumer" ? "success" : "info",
-      text: topictype,
-    }),
-  },
-  {
-    type: "text",
-    field: "username",
-    headerName: "Requested by",
-  },
-  {
-    type: "text",
-    field: "requesttimestring",
-    headerName: "Date requested",
-  },
-  {
-    // Not having a headerName triggers React error:
-    // Warning: Encountered two children with the same key, ``.
-    headerName: "",
-    type: "custom",
-    UNSAFE_render: () => {
-      return (
-        <GhostButton
-          icon={infoSign}
-          onClick={() => alert("Details modal with approve and reject buttons")}
-          title={"View request details"}
-          dense
-        >
-          View details
-        </GhostButton>
-      );
-    },
-  },
-  {
-    width: 30,
-    // Not having a headerName triggers React error:
-    // Warning: Encountered two children with the same key, ``.
-    headerName: "",
-    type: "custom",
-    UNSAFE_render: () => {
-      return (
-        <GhostButton
-          onClick={() => alert("Approve request right away")}
-          title={"Approve request"}
-        >
-          <Icon color="grey-70" icon={tickCircle} />
-        </GhostButton>
-      );
-    },
-  },
-  {
-    width: 30,
-    // Not having a headerName triggers React error:
-    // Warning: Encountered two children with the same key, ``.
-    headerName: "",
-    type: "custom",
-    UNSAFE_render: () => {
-      return (
-        <GhostButton
-          onClick={() => alert("Reject modal with form for reason")}
-          title={"Reject request"}
-        >
-          <Icon color="grey-70" icon={deleteIcon} />
-        </GhostButton>
-      );
-    },
-  },
-];
-
 function AclApprovals() {
   const [searchParams, setSearchParams] = useSearchParams();
   const initialPage = Number(searchParams.get("page"));
-
   const [activePage, setActivePage] = useState(initialPage || 1);
 
   const { data, isLoading } = useQuery<AclRequestsForApprover, Error>({
@@ -185,35 +36,127 @@ function AclApprovals() {
     keepPreviousData: true,
   });
 
-  if (data === undefined || isLoading) {
-    return <SkeletonTable />;
-  }
+  const columns: Array<DataTableColumn<AclRequestTableData>> = [
+    {
+      type: "custom",
+      field: "acl_ssl",
+      headerName: "Principals/Usernames",
+      UNSAFE_render: ({ acl_ssl }: AclRequestTableData) => {
+        return (
+          <Flexbox wrap={"wrap"} gap={"2"}>
+            {acl_ssl.map((ssl, index) => (
+              <StatusChip
+                status="neutral"
+                key={`${ssl}-${index}`}
+                // We need to add a space after text value
+                // Otherwise a list of values would be rendered as value1value2value3 for screen readers
+                // Instead of value1 value2 value3
+                text={`${ssl} `}
+              />
+            ))}
+          </Flexbox>
+        );
+      },
+    },
+    {
+      type: "custom",
+      field: "acl_ip",
+      headerName: "IP addresses",
+      UNSAFE_render: ({ acl_ip }: AclRequestTableData) => {
+        return (
+          <Flexbox wrap={"wrap"} gap={"2"}>
+            {acl_ip.map((ip, index) => (
+              <StatusChip
+                status="neutral"
+                key={`${ip}-${index}`}
+                // We need to add a space after text value
+                // Otherwise a list of values would be rendered as value1value2value3 for screen readers
+                // Instead of value1 value2 value3
+                text={`${ip} `}
+              />
+            ))}
+          </Flexbox>
+        );
+      },
+    },
+    {
+      type: "custom",
+      field: "topicname",
+      headerName: "Topic",
+      UNSAFE_render({ topicname, prefixed }: AclRequestTableData) {
+        return (
+          <>
+            {topicname}
+            {prefixed && <code>(prefixed)</code>}
+          </>
+        );
+      },
+    },
+    {
+      type: "status",
+      field: "environmentName",
+      headerName: "Cluster",
+      status: ({ environmentName }) => ({
+        status: "neutral",
+        text: environmentName,
+      }),
+    },
+    {
+      type: "text",
+      field: "teamname",
+      headerName: "Team",
+    },
+    {
+      type: "status",
+      field: "topictype",
+      headerName: "ACL type",
+      status: ({ topictype }) => ({
+        status: topictype === "Consumer" ? "success" : "info",
+        text: topictype,
+      }),
+    },
+    {
+      type: "text",
+      field: "username",
+      headerName: "Requested by",
+    },
+    {
+      type: "text",
+      field: "requesttimestring",
+      headerName: "Date requested",
+    },
+  ];
 
-  const tableData: AclRequestTableData[] = data.entries.map(
-    ({
-      req_no,
-      acl_ssl,
-      acl_ip,
-      topicname,
-      aclPatternType,
-      environmentName,
-      teamname,
-      topictype,
-      username,
-      requesttimestring,
-    }) => ({
-      id: Number(req_no),
-      acl_ssl: acl_ssl ?? [],
-      acl_ip: acl_ip ?? [],
-      topicname: topicname,
-      prefixed: aclPatternType === "PREFIXED",
-      environmentName: environmentName ?? "-",
-      teamname,
-      topictype,
-      username: username ?? "-",
-      requesttimestring: requesttimestring ?? "-",
-    })
-  );
+  const getRows = (): AclRequestTableData[] => {
+    if (data === undefined) {
+      return [];
+    }
+    return data.entries.map(
+      ({
+        req_no,
+        acl_ssl,
+        acl_ip,
+        topicname,
+        aclPatternType,
+        environmentName,
+        teamname,
+        topictype,
+        username,
+        requesttimestring,
+      }) => ({
+        id: Number(req_no),
+        acl_ssl: acl_ssl ?? [],
+        acl_ip: acl_ip ?? [],
+        topicname: topicname,
+        prefixed: aclPatternType === "PREFIXED",
+        environmentName: environmentName ?? "-",
+        teamname,
+        topictype,
+        username: username ?? "-",
+        requesttimestring: requesttimestring ?? "-",
+      })
+    );
+  };
 
   const handleChangePage = (activePage: number) => {
     setActivePage(activePage);
@@ -223,15 +166,21 @@ function AclApprovals() {
 
   return (
     <>
-      <DataTable
-        ariaLabel={"Acl requests"}
-        columns={columns}
-        rows={tableData}
-        noWrap={false}
-      />
+      {data === undefined || isLoading ? (
+        <SkeletonTable />
+      ) : (
+        <RequestApprovalTable<AclRequestTableData>
+          name={"Acl requests"}
+          columns={columns}
+          rows={getRows()}
+          dataQueryKey={["aclRequests", activePage]}
+          approveFn={approveAclRequest}
+          rejectFn={declineAclRequest}
+        />
+      )}
       <Pagination
-        activePage={data.currentPage}
-        totalPages={data.totalPages}
+        activePage={data?.currentPage || 1}
+        totalPages={data?.totalPages || 1}
         setActivePage={handleChangePage}
       />
     </>

--- a/coral/src/app/features/approvals/components/RequestApprovalTable.tsx
+++ b/coral/src/app/features/approvals/components/RequestApprovalTable.tsx
@@ -1,0 +1,180 @@
+import {
+  DataTable,
+  DataTableColumn,
+  GhostButton,
+  Icon,
+} from "@aivenio/aquarium";
+import deleteIcon from "@aivenio/aquarium/dist/src/icons/delete";
+import infoSign from "@aivenio/aquarium/dist/src/icons/infoSign";
+import loadingIcon from "@aivenio/aquarium/dist/src/icons/loading";
+import tickCircle from "@aivenio/aquarium/dist/src/icons/tickCircle";
+import {
+  MutationFunction,
+  QueryKey,
+  useMutation,
+  useQueryClient,
+} from "@tanstack/react-query";
+import { useState } from "react";
+import RequestDetailsModal from "src/app/features/approvals/components/RequestDetailsModal";
+import RequestRejectModal from "src/app/features/approvals/components/RequestRejectModal";
+
+interface BaseTableData {
+  // id should be req_no of request
+  id: number;
+}
+
+interface RequestApprovalTableProps<TableData extends BaseTableData> {
+  name: string;
+  columns: Array<DataTableColumn<TableData>>;
+  rows: TableData[];
+  dataQueryKey: QueryKey;
+  approveFn: MutationFunction<unknown, { req_no: string }>;
+  rejectFn: MutationFunction<
+    unknown,
+    { req_no: string; reasonForDecline: string }
+  >;
+}
+
+function RequestApprovalTable<TableData extends BaseTableData>({
+  name,
+  columns,
+  rows,
+  dataQueryKey,
+  approveFn,
+  rejectFn,
+}: RequestApprovalTableProps<TableData>) {
+  const queryClient = useQueryClient();
+
+  const [detailsModal, setDetailsModal] = useState({
+    isOpen: false,
+    reqNo: "",
+  });
+  const [rejectModal, setRejectModal] = useState({ isOpen: false, reqNo: "" });
+
+  const { isLoading: approveIsLoading, mutate: approveRequest } = useMutation({
+    mutationFn: approveFn,
+    onSuccess: () => {
+      setDetailsModal({ isOpen: false, reqNo: "" });
+      // We need to invalidate the query populating the table to reflect the change
+      queryClient.invalidateQueries(dataQueryKey);
+    },
+  });
+
+  const { isLoading: rejectIsLoading, mutate: rejectRequest } = useMutation({
+    mutationFn: rejectFn,
+    onSuccess: () => {
+      setRejectModal({ isOpen: false, reqNo: "" });
+      // We need to invalidate the query populating the table to reflect the change
+      queryClient.invalidateQueries(dataQueryKey);
+    },
+  });
+
+  const columnsWithActions: Array<DataTableColumn<TableData>> = [
+    ...columns,
+    {
+      // Not having a headerName triggers React error:
+      // Warning: Encountered two children with the same key, ``.
+      headerName: "",
+      type: "custom",
+      UNSAFE_render: ({ id }: TableData) => {
+        return (
+          <GhostButton
+            icon={infoSign}
+            onClick={() => setDetailsModal({ isOpen: true, reqNo: String(id) })}
+            title={"View request details"}
+            dense
+          >
+            View details
+          </GhostButton>
+        );
+      },
+    },
+    {
+      width: 30,
+      // Not having a headerName triggers React error:
+      // Warning: Encountered two children with the same key, ``.
+      headerName: "",
+      type: "custom",
+      UNSAFE_render: ({ id }: TableData) => {
+        const [isLoading, setIsLoading] = useState(false);
+        return isLoading ? (
+          <Icon icon={loadingIcon} />
+        ) : (
+          <GhostButton
+            onClick={() => {
+              setIsLoading(true);
+              return approveRequest({ req_no: String(id) });
+            }}
+            title={"Approve request"}
+          >
+            <Icon color="grey-70" icon={tickCircle} />
+          </GhostButton>
+        );
+      },
+    },
+    {
+      width: 30,
+      // Not having a headerName triggers React error:
+      // Warning: Encountered two children with the same key, ``.
+      headerName: "",
+      type: "custom",
+      UNSAFE_render: ({ id }: TableData) => {
+        return (
+          <GhostButton
+            onClick={() => setRejectModal({ isOpen: true, reqNo: String(id) })}
+            title={"Reject request"}
+          >
+            <Icon color="grey-70" icon={deleteIcon} />
+          </GhostButton>
+        );
+      },
+    },
+  ];
+
+  return (
+    <>
+      {detailsModal.isOpen && (
+        <RequestDetailsModal
+          onClose={() => setDetailsModal({ isOpen: false, reqNo: "" })}
+          onApprove={() => {
+            approveRequest({ req_no: detailsModal.reqNo });
+          }}
+          onReject={() => {
+            setDetailsModal({ isOpen: false, reqNo: "" });
+            setRejectModal({ isOpen: true, reqNo: detailsModal.reqNo });
+          }}
+          isLoading={approveIsLoading}
+        >
+          <div>
+            {JSON.stringify(
+              rows.find((request) => request.id === Number(detailsModal.reqNo))
+            )}
+          </div>
+        </RequestDetailsModal>
+      )}
+      {rejectModal.isOpen && (
+        <RequestRejectModal
+          onClose={() => setRejectModal({ isOpen: false, reqNo: "" })}
+          onCancel={() =>
+            setRejectModal({ isOpen: false, reqNo: rejectModal.reqNo })
+          }
+          onSubmit={(message: string) => {
+            rejectRequest({
+              req_no: rejectModal.reqNo,
+              reasonForDecline: message,
+            });
+          }}
+          isLoading={rejectIsLoading}
+        />
+      )}
+      <DataTable
+        ariaLabel={name}
+        columns={columnsWithActions}
+        rows={rows}
+        noWrap={false}
+      />
+    </>
+  );
+}
+
+export default RequestApprovalTable;

--- a/coral/src/app/features/approvals/components/RequestDetailsModal.tsx
+++ b/coral/src/app/features/approvals/components/RequestDetailsModal.tsx
@@ -1,0 +1,32 @@
+import { ReactElement } from "react";
+import { Modal } from "src/app/components/Modal";
+
+interface RequestDetailsModalProps {
+  onClose: () => void;
+  onApprove: () => void;
+  onReject: () => void;
+  children: ReactElement;
+  isLoading: boolean;
+}
+
+const RequestDetailsModal = ({
+  children,
+  onClose,
+  onApprove,
+  onReject,
+  isLoading,
+}: RequestDetailsModalProps) => {
+  return (
+    <Modal
+      title={"Request details"}
+      close={onClose}
+      primaryAction={{ text: "Approve", onClick: onApprove }}
+      secondaryAction={{ text: "Reject", onClick: onReject }}
+      isLoading={isLoading}
+    >
+      {children}
+    </Modal>
+  );
+};
+
+export default RequestDetailsModal;

--- a/coral/src/app/features/approvals/components/RequestRejectModal.tsx
+++ b/coral/src/app/features/approvals/components/RequestRejectModal.tsx
@@ -1,0 +1,42 @@
+import { Textarea } from "@aivenio/aquarium";
+import { useState } from "react";
+import { Modal } from "src/app/components/Modal";
+
+interface RequestRejectModalProps {
+  onClose: () => void;
+  onCancel: () => void;
+  onSubmit: (message: string) => void;
+  isLoading: boolean;
+}
+
+const RequestRejectModal = ({
+  onClose,
+  onSubmit,
+  onCancel,
+  isLoading,
+}: RequestRejectModalProps) => {
+  const [rejectionMessage, setRejectionMessage] = useState("");
+  return (
+    <Modal
+      title={"Reject request"}
+      close={onClose}
+      primaryAction={{
+        text: "Reject request",
+        onClick: () => onSubmit(rejectionMessage),
+      }}
+      secondaryAction={{ text: "Cancel", onClick: onCancel }}
+      disabled={rejectionMessage === ""}
+      isLoading={isLoading}
+    >
+      <Textarea
+        labelText="Submit a reason to decline the request"
+        name="rejection-reason"
+        placeholder="Write a message ..."
+        onChange={(e) => setRejectionMessage(e.target.value)}
+        required
+      />
+    </Modal>
+  );
+};
+
+export default RequestRejectModal;

--- a/coral/src/domain/acl/acl-api.ts
+++ b/coral/src/domain/acl/acl-api.ts
@@ -42,7 +42,7 @@ const declineAclRequest = (
   params: KlawApiRequestQueryParameters<"declineAclRequests">
 ): Promise<KlawApiResponse<"declineAclRequests">> => {
   return api.post<KlawApiResponse<"declineAclRequests">, never>(
-    `/execAclRequest?${new URLSearchParams(params)}`
+    `/execAclRequestDecline?${new URLSearchParams(params)}`
   );
 };
 


### PR DESCRIPTION
## About this change - What it does

This implements the same solution as https://github.com/aiven/klaw/pull/611, but using a `RequestApprovalTable` as a mean to encapsulate the approve/request logic.

This is *intensely dependent* on *every* approve and request api calls having the exact same type signature:
- approve: only `req_no` param required
- reject: `req_no` and `reasonForDecline` params required
