### PR TITLE
feat(coral): Add approve/reject ACL subcription request behaviour

### DIFF
--- a/coral/src/app/components/Modal.module.css
+++ b/coral/src/app/components/Modal.module.css
@@ -8,5 +8,5 @@
 
 .modalTextBlock {
   overflow: scroll;
-  max-height: 50vh;
+  max-height: 70vh;
 }

--- a/coral/src/app/features/approvals/acls/AclApprovals.test.tsx
+++ b/coral/src/app/features/approvals/acls/AclApprovals.test.tsx
@@ -37,6 +37,7 @@ const mockedAclRequestsForApproverApiResponse: AclRequest[] = [
     environmentName: "DEV",
     teamId: 1003,
     requestingteam: 1003,
+    requestingTeamName: "Ospo",
     appname: "App",
     username: "amathieu",
     requesttime: "2023-01-06T14:50:37.912+00:00",

--- a/coral/src/app/features/approvals/acls/AclApprovals.tsx
+++ b/coral/src/app/features/approvals/acls/AclApprovals.tsx
@@ -65,13 +65,24 @@ function AclApprovals() {
 
   const { isLoading: approveIsLoading, mutate: approveRequest } = useMutation({
     mutationFn: approveAclRequest,
-    onSuccess: (data) => {
-      if (data.result !== "success") {
+    onSuccess: (response) => {
+      if (response.result !== "success") {
         return setErrorMessage(
-          data.message || data.result || "Unexpected error"
+          response.message || response.result || "Unexpected error"
         );
       }
+      setErrorMessage("");
       setDetailsModal({ isOpen: false, reqNo: "" });
+
+      // If approved request is last in the page, go back to previous page
+      // This avoids staying on a non-existent page of entries, which makes the table bug hard
+      // With pagination being 0 of 0, and clicking Previous button sets active page at -1
+      // We also do not need to invalidate the query, as the activePage does not exist any more
+      // And there is no need to update anything on it
+      if (data?.entries.length === 1 && data?.currentPage > 1) {
+        return setActivePage(activePage - 1);
+      }
+
       // We need to invalidate the query populating the table to reflect the change
       queryClient.invalidateQueries(["aclRequests", activePage]);
     },
@@ -82,13 +93,24 @@ function AclApprovals() {
 
   const { isLoading: rejectIsLoading, mutate: rejectRequest } = useMutation({
     mutationFn: declineAclRequest,
-    onSuccess: (data) => {
-      if (data.result !== "success") {
+    onSuccess: (response) => {
+      if (response.result !== "success") {
         return setErrorMessage(
-          data.message || data.result || "Unexpected error"
+          response.message || response.result || "Unexpected error"
         );
       }
+      setErrorMessage("");
       setRejectModal({ isOpen: false, reqNo: "" });
+
+      // If approved request is last in the page, go back to previous page
+      // This avoids staying on a non-existent page of entries, which makes the table bug hard
+      // With pagination being 0 of 0, and clicking Previous button sets active page at -1
+      // We also do not need to invalidate the query, as the activePage does not exist any more
+      // And there is no need to update anything on it
+      if (data?.entries.length === 1 && data?.currentPage > 1) {
+        return setActivePage(activePage - 1);
+      }
+
       // We need to invalidate the query populating the table to reflect the change
       queryClient.invalidateQueries(["aclRequests", activePage]);
     },

--- a/coral/src/app/features/approvals/acls/AclApprovals.tsx
+++ b/coral/src/app/features/approvals/acls/AclApprovals.tsx
@@ -340,13 +340,11 @@ function AclApprovals() {
           }}
           isLoading={approveIsLoading}
         >
-          {
-            <DetailsModalContent
-              aclRequest={data.entries.find(
-                (request) => request.req_no === Number(detailsModal.reqNo)
-              )}
-            />
-          }
+          <DetailsModalContent
+            aclRequest={data.entries.find(
+              (request) => request.req_no === Number(detailsModal.reqNo)
+            )}
+          />
         </RequestDetailsModal>
       )}
       {rejectModal.isOpen && (

--- a/coral/src/app/features/approvals/acls/AclApprovals.tsx
+++ b/coral/src/app/features/approvals/acls/AclApprovals.tsx
@@ -3,6 +3,8 @@ import {
   DataTableColumn,
   Flexbox,
   GhostButton,
+  Grid,
+  GridItem,
   Icon,
   NativeSelect,
   SearchInput,
@@ -145,7 +147,7 @@ function AclApprovals() {
     {
       type: "status",
       field: "environmentName",
-      headerName: "Cluster",
+      headerName: "Environment",
       status: ({ environmentName }) => ({
         status: "neutral",
         text: environmentName,
@@ -173,7 +175,10 @@ function AclApprovals() {
     {
       type: "text",
       field: "requesttimestring",
-      headerName: "Date requested",
+      headerName: "Requested on",
+      formatter: (value) => {
+        return `${value} UTC`;
+      },
     },
     {
       // Not having a headerName triggers React error:
@@ -308,6 +313,120 @@ function AclApprovals() {
     </div>,
   ];
 
+  const renderRequestDetails = (request?: AclRequest) => {
+    if (request === undefined) {
+      return <div>Request not found.</div>;
+    }
+
+    const {
+      topictype,
+      environmentName = "Environment not found",
+      topicname,
+      acl_ssl,
+      acl_ip,
+      consumergroup = "Consumer group not found",
+      remarks,
+      requesttimestring = "Request time not found",
+      username = "User not found",
+      requestingTeamName = "Team name not found",
+    } = request;
+
+    const ips = acl_ip || [];
+    const principals = acl_ssl || [];
+
+    const Label = ({ children }: { children: React.ReactNode }) => (
+      <label className="inline-block mb-2 typography-small-strong text-grey-60">
+        {children}
+      </label>
+    );
+
+    return (
+      <Grid cols={"2"} rows={"6"} rowGap={"6"}>
+        <GridItem>
+          <Flexbox direction={"column"} width={"min"}>
+            <Label>ACL type</Label>
+            <div>
+              <StatusChip
+                status={topictype === "Producer" ? "info" : "success"}
+                text={topictype}
+              />
+            </div>
+          </Flexbox>
+        </GridItem>
+        <GridItem>
+          <Flexbox direction={"column"}>
+            <Label>Requesting team</Label>
+            {requestingTeamName}
+          </Flexbox>
+        </GridItem>
+        <GridItem>
+          <Flexbox direction={"column"} width={"min"}>
+            <Label>Environment</Label>
+            <div>
+              <StatusChip status={"neutral"} text={environmentName} />
+            </div>
+          </Flexbox>
+        </GridItem>
+        <GridItem>
+          <Flexbox direction={"column"}>
+            <Label>Topic</Label>
+            {topicname}
+          </Flexbox>
+        </GridItem>
+        <GridItem colSpan={"span-2"}>
+          <Flexbox direction={"column"}>
+            <Label>Principals/Usernames</Label>
+            <Flexbox direction={"row"} gap={"2"}>
+              {principals.map((principal) => (
+                <StatusChip
+                  key={principal}
+                  status={"neutral"}
+                  text={`${principal} `}
+                />
+              ))}
+            </Flexbox>
+          </Flexbox>
+        </GridItem>
+        {ips.length > 0 && (
+          <GridItem colSpan={"span-2"}>
+            <Flexbox direction={"column"}>
+              <Label>IP addresses</Label>
+              <Flexbox direction={"row"} gap={"2"}>
+                {ips.map((ip) => (
+                  <StatusChip key={ip} status={"neutral"} text={`${ip} `} />
+                ))}
+              </Flexbox>
+            </Flexbox>
+          </GridItem>
+        )}
+        <GridItem colSpan={"span-2"}>
+          <Flexbox direction={"column"}>
+            <Label>Consumer group</Label>
+            {topictype === "Consumer" ? consumergroup : <i>Not applicable</i>}
+          </Flexbox>
+        </GridItem>
+        <GridItem colSpan={"span-2"}>
+          <Flexbox direction={"column"}>
+            <Label>Message for the approver</Label>
+            {remarks || <i>No message</i>}
+          </Flexbox>
+        </GridItem>
+        <GridItem>
+          <Flexbox direction={"column"}>
+            <Label> Request by</Label>
+            {username}
+          </Flexbox>
+        </GridItem>
+        <GridItem>
+          <Flexbox direction={"column"}>
+            <Label> Requested on</Label>
+            {requesttimestring} UTC
+          </Flexbox>
+        </GridItem>
+      </Grid>
+    );
+  };
+
   return (
     <>
       {detailsModal.isOpen && (
@@ -322,13 +441,11 @@ function AclApprovals() {
           }}
           isLoading={approveIsLoading}
         >
-          <div>
-            {JSON.stringify(
-              data.entries.find(
-                (request) => request.req_no === Number(detailsModal.reqNo)
-              )
-            )}
-          </div>
+          {renderRequestDetails(
+            data.entries.find(
+              (request) => request.req_no === Number(detailsModal.reqNo)
+            )
+          )}
         </RequestDetailsModal>
       )}
       {rejectModal.isOpen && (

--- a/coral/src/app/features/approvals/acls/AclApprovals.tsx
+++ b/coral/src/app/features/approvals/acls/AclApprovals.tsx
@@ -3,8 +3,6 @@ import {
   DataTableColumn,
   Flexbox,
   GhostButton,
-  Grid,
-  GridItem,
   Icon,
   NativeSelect,
   SearchInput,
@@ -18,6 +16,7 @@ import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { useState } from "react";
 import { useSearchParams } from "react-router-dom";
 import { Pagination } from "src/app/components/Pagination";
+import DetailsModalContent from "src/app/features/approvals/acls/components/DetailsModalContent";
 import { ApprovalsLayout } from "src/app/features/approvals/components/ApprovalsLayout";
 import RequestDetailsModal from "src/app/features/approvals/components/RequestDetailsModal";
 import RequestRejectModal from "src/app/features/approvals/components/RequestRejectModal";
@@ -313,120 +312,6 @@ function AclApprovals() {
     </div>,
   ];
 
-  const renderRequestDetails = (request?: AclRequest) => {
-    if (request === undefined) {
-      return <div>Request not found.</div>;
-    }
-
-    const {
-      topictype,
-      environmentName = "Environment not found",
-      topicname,
-      acl_ssl,
-      acl_ip,
-      consumergroup = "Consumer group not found",
-      remarks,
-      requesttimestring = "Request time not found",
-      username = "User not found",
-      requestingTeamName = "Team name not found",
-    } = request;
-
-    const ips = acl_ip || [];
-    const principals = acl_ssl || [];
-
-    const Label = ({ children }: { children: React.ReactNode }) => (
-      <label className="inline-block mb-2 typography-small-strong text-grey-60">
-        {children}
-      </label>
-    );
-
-    return (
-      <Grid cols={"2"} rows={"6"} rowGap={"6"}>
-        <GridItem>
-          <Flexbox direction={"column"} width={"min"}>
-            <Label>ACL type</Label>
-            <div>
-              <StatusChip
-                status={topictype === "Producer" ? "info" : "success"}
-                text={topictype}
-              />
-            </div>
-          </Flexbox>
-        </GridItem>
-        <GridItem>
-          <Flexbox direction={"column"}>
-            <Label>Requesting team</Label>
-            {requestingTeamName}
-          </Flexbox>
-        </GridItem>
-        <GridItem>
-          <Flexbox direction={"column"} width={"min"}>
-            <Label>Environment</Label>
-            <div>
-              <StatusChip status={"neutral"} text={environmentName} />
-            </div>
-          </Flexbox>
-        </GridItem>
-        <GridItem>
-          <Flexbox direction={"column"}>
-            <Label>Topic</Label>
-            {topicname}
-          </Flexbox>
-        </GridItem>
-        <GridItem colSpan={"span-2"}>
-          <Flexbox direction={"column"}>
-            <Label>Principals/Usernames</Label>
-            <Flexbox direction={"row"} gap={"2"}>
-              {principals.map((principal) => (
-                <StatusChip
-                  key={principal}
-                  status={"neutral"}
-                  text={`${principal} `}
-                />
-              ))}
-            </Flexbox>
-          </Flexbox>
-        </GridItem>
-        {ips.length > 0 && (
-          <GridItem colSpan={"span-2"}>
-            <Flexbox direction={"column"}>
-              <Label>IP addresses</Label>
-              <Flexbox direction={"row"} gap={"2"}>
-                {ips.map((ip) => (
-                  <StatusChip key={ip} status={"neutral"} text={`${ip} `} />
-                ))}
-              </Flexbox>
-            </Flexbox>
-          </GridItem>
-        )}
-        <GridItem colSpan={"span-2"}>
-          <Flexbox direction={"column"}>
-            <Label>Consumer group</Label>
-            {topictype === "Consumer" ? consumergroup : <i>Not applicable</i>}
-          </Flexbox>
-        </GridItem>
-        <GridItem colSpan={"span-2"}>
-          <Flexbox direction={"column"}>
-            <Label>Message for the approver</Label>
-            {remarks || <i>No message</i>}
-          </Flexbox>
-        </GridItem>
-        <GridItem>
-          <Flexbox direction={"column"}>
-            <Label> Request by</Label>
-            {username}
-          </Flexbox>
-        </GridItem>
-        <GridItem>
-          <Flexbox direction={"column"}>
-            <Label> Requested on</Label>
-            {requesttimestring} UTC
-          </Flexbox>
-        </GridItem>
-      </Grid>
-    );
-  };
-
   return (
     <>
       {detailsModal.isOpen && (
@@ -441,11 +326,13 @@ function AclApprovals() {
           }}
           isLoading={approveIsLoading}
         >
-          {renderRequestDetails(
-            data.entries.find(
-              (request) => request.req_no === Number(detailsModal.reqNo)
-            )
-          )}
+          {
+            <DetailsModalContent
+              aclRequest={data.entries.find(
+                (request) => request.req_no === Number(detailsModal.reqNo)
+              )}
+            />
+          }
         </RequestDetailsModal>
       )}
       {rejectModal.isOpen && (

--- a/coral/src/app/features/approvals/acls/AclApprovals.tsx
+++ b/coral/src/app/features/approvals/acls/AclApprovals.tsx
@@ -84,7 +84,7 @@ function AclApprovals() {
       }
 
       // We need to invalidate the query populating the table to reflect the change
-      queryClient.invalidateQueries(["aclRequests", activePage]);
+      queryClient.refetchQueries(["aclRequests"]);
     },
     onError: (error: Error) => {
       setErrorMessage(parseErrorMsg(error));
@@ -112,7 +112,7 @@ function AclApprovals() {
       }
 
       // We need to invalidate the query populating the table to reflect the change
-      queryClient.invalidateQueries(["aclRequests", activePage]);
+      queryClient.refetchQueries(["aclRequests"]);
     },
     onError: (error: Error) => {
       setErrorMessage(parseErrorMsg(error));

--- a/coral/src/app/features/approvals/acls/AclApprovals.tsx
+++ b/coral/src/app/features/approvals/acls/AclApprovals.tsx
@@ -382,7 +382,11 @@ function AclApprovals() {
           isLoading={rejectIsLoading}
         />
       )}
-      {errorMessage !== "" && <Alert type="warning">{errorMessage}</Alert>}
+      {errorMessage !== "" && (
+        <div role="alert">
+          <Alert type="warning">{errorMessage}</Alert>
+        </div>
+      )}
       <ApprovalsLayout
         filters={filters}
         table={

--- a/coral/src/app/features/approvals/acls/components/DetailsModalContent.test.tsx
+++ b/coral/src/app/features/approvals/acls/components/DetailsModalContent.test.tsx
@@ -1,0 +1,188 @@
+import { cleanup, render, screen } from "@testing-library/react";
+import DetailsModalContent from "src/app/features/approvals/acls/components/DetailsModalContent";
+import { AclRequest } from "src/domain/acl/acl-types";
+
+const mockedIpsAclRequest: AclRequest = {
+  remarks: "hello",
+  consumergroup: undefined,
+  acl_ip: ["3.3.3.32", "3.3.3.33"],
+  acl_ssl: ["User:*"],
+  aclPatternType: "PREFIXED",
+  transactionalId: undefined,
+  req_no: 1015,
+  topicname: "newaudittopic",
+  environment: "2",
+  teamname: "Ospo",
+  topictype: "Producer",
+  aclIpPrincipleType: "IP_ADDRESS",
+  environmentName: "TST",
+  teamId: 1003,
+  requestingteam: 1003,
+  requestingTeamName: "Ospo",
+  appname: "App",
+  username: "amathieu",
+  requesttime: "2023-01-10T13:19:10.757+00:00",
+  requesttimestring: "10-Jan-2023 13:19:10",
+  aclstatus: "created",
+  approver: undefined,
+  approvingtime: undefined,
+  aclType: "Producer",
+  aclResourceType: undefined,
+  currentPage: "1",
+  otherParams: undefined,
+  totalNoPages: "2",
+  allPageNos: ["1", ">", ">>"],
+  approvingTeamDetails:
+    "Team : Ospo, Users : muralibasani,josepprat,samulisuortti,mirjamaulbach,smustafa,aindriul,",
+};
+
+const mockedPrincipalsAclrequest: AclRequest = {
+  remarks: undefined,
+  consumergroup: "-na-",
+  acl_ip: undefined,
+  acl_ssl: ["mbasani", "maulbach"],
+  aclPatternType: "LITERAL",
+  transactionalId: undefined,
+  req_no: 1014,
+  topicname: "aivtopic1",
+  environment: "1",
+  teamname: "Ospo",
+  topictype: "Consumer",
+  aclIpPrincipleType: "PRINCIPAL",
+  environmentName: "DEV",
+  teamId: 1003,
+  requestingteam: 1003,
+  requestingTeamName: "Ospo",
+  appname: "App",
+  username: "amathieu",
+  requesttime: "2023-01-06T14:50:37.912+00:00",
+  requesttimestring: "06-Jan-2023 14:50:37",
+  aclstatus: "created",
+  approver: undefined,
+  approvingtime: undefined,
+  aclType: "Consumer",
+  aclResourceType: undefined,
+  currentPage: "1",
+  otherParams: undefined,
+  totalNoPages: "2",
+  allPageNos: ["1", ">", ">>"],
+  approvingTeamDetails:
+    "Team : Ospo, Users : muralibasani,josepprat,samulisuortti,mirjamaulbach,smustafa,aindriul,",
+};
+
+const findDefinition = (term?: string) => {
+  return screen
+    .getAllByRole("definition")
+    .find((value) => value.textContent === term);
+};
+
+const findTerm = (term: string) => {
+  return screen
+    .getAllByRole("term")
+    .find((value) => value.textContent === term);
+};
+
+describe("DetailsModalContent", () => {
+  describe("renders correct content for ACL request (IPs, Producer, Prefixed)", () => {
+    beforeAll(() => {
+      render(<DetailsModalContent aclRequest={mockedIpsAclRequest} />);
+    });
+    afterAll(cleanup);
+
+    it("renders ACL type", () => {
+      expect(findTerm("ACL type")).toBeVisible();
+      expect(findDefinition(mockedIpsAclRequest.topictype)).toBeVisible();
+    });
+    it("renders Requesting team", () => {
+      expect(findTerm("Requesting team")).toBeVisible();
+      expect(
+        findDefinition(mockedIpsAclRequest.requestingTeamName)
+      ).toBeVisible();
+    });
+    it("renders Topic", () => {
+      expect(findTerm("Topic")).toBeVisible();
+      expect(findDefinition(mockedIpsAclRequest.topicname)).toBeVisible();
+    });
+    it("renders Principals/Username", () => {
+      expect(findTerm("Principals/Usernames")).toBeVisible();
+      expect(findDefinition("User:* ")).toBeVisible();
+    });
+    it("renders IP addresses", () => {
+      expect(findTerm("IP addresses")).toBeVisible();
+      expect(findDefinition("3.3.3.32 ")).toBeVisible();
+      expect(findDefinition("3.3.3.33 ")).toBeVisible();
+    });
+    it("renders Consumer group default text", () => {
+      expect(findTerm("Consumer group")).toBeVisible();
+      expect(findDefinition("Not applicable")).toBeVisible();
+    });
+    it("renders Message for the approver", () => {
+      expect(findTerm("Message for the approver")).toBeVisible();
+      expect(findDefinition(mockedIpsAclRequest.remarks)).toBeVisible();
+    });
+    it("renders Requested by", () => {
+      expect(findTerm("Requested by")).toBeVisible();
+      expect(findDefinition(mockedIpsAclRequest.username)).toBeVisible();
+    });
+    it("renders Requested on", () => {
+      expect(findTerm("Requested on")).toBeVisible();
+      expect(
+        findDefinition(`${mockedIpsAclRequest.requesttimestring} UTC`)
+      ).toBeVisible();
+    });
+  });
+
+  describe("renders correct content for ACL request with Principals (Principals, Consumer, Literal", () => {
+    beforeAll(() => {
+      render(<DetailsModalContent aclRequest={mockedPrincipalsAclrequest} />);
+    });
+    afterAll(cleanup);
+
+    it("renders ACL type", () => {
+      expect(findTerm("ACL type")).toBeVisible();
+      expect(
+        findDefinition(mockedPrincipalsAclrequest.topictype)
+      ).toBeVisible();
+    });
+    it("renders Requesting team", () => {
+      expect(findTerm("Requesting team")).toBeVisible();
+      expect(
+        findDefinition(mockedPrincipalsAclrequest.requestingTeamName)
+      ).toBeVisible();
+    });
+    it("renders Topic", () => {
+      expect(findTerm("Topic")).toBeVisible();
+      expect(
+        findDefinition(mockedPrincipalsAclrequest.topicname)
+      ).toBeVisible();
+    });
+    it("renders Principals/Username", () => {
+      expect(findTerm("Principals/Usernames")).toBeVisible();
+      expect(findDefinition("mbasani ")).toBeVisible();
+      expect(findDefinition("maulbach ")).toBeVisible();
+    });
+    it("does not renders IP addresses", () => {
+      expect(findTerm("IP addresses")).toBeUndefined();
+    });
+    it("renders Consumer group", () => {
+      expect(findTerm("Consumer group")).toBeVisible();
+      expect(
+        findDefinition(mockedPrincipalsAclrequest.consumergroup)
+      ).toBeVisible();
+    });
+    it("renders Message for the approver default text", () => {
+      expect(findTerm("Message for the approver")).toBeVisible();
+      expect(findDefinition("No message")).toBeVisible();
+    });
+    it("renders Requested by", () => {
+      expect(findTerm("Requested by")).toBeVisible();
+      expect(findDefinition(mockedPrincipalsAclrequest.username)).toBeVisible();
+    });
+    it("renders Requested on", () => {
+      expect(findTerm("Requested on")).toBeVisible();
+      expect(
+        findDefinition(`${mockedPrincipalsAclrequest.requesttimestring} UTC`)
+      ).toBeVisible();
+    });
+  });
+});

--- a/coral/src/app/features/approvals/acls/components/DetailsModalContent.tsx
+++ b/coral/src/app/features/approvals/acls/components/DetailsModalContent.tsx
@@ -47,17 +47,18 @@ const DetailsModalContent = ({ aclRequest }: DetailsModalContentProps) => {
         <Label>Requesting team</Label>
         <dd>{requestingTeamName}</dd>
       </Flexbox>
+
       <Flexbox direction={"column"} width={"min"}>
         <Label>Environment</Label>
         <dd>
           <StatusChip status={"neutral"} text={environmentName} />
         </dd>
       </Flexbox>
-
       <Flexbox direction={"column"}>
         <Label>Topic</Label>
         <dd>{topicname}</dd>
       </Flexbox>
+
       <GridItem colSpan={"span-2"}>
         <Flexbox direction={"column"}>
           <Label>Principals/Usernames</Label>
@@ -70,6 +71,7 @@ const DetailsModalContent = ({ aclRequest }: DetailsModalContentProps) => {
           </Flexbox>
         </Flexbox>
       </GridItem>
+
       {ips.length > 0 && (
         <GridItem colSpan={"span-2"}>
           <Flexbox direction={"column"}>
@@ -84,6 +86,7 @@ const DetailsModalContent = ({ aclRequest }: DetailsModalContentProps) => {
           </Flexbox>
         </GridItem>
       )}
+
       <GridItem colSpan={"span-2"}>
         <Flexbox direction={"column"}>
           <Label>Consumer group</Label>
@@ -92,18 +95,20 @@ const DetailsModalContent = ({ aclRequest }: DetailsModalContentProps) => {
           </dd>
         </Flexbox>
       </GridItem>
+
       <GridItem colSpan={"span-2"}>
         <Flexbox direction={"column"}>
           <Label>Message for the approver</Label>
           <dd>{remarks || <i>No message</i>}</dd>
         </Flexbox>
       </GridItem>
+
       <Flexbox direction={"column"}>
-        <Label> Request by</Label>
+        <Label>Requested by</Label>
         <dd>{username}</dd>
       </Flexbox>
       <Flexbox direction={"column"}>
-        <Label> Requested on</Label>
+        <Label>Requested on</Label>
         <dd>{requesttimestring} UTC</dd>
       </Flexbox>
     </Grid>

--- a/coral/src/app/features/approvals/acls/components/DetailsModalContent.tsx
+++ b/coral/src/app/features/approvals/acls/components/DetailsModalContent.tsx
@@ -29,8 +29,8 @@ const DetailsModalContent = ({ aclRequest }: DetailsModalContentProps) => {
     requestingTeamName = "Team name not found",
   } = aclRequest;
 
-  const ips = acl_ip || [];
-  const principals = acl_ssl || [];
+  const ips = acl_ip ?? [];
+  const principals = acl_ssl ?? [];
 
   return (
     <Grid htmlTag={"dl"} cols={"2"} rows={"6"} rowGap={"6"}>

--- a/coral/src/app/features/approvals/acls/components/DetailsModalContent.tsx
+++ b/coral/src/app/features/approvals/acls/components/DetailsModalContent.tsx
@@ -1,0 +1,122 @@
+import { Flexbox, Grid, GridItem, StatusChip } from "@aivenio/aquarium";
+import { AclRequest } from "src/domain/acl/acl-types";
+
+interface DetailsModalContentProps {
+  aclRequest?: AclRequest;
+}
+
+const Label = ({ children }: { children: React.ReactNode }) => (
+  <label className="inline-block mb-2 typography-small-strong text-grey-60">
+    {children}
+  </label>
+);
+
+const DetailsModalContent = ({ aclRequest }: DetailsModalContentProps) => {
+  if (aclRequest === undefined) {
+    return <div>Request not found.</div>;
+  }
+
+  const {
+    topictype,
+    environmentName = "Environment not found",
+    topicname,
+    acl_ssl,
+    acl_ip,
+    consumergroup = "Consumer group not found",
+    remarks,
+    requesttimestring = "Request time not found",
+    username = "User not found",
+    requestingTeamName = "Team name not found",
+  } = aclRequest;
+
+  const ips = acl_ip || [];
+  const principals = acl_ssl || [];
+
+  return (
+    <Grid cols={"2"} rows={"6"} rowGap={"6"}>
+      <GridItem>
+        <Flexbox direction={"column"} width={"min"}>
+          <Label>ACL type</Label>
+          <div>
+            <StatusChip
+              status={topictype === "Producer" ? "info" : "success"}
+              text={topictype}
+            />
+          </div>
+        </Flexbox>
+      </GridItem>
+      <GridItem>
+        <Flexbox direction={"column"}>
+          <Label>Requesting team</Label>
+          {requestingTeamName}
+        </Flexbox>
+      </GridItem>
+      <GridItem>
+        <Flexbox direction={"column"} width={"min"}>
+          <Label>Environment</Label>
+          <div>
+            <StatusChip status={"neutral"} text={environmentName} />
+          </div>
+        </Flexbox>
+      </GridItem>
+      <GridItem>
+        <Flexbox direction={"column"}>
+          <Label>Topic</Label>
+          {topicname}
+        </Flexbox>
+      </GridItem>
+      <GridItem colSpan={"span-2"}>
+        <Flexbox direction={"column"}>
+          <Label>Principals/Usernames</Label>
+          <Flexbox direction={"row"} gap={"2"}>
+            {principals.map((principal) => (
+              <StatusChip
+                key={principal}
+                status={"neutral"}
+                text={`${principal} `}
+              />
+            ))}
+          </Flexbox>
+        </Flexbox>
+      </GridItem>
+      {ips.length > 0 && (
+        <GridItem colSpan={"span-2"}>
+          <Flexbox direction={"column"}>
+            <Label>IP addresses</Label>
+            <Flexbox direction={"row"} gap={"2"}>
+              {ips.map((ip) => (
+                <StatusChip key={ip} status={"neutral"} text={`${ip} `} />
+              ))}
+            </Flexbox>
+          </Flexbox>
+        </GridItem>
+      )}
+      <GridItem colSpan={"span-2"}>
+        <Flexbox direction={"column"}>
+          <Label>Consumer group</Label>
+          {topictype === "Consumer" ? consumergroup : <i>Not applicable</i>}
+        </Flexbox>
+      </GridItem>
+      <GridItem colSpan={"span-2"}>
+        <Flexbox direction={"column"}>
+          <Label>Message for the approver</Label>
+          {remarks || <i>No message</i>}
+        </Flexbox>
+      </GridItem>
+      <GridItem>
+        <Flexbox direction={"column"}>
+          <Label> Request by</Label>
+          {username}
+        </Flexbox>
+      </GridItem>
+      <GridItem>
+        <Flexbox direction={"column"}>
+          <Label> Requested on</Label>
+          {requesttimestring} UTC
+        </Flexbox>
+      </GridItem>
+    </Grid>
+  );
+};
+
+export default DetailsModalContent;

--- a/coral/src/app/features/approvals/acls/components/DetailsModalContent.tsx
+++ b/coral/src/app/features/approvals/acls/components/DetailsModalContent.tsx
@@ -6,9 +6,9 @@ interface DetailsModalContentProps {
 }
 
 const Label = ({ children }: { children: React.ReactNode }) => (
-  <label className="inline-block mb-2 typography-small-strong text-grey-60">
+  <dt className="inline-block mb-2 typography-small-strong text-grey-60">
     {children}
-  </label>
+  </dt>
 );
 
 const DetailsModalContent = ({ aclRequest }: DetailsModalContentProps) => {
@@ -33,48 +33,39 @@ const DetailsModalContent = ({ aclRequest }: DetailsModalContentProps) => {
   const principals = acl_ssl || [];
 
   return (
-    <Grid cols={"2"} rows={"6"} rowGap={"6"}>
-      <GridItem>
-        <Flexbox direction={"column"} width={"min"}>
-          <Label>ACL type</Label>
-          <div>
-            <StatusChip
-              status={topictype === "Producer" ? "info" : "success"}
-              text={topictype}
-            />
-          </div>
-        </Flexbox>
-      </GridItem>
-      <GridItem>
-        <Flexbox direction={"column"}>
-          <Label>Requesting team</Label>
-          {requestingTeamName}
-        </Flexbox>
-      </GridItem>
-      <GridItem>
-        <Flexbox direction={"column"} width={"min"}>
-          <Label>Environment</Label>
-          <div>
-            <StatusChip status={"neutral"} text={environmentName} />
-          </div>
-        </Flexbox>
-      </GridItem>
-      <GridItem>
-        <Flexbox direction={"column"}>
-          <Label>Topic</Label>
-          {topicname}
-        </Flexbox>
-      </GridItem>
+    <Grid htmlTag={"dl"} cols={"2"} rows={"6"} rowGap={"6"}>
+      <Flexbox direction={"column"} width={"min"}>
+        <Label>ACL type</Label>
+        <dd>
+          <StatusChip
+            status={topictype === "Producer" ? "info" : "success"}
+            text={topictype}
+          />
+        </dd>
+      </Flexbox>
+      <Flexbox direction={"column"}>
+        <Label>Requesting team</Label>
+        <dd>{requestingTeamName}</dd>
+      </Flexbox>
+      <Flexbox direction={"column"} width={"min"}>
+        <Label>Environment</Label>
+        <dd>
+          <StatusChip status={"neutral"} text={environmentName} />
+        </dd>
+      </Flexbox>
+
+      <Flexbox direction={"column"}>
+        <Label>Topic</Label>
+        <dd>{topicname}</dd>
+      </Flexbox>
       <GridItem colSpan={"span-2"}>
         <Flexbox direction={"column"}>
           <Label>Principals/Usernames</Label>
           <Flexbox direction={"row"} gap={"2"}>
             {principals.map((principal) => (
-              <StatusChip
-                key={principal}
-                status={"neutral"}
-                text={`${principal} `}
-              />
+              <dd key={principal}>
+                <StatusChip status={"neutral"} text={`${principal} `} />
+              </dd>
             ))}
           </Flexbox>
         </Flexbox>
@@ -85,7 +76,9 @@ const DetailsModalContent = ({ aclRequest }: DetailsModalContentProps) => {
             <Label>IP addresses</Label>
             <Flexbox direction={"row"} gap={"2"}>
               {ips.map((ip) => (
-                <StatusChip key={ip} status={"neutral"} text={`${ip} `} />
+                <dd key={ip}>
+                  <StatusChip status={"neutral"} text={`${ip} `} />
+                </dd>
               ))}
             </Flexbox>
           </Flexbox>
@@ -94,27 +87,25 @@ const DetailsModalContent = ({ aclRequest }: DetailsModalContentProps) => {
       <GridItem colSpan={"span-2"}>
         <Flexbox direction={"column"}>
           <Label>Consumer group</Label>
-          {topictype === "Consumer" ? consumergroup : <i>Not applicable</i>}
+          <dd>
+            {topictype === "Consumer" ? consumergroup : <i>Not applicable</i>}
+          </dd>
         </Flexbox>
       </GridItem>
       <GridItem colSpan={"span-2"}>
         <Flexbox direction={"column"}>
           <Label>Message for the approver</Label>
-          {remarks || <i>No message</i>}
+          <dd>{remarks || <i>No message</i>}</dd>
         </Flexbox>
       </GridItem>
-      <GridItem>
-        <Flexbox direction={"column"}>
-          <Label> Request by</Label>
-          {username}
-        </Flexbox>
-      </GridItem>
-      <GridItem>
-        <Flexbox direction={"column"}>
-          <Label> Requested on</Label>
-          {requesttimestring} UTC
-        </Flexbox>
-      </GridItem>
+      <Flexbox direction={"column"}>
+        <Label> Request by</Label>
+        <dd>{username}</dd>
+      </Flexbox>
+      <Flexbox direction={"column"}>
+        <Label> Requested on</Label>
+        <dd>{requesttimestring} UTC</dd>
+      </Flexbox>
     </Grid>
   );
 };

--- a/coral/types/api.d.ts
+++ b/coral/types/api.d.ts
@@ -652,6 +652,8 @@ export type components = {
        * @example 1
        */
       requestingteam?: number;
+      /** @example Ospo */
+      requestingTeamName?: string;
       /** @example App */
       appname?: string;
       /**

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1114,6 +1114,9 @@ components:
           type: integer
           format: int32
           example: 1
+        requestingTeamName:
+          type: string
+          example: "Ospo"
         appname:
           type: string
           example: "App"


### PR DESCRIPTION
### About this change - What it does

https://user-images.githubusercontent.com/20607294/219307114-5347d68a-0734-478f-b5aa-dc434566fd77.mov

- Add modals showing when clicking SHow details or Reject quick action
- Add business logic to handle approval and rejection of ACL requests


## Other changes

- Fix ACL request definition in `openapi.yaml` (was missing `requestingTeamName` property)
- Make `max-height` of `Modal` bigger to avoid scrolling in `Modal`

## Followup

https://github.com/aiven/klaw/issues/633

Resolves: #621
