### PR TITLE
feat(coral): Add Dialog component.

### DIFF
--- a/coral/src/app/components/Dialog.test.tsx
+++ b/coral/src/app/components/Dialog.test.tsx
@@ -1,0 +1,149 @@
+import { cleanup, render, screen, within } from "@testing-library/react";
+import { Dialog } from "src/app/components/Dialog";
+import confirm from "@aivenio/aquarium/dist/src/icons/confirm";
+import warningSign from "@aivenio/aquarium/dist/src/icons/warningSign";
+import error from "@aivenio/aquarium/dist/src/icons/error";
+
+describe("Dialog.tsx", () => {
+  const testTitle = "Dialog title";
+  const mockChildren = <div>This is child content</div>;
+  const mockPrimary = {
+    text: "Primary action 1",
+    onClick: jest.fn(),
+  };
+  const mockSecondary = {
+    text: "Secondary action 1",
+    onClick: jest.fn(),
+  };
+
+  afterEach(jest.clearAllMocks);
+
+  describe("renders all necessary elements", () => {
+    beforeAll(() => {
+      render(
+        <>
+          <div id={"root"}></div>
+          <Dialog
+            type="confirmation"
+            title={testTitle}
+            primaryAction={mockPrimary}
+            secondaryAction={mockSecondary}
+          >
+            {mockChildren}
+          </Dialog>
+        </>
+      );
+    });
+
+    afterAll(cleanup);
+
+    it("shows a dialog", () => {
+      const dialog = screen.getByRole("dialog");
+
+      expect(dialog).toBeVisible();
+      expect(dialog).toHaveAttribute("aria-modal", "true");
+    });
+
+    it("shows a given title with an icon", () => {
+      const title = screen.getByRole("heading", { name: testTitle });
+
+      expect(title).toBeVisible();
+    });
+
+    it("shows the given content", () => {
+      const text = screen.getByText("This is child content");
+
+      expect(text).toBeVisible();
+    });
+
+    it("shows a button with a given primary action", () => {
+      const button = screen.getByRole("button", { name: mockPrimary.text });
+
+      expect(button).toBeEnabled();
+    });
+
+    it("shows a button with a given secondary action", () => {
+      const button = screen.getByRole("button", { name: mockPrimary.text });
+
+      expect(button).toBeEnabled();
+    });
+
+    it("shows no close button", () => {
+      const buttons = screen.getAllByRole("button");
+
+      expect(buttons).toHaveLength(2);
+      expect(buttons[0]).toHaveTextContent(mockSecondary.text);
+      expect(buttons[1]).toHaveTextContent(mockPrimary.text);
+    });
+  });
+
+  describe("renders header icon and color dependent on type prop", () => {
+    afterEach(cleanup);
+
+    it("shows a confirmation header", () => {
+      render(
+        <>
+          <div id={"root"}></div>
+          <Dialog
+            type="confirmation"
+            title={testTitle}
+            primaryAction={mockPrimary}
+            secondaryAction={mockSecondary}
+          >
+            {mockChildren}
+          </Dialog>
+        </>
+      );
+
+      const headline = screen.getByRole("heading");
+      const icon = within(headline).getByTestId("ds-icon");
+
+      expect(headline).toHaveClass("text-info-70");
+      expect(icon).toHaveAttribute("data-icon", confirm.body);
+    });
+
+    it("shows a warning header", () => {
+      render(
+        <>
+          <div id={"root"}></div>
+          <Dialog
+            type="warning"
+            title={testTitle}
+            primaryAction={mockPrimary}
+            secondaryAction={mockSecondary}
+          >
+            {mockChildren}
+          </Dialog>
+        </>
+      );
+
+      const headline = screen.getByRole("heading");
+      const icon = within(headline).getByTestId("ds-icon");
+
+      expect(headline).toHaveClass("text-secondary-70");
+      expect(icon).toHaveAttribute("data-icon", warningSign.body);
+    });
+
+    it("shows a danger header", () => {
+      render(
+        <>
+          <div id={"root"}></div>
+          <Dialog
+            type="danger"
+            title={testTitle}
+            primaryAction={mockPrimary}
+            secondaryAction={mockSecondary}
+          >
+            {mockChildren}
+          </Dialog>
+        </>
+      );
+
+      const headline = screen.getByRole("heading");
+      const icon = within(headline).getByTestId("ds-icon");
+
+      expect(headline).toHaveClass("text-error-70");
+      expect(icon).toHaveAttribute("data-icon", error.body);
+    });
+  });
+});

