### PR TITLE
Extend Get Topics Requests API to use filter parameters

### DIFF
--- a/core/src/main/java/io/aiven/klaw/controller/TopicController.java
+++ b/core/src/main/java/io/aiven/klaw/controller/TopicController.java
@@ -67,6 +67,14 @@ public class TopicController {
         topicControllerService.createClaimTopicRequest(topicName, envId), HttpStatus.OK);
   }
 
+  /**
+   * @param pageNo Which page would you like returned e.g. 1
+   * @param currentPage Which Page are you currently on e.g. 1
+   * @param requestsType What type of requests are you looking for e.g. 'created' or 'deleted'
+   * @param env The name of the environment you would like returned e.g. '1' or '4'
+   * @param isMyRequest Only return requests created by the user calling the API
+   * @return A List of Topic Requests filtered by the provided parameters.
+   */
   @RequestMapping(
       value = "/getTopicRequests",
       method = RequestMethod.GET,
@@ -74,9 +82,14 @@ public class TopicController {
   public ResponseEntity<List<TopicRequestModel>> getTopicRequests(
       @RequestParam("pageNo") String pageNo,
       @RequestParam(value = "currentPage", defaultValue = "") String currentPage,
-      @RequestParam(value = "requestsType", defaultValue = "all") String requestsType) {
+      @RequestParam(value = "requestsType", defaultValue = "all") String requestsType,
+      @RequestParam(value = "env", required = false) String env,
+      @RequestParam(value = "isMyRequest", required = false, defaultValue = "false")
+          boolean isMyRequest) {
     return new ResponseEntity<>(
-        topicControllerService.getTopicRequests(pageNo, currentPage, requestsType), HttpStatus.OK);
+        topicControllerService.getTopicRequests(
+            pageNo, currentPage, requestsType, env, isMyRequest),
+        HttpStatus.OK);
   }
 
   @RequestMapping(

--- a/core/src/main/java/io/aiven/klaw/helpers/HandleDbRequests.java
+++ b/core/src/main/java/io/aiven/klaw/helpers/HandleDbRequests.java
@@ -67,7 +67,8 @@ public interface HandleDbRequests {
 
   RegisterUserInfo getRegistrationDetails(String registrationId, String status);
 
-  List<TopicRequest> getAllTopicRequests(String requestor, int tenantId);
+  List<TopicRequest> getAllTopicRequests(
+      String requestor, String status, String env, boolean isMyRequest, int tenantId);
 
   Map<String, Map<String, Long>> getTopicRequestsCounts(
       int teamId, RequestMode requestMode, int tenantId);
@@ -298,7 +299,7 @@ public interface HandleDbRequests {
   /*--------------------Delete */
   String deleteConnectorRequest(int topicId, int tenantId);
 
-  String deleteTopicRequest(int topicId, int tenantId);
+  String deleteTopicRequest(int topicId, String userName, int tenantId);
 
   String deleteTopic(int topicId, int tenantId);
 

--- a/core/src/main/java/io/aiven/klaw/helpers/db/rdbms/DeleteDataJdbc.java
+++ b/core/src/main/java/io/aiven/klaw/helpers/db/rdbms/DeleteDataJdbc.java
@@ -95,7 +95,7 @@ public class DeleteDataJdbc {
     return ApiResultStatus.SUCCESS.value;
   }
 
-  public String deleteTopicRequest(int topicId, int tenantId) {
+  public String deleteTopicRequest(int topicId, String userName, int tenantId) {
     log.debug("deleteTopicRequest {}", topicId);
 
     TopicRequestID topicRequestID = new TopicRequestID();
@@ -103,11 +103,15 @@ public class DeleteDataJdbc {
     topicRequestID.setTopicid(topicId);
 
     Optional<TopicRequest> topicReq = topicRequestsRepo.findById(topicRequestID);
-    if (topicReq.isPresent()) {
+    // UserName is transient and is not set in the database but the requestor is. Both are set to
+    // the userName when the request is created.
+    if (topicReq.isPresent() && topicReq.get().getRequestor().equals(userName)) {
       topicReq.get().setTopicstatus("deleted");
       topicRequestsRepo.save(topicReq.get());
+      return ApiResultStatus.SUCCESS.value;
     }
-    return ApiResultStatus.SUCCESS.value;
+    return ApiResultStatus.FAILURE.value
+        + " Unable to verify ownership of this request. you may only delete your own requests.";
   }
 
   public String deleteTopic(int topicId, int tenantId) {

--- a/core/src/main/java/io/aiven/klaw/helpers/db/rdbms/HandleDbRequestsJdbc.java
+++ b/core/src/main/java/io/aiven/klaw/helpers/db/rdbms/HandleDbRequestsJdbc.java
@@ -121,9 +121,10 @@ public class HandleDbRequestsJdbc implements HandleDbRequests {
 
   /*--------------------Select */
 
-  public List<TopicRequest> getAllTopicRequests(String requestor, int tenantId) {
+  public List<TopicRequest> getAllTopicRequests(
+      String requestor, String status, String env, boolean isMyRequest, int tenantId) {
     return jdbcSelectHelper.getFilteredTopicRequests(
-        false, requestor, RequestStatus.CREATED.value, false, tenantId, null, null, null);
+        false, requestor, status, false, tenantId, null, env, null, isMyRequest);
   }
 
   @Override
@@ -165,7 +166,15 @@ public class HandleDbRequestsJdbc implements HandleDbRequests {
       String env,
       String wildcardSearch) {
     return jdbcSelectHelper.getFilteredTopicRequests(
-        true, requestor, status, showRequestsOfAllTeams, tenantId, teamId, env, wildcardSearch);
+        true,
+        requestor,
+        status,
+        showRequestsOfAllTeams,
+        tenantId,
+        teamId,
+        env,
+        wildcardSearch,
+        false);
   }
 
   public List<KafkaConnectorRequest> getAllConnectorRequests(String requestor, int tenantId) {
@@ -660,8 +669,8 @@ public class HandleDbRequestsJdbc implements HandleDbRequests {
   }
 
   @Override
-  public String deleteTopicRequest(int topicId, int tenantId) {
-    return jdbcDeleteHelper.deleteTopicRequest(topicId, tenantId);
+  public String deleteTopicRequest(int topicId, String userName, int tenantId) {
+    return jdbcDeleteHelper.deleteTopicRequest(topicId, userName, tenantId);
   }
 
   @Override

--- a/core/src/main/java/io/aiven/klaw/helpers/db/rdbms/SelectDataJdbc.java
+++ b/core/src/main/java/io/aiven/klaw/helpers/db/rdbms/SelectDataJdbc.java
@@ -473,7 +473,8 @@ public class SelectDataJdbc {
       int tenantId,
       Integer teamId,
       String env,
-      String wildcardSearch) {
+      String wildcardSearch,
+      boolean isMyRequest) {
     if (log.isDebugEnabled()) {
       log.debug(
           "selectTopicRequests {} {} {} {} {} {}",
@@ -499,10 +500,13 @@ public class SelectDataJdbc {
                   env,
                   status,
                   tenantId,
-                  String.valueOf(teamSelected)));
+                  String.valueOf(teamSelected),
+                  isMyRequest ? requestor : null));
 
       topicRequestListSub =
-          Lists.newArrayList(findTopicRequestsByExample(null, teamId, env, status, tenantId, null));
+          Lists.newArrayList(
+              findTopicRequestsByExample(
+                  null, teamId, env, status, tenantId, null, isMyRequest ? requestor : null));
 
       // Only execute just before adding the separate claim list as this will make sure only the
       // claim topics this team is able to approve will be returned.
@@ -523,12 +527,21 @@ public class SelectDataJdbc {
     } else {
       if (showRequestsOfAllTeams) {
         topicRequestListSub =
-            Lists.newArrayList(findTopicRequestsByExample(null, null, null, null, tenantId, null));
+            Lists.newArrayList(
+                findTopicRequestsByExample(
+                    null, null, env, status, tenantId, null, isMyRequest ? requestor : null));
       } else {
 
         topicRequestListSub =
             Lists.newArrayList(
-                findTopicRequestsByExample(null, teamSelected, null, null, tenantId, null));
+                findTopicRequestsByExample(
+                    null,
+                    teamSelected,
+                    env,
+                    status,
+                    tenantId,
+                    null,
+                    isMyRequest ? requestor : null));
       }
     }
 
@@ -575,7 +588,8 @@ public class SelectDataJdbc {
       String environment,
       String status,
       int tenantId,
-      String description) {
+      String description,
+      String userName) {
 
     TopicRequest request = new TopicRequest();
     request.setTenantId(tenantId);
@@ -596,6 +610,10 @@ public class SelectDataJdbc {
 
     if (status != null && !status.equalsIgnoreCase("all")) {
       request.setTopicstatus(status);
+    }
+
+    if (userName != null && !userName.isEmpty()) {
+      request.setUsername(userName);
     }
     // check if debug is enabled so the logger doesn't waste resources converting object request to
     // a

--- a/core/src/main/java/io/aiven/klaw/helpers/db/rdbms/SelectDataJdbc.java
+++ b/core/src/main/java/io/aiven/klaw/helpers/db/rdbms/SelectDataJdbc.java
@@ -611,9 +611,9 @@ public class SelectDataJdbc {
     if (status != null && !status.equalsIgnoreCase("all")) {
       request.setTopicstatus(status);
     }
-
+    // userName is transient and so not available in the database to be queried.
     if (userName != null && !userName.isEmpty()) {
-      request.setUsername(userName);
+      request.setRequestor(userName);
     }
     // check if debug is enabled so the logger doesn't waste resources converting object request to
     // a

--- a/core/src/main/java/io/aiven/klaw/model/TopicRequestModel.java
+++ b/core/src/main/java/io/aiven/klaw/model/TopicRequestModel.java
@@ -77,4 +77,8 @@ public class TopicRequestModel implements Serializable {
   private List<String> possibleTeams;
 
   private String currentPage;
+
+  private boolean isDeletable;
+
+  private boolean isEditable;
 }

--- a/core/src/main/java/io/aiven/klaw/service/AclControllerService.java
+++ b/core/src/main/java/io/aiven/klaw/service/AclControllerService.java
@@ -219,7 +219,7 @@ public class AclControllerService {
     return getAclRequestsModels(aclReqs, tenantId, userName);
   }
 
-  private AclRequestsModel isRequestorPermissions(AclRequestsModel req, String userName) {
+  private AclRequestsModel setRequestorPermissions(AclRequestsModel req, String userName) {
     if (userName != null && userName.equals(req.getUsername())) {
       req.setDeletable(true);
       req.setEditable(true);
@@ -266,7 +266,7 @@ public class AclControllerService {
                   tenantId));
         }
 
-        aclRequestsModels.add(isRequestorPermissions(aclRequestsModel, userName));
+        aclRequestsModels.add(setRequestorPermissions(aclRequestsModel, userName));
       }
     return aclRequestsModels;
   }

--- a/core/src/main/java/io/aiven/klaw/service/TopicControllerService.java
+++ b/core/src/main/java/io/aiven/klaw/service/TopicControllerService.java
@@ -320,7 +320,7 @@ public class TopicControllerService {
     return getTopicRequestModels(topicReqs, true);
   }
 
-  private TopicRequestModel isRequestorPermissions(TopicRequestModel req, String userName) {
+  private TopicRequestModel setRequestorPermissions(TopicRequestModel req, String userName) {
     if (userName != null && userName.equals(req.getUsername())) {
       req.setDeletable(true);
       req.setEditable(true);
@@ -520,7 +520,7 @@ public class TopicControllerService {
         }
       }
 
-      topicRequestModelList.add(isRequestorPermissions(topicRequestModel, userName));
+      topicRequestModelList.add(setRequestorPermissions(topicRequestModel, userName));
     }
     return topicRequestModelList;
   }

--- a/core/src/main/java/io/aiven/klaw/service/TopicControllerService.java
+++ b/core/src/main/java/io/aiven/klaw/service/TopicControllerService.java
@@ -47,7 +47,6 @@ import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import lombok.extern.slf4j.Slf4j;
-import org.apache.commons.lang3.EnumUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.context.SecurityContextHolder;
@@ -300,13 +299,14 @@ public class TopicControllerService {
   }
 
   public List<TopicRequestModel> getTopicRequests(
-      String pageNo, String currentPage, String requestsType) {
+      String pageNo, String currentPage, String requestsType, String env, boolean isMyRequest) {
     log.debug("getTopicRequests page {} requestsType {}", pageNo, requestsType);
     String userName = getUserName();
     List<TopicRequest> topicReqs =
         manageDatabase
             .getHandleDbRequests()
-            .getAllTopicRequests(userName, commonUtilsService.getTenantId(userName));
+            .getAllTopicRequests(
+                userName, requestsType, env, isMyRequest, commonUtilsService.getTenantId(userName));
 
     // tenant filtering
     final Set<String> allowedEnvIdSet = commonUtilsService.getEnvsFromUserId(userName);
@@ -316,16 +316,17 @@ public class TopicControllerService {
             .sorted(Collections.reverseOrder(Comparator.comparing(TopicRequest::getRequesttime)))
             .collect(Collectors.toList());
 
-    if (!"all".equals(requestsType)
-        && EnumUtils.isValidEnumIgnoreCase(RequestStatus.class, requestsType)) {
-      topicReqs =
-          topicReqs.stream()
-              .filter(topicRequest -> Objects.equals(topicRequest.getTopicstatus(), requestsType))
-              .collect(Collectors.toList());
-    }
-
     topicReqs = getTopicRequestsPaged(topicReqs, pageNo, currentPage);
     return getTopicRequestModels(topicReqs, true);
+  }
+
+  private TopicRequestModel isRequestorPermissions(TopicRequestModel req, String userName) {
+    if (userName != null && userName.equals(req.getUsername())) {
+      req.setDeletable(true);
+      req.setEditable(true);
+    }
+
+    return req;
   }
 
   private List<TopicRequest> getTopicRequestsPaged(
@@ -519,7 +520,7 @@ public class TopicControllerService {
         }
       }
 
-      topicRequestModelList.add(topicRequestModel);
+      topicRequestModelList.add(isRequestorPermissions(topicRequestModel, userName));
     }
     return topicRequestModelList;
   }
@@ -568,12 +569,15 @@ public class TopicControllerService {
         getPrincipal(), PermissionType.REQUEST_CREATE_TOPICS)) {
       return ApiResponse.builder().result(ApiResultStatus.NOT_AUTHORIZED.value).build();
     }
+    String userName = getUserName();
     try {
       String deleteTopicReqStatus =
           manageDatabase
               .getHandleDbRequests()
               .deleteTopicRequest(
-                  Integer.parseInt(topicId), commonUtilsService.getTenantId(getUserName()));
+                  Integer.parseInt(topicId),
+                  userName,
+                  commonUtilsService.getTenantId(getUserName()));
 
       return ApiResponse.builder().result(deleteTopicReqStatus).build();
     } catch (Exception e) {

--- a/core/src/main/resources/swagger_spec.json
+++ b/core/src/main/resources/swagger_spec.json
@@ -2451,6 +2451,17 @@
           "required" : false,
           "type" : "string",
           "default" : "all"
+        }, {
+          "name" : "env",
+          "in" : "query",
+          "required" : false,
+          "type" : "string"
+        }, {
+          "name" : "isMyRequest",
+          "in" : "query",
+          "required" : false,
+          "type" : "boolean",
+          "default" : false
         } ],
         "responses" : {
           "200" : {
@@ -4782,6 +4793,12 @@
         },
         "currentPage" : {
           "type" : "string"
+        },
+        "editable" : {
+          "type" : "boolean"
+        },
+        "deletable" : {
+          "type" : "boolean"
         }
       }
     },
@@ -5032,6 +5049,12 @@
         },
         "currentPage" : {
           "type" : "string"
+        },
+        "editable" : {
+          "type" : "boolean"
+        },
+        "deletable" : {
+          "type" : "boolean"
         }
       }
     },
@@ -5132,6 +5155,12 @@
         },
         "currentPage" : {
           "type" : "string"
+        },
+        "editable" : {
+          "type" : "boolean"
+        },
+        "deletable" : {
+          "type" : "boolean"
         }
       }
     },

