### PR TITLE
Issue 601 extend get schema requests with filters

### DIFF
--- a/core/src/main/java/io/aiven/klaw/controller/SchemaRegstryController.java
+++ b/core/src/main/java/io/aiven/klaw/controller/SchemaRegstryController.java
@@ -45,10 +45,14 @@ public class SchemaRegstryController {
   public ResponseEntity<List<SchemaRequestModel>> getSchemaRequests(
       @RequestParam("pageNo") String pageNo,
       @RequestParam(value = "currentPage", defaultValue = "") String currentPage,
-      @RequestParam(value = "requestsType", defaultValue = "all") String requestsType) {
+      @RequestParam(value = "requestsType", defaultValue = "all") String requestsType,
+      @RequestParam(value = "topic", required = false) String topic,
+      @RequestParam(value = "env", required = false) String env,
+      @RequestParam(value = "isMyRequest", required = false, defaultValue = "false")
+          boolean isMyRequest) {
     return new ResponseEntity<>(
         schemaRegstryControllerService.getSchemaRequests(
-            pageNo, currentPage, requestsType, false, null, null, null),
+            pageNo, currentPage, requestsType, false, topic, env, null, isMyRequest),
         HttpStatus.OK);
   }
 
@@ -74,7 +78,7 @@ public class SchemaRegstryController {
       @RequestParam(value = "search", required = false) String search) {
     return new ResponseEntity<>(
         schemaRegstryControllerService.getSchemaRequests(
-            pageNo, currentPage, requestsType, true, topic, env, search),
+            pageNo, currentPage, requestsType, true, topic, env, search, false),
         HttpStatus.OK);
   }
 

--- a/core/src/main/java/io/aiven/klaw/helpers/HandleDbRequests.java
+++ b/core/src/main/java/io/aiven/klaw/helpers/HandleDbRequests.java
@@ -322,7 +322,7 @@ public interface HandleDbRequests {
 
   String deleteTeamRequest(Integer teamId, int tenantId);
 
-  String deleteSchemaRequest(int schemaId, int tenantId);
+  String deleteSchemaRequest(int schemaId, String userName, int tenantId);
 
   String deleteAllUsers(int tenantId);
 

--- a/core/src/main/java/io/aiven/klaw/helpers/HandleDbRequests.java
+++ b/core/src/main/java/io/aiven/klaw/helpers/HandleDbRequests.java
@@ -158,7 +158,8 @@ public interface HandleDbRequests {
       String topic,
       String env,
       String status,
-      String search);
+      String search,
+      boolean isMyRequest);
 
   SchemaRequest selectSchemaRequest(int avroSchemaId, int tenantId);
 

--- a/core/src/main/java/io/aiven/klaw/helpers/db/rdbms/DeleteDataJdbc.java
+++ b/core/src/main/java/io/aiven/klaw/helpers/db/rdbms/DeleteDataJdbc.java
@@ -132,11 +132,11 @@ public class DeleteDataJdbc {
     return ApiResultStatus.SUCCESS.value;
   }
 