--- a/coral/src/app/components/Dialog.tsx
+++ b/coral/src/app/components/Dialog.tsx
@@ -1,0 +1,70 @@
+import { Modal, ModalProps } from "src/app/components/Modal";
+import { DialogType } from "@aivenio/aquarium/atoms/Dialog/Dialog";
+import confirm from "@aivenio/aquarium/dist/src/icons/confirm";
+import warningSign from "@aivenio/aquarium/dist/src/icons/warningSign";
+import error from "@aivenio/aquarium/dist/src/icons/error";
+import data from "@aivenio/aquarium/icons/list";
+import { Box, Icon, Typography } from "@aivenio/aquarium";
+import { ResolveIntersectionTypes } from "types/utils";
+
+type DialogProps = ResolveIntersectionTypes<
+  Omit<ModalProps, "isDialog" | "dialogTitle" | "close"> &
+    Required<Pick<ModalProps, "secondaryAction">> & {
+      type: DialogType;
+    }
+>;
+
+const dialogTypeMap: Record<
+  DialogType,
+  { icon: typeof data; color: "info-70" | "secondary-70" | "error-70" }
+> = {
+  confirmation: {
+    icon: confirm,
+    color: "info-70",
+  },
+  warning: {
+    icon: warningSign,
+    color: "secondary-70",
+  },
+  danger: {
+    icon: error,
+    color: "error-70",
+  },
+};
+
+function Dialog(props: DialogProps) {
+  const { type, title } = props;
+
+  const dialogTitle = (
+    <Typography.LargeStrong
+      htmlTag={"h1"}
+      id={"modal-focus"}
+      data-focusable
+      color={dialogTypeMap[type].color}
+    >
+      <Box
+        component={"span"}
+        display={"flex"}
+        alignItems={"center"}
+        colGap={"l1"}
+      >
+        <Icon icon={dialogTypeMap[type].icon} />
+        <span>{title}</span>
+      </Box>
+    </Typography.LargeStrong>
+  );
+
+  return (
+    <Modal
+      title={""}
+      dialogTitle={dialogTitle}
+      isDialog={true}
+      primaryAction={props.primaryAction}
+      secondaryAction={props.secondaryAction}
+    >
+      <>{props.children}</>
+    </Modal>
+  );
+}
+
+export { Dialog };

--- a/coral/src/app/components/Modal.test.tsx
+++ b/coral/src/app/components/Modal.test.tsx
@@ -322,5 +322,36 @@ describe("Modal.tsx", () => {
         expect(buttonSecondary).toBeDisabled();
       });
     });
+
+    describe("renders a dialog based on props", () => {
+      const dialogTitle = (
+        <div>
+          <h1>This is a title</h1>
+        </div>
+      );
+      beforeAll(() => {
+        render(
+          <Modal
+            title={testTitle}
+            primaryAction={mockPrimary}
+            isDialog={true}
+            dialogTitle={dialogTitle}
+          >
+            {mockChildren}
+          </Modal>
+        );
+      });
+
+      it("does not show the headline given by the title prop", () => {
+        const titlePropHeadline = screen.queryByText(testTitle);
+        expect(titlePropHeadline).not.toBeInTheDocument();
+      });
+
+      it("shows the element passed as dialogTitle as title", () => {
+        const title = screen.getByRole("heading", { name: "This is a title" });
+
+        expect(title).toBeVisible();
+      });
+    });
   });
 });

--- a/coral/src/app/components/Modal.tsx
+++ b/coral/src/app/components/Modal.tsx
@@ -18,11 +18,21 @@ type ModalProps = {
   primaryAction: ModalAction;
   secondaryAction?: ModalAction;
   children: ReactElement;
+  isDialog?: boolean;
+  dialogTitle?: ReactElement;
 };
 
 function Modal(props: ModalProps) {
-  const { close, primaryAction, secondaryAction, children, title, subtitle } =
-    props;
+  const {
+    close,
+    primaryAction,
+    secondaryAction,
+    children,
+    title,
+    subtitle,
+    isDialog = false,
+    dialogTitle,
+  } = props;
 
   function setFocus(appRoot: HTMLElement, modal: HTMLElement) {
     appRoot.setAttribute("aria-hidden", "true");
@@ -128,18 +138,23 @@ function Modal(props: ModalProps) {
               paddingBottom={"l2"}
             >
               <div>
-                <Typography.Subheading
-                  htmlTag={"h1"}
-                  id={"modal-focus"}
-                  data-focusable
-                >
-                  {title}
-                </Typography.Subheading>
-                {subtitle && (
-                  <Typography.SmallText htmlTag={"h2"} color={"grey-60"}>
-                    {subtitle}
-                  </Typography.SmallText>
+                {!isDialog && (
+                  <>
+                    <Typography.Subheading
+                      htmlTag={"h1"}
+                      id={"modal-focus"}
+                      data-focusable
+                    >
+                      {title}
+                    </Typography.Subheading>
+                    {subtitle && (
+                      <Typography.SmallText htmlTag={"h2"} color={"grey-60"}>
+                        {subtitle}
+                      </Typography.SmallText>
+                    )}
+                  </>
                 )}
+                {isDialog && dialogTitle && <>{dialogTitle}</>}
               </div>
               {close && (
                 <IconButton
@@ -160,7 +175,7 @@ function Modal(props: ModalProps) {
             >
               {secondaryAction && (
                 <Button
-                  kind={"secondary"}
+                  kind={isDialog ? "ghost" : "secondary"}
                   onClick={secondaryAction.onClick}
                   data-focusable
                   disabled={secondaryAction.disabled}
@@ -170,7 +185,7 @@ function Modal(props: ModalProps) {
                 </Button>
               )}
               <Button
-                kind={"primary"}
+                kind={isDialog ? "secondary" : "primary"}
                 onClick={primaryAction.onClick}
                 data-focusable
                 disabled={primaryAction.disabled}
@@ -188,3 +203,4 @@ function Modal(props: ModalProps) {
 }
 
 export { Modal };
+export type { ModalProps };


### PR DESCRIPTION
# About this change - What it does

Adds a `Dialog` component with a similar API to the one in DS so we can replace it smoothly later. 

## Note about implementation 
The additional tests in `Modal` are a bit sparse, since the new props are only to be used in `<Dialog />` and `<Dialog />` itself is tested for its rendered output. Since both components are temp implementations, I felt it's ok to cover it like that instead of more in depth. It's very unlikely that we will suddenly start to use a `<Modal />` with a dialog-related prop in the wild 😅  



Resolves: #615 

