### PR TITLE
KafkaConnector Requests indicate if they are editable or deletable in response

### DIFF
--- a/core/src/main/java/io/aiven/klaw/model/KafkaConnectorRequestModel.java
+++ b/core/src/main/java/io/aiven/klaw/model/KafkaConnectorRequestModel.java
@@ -66,4 +66,8 @@ public class KafkaConnectorRequestModel implements Serializable {
   private List<String> possibleTeams;
 
   private String currentPage;
+
+  private boolean editable;
+
+  private boolean deletable;
 }

--- a/core/src/main/java/io/aiven/klaw/service/KafkaConnectControllerService.java
+++ b/core/src/main/java/io/aiven/klaw/service/KafkaConnectControllerService.java
@@ -1157,9 +1157,10 @@ public class KafkaConnectControllerService {
       List<KafkaConnectorRequest> topicsList, boolean fromSyncTopics) {
     List<KafkaConnectorRequestModel> topicRequestModelList = new ArrayList<>();
     KafkaConnectorRequestModel topicRequestModel;
-    Integer userTeamId = commonUtilsService.getTeamId(getUserName());
+    String userName = getUserName();
+    Integer userTeamId = commonUtilsService.getTeamId(userName);
 
-    int tenantId = commonUtilsService.getTenantId(getUserName());
+    int tenantId = commonUtilsService.getTenantId(userName);
     List<String> approverRoles =
         rolesPermissionsControllerService.getApproverRoles("CONNECTORS", tenantId);
     List<UserInfo> userList =
@@ -1196,9 +1197,20 @@ public class KafkaConnectControllerService {
         }
       }
 
-      topicRequestModelList.add(topicRequestModel);
+      topicRequestModelList.add(setRequestorPermissions(topicRequestModel, userName));
     }
     return topicRequestModelList;
+  }
+
+  private KafkaConnectorRequestModel setRequestorPermissions(
+      KafkaConnectorRequestModel req, String userName) {
+    if (RequestStatus.CREATED.value.equals(req.getConnectorStatus())
+        && userName != null
+        && userName.equals(req.getRequestor())) {
+      req.setDeletable(true);
+      req.setEditable(true);
+    }
+    return req;
   }
 
   private String updateApproverInfo(

--- a/core/src/main/resources/swagger_spec.json
+++ b/core/src/main/resources/swagger_spec.json
@@ -4015,6 +4015,12 @@
         },
         "currentPage" : {
           "type" : "string"
+        },
+        "editable" : {
+          "type" : "boolean"
+        },
+        "deletable" : {
+          "type" : "boolean"
         }
       }
     },


### PR DESCRIPTION
Adds isEditable and isDeletable to KafkaConnectorRequests which is the last request to get this update.

About this change - What it does
This conforms the KafkaConnect response to be the same as all the other request types and allows us to 
Resolves: #596 
Why this way
