### PR TITLE
feat(coral): Update api definition, types and functions for `getTopicRequestsForApprover`

### DIFF
--- a/coral/src/app/features/approvals/topics/components/TopicApprovalsTable.tsx
+++ b/coral/src/app/features/approvals/topics/components/TopicApprovalsTable.tsx
@@ -2,7 +2,7 @@ import { DataTable, DataTableColumn, GhostButton } from "@aivenio/aquarium";
 import deleteIcon from "@aivenio/aquarium/dist/src/icons/delete";
 import tickCircle from "@aivenio/aquarium/dist/src/icons/tickCircle";
 import infoSign from "@aivenio/aquarium/dist/src/icons/infoSign";
-import { TopicRequestNew } from "src/domain/topic/topic-types";
+import { TopicRequest } from "src/domain/topic/topic-types";
 
 interface TopicRequestTableData {
   id: number; // unclear
@@ -89,13 +89,13 @@ const columns: Array<DataTableColumn<TopicRequestTableData>> = [
 ];
 
 type TopicApprovalsTableProp = {
-  requests: TopicRequestNew[];
+  requests: TopicRequest[];
 };
 function TopicApprovalsTable(props: TopicApprovalsTableProp) {
   const { requests } = props;
 
   const rows: TopicRequestTableData[] = requests.map(
-    (request: TopicRequestNew) => {
+    (request: TopicRequest) => {
       return {
         id: request.topicid,
         topicname: request.topicname,

--- a/coral/src/domain/requests.ts
+++ b/coral/src/domain/requests.ts
@@ -1,0 +1,6 @@
+import { components } from "types/api";
+
+type RequestType = components["schemas"]["RequestType"];
+type RequestStatus = components["schemas"]["RequestStatus"];
+
+export type { RequestType, RequestStatus };

--- a/coral/src/domain/topic/index.ts
+++ b/coral/src/domain/topic/index.ts
@@ -6,11 +6,10 @@ import {
 import {
   Topic,
   TopicNames,
-  TopicRequest,
   TopicRequestTypes,
   TopicTeam,
   TopicRequestStatus,
-  TopicRequestNew,
+  TopicRequest,
 } from "src/domain/topic/topic-types";
 
 export type {
@@ -18,7 +17,6 @@ export type {
   TopicNames,
   TopicTeam,
   TopicRequest,
-  TopicRequestNew,
   TopicRequestTypes,
   TopicRequestStatus,
 };

--- a/coral/src/domain/topic/topic-api.msw.ts
+++ b/coral/src/domain/topic/topic-api.msw.ts
@@ -217,12 +217,14 @@ function mockGetTopicRequests({
   mswInstance: MswInstance;
   response: {
     status?: number;
-    data: KlawApiResponse<"getCreatedTopicRequests"> | { message: string };
+    data: KlawApiResponse<"getTopicRequestsForApprover"> | { message: string };
   };
 }) {
   mswInstance.use(
-    rest.get(`${getHTTPBaseAPIUrl()}/getCreatedTopicRequests`, (_, res, ctx) =>
-      res(ctx.status(response.status ?? 200), ctx.json(response.data))
+    rest.get(
+      `${getHTTPBaseAPIUrl()}/getTopicRequestsForApprover`,
+      (_, res, ctx) =>
+        res(ctx.status(response.status ?? 200), ctx.json(response.data))
     )
   );
 }

--- a/coral/src/domain/topic/topic-api.test.ts
+++ b/coral/src/domain/topic/topic-api.test.ts
@@ -1,4 +1,7 @@
-import { getTopicRequests, requestTopic } from "src/domain/topic/topic-api";
+import {
+  getTopicRequestsForApprover,
+  requestTopic,
+} from "src/domain/topic/topic-api";
 import { server } from "src/services/api-mocks/server";
 import api from "src/services/api";
 import {
@@ -56,10 +59,10 @@ describe("topic-api", () => {
     });
     it("calls api.get with correct URL", async () => {
       const getSpy = jest.spyOn(api, "get");
-      await getTopicRequests({ requestType: "created" });
+      await getTopicRequestsForApprover({ requestStatus: "created" });
       expect(getSpy).toHaveBeenCalledTimes(1);
       expect(getSpy).toHaveBeenCalledWith(
-        "/getCreatedTopicRequests?pageNo=1&currentPage=1&requestsType=created"
+        "/getTopicRequestsForApprover?pageNo=1&currentPage=1&requestsType=created"
       );
     });
   });

--- a/coral/src/domain/topic/topic-api.ts
+++ b/coral/src/domain/topic/topic-api.ts
@@ -4,16 +4,21 @@ import { Team } from "src/domain/team";
 import { ALL_TEAMS_VALUE } from "src/domain/team/team-types";
 import {
   transformgetTopicAdvancedConfigOptionsResponse,
-  transformGetTopicRequestsResponse,
+  transformGetTopicRequestsForApproverResponse,
   transformTopicApiResponse,
 } from "src/domain/topic/topic-transformer";
 import {
   TopicAdvancedConfigurationOptions,
   TopicApiResponse,
-  TopicRequest,
+  TopicRequestApiResponse,
+  TopicRequestStatus,
 } from "src/domain/topic/topic-types";
 import api from "src/services/api";
-import { KlawApiRequest, KlawApiResponse } from "types/utils";
+import {
+  KlawApiRequest,
+  KlawApiResponse,
+  ResolveIntersectionTypes,
+} from "types/utils";
 
 const getTopics = async ({
   currentPage = 1,
@@ -101,25 +106,37 @@ const requestTopic = (
 type GetTopicRequestsArgs = {
   pageNumber?: number;
   currentPage?: number;
-  requestType: operations["getCreatedTopicRequests"]["parameters"]["query"]["requestsType"];
+  requestStatus: TopicRequestStatus;
 };
 
-const getTopicRequests = ({
-  requestType,
+type GetTopicRequestsQueryParams = ResolveIntersectionTypes<
+  Required<
+    Pick<
+      operations["getTopicRequestsForApprover"]["parameters"]["query"],
+      "pageNo" | "currentPage" | "requestsType"
+    >
+  >
+>;
+
+const getTopicRequestsForApprover = ({
+  requestStatus,
   pageNumber = 1,
   currentPage = 1,
-}: GetTopicRequestsArgs): Promise<TopicRequest[]> => {
-  const queryObject: operations["getCreatedTopicRequests"]["parameters"]["query"] =
-    {
-      pageNo: pageNumber.toString(),
-      currentPage: currentPage.toString(),
-      requestsType: requestType,
-    };
+}: GetTopicRequestsArgs): Promise<TopicRequestApiResponse> => {
+  const queryObject: GetTopicRequestsQueryParams = {
+    pageNo: pageNumber.toString(),
+    currentPage: currentPage.toString(),
+    // This is a naming mix up in backend, we want to query
+    // for the status, not the type. Will be changed there soon.
+    requestsType: requestStatus,
+  };
   return api
-    .get<KlawApiResponse<"getCreatedTopicRequests">>(
-      `/getCreatedTopicRequests?${new URLSearchParams(queryObject).toString()}`
+    .get<KlawApiResponse<"getTopicRequestsForApprover">>(
+      `/getTopicRequestsForApprover?${new URLSearchParams(
+        queryObject
+      ).toString()}`
     )
-    .then(transformGetTopicRequestsResponse);
+    .then(transformGetTopicRequestsForApproverResponse);
 };
 
 export {
@@ -128,5 +145,5 @@ export {
   getTopicTeam,
   getTopicAdvancedConfigOptions,
   requestTopic,
-  getTopicRequests,
+  getTopicRequestsForApprover,
 };

--- a/coral/src/domain/topic/topic-api.ts
+++ b/coral/src/domain/topic/topic-api.ts
@@ -3,7 +3,7 @@ import { ALL_ENVIRONMENTS_VALUE } from "src/domain/environment";
 import { Team } from "src/domain/team";
 import { ALL_TEAMS_VALUE } from "src/domain/team/team-types";
 import {
-  transformgetTopicAdvancedConfigOptionsResponse,
+  transformGetTopicAdvancedConfigOptionsResponse,
   transformGetTopicRequestsForApproverResponse,
   transformTopicApiResponse,
 } from "src/domain/topic/topic-transformer";
@@ -92,7 +92,7 @@ const getTopicAdvancedConfigOptions = (): Promise<
 > =>
   api
     .get<KlawApiResponse<"topicAdvancedConfigGet">>("/getAdvancedTopicConfigs")
-    .then(transformgetTopicAdvancedConfigOptionsResponse);
+    .then(transformGetTopicAdvancedConfigOptionsResponse);
 
 const requestTopic = (
   payload: KlawApiRequest<"topicCreate">

--- a/coral/src/domain/topic/topic-test-helper.ts
+++ b/coral/src/domain/topic/topic-test-helper.ts
@@ -1,4 +1,9 @@
-import { Topic, TopicRequest } from "src/domain/topic/topic-types";
+import {
+  Topic,
+  TopicRequest,
+  TopicRequestStatus,
+  TopicRequestTypes,
+} from "src/domain/topic/topic-types";
 import { KlawApiModel, KlawApiResponse } from "types/utils";
 
 // currently this file is used in code (topcis-api.msw.ts)
@@ -113,7 +118,32 @@ function createMockTopicApiResponse({
 }
 
 const defaultTopicRequest: TopicRequest = {
-  topicName: "test",
+  topicname: "test-topic-1",
+  environment: "1",
+  topicpartitions: 4,
+  teamname: "NCC1701D",
+  remarks: "asap",
+  description: "This topic is for test",
+  replicationfactor: "2",
+  environmentName: "BRG",
+  topicid: 1000,
+  advancedTopicConfigEntries: [
+    {
+      configKey: "cleanup.policy",
+      configValue: "delete",
+    },
+  ],
+  topictype: "Create" as TopicRequestTypes,
+  requestor: "jlpicard",
+  requesttime: "1987-09-28T13:37:00.001+00:00",
+  requesttimestring: "28-Sep-1987 13:37:00",
+  topicstatus: "created" as TopicRequestStatus,
+  totalNoPages: "1",
+  approvingTeamDetails:
+    "Team : NCC1701D, Users : jlpicard, worf, bcrusher, geordilf,",
+  teamId: 1003,
+  allPageNos: ["1"],
+  currentPage: "1",
 };
 
 function createMockTopicRequest(request?: Partial<TopicRequest>): TopicRequest {

--- a/coral/src/domain/topic/topic-transformer.test.ts
+++ b/coral/src/domain/topic/topic-transformer.test.ts
@@ -1,5 +1,5 @@
 import {
-  transformgetTopicAdvancedConfigOptionsResponse,
+  transformGetTopicAdvancedConfigOptionsResponse,
   transformGetTopicRequestsForApproverResponse,
   transformTopicApiResponse,
 } from "src/domain/topic/topic-transformer";
@@ -59,8 +59,8 @@ describe("topic-transformer.ts", () => {
     });
   });
 
-  describe("transformgetTopicAdvancedConfigOptionsResponse", () => {
-    it("transforms an config without known documenation", () => {
+  describe("transformGetTopicAdvancedConfigOptionsResponse", () => {
+    it("transforms an config without known documentation", () => {
       const apiResponse: KlawApiResponse<"topicAdvancedConfigGet"> = {
         MIN_COMPACTION_LAG_MS: "min.compaction.lag.ms",
       };
@@ -75,10 +75,10 @@ describe("topic-transformer.ts", () => {
         },
       ];
       expect(
-        transformgetTopicAdvancedConfigOptionsResponse(apiResponse)
+        transformGetTopicAdvancedConfigOptionsResponse(apiResponse)
       ).toStrictEqual(result);
     });
-    it("transforms an config without known documenation", () => {
+    it("transforms an config without known documentation", () => {
       const apiResponse: KlawApiResponse<"topicAdvancedConfigGet"> = {
         CONFIG_WITHOUT_DOCUMENTATION: "config.without.documentation",
       };
@@ -89,7 +89,7 @@ describe("topic-transformer.ts", () => {
         },
       ];
       expect(
-        transformgetTopicAdvancedConfigOptionsResponse(apiResponse)
+        transformGetTopicAdvancedConfigOptionsResponse(apiResponse)
       ).toStrictEqual(result);
     });
   });

--- a/coral/src/domain/topic/topic-transformer.test.ts
+++ b/coral/src/domain/topic/topic-transformer.test.ts
@@ -1,13 +1,18 @@
 import {
   transformgetTopicAdvancedConfigOptionsResponse,
-  transformGetTopicRequestsResponse,
+  transformGetTopicRequestsForApproverResponse,
   transformTopicApiResponse,
 } from "src/domain/topic/topic-transformer";
-import { Topic, TopicApiResponse } from "src/domain/topic/topic-types";
+import {
+  Topic,
+  TopicApiResponse,
+  TopicRequestApiResponse,
+  TopicRequestStatus,
+  TopicRequestTypes,
+} from "src/domain/topic/topic-types";
 import {
   baseTestObjectMockedTopic,
   createMockTopicApiResponse,
-  createMockTopicRequestApiResource,
 } from "src/domain/topic/topic-test-helper";
 import { KlawApiResponse } from "types/utils";
 
@@ -89,19 +94,92 @@ describe("topic-transformer.ts", () => {
     });
   });
 
-  describe("transformGetTopicRequestsResponse", () => {
+  describe("transformGetTopicRequestsForApproverResponse", () => {
     it("transforms empty payload into empty array", () => {
-      const transformedResponse = transformGetTopicRequestsResponse([]);
-      expect(transformedResponse).toEqual([]);
+      const transformedResponse = transformGetTopicRequestsForApproverResponse(
+        []
+      );
+
+      const result: TopicRequestApiResponse = {
+        totalPages: 0,
+        currentPage: 0,
+        entries: [],
+      };
+
+      expect(transformedResponse).toEqual(result);
     });
 
     it("transforms all response items into expected type", () => {
-      const transformedResponse = transformGetTopicRequestsResponse([
-        createMockTopicRequestApiResource({ topicname: "this-is-topic-name" }),
-      ]);
-      expect(transformedResponse).toHaveLength(1);
-      const topicRequest = transformedResponse[0];
-      expect(topicRequest).toEqual({ topicName: "this-is-topic-name" });
+      const mockedResponse = [
+        {
+          topicname: "test-topic-1",
+          environment: "1",
+          topicpartitions: 4,
+          teamname: "NCC1701D",
+          remarks: "asap",
+          description: "This topic is for test",
+          replicationfactor: "2",
+          environmentName: "BRG",
+          topicid: 1000,
+          advancedTopicConfigEntries: [
+            {
+              configKey: "cleanup.policy",
+              configValue: "delete",
+            },
+          ],
+          topictype: "Create" as TopicRequestTypes,
+          requestor: "jlpicard",
+          requesttime: "1987-09-28T13:37:00.001+00:00",
+          requesttimestring: "28-Sep-1987 13:37:00",
+          topicstatus: "created" as TopicRequestStatus,
+          totalNoPages: "3",
+          approvingTeamDetails:
+            "Team : NCC1701D, Users : jlpicard, worf, bcrusher, geordilf,",
+          teamId: 1003,
+          allPageNos: ["1"],
+          currentPage: "1",
+        },
+        {
+          topicname: "test-topic-2",
+          environment: "1",
+          topicpartitions: 4,
+          teamname: "MIRRORUNIVERSE",
+          remarks: "asap",
+          description: "This topic is for test",
+          replicationfactor: "2",
+          environmentName: "SBY",
+          topicid: 1001,
+          advancedTopicConfigEntries: [
+            {
+              configKey: "compression.type",
+              configValue: "snappy",
+            },
+          ],
+
+          topictype: "Update" as TopicRequestTypes,
+          requestor: "bcrusher",
+          requesttime: "1994-23-05T13:37:00.001+00:00",
+          requesttimestring: "23-May-1994 13:37:00",
+          topicstatus: "approved" as TopicRequestStatus,
+          totalNoPages: "3",
+          approvingTeamDetails:
+            "Team : NCC1701D, Users : jlpicard, worf, bcrusher, geordilf,",
+          teamId: 1003,
+          allPageNos: ["1"],
+          currentPage: "1",
+        },
+      ];
+      const transformedResponse =
+        transformGetTopicRequestsForApproverResponse(mockedResponse);
+
+      const result: TopicRequestApiResponse = {
+        totalPages: 3,
+        currentPage: 1,
+        entries: mockedResponse,
+      };
+
+      expect(transformedResponse.entries).toHaveLength(2);
+      expect(transformedResponse).toEqual(result);
     });
   });
 });

--- a/coral/src/domain/topic/topic-transformer.ts
+++ b/coral/src/domain/topic/topic-transformer.ts
@@ -1,7 +1,7 @@
 import {
   TopicAdvancedConfigurationOptions,
   TopicApiResponse,
-  TopicRequest,
+  TopicRequestApiResponse,
 } from "src/domain/topic/topic-types";
 import { KlawApiResponse } from "types/utils";
 
@@ -149,14 +149,26 @@ function transformgetTopicAdvancedConfigOptionsResponse(
   });
 }
 
-function transformGetTopicRequestsResponse(
-  apiResponse: KlawApiResponse<"getCreatedTopicRequests">
-): TopicRequest[] {
-  return apiResponse.map((request) => ({ topicName: request.topicname }));
+function transformGetTopicRequestsForApproverResponse(
+  apiResponse: KlawApiResponse<"getTopicRequestsForApprover">
+): TopicRequestApiResponse {
+  if (apiResponse.length === 0) {
+    return {
+      totalPages: 0,
+      currentPage: 0,
+      entries: [],
+    };
+  }
+
+  return {
+    totalPages: Number(apiResponse[0].totalNoPages),
+    currentPage: Number(apiResponse[0].currentPage),
+    entries: apiResponse,
+  };
 }
 
 export {
   transformTopicApiResponse,
   transformgetTopicAdvancedConfigOptionsResponse,
-  transformGetTopicRequestsResponse,
+  transformGetTopicRequestsForApproverResponse,
 };

--- a/coral/src/domain/topic/topic-transformer.ts
+++ b/coral/src/domain/topic/topic-transformer.ts
@@ -134,7 +134,7 @@ const ADVANCED_TOPIC_CONFIG_DOCUMENTATION: Record<
   },
 };
 
-function transformgetTopicAdvancedConfigOptionsResponse(
+function transformGetTopicAdvancedConfigOptionsResponse(
   apiResponse: KlawApiResponse<"topicAdvancedConfigGet">
 ): TopicAdvancedConfigurationOptions[] {
   return Object.entries(apiResponse).map(([key, name]) => {
@@ -169,6 +169,6 @@ function transformGetTopicRequestsForApproverResponse(
 
 export {
   transformTopicApiResponse,
-  transformgetTopicAdvancedConfigOptionsResponse,
+  transformGetTopicAdvancedConfigOptionsResponse,
   transformGetTopicRequestsForApproverResponse,
 };

--- a/coral/src/domain/topic/topic-types.ts
+++ b/coral/src/domain/topic/topic-types.ts
@@ -1,5 +1,5 @@
 import type { KlawApiModel, ResolveIntersectionTypes } from "types/utils";
-import { components } from "types/api";
+import { RequestStatus, RequestType } from "src/domain/requests";
 
 type Paginated<T> = {
   totalPages: number;
@@ -7,7 +7,7 @@ type Paginated<T> = {
   entries: T;
 };
 
-type TopicApiResponse = Paginated<Topic[]>;
+type TopicApiResponse = ResolveIntersectionTypes<Paginated<Topic[]>>;
 
 type Topic = ResolveIntersectionTypes<KlawApiModel<"TopicInfo">>;
 type TopicNames = ResolveIntersectionTypes<
@@ -24,11 +24,10 @@ type TopicAdvancedConfigurationOptions = {
   };
 };
 
-// @TODO add more refined typing when implementation needs are more clear
-type TopicRequestTypes = components["schemas"]["TopicRequestTypes"];
-type TopicRequestStatus = components["schemas"]["RequestStatus"];
+type TopicRequestTypes = RequestType;
+type TopicRequestStatus = RequestStatus;
 
-type TopicRequestNew = ResolveIntersectionTypes<
+type TopicRequest = ResolveIntersectionTypes<
   Required<
     Pick<
       KlawApiModel<"TopicRequest">,
@@ -44,11 +43,9 @@ type TopicRequestNew = ResolveIntersectionTypes<
     KlawApiModel<"TopicRequest">
 >;
 
-// The proper type for this will take shape once we know what data
-// we need in the upcoming features.
-type TopicRequest = {
-  topicName: KlawApiModel<"TopicRequest">["topicname"];
-};
+type TopicRequestApiResponse = ResolveIntersectionTypes<
+  Paginated<TopicRequest[]>
+>;
 
 export type {
   Topic,
@@ -57,7 +54,7 @@ export type {
   TopicApiResponse,
   TopicAdvancedConfigurationOptions,
   TopicRequest,
-  TopicRequestNew,
   TopicRequestTypes,
   TopicRequestStatus,
+  TopicRequestApiResponse,
 };

--- a/coral/types/api.d.ts
+++ b/coral/types/api.d.ts
@@ -54,8 +54,8 @@ export type paths = {
   "/uploadSchema": {
     post: operations["schemaUpload"];
   };
-  "/getCreatedTopicRequests": {
-    get: operations["getCreatedTopicRequests"];
+  "/getTopicRequestsForApprover": {
+    get: operations["getTopicRequestsForApprover"];
   };
   "/getAuth": {
     get: operations["getAuth"];
@@ -154,6 +154,18 @@ export type components = {
       result?: string;
       data?: { [key: string]: unknown };
     };
+    /**
+     * Type of request related to topic
+     * @example Update
+     * @enum {string}
+     */
+    RequestType: "Create" | "Update" | "Delete" | "Claim" | "Promote";
+    /**
+     * Status of a request
+     * @example created
+     * @enum {string}
+     */
+    RequestStatus: "created" | "deleted" | "declined" | "approved" | "all";
     UserAuthenticationRequest: {
       /**
        * username
@@ -181,12 +193,6 @@ export type components = {
        */
       tokenType: "JWT";
     };
-    /**
-     * Type of request related to topic
-     * @example Update
-     * @enum {string}
-     */
-    TopicRequestTypes: "Create" | "Update" | "Delete" | "Claim";
     TopicsGetResponse: components["schemas"]["TopicInfo"][][];
     /**
      * @example [
@@ -465,12 +471,6 @@ export type components = {
       /** @enum {string} */
       aivenCluster: "true" | "false";
     };
-    /**
-     * Status of a request
-     * @example created
-     * @enum {string}
-     */
-    RequestStatus: "created" | "deleted" | "declined" | "approved";
     /** TopicCreateRequest */
     topicCreateRequest: {
       /**
@@ -668,11 +668,7 @@ export type components = {
       requesttime?: string;
       /** @example 10-11-2020 10:45:30 */
       requesttimestring?: string;
-      /**
-       * @example created
-       * @enum {string}
-       */
-      aclstatus?: "created" | "approved" | "denied" | "deleted";
+      aclstatus?: components["schemas"]["RequestStatus"];
       approver?: string;
       /**
        * Format: date-time
@@ -796,7 +792,7 @@ export type components = {
        */
       requesttimestring?: string;
       topicstatus?: components["schemas"]["RequestStatus"];
-      requesttype?: components["schemas"]["TopicRequestTypes"];
+      requesttype?: components["schemas"]["RequestType"];
       /**
        * Remarks
        * @description SchemaRequest specific comment
@@ -896,11 +892,7 @@ export type components = {
       }[];
       /** App name */
       appname?: string;
-      /**
-       * Topic type
-       * @enum {string}
-       */
-      topictype?: "Create" | "Update" | "Delete" | "Claim";
+      topictype?: components["schemas"]["RequestType"];
       /** Requestor */
       requestor?: string;
       /**
@@ -1254,19 +1246,23 @@ export type operations = {
       };
     };
   };
-  getCreatedTopicRequests: {
+  getTopicRequestsForApprover: {
     parameters: {
       query: {
         pageNo: string;
         currentPage?: string;
-        requestsType?: "all" | "created" | "declined" | "approved";
+        /** Naming is a mistake (will change), this relates to the status of a request */
+        requestsType?: components["schemas"]["RequestStatus"];
+        teamId?: number;
+        env?: string;
+        search?: string;
       };
     };
     responses: {
       /** successful operation */
       200: {
         content: {
-          "application/json": components["schemas"]["TopicRequest"][];
+          "application/json": components["schemas"]["TopicRequestModel"][];
         };
       };
     };
@@ -1301,6 +1297,6 @@ export enum ApiPaths {
   createAclRequest = "/createAcl",
   schemaRegEnvsGet = "/getSchemaRegEnvs",
   schemaUpload = "/uploadSchema",
-  getCreatedTopicRequests = "/getCreatedTopicRequests",
+  getTopicRequestsForApprover = "/getTopicRequestsForApprover",
   getAuth = "/getAuth",
 }

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -295,7 +295,6 @@ paths:
             type: string
             enum: ["all", "created", "approved", "denied", "deleted"]
           example: "created"
-          default: "created"
         - name: topic
           in: query
           required: false
@@ -461,6 +460,55 @@ paths:
                 type: array
                 items:
                   $ref: "#/components/schemas/TopicRequest"
+  /getTopicRequestsForApprover:
+    get:
+      operationId: getTopicRequestsForApprover
+      parameters:
+        - name: pageNo
+          in: query
+          required: true
+          example: "2"
+          schema:
+            type: string
+        - name: currentPage
+          in: query
+          example: "2"
+          schema:
+            type: string
+        - name: requestsType
+          in: query
+          schema:
+            type: string
+            enum:
+              - all
+              - created
+              - declined
+              - approved
+            default: created
+        - name: teamId
+          in: query
+          schema:
+            type: integer
+            format: int32
+            example: 1001
+        - name: env
+          in: query
+          schema:
+            type: string
+          example: "1"
+        - name: search
+          in: query
+          schema:
+            type: string
+      responses:
+        200:
+          description: successful operation
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/TopicRequestModel"
   /getAuth:
     get:
       operationId: getAuth

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -477,14 +477,9 @@ paths:
             type: string
         - name: requestsType
           in: query
+          description: Naming is a mistake (will change), this relates to the status of a request
           schema:
-            type: string
-            enum:
-              - all
-              - created
-              - declined
-              - approved
-            default: created
+            $ref: "#/components/schemas/RequestStatus"
         - name: teamId
           in: query
           schema:
@@ -615,6 +610,26 @@ components:
           type: string
         data:
           type: object
+    RequestType:
+      title: Type of request related to topic
+      type: string
+      enum:
+        - Create
+        - Update
+        - Delete
+        - Claim
+        - Promote
+      example: Update
+    RequestStatus:
+      type: string
+      title: Status of a request
+      enum:
+        - created
+        - deleted
+        - declined
+        - approved
+        - all
+      example: created
     UserAuthenticationRequest:
       type: object
       required:
@@ -648,15 +663,6 @@ components:
           example: JWT
           type: string
           enum: [JWT]
-    TopicRequestTypes:
-      title: Type of request related to topic
-      type: string
-      enum:
-        - Create
-        - Update
-        - Delete
-        - Claim
-      example: Update
     TopicsGetResponse:
       type: array
       items:
@@ -953,15 +959,6 @@ components:
           type: string
           enum: ["true", "false"]
       example: { "aivenCluster": "false" }
-    RequestStatus:
-      type: string
-      title: Status of a request
-      enum:
-        - created
-        - deleted
-        - declined
-        - approved
-      example: created
     topicCreateRequest:
       title: TopicCreateRequest
       type: object
@@ -1181,9 +1178,7 @@ components:
           pattern: dd-MMM-yyyy HH:mm:ss
           example: "10-11-2020 10:45:30"
         aclstatus:
-          type: string
-          enum: ["created", "approved", "denied", "deleted"]
-          example: "created"
+          $ref: "#/components/schemas/RequestStatus"
         approver:
           type: string
         approvingtime:
@@ -1287,7 +1282,7 @@ components:
         topicstatus:
           $ref: "#/components/schemas/RequestStatus"
         requesttype:
-          $ref: "#/components/schemas/TopicRequestTypes"
+          $ref: "#/components/schemas/RequestType"
         remarks:
           title: Remarks
           description: SchemaRequest specific comment
@@ -1382,13 +1377,7 @@ components:
           title: App name
           type: string
         topictype:
-          title: Topic type
-          type: string
-          enum:
-            - Create
-            - Update
-            - Delete
-            - Claim
+          $ref: "#/components/schemas/RequestType"
         requestor:
           title: Requestor
           type: string

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -424,42 +424,6 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/GenericApiResponse"
-  /getCreatedTopicRequests:
-    get:
-      operationId: getCreatedTopicRequests
-      tags:
-        - Topic
-      parameters:
-        - name: pageNo
-          in: query
-          required: true
-          schema:
-            type: string
-        - name: currentPage
-          in: query
-          required: false
-          schema:
-            type: string
-        - name: requestsType
-          in: query
-          required: false
-          schema:
-            type: string
-            enum:
-              - all
-              - created
-              - declined
-              - approved
-            default: created
-      responses:
-        "200":
-          description: successful operation
-          content:
-            application/json:
-              schema:
-                type: array
-                items:
-                  $ref: "#/components/schemas/TopicRequest"
   /getTopicRequestsForApprover:
     get:
       operationId: getTopicRequestsForApprover


### PR DESCRIPTION
# About this change - What it does
The api endpoint changed from `getCreatedTopicRequests` to `getTopicRequestsForApprover`. 

This MR: 
(also commit body)

- removes `getCreatedTopicRequests` from api definition and types
- adds general enums for `RequestType` and `RequestStatus` in api definition and types
- adds `getTopicRequestsForApprover` in api definition and types
- updates types and api function related to topic requests 

Resolves: #607