--- a/core/src/test/java/io/aiven/klaw/controller/TopicControllerTest.java
+++ b/core/src/test/java/io/aiven/klaw/controller/TopicControllerTest.java
@@ -115,7 +115,8 @@ public class TopicControllerTest {
   public void getTopicRequests() throws Exception {
     List<TopicRequestModel> topicRequests = utilMethods.getTopicRequestsModel();
 
-    when(topicControllerService.getTopicRequests("1", "", "all")).thenReturn(topicRequests);
+    when(topicControllerService.getTopicRequests("1", "", "all", null, false))
+        .thenReturn(topicRequests);
 
     mvc.perform(
             MockMvcRequestBuilders.get("/getTopicRequests")

--- a/core/src/test/java/io/aiven/klaw/helpers/db/rdbms/DeleteDataJdbcTest.java
+++ b/core/src/test/java/io/aiven/klaw/helpers/db/rdbms/DeleteDataJdbcTest.java
@@ -1,13 +1,18 @@
 package io.aiven.klaw.helpers.db.rdbms;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.when;
 
 import io.aiven.klaw.UtilMethods;
 import io.aiven.klaw.dao.Env;
 import io.aiven.klaw.dao.EnvID;
+import io.aiven.klaw.dao.TopicRequest;
+import io.aiven.klaw.dao.TopicRequestID;
 import io.aiven.klaw.model.enums.ApiResultStatus;
+import io.aiven.klaw.model.enums.RequestStatus;
 import io.aiven.klaw.repository.*;
+import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -50,9 +55,26 @@ public class DeleteDataJdbcTest {
   }
 
   @Test
+  public void deleteTopicRequest_Failure() {
+    String result = deleteDataJdbc.deleteTopicRequest(1001, "uiuser1", 1);
+    assertThat(result).contains(ApiResultStatus.FAILURE.value);
+  }
+
+  @Test
   public void deleteTopicRequest() {
-    String result = deleteDataJdbc.deleteTopicRequest(1001, 1);
-    assertThat(result).isEqualTo(ApiResultStatus.SUCCESS.value);
+    TopicRequestID id = new TopicRequestID(1010, 1);
+    when(topicRequestsRepo.findById(eq(id)))
+        .thenReturn(createTopicRequest("uiuser1", RequestStatus.CREATED));
+    String result = deleteDataJdbc.deleteTopicRequest(1010, "uiuser1", 1);
+    assertThat(result).contains(ApiResultStatus.SUCCESS.value);
+  }
+
+  private Optional<TopicRequest> createTopicRequest(String userName, RequestStatus status) {
+    TopicRequest req = new TopicRequest();
+    req.setUsername(userName);
+    req.setRequestor(userName);
+    req.setTopicstatus(status.value);
+    return Optional.of(req);
   }
 
   @Test

--- a/core/src/test/java/io/aiven/klaw/helpers/db/rdbms/SelectDataJdbcTest.java
+++ b/core/src/test/java/io/aiven/klaw/helpers/db/rdbms/SelectDataJdbcTest.java
@@ -175,7 +175,8 @@ public class SelectDataJdbcTest {
         .thenReturn(java.util.Optional.of(userInfo));
 
     List<TopicRequest> topicRequestsActual =
-        selectData.getFilteredTopicRequests(false, requestor, "created", true, 1, null, null, null);
+        selectData.getFilteredTopicRequests(
+            false, requestor, "created", true, 1, null, null, null, false);
 
     assertThat(topicRequestsActual).hasSize(1);
   }

--- a/core/src/test/java/io/aiven/klaw/helpers/db/rdbms/TopicRequestsIntegrationTest.java
+++ b/core/src/test/java/io/aiven/klaw/helpers/db/rdbms/TopicRequestsIntegrationTest.java
@@ -748,12 +748,12 @@ public class TopicRequestsIntegrationTest {
   @Order(28)
   public void getRequestsRequestorsOnlyNoneReturned() {
 
-    List<TopicRequest> jackie =
+    List<TopicRequest> john =
         selectDataJdbc.getFilteredTopicRequests(
             false, "John", "created", false, 101, null, "dev", null, true);
 
-    assertThat(jackie.size()).isEqualTo(4);
-    for (TopicRequest req : jackie) {
+    assertThat(john.size()).isEqualTo(0);
+    for (TopicRequest req : john) {
       assertThat(req.getDescription().equals("John"));
     }
   }

--- a/core/src/test/java/io/aiven/klaw/helpers/db/rdbms/TopicRequestsIntegrationTest.java
+++ b/core/src/test/java/io/aiven/klaw/helpers/db/rdbms/TopicRequestsIntegrationTest.java
@@ -317,13 +317,13 @@ public class TopicRequestsIntegrationTest {
 
     List<TopicRequest> james =
         selectDataJdbc.getFilteredTopicRequests(
-            true, "James", "deleted", true, 101, null, null, null);
+            true, "James", "deleted", true, 101, null, null, null, false);
     List<TopicRequest> james2 =
         selectDataJdbc.getFilteredTopicRequests(
-            true, "James", "declined", true, 101, null, null, null);
+            true, "James", "declined", true, 101, null, null, null, false);
     List<TopicRequest> john =
         selectDataJdbc.getFilteredTopicRequests(
-            true, "John", "created", true, 103, null, null, null);
+            true, "John", "created", true, 103, null, null, null, false);
 
     assertThat(james.size()).isEqualTo(2);
 
@@ -346,15 +346,15 @@ public class TopicRequestsIntegrationTest {
 
     List<TopicRequest> james =
         selectDataJdbc.getFilteredTopicRequests(
-            true, "James", "ALL", true, 101, null, null, "first");
+            true, "James", "ALL", true, 101, null, null, "first", false);
 
     List<TopicRequest> john =
         selectDataJdbc.getFilteredTopicRequests(
-            true, "John", "ALL", true, 101, null, null, "second");
+            true, "John", "ALL", true, 101, null, null, "second", false);
 
     List<TopicRequest> all =
         selectDataJdbc.getFilteredTopicRequests(
-            true, "James", "ALL", true, 101, null, null, "topic");
+            true, "James", "ALL", true, 101, null, null, "topic", false);
 
     assertThat(james.size()).isEqualTo(22);
     for (TopicRequest req : james) {
@@ -372,7 +372,7 @@ public class TopicRequestsIntegrationTest {
 
     List<TopicRequest> james =
         selectDataJdbc.getFilteredTopicRequests(
-            true, "James", "ALL", true, 101, null, "test", "second");
+            true, "James", "ALL", true, 101, null, "test", "second", false);
 
     assertThat(james.size()).isEqualTo(10);
     for (TopicRequest req : james) {
@@ -387,11 +387,11 @@ public class TopicRequestsIntegrationTest {
 
     List<TopicRequest> james =
         selectDataJdbc.getFilteredTopicRequests(
-            true, "James", "ALL", true, 101, Integer.valueOf(101), null, null);
+            true, "James", "ALL", true, 101, Integer.valueOf(101), null, null, false);
 
     List<TopicRequest> john =
         selectDataJdbc.getFilteredTopicRequests(
-            true, "John", "ALL", true, 103, Integer.valueOf(103), null, null);
+            true, "John", "ALL", true, 103, Integer.valueOf(103), null, null, false);
 
     assertThat(james.size()).isEqualTo(32);
     for (TopicRequest req : james) {
@@ -416,7 +416,7 @@ public class TopicRequestsIntegrationTest {
     // topic name is case sensitive.
     List<TopicRequest> james =
         selectDataJdbc.getFilteredTopicRequests(
-            true, "James", "ALL", true, 101, null, "tsst", null);
+            true, "James", "ALL", true, 101, null, "tsst", null, false);
     assertThat(james.size()).isEqualTo(0);
   }
 
@@ -425,10 +425,12 @@ public class TopicRequestsIntegrationTest {
   public void getNonApproversRequestsFilteredByTenantId_willIgnoreOtherPassedParameters() {
 
     List<TopicRequest> tenant1 =
-        selectDataJdbc.getFilteredTopicRequests(false, "James", null, true, 101, null, null, null);
+        selectDataJdbc.getFilteredTopicRequests(
+            false, "James", null, true, 101, null, null, null, false);
 
     List<TopicRequest> tenant2 =
-        selectDataJdbc.getFilteredTopicRequests(false, "John", null, true, 103, null, null, null);
+        selectDataJdbc.getFilteredTopicRequests(
+            false, "John", null, true, 103, null, null, null, false);
 
     assertThat(tenant1.size()).isEqualTo(39);
     for (TopicRequest req : tenant1) {
@@ -443,17 +445,16 @@ public class TopicRequestsIntegrationTest {
 
   @Test
   @Order(10)
-  public void
-      getNonApproversRequestsFilteredByEnvironmentByStatus_willIgnoreOtherPassedParameters() {
+  public void getNonApproversRequestsFilteredByEnvironmentByStatus() {
 
     List<TopicRequest> tenant1 =
         selectDataJdbc.getFilteredTopicRequests(
-            false, "James", "created", true, 101, null, "dev", null);
+            false, "James", "created", true, 101, null, "dev", null, false);
     List<TopicRequest> tenant2 =
         selectDataJdbc.getFilteredTopicRequests(
-            false, "John", "declined", true, 103, null, "test", null);
+            false, "John", "approved", true, 103, null, "test", null, false);
 
-    assertThat(tenant1.size()).isEqualTo(39);
+    assertThat(tenant1.size()).isEqualTo(17);
     for (TopicRequest req : tenant1) {
       assertThat(req.getTenantId()).isEqualTo(101);
     }
@@ -466,17 +467,17 @@ public class TopicRequestsIntegrationTest {
 
   @Test
   @Order(11)
-  public void getNonApproversRequestsFilteredByStatusByWildcard_willIgnoreOtherPassedParameters() {
+  public void getNonApproversRequestsFilteredByStatusByWildcard_willIgnoreWildcardParameter() {
 
     List<TopicRequest> tenant1 =
         selectDataJdbc.getFilteredTopicRequests(
-            false, "James", "deleted", true, 101, null, null, "One");
+            false, "James", "deleted", true, 101, null, null, "One", false);
 
     List<TopicRequest> tenant2 =
         selectDataJdbc.getFilteredTopicRequests(
-            false, "John", "created", true, 103, null, null, "two");
+            false, "John", "approved", true, 103, null, null, "two", false);
 
-    assertThat(tenant1.size()).isEqualTo(39);
+    assertThat(tenant1.size()).isEqualTo(2);
 
     assertThat(tenant2.size()).isEqualTo(1);
   }
@@ -487,7 +488,7 @@ public class TopicRequestsIntegrationTest {
 
     List<TopicRequest> james =
         selectDataJdbc.getFilteredTopicRequests(
-            true, "James", "declined", true, 101, Integer.valueOf(99), null, null);
+            true, "James", "declined", true, 101, Integer.valueOf(99), null, null, false);
 
     assertThat(james.size()).isEqualTo(0);
   }
@@ -499,7 +500,8 @@ public class TopicRequestsIntegrationTest {
     List<TopicRequest> topicRequestList = Lists.newArrayList(repo.findAllByTenantId(101));
 
     List<TopicRequest> results =
-        selectDataJdbc.getFilteredTopicRequests(false, "James", null, true, 101, null, null, null);
+        selectDataJdbc.getFilteredTopicRequests(
+            false, "James", null, true, 101, null, null, null, false);
 
     assertThat(topicRequestList.size()).isEqualTo(results.size());
 
@@ -511,9 +513,11 @@ public class TopicRequestsIntegrationTest {
   public void getAllRequestsFilteredByTenantId() {
 
     List<TopicRequest> james =
-        selectDataJdbc.getFilteredTopicRequests(true, "James", null, true, 101, null, null, null);
+        selectDataJdbc.getFilteredTopicRequests(
+            true, "James", null, true, 101, null, null, null, false);
     List<TopicRequest> john =
-        selectDataJdbc.getFilteredTopicRequests(true, "John", null, true, 103, null, null, null);
+        selectDataJdbc.getFilteredTopicRequests(
+            true, "John", null, true, 103, null, null, null, false);
 
     assertThat(james.size()).isEqualTo(32);
     for (TopicRequest req : james) {
@@ -531,10 +535,10 @@ public class TopicRequestsIntegrationTest {
 
     List<TopicRequest> james =
         selectDataJdbc.getFilteredTopicRequests(
-            true, "James", "created", true, 101, null, "dev", null);
+            true, "James", "created", true, 101, null, "dev", null, false);
     List<TopicRequest> john =
         selectDataJdbc.getFilteredTopicRequests(
-            true, "John", "declined", true, 103, null, "test", null);
+            true, "John", "declined", true, 103, null, "test", null, false);
 
     assertThat(james.size()).isEqualTo(17);
     for (TopicRequest req : james) {
@@ -550,7 +554,8 @@ public class TopicRequestsIntegrationTest {
   public void getAllRequestsDontReturnOwnRequestsAsAllReqsIsTrue() {
 
     List<TopicRequest> jackie =
-        selectDataJdbc.getFilteredTopicRequests(true, "Jackie", "all", true, 101, null, null, null);
+        selectDataJdbc.getFilteredTopicRequests(
+            true, "Jackie", "all", true, 101, null, null, null, false);
 
     assertThat(jackie.size()).isEqualTo(0);
   }
@@ -561,7 +566,7 @@ public class TopicRequestsIntegrationTest {
 
     List<TopicRequest> jackie =
         selectDataJdbc.getFilteredTopicRequests(
-            false, "Jackie", "all", true, 101, null, null, null);
+            false, "Jackie", "all", true, 101, null, null, null, false);
 
     assertThat(jackie.size()).isEqualTo(39);
   }
@@ -572,7 +577,7 @@ public class TopicRequestsIntegrationTest {
 
     List<TopicRequest> joan =
         selectDataJdbc.getFilteredTopicRequests(
-            true, "Joan", RequestStatus.CREATED.value, true, 104, null, null, null);
+            true, "Joan", RequestStatus.CREATED.value, true, 104, null, null, null, false);
 
     assertThat(joan.size()).isEqualTo(7);
     for (TopicRequest req : joan) {
@@ -588,7 +593,7 @@ public class TopicRequestsIntegrationTest {
 
     List<TopicRequest> joan =
         selectDataJdbc.getFilteredTopicRequests(
-            true, "Joan", RequestStatus.DELETED.value, true, 104, null, null, null);
+            true, "Joan", RequestStatus.DELETED.value, true, 104, null, null, null, false);
 
     assertThat(joan.size()).isEqualTo(6);
     for (TopicRequest req : joan) {
@@ -604,7 +609,7 @@ public class TopicRequestsIntegrationTest {
 
     List<TopicRequest> resultSet =
         selectDataJdbc.getFilteredTopicRequests(
-            true, "James", RequestStatus.ALL.value, true, 101, null, null, null);
+            true, "James", RequestStatus.ALL.value, true, 101, null, null, null, false);
 
     assertThat(resultSet.size()).isEqualTo(32);
     for (TopicRequest req : resultSet) {
@@ -625,7 +630,7 @@ public class TopicRequestsIntegrationTest {
 
     List<TopicRequest> resultSet =
         selectDataJdbc.getFilteredTopicRequests(
-            false, "James", RequestStatus.ALL.value, false, 101, null, null, null);
+            false, "James", RequestStatus.ALL.value, false, 101, null, null, null, false);
 
     assertThat(resultSet.size()).isEqualTo(35);
     for (TopicRequest req : resultSet) {
@@ -643,7 +648,7 @@ public class TopicRequestsIntegrationTest {
 
     List<TopicRequest> resultSet =
         selectDataJdbc.getFilteredTopicRequests(
-            true, "John", RequestStatus.ALL.value, true, 101, null, null, null);
+            true, "John", RequestStatus.ALL.value, true, 101, null, null, null, false);
 
     assertThat(resultSet.size()).isEqualTo(35);
     for (TopicRequest req : resultSet) {
@@ -664,7 +669,7 @@ public class TopicRequestsIntegrationTest {
 
     List<TopicRequest> resultSet =
         selectDataJdbc.getFilteredTopicRequests(
-            false, "John", RequestStatus.ALL.value, false, 101, null, null, null);
+            false, "John", RequestStatus.ALL.value, false, 101, null, null, null, false);
 
     assertThat(resultSet.size()).isEqualTo(4);
     // MyTeamsRequests only
@@ -675,6 +680,81 @@ public class TopicRequestsIntegrationTest {
       if (req.getTopictype().equals(RequestOperationType.CLAIM.value)) {
         assertThat(req.getDescription()).isNotEqualTo("103");
       }
+    }
+  }
+
+  @Test
+  @Order(24)
+  public void getAllRequestsAndReturnOwnRequestsOnly() {
+
+    List<TopicRequest> jackie =
+        selectDataJdbc.getFilteredTopicRequests(
+            false, "Jackie", "all", true, 101, null, null, null, true);
+
+    assertThat(jackie.size()).isEqualTo(39);
+    for (TopicRequest req : jackie) {
+      assertThat(req.getRequestor().equals("Jackie"));
+    }
+  }
+
+  @Test
+  @Order(25)
+  public void getAllRequestsAndReturnOwnRequestsOnlyFromDevEnv() {
+
+    List<TopicRequest> jackie =
+        selectDataJdbc.getFilteredTopicRequests(
+            false, "Jackie", "all", true, 101, null, "dev", null, true);
+
+    assertThat(jackie.size()).isEqualTo(29);
+    for (TopicRequest req : jackie) {
+      assertThat(req.getRequestor().equals("Jackie"));
+      assertThat(req.getEnvironment().equals("dev"));
+    }
+  }
+
+  @Test
+  @Order(26)
+  public void getAllRequestsAndReturnOwnRequestsOnlyCreatedStatusFromDevEnv() {
+
+    List<TopicRequest> jackie =
+        selectDataJdbc.getFilteredTopicRequests(
+            false, "Jackie", "created", true, 101, null, "dev", null, true);
+
+    assertThat(jackie.size()).isEqualTo(17);
+    for (TopicRequest req : jackie) {
+      assertThat(req.getRequestor().equals("Jackie"));
+      assertThat(req.getEnvironment().equals("dev"));
+      assertThat(req.getTopicstatus().equals("created"));
+    }
+  }
+
+  @Test
+  @Order(27)
+  public void getRequestsAndReturnOwnRequestsOnlyCreatedStatusFromDevEnv() {
+
+    List<TopicRequest> jackie =
+        selectDataJdbc.getFilteredTopicRequests(
+            false, "Jackie", "created", false, 101, null, "dev", null, true);
+
+    assertThat(jackie.size()).isEqualTo(4);
+    for (TopicRequest req : jackie) {
+      assertThat(req.getRequestor().equals("Jackie"));
+      assertThat(req.getEnvironment().equals("dev"));
+      assertThat(req.getTopicstatus().equals("created"));
+    }
+  }
+
+  @Test
+  @Order(28)
+  public void getRequestsRequestorsOnlyNoneReturned() {
+
+    List<TopicRequest> jackie =
+        selectDataJdbc.getFilteredTopicRequests(
+            false, "John", "created", false, 101, null, "dev", null, true);
+
+    assertThat(jackie.size()).isEqualTo(4);
+    for (TopicRequest req : jackie) {
+      assertThat(req.getDescription().equals("John"));
     }
   }
 

--- a/core/src/test/java/io/aiven/klaw/service/TopicControllerServiceTest.java
+++ b/core/src/test/java/io/aiven/klaw/service/TopicControllerServiceTest.java
@@ -396,12 +396,14 @@ public class TopicControllerServiceTest {
     when(manageDatabase.getKafkaEnvList(anyInt())).thenReturn(utilMethods.getEnvLists());
     when(commonUtilsService.getEnvsFromUserId(anyString()))
         .thenReturn(new HashSet<>(Collections.singletonList("1")));
-    when(handleDbRequests.getAllTopicRequests(anyString(), anyInt()))
+    when(handleDbRequests.getAllTopicRequests(
+            anyString(), anyString(), eq(null), eq(false), anyInt()))
         .thenReturn(getListTopicRequests());
     when(commonUtilsService.deriveCurrentPage(anyString(), anyString(), anyInt())).thenReturn("1");
     when(manageDatabase.getTeamNameFromTeamId(anyInt(), anyInt())).thenReturn("INFRATEAM");
 
-    List<TopicRequestModel> listTopicRqs = topicControllerService.getTopicRequests("1", "", "all");
+    List<TopicRequestModel> listTopicRqs =
+        topicControllerService.getTopicRequests("1", "", "all", null, false);
     assertThat(listTopicRqs).hasSize(2);
   }
 
@@ -414,13 +416,16 @@ public class TopicControllerServiceTest {
         .thenReturn(new HashSet<>(Collections.singletonList("1")));
     List<TopicRequest> topicRequests = getListTopicRequests();
     topicRequests.get(0).setTopictype(RequestOperationType.CLAIM.value);
-    when(handleDbRequests.getAllTopicRequests(anyString(), anyInt())).thenReturn(topicRequests);
+    when(handleDbRequests.getAllTopicRequests(
+            anyString(), anyString(), eq(null), eq(false), anyInt()))
+        .thenReturn(topicRequests);
     when(commonUtilsService.deriveCurrentPage(anyString(), anyString(), anyInt())).thenReturn("1");
     when(manageDatabase.getTeamNameFromTeamId(anyInt(), anyInt())).thenReturn("INFRATEAM");
     when(handleDbRequests.getTopicTeam(anyString(), anyInt())).thenReturn(utilMethods.getTopics());
     when(commonUtilsService.getFilteredTopicsForTenant(any())).thenReturn(utilMethods.getTopics());
 
-    List<TopicRequestModel> listTopicRqs = topicControllerService.getTopicRequests("1", "", "all");
+    List<TopicRequestModel> listTopicRqs =
+        topicControllerService.getTopicRequests("1", "", "all", null, false);
     assertThat(listTopicRqs).hasSize(2);
   }
 
@@ -433,14 +438,16 @@ public class TopicControllerServiceTest {
         .thenReturn(new HashSet<>(Collections.singletonList("1")));
     List<TopicRequest> topicRequests = getListTopicRequests();
     topicRequests.get(0).setTopictype(RequestOperationType.CLAIM.value);
-    when(handleDbRequests.getAllTopicRequests(anyString(), anyInt())).thenReturn(topicRequests);
+    when(handleDbRequests.getAllTopicRequests(
+            anyString(), anyString(), eq(null), eq(false), anyInt()))
+        .thenReturn(topicRequests);
     when(commonUtilsService.deriveCurrentPage(anyString(), anyString(), anyInt())).thenReturn("1");
     when(manageDatabase.getTeamNameFromTeamId(anyInt(), anyInt())).thenReturn("INFRATEAM");
     when(handleDbRequests.getTopicTeam(anyString(), anyInt())).thenReturn(utilMethods.getTopics());
     when(commonUtilsService.getFilteredTopicsForTenant(any())).thenReturn(utilMethods.getTopics());
 
     List<TopicRequestModel> listTopicRqs =
-        topicControllerService.getTopicRequests("1", "", "created");
+        topicControllerService.getTopicRequests("1", "", "created", null, false);
     assertThat(listTopicRqs).hasSize(2);
   }
 
@@ -563,8 +570,9 @@ public class TopicControllerServiceTest {
   @Test
   @Order(22)
   public void deleteTopicRequests() throws KlawException {
-    when(handleDbRequests.deleteTopicRequest(anyInt(), anyInt()))
+    when(handleDbRequests.deleteTopicRequest(anyInt(), anyString(), anyInt()))
         .thenReturn(ApiResultStatus.SUCCESS.value);
+    when(mailService.getUserName(any())).thenReturn("uiuser1");
     when(commonUtilsService.isNotAuthorizedUser(any(), any())).thenReturn(false);
     ApiResponse resultResp = topicControllerService.deleteTopicRequests("1001");
     assertThat(resultResp.getResult()).isEqualTo(ApiResultStatus.SUCCESS.value);


### PR DESCRIPTION
Adds filter parameters to My Topic Requests 
Add isEditable and isDeleteable parameters 
Enforcement checks to only allow a request owner delete their own request.

Signed-off-by: Aindriu Lavelle <aindriu.lavelle@aiven.io>

About this change - What it does

Resolves: #600 
Why this way