-  public String deleteSchemaRequest(int avroSchemaId, int tenantId) {
+  public String deleteSchemaRequest(int avroSchemaId, String userName, int tenantId) {
     log.debug("deleteSchemaRequest {}", avroSchemaId);
     SchemaRequestID schemaRequestID = new SchemaRequestID(avroSchemaId, tenantId);
     Optional<SchemaRequest> schemaReq = schemaRequestRepo.findById(schemaRequestID);
-    if (schemaReq.isPresent()) {
+    if (schemaReq.isPresent() && schemaReq.get().getUsername().equals(userName)) {
       schemaReq.get().setTopicstatus("deleted");
       schemaRequestRepo.save(schemaReq.get());
     }

--- a/core/src/main/java/io/aiven/klaw/helpers/db/rdbms/DeleteDataJdbc.java
+++ b/core/src/main/java/io/aiven/klaw/helpers/db/rdbms/DeleteDataJdbc.java
@@ -139,8 +139,11 @@ public class DeleteDataJdbc {
     if (schemaReq.isPresent() && schemaReq.get().getUsername().equals(userName)) {
       schemaReq.get().setTopicstatus("deleted");
       schemaRequestRepo.save(schemaReq.get());
+      return ApiResultStatus.SUCCESS.value;
     }
-    return ApiResultStatus.SUCCESS.value;
+
+    return ApiResultStatus.FAILURE.value
+        + " Unable to verify ownership of this request. you may only delete your own requests.";
   }
 
   public String deleteAclRequest(int aclId, String userName, int tenantId) {

--- a/core/src/main/java/io/aiven/klaw/helpers/db/rdbms/HandleDbRequestsJdbc.java
+++ b/core/src/main/java/io/aiven/klaw/helpers/db/rdbms/HandleDbRequestsJdbc.java
@@ -732,8 +732,8 @@ public class HandleDbRequestsJdbc implements HandleDbRequests {
   }
 
   @Override
-  public String deleteSchemaRequest(int schemaId, int tenantId) {
-    return jdbcDeleteHelper.deleteSchemaRequest(schemaId, tenantId);
+  public String deleteSchemaRequest(int schemaId, String userName, int tenantId) {
+    return jdbcDeleteHelper.deleteSchemaRequest(schemaId, userName, tenantId);
   }
 
   @Override

--- a/core/src/main/java/io/aiven/klaw/helpers/db/rdbms/HandleDbRequestsJdbc.java
+++ b/core/src/main/java/io/aiven/klaw/helpers/db/rdbms/HandleDbRequestsJdbc.java
@@ -324,9 +324,10 @@ public class HandleDbRequestsJdbc implements HandleDbRequests {
       String topic,
       String env,
       String status,
-      String search) {
+      String search,
+      boolean isMyRequest) {
     return jdbcSelectHelper.selectFilteredSchemaRequests(
-        allReqs, requestor, tenantId, topic, env, status, search);
+        allReqs, requestor, tenantId, topic, env, status, search, isMyRequest);
   }
 
   @Override

--- a/core/src/main/java/io/aiven/klaw/helpers/db/rdbms/SelectDataJdbc.java
+++ b/core/src/main/java/io/aiven/klaw/helpers/db/rdbms/SelectDataJdbc.java
@@ -224,17 +224,19 @@ public class SelectDataJdbc {
       String topic,
       String env,
       String status,
-      String wildcardSearch) {
+      String wildcardSearch,
+      boolean isMyRequest) {
     if (log.isDebugEnabled()) {
       log.debug(
-          "selectSchemaRequests allReqs {} Requestor: {} , tenantIf:{} , topic: {}, env: {}, status: {}, wildcardSearch: {}",
+          "selectSchemaRequests allReqs {} Requestor: {} , tenantIf:{} , topic: {}, env: {}, status: {}, wildcardSearch: {}, isMyRequest: {}",
           allReqs,
           requestor,
           tenantId,
           topic,
           env,
           status,
-          wildcardSearch);
+          wildcardSearch,
+          isMyRequest);
     }
     List<SchemaRequest> schemaList = new ArrayList<>();
     List<SchemaRequest> schemaListSub;
@@ -243,7 +245,12 @@ public class SelectDataJdbc {
       schemaListSub =
           Lists.newArrayList(
               findSchemaRequestsByExample(
-                  topic, env, status != null ? status : "created", teamSelected, tenantId));
+                  topic,
+                  env,
+                  status != null ? status : "created",
+                  teamSelected,
+                  tenantId,
+                  isMyRequest ? requestor : null));
 
       // Placed here as it should only apply for approvers.
       schemaListSub =
@@ -265,7 +272,8 @@ public class SelectDataJdbc {
       // being filtered out after the data was returned.
       schemaListSub =
           Lists.newArrayList(
-              findSchemaRequestsByExample(null, null, status, teamSelected, tenantId));
+              findSchemaRequestsByExample(
+                  topic, env, status, teamSelected, tenantId, isMyRequest ? requestor : null));
     }
 
     for (SchemaRequest row : schemaListSub) {
@@ -284,7 +292,12 @@ public class SelectDataJdbc {
   }
 
   public Iterable<SchemaRequest> findSchemaRequestsByExample(
-      String topic, String environment, String status, Integer teamId, int tenantId) {
+      String topic,
+      String environment,
+      String status,
+      Integer teamId,
+      int tenantId,
+      String userName) {
 
     SchemaRequest request = new SchemaRequest();
 
@@ -301,6 +314,9 @@ public class SelectDataJdbc {
     }
     if (teamId != null) {
       request.setTeamId(teamId);
+    }
+    if (userName != null && !userName.isEmpty()) {
+      request.setUsername(userName);
     }
     // check if debug is enabled so the logger doesnt waste resources converting object request to a
     // string

--- a/core/src/main/java/io/aiven/klaw/model/SchemaRequestModel.java
+++ b/core/src/main/java/io/aiven/klaw/model/SchemaRequestModel.java
@@ -67,4 +67,7 @@ public class SchemaRequestModel implements Serializable {
   private List<String> allPageNos;
 
   private String currentPage;
+
+  private boolean isEditable;
+  private boolean isDeletable;
 }

--- a/core/src/main/java/io/aiven/klaw/service/AclControllerService.java
+++ b/core/src/main/java/io/aiven/klaw/service/AclControllerService.java
@@ -220,7 +220,9 @@ public class AclControllerService {
   }
 
   private AclRequestsModel setRequestorPermissions(AclRequestsModel req, String userName) {
-    if (userName != null && userName.equals(req.getUsername())) {
+    if (RequestStatus.CREATED.value.equals(req.getAclstatus())
+        && userName != null
+        && userName.equals(req.getUsername())) {
       req.setDeletable(true);
       req.setEditable(true);
     }

--- a/core/src/main/java/io/aiven/klaw/service/SchemaRegstryControllerService.java
+++ b/core/src/main/java/io/aiven/klaw/service/SchemaRegstryControllerService.java
@@ -57,14 +57,16 @@ public class SchemaRegstryControllerService {
       boolean isApproval,
       String topic,
       String env,
-      String search) {
+      String search,
+      boolean isMyRequest) {
     log.debug("getSchemaRequests page {} requestsType {}", pageNo, requestsType);
     String userName = getUserName();
     int tenantId = commonUtilsService.getTenantId(userName);
     List<SchemaRequest> schemaReqs =
         manageDatabase
             .getHandleDbRequests()
-            .getAllSchemaRequests(isApproval, userName, tenantId, topic, env, requestsType, search);
+            .getAllSchemaRequests(
+                isApproval, userName, tenantId, topic, env, requestsType, search, isMyRequest);
 
     // tenant filtering
     final Set<String> allowedEnvIdSet = commonUtilsService.getEnvsFromUserId(userName);
@@ -402,7 +404,7 @@ public class SchemaRegstryControllerService {
     List<SchemaRequest> schemaReqs =
         manageDatabase
             .getHandleDbRequests()
-            .getAllSchemaRequests(false, userDetails, tenantId, null, null, null, null);
+            .getAllSchemaRequests(false, userDetails, tenantId, null, null, null, null, false);
 
     // tenant filtering
     final Set<String> allowedEnvIdSet = commonUtilsService.getEnvsFromUserId(getUserName());

--- a/core/src/main/java/io/aiven/klaw/service/SchemaRegstryControllerService.java
+++ b/core/src/main/java/io/aiven/klaw/service/SchemaRegstryControllerService.java
@@ -128,7 +128,9 @@ public class SchemaRegstryControllerService {
 
   private SchemaRequestModel setRequestorPermissions(SchemaRequestModel req, String userName) {
 
-    if (userName != null && userName.equals(req.getUsername())) {
+    if (RequestStatus.CREATED.value.equals(req.getTopicstatus())
+        && userName != null
+        && userName.equals(req.getUsername())) {
       req.setDeletable(true);
       req.setEditable(true);
     }

--- a/core/src/main/java/io/aiven/klaw/service/SchemaRegstryControllerService.java
+++ b/core/src/main/java/io/aiven/klaw/service/SchemaRegstryControllerService.java
@@ -103,7 +103,7 @@ public class SchemaRegstryControllerService {
                   approverRoles,
                   schemaRequestModel.getUsername()));
         }
-        schemaRequestModels.add(schemaRequestModel);
+        schemaRequestModels.add(setRequestorPermissions(schemaRequestModel, userName));
       }
     }
 
@@ -122,6 +122,16 @@ public class SchemaRegstryControllerService {
     }
 
     return String.valueOf(approvingInfo);
+  }
+
+  private SchemaRequestModel setRequestorPermissions(SchemaRequestModel req, String userName) {
+
+    if (userName != null && userName.equals(req.getUsername())) {
+      req.setDeletable(true);
+      req.setEditable(true);
+    }
+
+    return req;
   }
 
   private List<SchemaRequestModel> getSchemaRequestsPaged(
@@ -168,13 +178,15 @@ public class SchemaRegstryControllerService {
         getPrincipal(), PermissionType.REQUEST_DELETE_SCHEMAS)) {
       return ApiResponse.builder().result(ApiResultStatus.NOT_AUTHORIZED.value).build();
     }
-
+    String userName = getUserName();
     try {
       String result =
           manageDatabase
               .getHandleDbRequests()
               .deleteSchemaRequest(
-                  Integer.parseInt(avroSchemaId), commonUtilsService.getTenantId(getUserName()));
+                  Integer.parseInt(avroSchemaId),
+                  userName,
+                  commonUtilsService.getTenantId(getUserName()));
       return ApiResponse.builder().result(result).build();
     } catch (Exception e) {
       log.error("Exception:", e);

--- a/core/src/main/java/io/aiven/klaw/service/TopicControllerService.java
+++ b/core/src/main/java/io/aiven/klaw/service/TopicControllerService.java
@@ -321,7 +321,14 @@ public class TopicControllerService {
   }
 
   private TopicRequestModel setRequestorPermissions(TopicRequestModel req, String userName) {
-    if (userName != null && userName.equals(req.getUsername())) {
+    log.info(
+        " My Topic Status {} and userName {} and userName {}",
+        req.getTopicstatus(),
+        userName,
+        req.getRequestor());
+    if (RequestStatus.CREATED.value.equals(req.getTopicstatus())
+        && userName != null
+        && userName.equals(req.getRequestor())) {
       req.setDeletable(true);
       req.setEditable(true);
     }

--- a/core/src/main/java/io/aiven/klaw/service/UtilControllerService.java
+++ b/core/src/main/java/io/aiven/klaw/service/UtilControllerService.java
@@ -121,7 +121,7 @@ public class UtilControllerService {
       roleToSet = "requestor_subscriptions";
     }
     List<SchemaRequest> allSchemaReqs =
-        reqsHandle.getAllSchemaRequests(true, requestor, tenantId, null, null, null, null);
+        reqsHandle.getAllSchemaRequests(true, requestor, tenantId, null, null, null, null, false);
 
     List<AclRequests> allAclReqs;
     List<TopicRequest> allTopicReqs;

--- a/core/src/main/resources/swagger_spec.json
+++ b/core/src/main/resources/swagger_spec.json
@@ -2011,6 +2011,22 @@
           "required" : false,
           "type" : "string",
           "default" : "all"
+        }, {
+          "name" : "topic",
+          "in" : "query",
+          "required" : false,
+          "type" : "string"
+        }, {
+          "name" : "env",
+          "in" : "query",
+          "required" : false,
+          "type" : "string"
+        }, {
+          "name" : "isMyRequest",
+          "in" : "query",
+          "required" : false,
+          "type" : "boolean",
+          "default" : false
         } ],
         "responses" : {
           "200" : {

--- a/core/src/main/resources/swagger_spec.json
+++ b/core/src/main/resources/swagger_spec.json
@@ -4442,6 +4442,12 @@
         },
         "currentPage" : {
           "type" : "string"
+        },
+        "editable" : {
+          "type" : "boolean"
+        },
+        "deletable" : {
+          "type" : "boolean"
         }
       }
     },

--- a/core/src/test/java/io/aiven/klaw/controller/SchemaRegstryControllerTest.java
+++ b/core/src/test/java/io/aiven/klaw/controller/SchemaRegstryControllerTest.java
@@ -58,7 +58,14 @@ public class SchemaRegstryControllerTest {
     List<SchemaRequestModel> schRequests = utilMethods.getSchemaRequests();
 
     when(schemaRegstryControllerService.getSchemaRequests(
-            anyString(), anyString(), anyString(), anyBoolean(), eq(null), eq(null), eq(null)))
+            anyString(),
+            anyString(),
+            anyString(),
+            anyBoolean(),
+            eq(null),
+            eq(null),
+            eq(null),
+            anyBoolean()))
         .thenReturn(schRequests);
 
     mvc.perform(

--- a/core/src/test/java/io/aiven/klaw/helpers/db/rdbms/DeleteDataJdbcTest.java
+++ b/core/src/test/java/io/aiven/klaw/helpers/db/rdbms/DeleteDataJdbcTest.java
@@ -8,6 +8,8 @@ import io.aiven.klaw.dao.AclRequestID;
 import io.aiven.klaw.dao.AclRequests;
 import io.aiven.klaw.dao.Env;
 import io.aiven.klaw.dao.EnvID;
+import io.aiven.klaw.dao.SchemaRequest;
+import io.aiven.klaw.dao.SchemaRequestID;
 import io.aiven.klaw.model.enums.ApiResultStatus;
 import io.aiven.klaw.repository.*;
 import java.util.Optional;
@@ -60,7 +62,11 @@ public class DeleteDataJdbcTest {
 
   @Test
   public void deleteSchemaRequest() {
-    String result = deleteDataJdbc.deleteSchemaRequest(1001, 1);
+    SchemaRequest req = new SchemaRequest();
+    req.setUsername("uiuser1");
+    req.setReq_no(1001);
+    when(schemaRequestRepo.findById(new SchemaRequestID(1001, 1))).thenReturn(Optional.of(req));
+    String result = deleteDataJdbc.deleteSchemaRequest(1001, "uiuser1", 1);
     assertThat(result).isEqualTo(ApiResultStatus.SUCCESS.value);
   }
 

--- a/core/src/test/java/io/aiven/klaw/helpers/db/rdbms/SchemaRequestsIntegrationTest.java
+++ b/core/src/test/java/io/aiven/klaw/helpers/db/rdbms/SchemaRequestsIntegrationTest.java
@@ -105,7 +105,12 @@ public class SchemaRequestsIntegrationTest {
     user2.setUsername("John");
     entityManager.persistAndFlush(user);
     entityManager.persistAndFlush(user2);
-
+    UserInfo user3 = new UserInfo();
+    user3.setTenantId(101);
+    user3.setTeamId(101);
+    user3.setRole("USER");
+    user3.setUsername("Jackie");
+    entityManager.persistAndFlush(user3);
     Team t1 = new Team();
     t1.setTeamId(101);
     t1.setTenantId(101);
@@ -208,7 +213,8 @@ public class SchemaRequestsIntegrationTest {
   public void givenAllReqsTrueNoFilterOptionsOnlyReturnCreatedByOthersOnMyTeam() {
 
     List<SchemaRequest> results =
-        selectDataJdbc.selectFilteredSchemaRequests(true, "James", 101, null, null, null, null);
+        selectDataJdbc.selectFilteredSchemaRequests(
+            true, "James", 101, null, null, null, null, false);
 
     for (SchemaRequest req : results) {
       assertThat(req.getTopicstatus()).isEqualTo(RequestStatus.CREATED.value);
@@ -222,7 +228,8 @@ public class SchemaRequestsIntegrationTest {
   public void givenAllReqsFalseNoFilterOptionsOnlyReturnCreatedByOthersOnMyTeam() {
 
     List<SchemaRequest> results =
-        selectDataJdbc.selectFilteredSchemaRequests(false, "James", 101, null, null, null, null);
+        selectDataJdbc.selectFilteredSchemaRequests(
+            false, "James", 101, null, null, null, null, false);
 
     for (SchemaRequest req : results) {
       // All Statuses allowed
@@ -243,7 +250,7 @@ public class SchemaRequestsIntegrationTest {
 
     List<SchemaRequest> results =
         selectDataJdbc.selectFilteredSchemaRequests(
-            true, "James", 101, null, null, RequestStatus.DECLINED.value, null);
+            true, "James", 101, null, null, RequestStatus.DECLINED.value, null, false);
 
     for (SchemaRequest req : results) {
       // All Statuses allowed
@@ -259,7 +266,7 @@ public class SchemaRequestsIntegrationTest {
 
     List<SchemaRequest> results =
         selectDataJdbc.selectFilteredSchemaRequests(
-            true, "James", 101, null, null, RequestStatus.APPROVED.value, null);
+            true, "James", 101, null, null, RequestStatus.APPROVED.value, null, false);
 
     for (SchemaRequest req : results) {
       // All Statuses allowed
@@ -275,7 +282,7 @@ public class SchemaRequestsIntegrationTest {
 
     List<SchemaRequest> results =
         selectDataJdbc.selectFilteredSchemaRequests(
-            false, "James", 101, null, null, RequestStatus.DECLINED.value, null);
+            false, "James", 101, null, null, RequestStatus.DECLINED.value, null, false);
 
     for (SchemaRequest req : results) {
       // All Statuses allowed
@@ -291,7 +298,7 @@ public class SchemaRequestsIntegrationTest {
 
     List<SchemaRequest> results =
         selectDataJdbc.selectFilteredSchemaRequests(
-            false, "James", 101, null, null, RequestStatus.APPROVED.value, null);
+            false, "James", 101, null, null, RequestStatus.APPROVED.value, null, false);
 
     for (SchemaRequest req : results) {
       // All Statuses allowed
@@ -308,7 +315,7 @@ public class SchemaRequestsIntegrationTest {
 
     List<SchemaRequest> results =
         selectDataJdbc.selectFilteredSchemaRequests(
-            true, "James", 101, null, null, RequestStatus.ALL.value, "topic1");
+            true, "James", 101, null, null, RequestStatus.ALL.value, "topic1", false);
 
     for (SchemaRequest req : results) {
       // firsttopic1 is the noly one that should match.
@@ -325,7 +332,7 @@ public class SchemaRequestsIntegrationTest {
 
     List<SchemaRequest> results =
         selectDataJdbc.selectFilteredSchemaRequests(
-            true, "James", 101, null, null, RequestStatus.ALL.value, "topic");
+            true, "James", 101, null, null, RequestStatus.ALL.value, "topic", false);
 
     for (SchemaRequest req : results) {
       // firstopic5 was created by james so should not be returned.
@@ -341,7 +348,7 @@ public class SchemaRequestsIntegrationTest {
 
     List<SchemaRequest> results =
         selectDataJdbc.selectFilteredSchemaRequests(
-            false, "James", 101, null, null, RequestStatus.ALL.value, "topic1");
+            false, "James", 101, null, null, RequestStatus.ALL.value, "topic1", false);
     assertThat(results.size()).isEqualTo(17);
     for (SchemaRequest req : results) {
       // All Statuses allowed
@@ -362,7 +369,7 @@ public class SchemaRequestsIntegrationTest {
 
     List<SchemaRequest> results =
         selectDataJdbc.selectFilteredSchemaRequests(
-            false, "James", 101, null, null, RequestStatus.ALL.value, "topic2");
+            false, "James", 101, null, null, RequestStatus.ALL.value, "topic2", false);
     assertThat(results.size()).isEqualTo(17);
     for (SchemaRequest req : results) {
       // All Statuses allowed
@@ -383,7 +390,7 @@ public class SchemaRequestsIntegrationTest {
 
     List<SchemaRequest> results =
         selectDataJdbc.selectFilteredSchemaRequests(
-            true, "James", 101, null, "dev", RequestStatus.ALL.value, null);
+            true, "James", 101, null, "dev", RequestStatus.ALL.value, null, false);
 
     for (SchemaRequest req : results) {
       // firstopic5 was created by james so should not be returned.
@@ -399,7 +406,7 @@ public class SchemaRequestsIntegrationTest {
 
     List<SchemaRequest> results =
         selectDataJdbc.selectFilteredSchemaRequests(
-            false, "James", 101, null, "dev", RequestStatus.ALL.value, null);
+            false, "James", 101, null, "dev", RequestStatus.ALL.value, null, false);
     assertThat(results.size()).isEqualTo(17);
     for (SchemaRequest req : results) {
       // All Statuses allowed
@@ -415,12 +422,12 @@ public class SchemaRequestsIntegrationTest {
   }
 
   @Test
-  @Order(10)
+  @Order(16)
   public void givenAllReqsTrueStatusFilterOptionsOnlyReturnMatchingSpecificTopicByOthersOnMyTeam() {
 
     List<SchemaRequest> results =
         selectDataJdbc.selectFilteredSchemaRequests(
-            true, "James", 101, "firsttopic10", null, RequestStatus.ALL.value, null);
+            true, "James", 101, "firsttopic10", null, RequestStatus.ALL.value, null, false);
 
     for (SchemaRequest req : results) {
       // firsttopic1 is the noly one that should match.
@@ -428,6 +435,88 @@ public class SchemaRequestsIntegrationTest {
       assertThat(req.getUsername()).isNotEqualTo("James");
       assertThat(req.getTeamId()).isEqualTo(101);
     }
+  }
+
+  @Test
+  @Order(17)
+  public void givenReqsReturnMyRequestsOnlyForTSingleTopic() {
+
+    List<SchemaRequest> results =
+        selectDataJdbc.selectFilteredSchemaRequests(
+            false, "John", 101, "firsttopic5", null, RequestStatus.ALL.value, null, true);
+    assertThat(results.size()).isEqualTo(0);
+  }
+
+  @Test
+  @Order(18)
+  public void givenReqsReturnMyRequestsOnly() {
+
+    List<SchemaRequest> results =
+        selectDataJdbc.selectFilteredSchemaRequests(
+            false, "Jackie", 101, null, null, RequestStatus.ALL.value, null, true);
+    assertThat(results.size()).isEqualTo(17);
+    for (SchemaRequest req : results) {
+      assertThat(req.getUsername()).isEqualTo("Jackie");
+      assertThat(req.getTeamId()).isEqualTo(101);
+    }
+  }
+
+  @Test
+  @Order(19)
+  public void givenReqsReturnMyRequestsOnlyFromDevEnv() {
+
+    List<SchemaRequest> results =
+        selectDataJdbc.selectFilteredSchemaRequests(
+            false, "Jackie", 101, null, "dev", RequestStatus.ALL.value, null, true);
+    assertThat(results.size()).isEqualTo(17);
+    for (SchemaRequest req : results) {
+      assertThat(req.getUsername()).isEqualTo("Jackie");
+      assertThat(req.getTeamId()).isEqualTo(101);
+    }
+  }
+
+  @Test
+  @Order(20)
+  public void givenReqsReturnMyRequestsOnlyFromTestEnv() {
+
+    List<SchemaRequest> results =
+        selectDataJdbc.selectFilteredSchemaRequests(
+            false, "Jackie", 101, null, "test", RequestStatus.ALL.value, null, true);
+    assertThat(results.size()).isEqualTo(0);
+  }
+
+  @Test
+  @Order(21)
+  public void givenReqsReturnAllRequestsOnlyFromDevEnv() {
+
+    List<SchemaRequest> results =
+        selectDataJdbc.selectFilteredSchemaRequests(
+            false, "John", 101, null, "dev", RequestStatus.ALL.value, null, false);
+    assertThat(results.size()).isEqualTo(4);
+    for (SchemaRequest req : results) {
+      assertThat(req.getUsername()).isNotEqualTo("John");
+      assertThat(req.getTeamId()).isEqualTo(103);
+    }
+  }
+
+  @Test
+  @Order(22)
+  public void givenReqsReturnAllRequests() {
+
+    List<SchemaRequest> results =
+        selectDataJdbc.selectFilteredSchemaRequests(
+            false, "John", 101, null, null, RequestStatus.ALL.value, null, false);
+    assertThat(results.size()).isEqualTo(4);
+  }
+
+  @Test
+  @Order(23)
+  public void givenReqsReturnAllRequestsForTeam101() {
+
+    List<SchemaRequest> results =
+        selectDataJdbc.selectFilteredSchemaRequests(
+            false, "James", 101, null, null, RequestStatus.ALL.value, null, false);
+    assertThat(results.size()).isEqualTo(17);
   }
 
   private void generateData(

--- a/core/src/test/java/io/aiven/klaw/helpers/db/rdbms/SelectDataJdbcTest.java
+++ b/core/src/test/java/io/aiven/klaw/helpers/db/rdbms/SelectDataJdbcTest.java
@@ -111,7 +111,7 @@ public class SelectDataJdbcTest {
         .thenReturn(java.util.Optional.of(userInfo));
 
     List<SchemaRequest> schemaRequestsActual =
-        selectData.selectFilteredSchemaRequests(false, requestor, 1, null, null, null, null);
+        selectData.selectFilteredSchemaRequests(false, requestor, 1, null, null, null, null, false);
     assertThat(schemaRequestsActual).isEmpty();
   }
 

--- a/core/src/test/java/io/aiven/klaw/service/SchemaRegistryControllerServiceTest.java
+++ b/core/src/test/java/io/aiven/klaw/service/SchemaRegistryControllerServiceTest.java
@@ -141,7 +141,7 @@ public class SchemaRegistryControllerServiceTest {
     int schemaReqId = 1001;
 
     stubUserInfo();
-    when(handleDbRequests.deleteSchemaRequest(anyInt(), anyInt()))
+    when(handleDbRequests.deleteSchemaRequest(anyInt(), anyString(), anyInt()))
         .thenReturn(ApiResultStatus.SUCCESS.value);
     ApiResponse resultResp = schemaRegstryControllerService.deleteSchemaRequests("" + schemaReqId);
     assertThat(resultResp.getResult()).isEqualTo(ApiResultStatus.SUCCESS.value);
@@ -153,7 +153,7 @@ public class SchemaRegistryControllerServiceTest {
     int schemaReqId = 1001;
 
     stubUserInfo();
-    when(handleDbRequests.deleteSchemaRequest(anyInt(), anyInt()))
+    when(handleDbRequests.deleteSchemaRequest(anyInt(), anyString(), anyInt()))
         .thenThrow(new RuntimeException("Error from Schema upload"));
     try {
       schemaRegstryControllerService.deleteSchemaRequests("" + schemaReqId);

--- a/core/src/test/java/io/aiven/klaw/service/SchemaRegistryControllerServiceTest.java
+++ b/core/src/test/java/io/aiven/klaw/service/SchemaRegistryControllerServiceTest.java
@@ -118,7 +118,14 @@ public class SchemaRegistryControllerServiceTest {
     stubUserInfo();
     when(commonUtilsService.getTenantId(anyString())).thenReturn(101);
     when(handleDbRequests.getAllSchemaRequests(
-            anyBoolean(), anyString(), anyInt(), eq(null), eq(null), eq("all"), eq(null)))
+            anyBoolean(),
+            anyString(),
+            anyInt(),
+            eq(null),
+            eq(null),
+            eq("all"),
+            eq(null),
+            eq(false)))
         .thenReturn(getSchemasReqs());
     when(rolesPermissionsControllerService.getApproverRoles(anyString(), anyInt()))
         .thenReturn(List.of(""));
@@ -131,7 +138,8 @@ public class SchemaRegistryControllerServiceTest {
     when(manageDatabase.getTeamNameFromTeamId(anyInt(), anyInt())).thenReturn("teamname");
 
     List<SchemaRequestModel> listReqs =
-        schemaRegstryControllerService.getSchemaRequests("1", "", "all", true, null, null, null);
+        schemaRegstryControllerService.getSchemaRequests(
+            "1", "", "all", true, null, null, null, false);
     assertThat(listReqs).hasSize(2);
   }
 


### PR DESCRIPTION
About this change - What it does
Adds Filter parameters required for new React UIs
Adds isEditable and isDeletable to responses
Enforces only request creator can delete their own request Also only returns true if the status of the ticket is created.
Resolves: #601 
Why this way
