### PR TITLE
style(coral): Consistent font-sizes to console

### DIFF
--- a/coral/src/app/layout/Layout.tsx
+++ b/coral/src/app/layout/Layout.tsx
@@ -13,7 +13,7 @@ function Layout({ children }: { children: ReactNode }) {
         colGap={"l1"}
         minHeight={"screen"}
         style={{
-          gridTemplateColumns: "240px 1fr",
+          gridTemplateColumns: "245px 1fr",
           gridTemplateRows: "auto 1fr",
         }}
       >

--- a/coral/src/app/main.module.css
+++ b/coral/src/app/main.module.css
@@ -11,7 +11,8 @@
 }
 
 :root {
-  font-size: 14px;
+  font-size: 16px;
+  font-family: "Inter", serif;
 }
 
 body {


### PR DESCRIPTION
# About this change - What it does

- sets the global font-size to 16px to match DS instead of console so styles for DS are applied correctly.


## Note
The navigation links now are 16px (default), but in console they are 14px (default from console). Since we're not integrated in console yet, we're not implementing overwrites for that now. 

Resolves: #620 

