### PR TITLE
fix(coral): Align naming in form/table views

### DIFF
--- a/coral/src/app/features/approvals/schemas/SchemaApprovals.tsx
+++ b/coral/src/app/features/approvals/schemas/SchemaApprovals.tsx
@@ -68,7 +68,10 @@ function SchemaApprovals() {
       <option> three </option>
     </NativeSelect>,
 
-    <NativeSelect labelText={"Filter by cluster"} key={"filter-cluster"}>
+    <NativeSelect
+      labelText={"Filter by environment"}
+      key={"filter-environment"}
+    >
       <option> one </option>
       <option> two </option>
       <option> three </option>

--- a/coral/src/app/features/approvals/schemas/SchemaApprovals.tsx
+++ b/coral/src/app/features/approvals/schemas/SchemaApprovals.tsx
@@ -69,7 +69,7 @@ function SchemaApprovals() {
     </NativeSelect>,
 
     <NativeSelect
-      labelText={"Filter by environment"}
+      labelText={"Filter by Environment"}
       key={"filter-environment"}
     >
       <option> one </option>

--- a/coral/src/app/features/approvals/schemas/components/SchemaApprovalsTable.test.tsx
+++ b/coral/src/app/features/approvals/schemas/components/SchemaApprovalsTable.test.tsx
@@ -58,7 +58,7 @@ const mockedRequests = [
 describe("SchemaApprovalsTable", () => {
   const columnsFieldMap = [
     { columnHeader: "Topic", relatedField: "topicname" },
-    { columnHeader: "Cluster", relatedField: "environmentName" },
+    { columnHeader: "Environment", relatedField: "environmentName" },
     { columnHeader: "Requested by", relatedField: "username" },
     { columnHeader: "Date requested", relatedField: "requesttimestring" },
     { columnHeader: "Details", relatedField: null },

--- a/coral/src/app/features/approvals/schemas/components/SchemaApprovalsTable.tsx
+++ b/coral/src/app/features/approvals/schemas/components/SchemaApprovalsTable.tsx
@@ -14,7 +14,7 @@ interface SchemaRequestTableData {
 
 const columns: Array<DataTableColumn<SchemaRequestTableData>> = [
   { type: "text", field: "topicname", headerName: "Topic" },
-  { type: "text", field: "environmentName", headerName: "Cluster" },
+  { type: "text", field: "environmentName", headerName: "Environment" },
   { type: "text", field: "username", headerName: "Requested by" },
   {
     type: "text",

--- a/coral/src/app/features/approvals/topics/TopicApprovals.tsx
+++ b/coral/src/app/features/approvals/topics/TopicApprovals.tsx
@@ -77,7 +77,7 @@ function TopicApprovals() {
     </NativeSelect>,
 
     <NativeSelect
-      labelText={"Filter by environment"}
+      labelText={"Filter by Environment"}
       key={"filter-environments"}
     >
       <option> one </option>

--- a/coral/src/app/features/approvals/topics/components/TopicApprovalsTable.test.tsx
+++ b/coral/src/app/features/approvals/topics/components/TopicApprovalsTable.test.tsx
@@ -66,7 +66,7 @@ const mockedRequests = [
 describe("TopicApprovalsTable", () => {
   const columnsFieldMap = [
     { columnHeader: "Topic", relatedField: "topicname" },
-    { columnHeader: "Cluster", relatedField: "environmentName" },
+    { columnHeader: "Environment", relatedField: "environmentName" },
     { columnHeader: "Type", relatedField: "topictype" },
     { columnHeader: "Claim by team", relatedField: "teamname" },
     { columnHeader: "Requested by", relatedField: "requestor" },

--- a/coral/src/app/features/approvals/topics/components/TopicApprovalsTable.tsx
+++ b/coral/src/app/features/approvals/topics/components/TopicApprovalsTable.tsx
@@ -16,7 +16,7 @@ interface TopicRequestTableData {
 
 const columns: Array<DataTableColumn<TopicRequestTableData>> = [
   { type: "text", field: "topicname", headerName: "Topic" },
-  { type: "text", field: "environmentName", headerName: "Cluster" },
+  { type: "text", field: "environmentName", headerName: "Environment" },
   { type: "text", field: "topictype", headerName: "Type" },
   { type: "text", field: "teamname", headerName: "Claim by team" },
   { type: "text", field: "requestor", headerName: "Requested by" },

--- a/coral/src/app/features/topics/acl-request/TopicAclRequest.test.tsx
+++ b/coral/src/app/features/topics/acl-request/TopicAclRequest.test.tsx
@@ -81,7 +81,7 @@ const assertSkeleton = async () => {
 
 const selectTestEnvironment = async () => {
   const environmentField = screen.getByRole("combobox", {
-    name: "Select Environment *",
+    name: "Environment *",
   });
   const option = screen.getByRole("option", { name: "TST" });
   await userEvent.selectOptions(environmentField, option);

--- a/coral/src/app/features/topics/acl-request/fields/EnvironmentField.test.tsx
+++ b/coral/src/app/features/topics/acl-request/fields/EnvironmentField.test.tsx
@@ -37,7 +37,7 @@ describe("EnvironmentField", () => {
       onError,
     });
     const select = screen.getByRole("combobox", {
-      name: "Select Environment *",
+      name: "Environment *",
     });
 
     expect(select).toBeVisible();
@@ -52,11 +52,11 @@ describe("EnvironmentField", () => {
       onError,
     });
     const select = screen.getByRole("combobox", {
-      name: "Select Environment *",
+      name: "Environment *",
     });
     const options = within(select).getAllByRole("option");
 
-    expect(select).toHaveDisplayValue("-- Select Environment --");
+    expect(select).toHaveDisplayValue("-- Please select --");
     expect(options).toHaveLength(mockedEnvironments.length + 1);
   });
 });

--- a/coral/src/app/features/topics/acl-request/fields/EnvironmentField.tsx
+++ b/coral/src/app/features/topics/acl-request/fields/EnvironmentField.tsx
@@ -10,8 +10,8 @@ const EnvironmentField = ({ environments }: EnvironmentFieldProps) => {
   return (
     <NativeSelect
       name="environment"
-      labelText="Select Environment"
-      placeholder={"-- Select Environment --"}
+      labelText="Environment"
+      placeholder={"-- Please select --"}
       required
     >
       {environments.map((env) => (

--- a/coral/src/app/features/topics/acl-request/forms/TopicConsumerForm.test.tsx
+++ b/coral/src/app/features/topics/acl-request/forms/TopicConsumerForm.test.tsx
@@ -79,7 +79,7 @@ describe("<TopicConsumerForm />", () => {
 
     it("renders EnvironmentField", () => {
       const environmentField = screen.getByRole("combobox", {
-        name: "Select Environment *",
+        name: "Environment *",
       });
 
       expect(environmentField).toBeVisible();
@@ -200,7 +200,7 @@ describe("<TopicConsumerForm />", () => {
 
     it("renders EnvironmentField with DEV selected", () => {
       const environmentField = screen.getByRole("combobox", {
-        name: "Select Environment *",
+        name: "Environment *",
       });
 
       expect(environmentField).toBeVisible();
@@ -313,7 +313,7 @@ describe("<TopicConsumerForm />", () => {
 
     it("renders EnvironmentField with TST selected", () => {
       const environmentField = screen.getByRole("combobox", {
-        name: "Select Environment *",
+        name: "Environment *",
       });
 
       expect(environmentField).toBeVisible();

--- a/coral/src/app/features/topics/acl-request/forms/TopicProducerForm.test.tsx
+++ b/coral/src/app/features/topics/acl-request/forms/TopicProducerForm.test.tsx
@@ -75,7 +75,7 @@ describe("<TopicProducerForm />", () => {
 
     it("renders EnvironmentField", () => {
       const environmentField = screen.getByRole("combobox", {
-        name: "Select Environment *",
+        name: "Environment *",
       });
 
       expect(environmentField).toBeVisible();
@@ -199,7 +199,7 @@ describe("<TopicProducerForm />", () => {
 
     it("renders EnvironmentField with DEV selected", () => {
       const environmentField = screen.getByRole("combobox", {
-        name: "Select Environment *",
+        name: "Environment *",
       });
 
       expect(environmentField).toBeVisible();
@@ -324,7 +324,7 @@ describe("<TopicProducerForm />", () => {
 
     it("renders EnvironmentField with TST selected", () => {
       const environmentField = screen.getByRole("combobox", {
-        name: "Select Environment *",
+        name: "Environment *",
       });
 
       expect(environmentField).toBeVisible();

--- a/coral/src/app/features/topics/browse/BrowseTopics.test.tsx
+++ b/coral/src/app/features/topics/browse/BrowseTopics.test.tsx
@@ -28,7 +28,7 @@ const mockGetEnvironments = getEnvironments as jest.MockedFunction<
   typeof getEnvironments
 >;
 
-const filterByEnvironmentLabel = "Filter by environment";
+const filterByEnvironmentLabel = "Filter by Environment";
 const filterByTeamLabel = "Filter by team";
 
 // @TODO find better location / handling for mocks

--- a/coral/src/app/features/topics/browse/components/select-environment/SelectEnvironment.test.tsx
+++ b/coral/src/app/features/topics/browse/components/select-environment/SelectEnvironment.test.tsx
@@ -12,7 +12,7 @@ import { waitForElementToBeRemoved } from "@testing-library/react/pure";
 import userEvent from "@testing-library/user-event";
 import { createEnvironment } from "src/domain/environment/environment-test-helper";
 
-const filterLabel = "Filter by environment";
+const filterLabel = "Filter by Environment";
 describe("SelectEnvironment.tsx", () => {
   beforeAll(() => {
     server.listen();

--- a/coral/src/app/features/topics/browse/components/select-environment/SelectEnvironment.tsx
+++ b/coral/src/app/features/topics/browse/components/select-environment/SelectEnvironment.tsx
@@ -50,7 +50,7 @@ function SelectEnv(props: SelectEnvProps) {
   } else {
     return (
       <NativeSelect
-        labelText="Filter by environment"
+        labelText="Filter by Environment"
         value={environment}
         onChange={(event) => onChangeEnv(event.target.value)}
       >

--- a/coral/src/app/features/topics/request/TopicRequest.test.tsx
+++ b/coral/src/app/features/topics/request/TopicRequest.test.tsx
@@ -74,7 +74,7 @@ describe("<TopicRequest />", () => {
           name: "Environment",
         });
 
-        expect(select).toHaveDisplayValue("-- Select Environment --");
+        expect(select).toHaveDisplayValue("-- Please select --");
       });
 
       it("shows all environment names as options", () => {
@@ -82,7 +82,7 @@ describe("<TopicRequest />", () => {
         // 3 environments + option for placeholder
         expect(options.length).toBe(4);
         expect(options.map((o) => o.textContent)).toEqual([
-          "-- Select Environment --",
+          "-- Please select --",
           "DEV",
           "TST",
           "PROD",
@@ -120,7 +120,7 @@ describe("<TopicRequest />", () => {
           const select = await screen.findByRole("combobox", {
             name: "Environment",
           });
-          expect(select).toHaveDisplayValue("-- Select Environment --");
+          expect(select).toHaveDisplayValue("-- Please select --");
 
           await user.selectOptions(select, "PROD");
 
@@ -139,13 +139,13 @@ describe("<TopicRequest />", () => {
 
           const options = within(select).getAllByRole("option");
           const placeholderOption = within(select).getByRole("option", {
-            name: "-- Select Environment --",
+            name: "-- Please select --",
           });
 
           expect(placeholderOption).toBeDisabled();
           expect(options.length).toBe(4);
           expect(options.map((o) => o.textContent)).toEqual([
-            "-- Select Environment --",
+            "-- Please select --",
             "DEV",
             "TST",
             "PROD",

--- a/coral/src/app/features/topics/request/TopicRequest.tsx
+++ b/coral/src/app/features/topics/request/TopicRequest.tsx
@@ -72,7 +72,7 @@ function TopicRequest() {
             <ComplexNativeSelect<Schema, Environment>
               name="environment"
               labelText={"Environment"}
-              placeholder={"-- Select Environment --"}
+              placeholder={"-- Please select --"}
               options={environments}
               identifierValue={"id"}
               identifierName={"name"}

--- a/coral/src/app/features/topics/schema-request/TopicSchemaRequest.test.tsx
+++ b/coral/src/app/features/topics/schema-request/TopicSchemaRequest.test.tsx
@@ -178,7 +178,7 @@ describe("TopicSchemaRequest", () => {
     it("shows a required select element to choose an environment", () => {
       const form = getForm();
       const select = within(form).getByRole("combobox", {
-        name: /Select environment/i,
+        name: /Environment/i,
       });
 
       expect(select).toBeEnabled();
@@ -188,7 +188,7 @@ describe("TopicSchemaRequest", () => {
     it("renders all options for environment based on api data", () => {
       const form = getForm();
       const select = within(form).getByRole("combobox", {
-        name: /Select environment/i,
+        name: /Environment/i,
       });
       const options = within(select).getAllByRole("option");
 
@@ -200,7 +200,7 @@ describe("TopicSchemaRequest", () => {
       ({ name, id }) => {
         const form = getForm();
         const select = within(form).getByRole("combobox", {
-          name: /Select environment/i,
+          name: /Environment/i,
         });
         const option = within(select).getByRole("option", { name: name });
 
@@ -295,7 +295,7 @@ describe("TopicSchemaRequest", () => {
     it("shows error when user does not fill out environment select", async () => {
       const form = getForm();
       const select = within(form).getByRole("combobox", {
-        name: /Select environment/i,
+        name: /Environment/i,
       });
 
       select.focus();
@@ -327,7 +327,7 @@ describe("TopicSchemaRequest", () => {
     it("does not enable button if user does not fill out all fields", async () => {
       const form = getForm();
       const select = within(form).getByRole("combobox", {
-        name: /Select environment/i,
+        name: /Environment/i,
       });
       const option = within(select).getByRole("option", {
         name: mockedEnvironments[0].name,
@@ -374,7 +374,7 @@ describe("TopicSchemaRequest", () => {
       const form = getForm();
 
       const select = within(form).getByRole("combobox", {
-        name: /Select environment/i,
+        name: /Environment/i,
       });
       const option = within(select).getByRole("option", {
         name: mockedEnvironments[0].name,
@@ -432,7 +432,7 @@ describe("TopicSchemaRequest", () => {
       const form = getForm();
 
       const select = within(form).getByRole("combobox", {
-        name: /Select environment/i,
+        name: /Environment/i,
       });
       const option = within(select).getByRole("option", {
         name: mockedEnvironments[0].name,
@@ -471,7 +471,7 @@ describe("TopicSchemaRequest", () => {
       const form = getForm();
 
       const select = within(form).getByRole("combobox", {
-        name: /Select environment/i,
+        name: /Environment/i,
       });
       const option = within(select).getByRole("option", {
         name: mockedEnvironments[0].name,
@@ -548,7 +548,7 @@ describe("TopicSchemaRequest", () => {
     it("enables user to select an environment", async () => {
       const form = getForm();
       const select = within(form).getByRole("combobox", {
-        name: /Select environment/i,
+        name: /Environment/i,
       });
       const option = within(select).getByRole("option", {
         name: mockedEnvironments[1].name,
@@ -589,7 +589,7 @@ describe("TopicSchemaRequest", () => {
       const form = getForm();
 
       const select = within(form).getByRole("combobox", {
-        name: /Select environment/i,
+        name: /Environment/i,
       });
       const option = within(select).getByRole("option", {
         name: mockedEnvironments[0].name,
@@ -613,7 +613,7 @@ describe("TopicSchemaRequest", () => {
       const form = getForm();
 
       const select = within(form).getByRole("combobox", {
-        name: /Select environment/i,
+        name: /Environment/i,
       });
       const option = within(select).getByRole("option", {
         name: mockedEnvironments[0].name,
@@ -643,7 +643,7 @@ describe("TopicSchemaRequest", () => {
       const form = getForm();
 
       const select = within(form).getByRole("combobox", {
-        name: /Select environment/i,
+        name: /Environment/i,
       });
       const option = within(select).getByRole("option", {
         name: mockedEnvironments[0].name,

--- a/coral/src/app/features/topics/schema-request/TopicSchemaRequest.tsx
+++ b/coral/src/app/features/topics/schema-request/TopicSchemaRequest.tsx
@@ -113,7 +113,7 @@ function TopicSchemaRequest(props: TopicSchemaRequestProps) {
         {environments && (
           <NativeSelect<TopicRequestFormSchema>
             name={"environment"}
-            labelText={"Select environment"}
+            labelText={"Environment"}
             placeholder={"-- Please select --"}
             required={true}
           >

--- a/coral/src/app/pages/topics/index.test.tsx
+++ b/coral/src/app/pages/topics/index.test.tsx
@@ -99,7 +99,7 @@ describe("Topics", () => {
 
     it("renders a select element to filter topics by Kafka environment", async () => {
       const select = screen.getByRole("combobox", {
-        name: "Filter by environment",
+        name: "Filter by Environment",
       });
 
       expect(select).toBeEnabled();


### PR DESCRIPTION
# About this change - What it does

- Removes mention of "cluster" from UI. User always interact with Klaw's environments. 
- Uses consistently `Environment` and "--- Please select ---" as placeholder in forms for select


Resolves: #541 

