### PR TITLE
Expand Team contact and Full Name Validation

### DIFF
--- a/core/src/main/java/io/aiven/klaw/model/TeamModel.java
+++ b/core/src/main/java/io/aiven/klaw/model/TeamModel.java
@@ -24,13 +24,13 @@ public class TeamModel implements Serializable {
   private String teammail;
 
   @NotNull
-  @Pattern(message = "Invalid Team phone.", regexp = "(^$|[0-9]*)")
+  @Pattern(message = "Invalid Team phone.", regexp = "(^$|[+]{0,1}[0-9]*)")
   private String teamphone;
 
   @NotNull
   @Pattern(
       message = "Invalid Team contact.",
-      regexp = "^[a-zA-z ]*$") // Pattern a-zA-z and/or spaces.
+      regexp = "^[A-Za-zÀ-ÖØ-öø-ÿ' ]*$") // Pattern a-zA-z accents and umlaut and/or spaces.
   private String contactperson;
 
   private Integer tenantId;

--- a/core/src/main/java/io/aiven/klaw/model/UserInfoModel.java
+++ b/core/src/main/java/io/aiven/klaw/model/UserInfoModel.java
@@ -30,7 +30,9 @@ public class UserInfoModel implements Serializable {
 
   @NotNull(message = "Fullname cannot be null")
   @Size(min = 5, max = 50, message = "Name must be above 4 characters")
-  @Pattern(message = "Invalid Full name", regexp = "^[a-zA-z ]*$")
+  @Pattern(
+      message = "Invalid Full name",
+      regexp = "^[A-Za-zÀ-ÖØ-öø-ÿ' ]*$") // Pattern a-zA-z accents and umlaut and/or spaces.
   private String fullname;
 
   @Email(message = "Email should be valid")

--- a/core/src/test/java/io/aiven/klaw/model/TeamModelTest.java
+++ b/core/src/test/java/io/aiven/klaw/model/TeamModelTest.java
@@ -115,6 +115,11 @@ public class TeamModelTest {
 
     model.setContactperson("Mr Jünemann");
     violations = validator.validate(model);
+    assertThat(violations.isEmpty()).isTrue(); // 'ä', 'ö', 'Ä', 'ß'
+
+    // explicitly just testing the special chars mentioned in raised Issue
+    model.setContactperson("äöÄß");
+    violations = validator.validate(model);
     assertThat(violations.isEmpty()).isTrue();
   }
 

--- a/core/src/test/java/io/aiven/klaw/model/TeamModelTest.java
+++ b/core/src/test/java/io/aiven/klaw/model/TeamModelTest.java
@@ -1,0 +1,146 @@
+package io.aiven.klaw.model;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import jakarta.validation.ConstraintViolation;
+import jakarta.validation.Validation;
+import jakarta.validation.Validator;
+import jakarta.validation.ValidatorFactory;
+import java.util.Set;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+@Slf4j
+@ExtendWith(SpringExtension.class)
+public class TeamModelTest {
+
+  private static Validator validator;
+
+  @BeforeAll
+  public static void setUp() {
+    ValidatorFactory factory = Validation.buildDefaultValidatorFactory();
+    validator = factory.getValidator();
+  }
+
+  @Test
+  public void validateInternationalSymbolsSupported() {
+    TeamModel model = getTeamModelForPhoneValidation();
+    model.setTeamphone("00353");
+    Set<ConstraintViolation<TeamModel>> violations = validator.validate(model);
+    assertThat(violations.isEmpty()).isTrue();
+    model.setTeamphone("+353");
+    violations = validator.validate(model);
+    assertThat(violations.isEmpty()).isTrue();
+
+    model.setTeamphone("+49123456789");
+    violations = validator.validate(model);
+    assertThat(violations.isEmpty()).isTrue();
+
+    model.setTeamphone("0049123456789");
+    violations = validator.validate(model);
+    assertThat(violations.isEmpty()).isTrue();
+  }
+
+  @Test
+  public void validateInternationalPlusNotSupportedIfNotLeading() {
+    TeamModel model = getTeamModelForPhoneValidation();
+
+    model.setTeamphone("353+");
+    Set<ConstraintViolation<TeamModel>> violations = validator.validate(model);
+    assertThat(violations.size()).isEqualTo(1);
+  }
+
+  @Test
+  public void validateInternationalPlusOnlyOneSupported() {
+    TeamModel model = getTeamModelForPhoneValidation();
+    model.setTeamphone("+353");
+    Set<ConstraintViolation<TeamModel>> violations = validator.validate(model);
+    assertThat(violations.isEmpty()).isTrue();
+    model.setTeamphone("++353");
+    violations = validator.validate(model);
+    assertThat(violations.size()).isEqualTo(1);
+  }
+
+  @Test
+  public void validateHyphenNotSupported() {
+    TeamModel model = getTeamModelForPhoneValidation();
+    model.setTeamphone("+353-123-4567");
+    Set<ConstraintViolation<TeamModel>> violations = validator.validate(model);
+    assertThat(violations.size()).isEqualTo(1);
+  }
+
+  @Test
+  public void validateParanthesisNotSupported() {
+    TeamModel model = getTeamModelForPhoneValidation();
+    model.setTeamphone("(353)1234567");
+    Set<ConstraintViolation<TeamModel>> violations = validator.validate(model);
+    assertThat(violations.size()).isEqualTo(1);
+  }
+
+  @Test
+  public void validateSpaceNotSupported() {
+    TeamModel model = getTeamModelForPhoneValidation();
+    model.setTeamphone("353 1234567");
+    Set<ConstraintViolation<TeamModel>> violations = validator.validate(model);
+    assertThat(violations.size()).isEqualTo(1);
+  }
+
+  @Test
+  public void validateAccentsAllowed() {
+    TeamModel model = getTeamModelForTeamContactValidation();
+    model.setContactperson("Aindriú");
+    Set<ConstraintViolation<TeamModel>> violations = validator.validate(model);
+    assertThat(violations.isEmpty()).isTrue();
+    model.setContactperson("Françoise");
+    violations = validator.validate(model);
+    assertThat(violations.isEmpty()).isTrue();
+  }
+
+  @Test
+  public void validateUmlautAllowed() {
+    TeamModel model = getTeamModelForTeamContactValidation();
+    model.setContactperson("Matthias Schweighöfer");
+    Set<ConstraintViolation<TeamModel>> violations = validator.validate(model);
+    assertThat(violations.isEmpty()).isTrue();
+    model.setContactperson("Schäfer");
+    violations = validator.validate(model);
+    assertThat(violations.isEmpty()).isTrue();
+
+    model.setContactperson("Köhne jr");
+    violations = validator.validate(model);
+    assertThat(violations.isEmpty()).isTrue();
+
+    model.setContactperson("Mr Jünemann");
+    violations = validator.validate(model);
+    assertThat(violations.isEmpty()).isTrue();
+  }
+
+  @Test
+  public void validateIrishSurnamesAllowed() {
+    TeamModel model = getTeamModelForTeamContactValidation();
+    model.setContactperson("Aindriú O'Maolfábhail");
+    Set<ConstraintViolation<TeamModel>> violations = validator.validate(model);
+    assertThat(violations.isEmpty()).isTrue();
+    model.setContactperson("Seán O'Neill");
+    violations = validator.validate(model);
+    assertThat(violations.isEmpty()).isTrue();
+  }
+
+  // validations for non nulls shouldn't impact our test.
+  private TeamModel getTeamModelForPhoneValidation() {
+    TeamModel model = new TeamModel();
+    model.setContactperson("valid");
+    model.setTeamname("team");
+    return model;
+  }
+
+  private TeamModel getTeamModelForTeamContactValidation() {
+    TeamModel model = new TeamModel();
+    model.setTeamphone("123456789");
+    model.setTeamname("team");
+    return model;
+  }
+}

--- a/core/src/test/java/io/aiven/klaw/model/UserInfoModelTest.java
+++ b/core/src/test/java/io/aiven/klaw/model/UserInfoModelTest.java
@@ -1,0 +1,84 @@
+package io.aiven.klaw.model;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import jakarta.validation.ConstraintViolation;
+import jakarta.validation.Validation;
+import jakarta.validation.Validator;
+import jakarta.validation.ValidatorFactory;
+import java.util.Set;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+@Slf4j
+@ExtendWith(SpringExtension.class)
+public class UserInfoModelTest {
+
+  private static Validator validator;
+
+  @BeforeAll
+  public static void setUp() {
+    ValidatorFactory factory = Validation.buildDefaultValidatorFactory();
+    validator = factory.getValidator();
+  }
+
+  @Test
+  public void validateAccentsAllowed() {
+    UserInfoModel model = getUserInfoModelForTeamContactValidation();
+    model.setFullname("Aindriú");
+    Set<ConstraintViolation<UserInfoModel>> violations = validator.validate(model);
+    violations.forEach(
+        vio -> {
+          log.info(" {}", vio.getMessage());
+        });
+    assertThat(violations.isEmpty()).isTrue();
+    model.setFullname("Françoise");
+    violations = validator.validate(model);
+    assertThat(violations.isEmpty()).isTrue();
+  }
+
+  @Test
+  public void validateUmlautAllowed() {
+    UserInfoModel model = getUserInfoModelForTeamContactValidation();
+    model.setFullname("Matthias Schweighöfer");
+    Set<ConstraintViolation<UserInfoModel>> violations = validator.validate(model);
+    assertThat(violations.isEmpty()).isTrue();
+    model.setFullname("Schäfer");
+    violations = validator.validate(model);
+    assertThat(violations.isEmpty()).isTrue();
+
+    model.setFullname("Köhne jr");
+    violations = validator.validate(model);
+    assertThat(violations.isEmpty()).isTrue();
+
+    model.setFullname("Mr Jünemann");
+    violations = validator.validate(model);
+    assertThat(violations.isEmpty()).isTrue(); // 'ä', 'ö', 'Ä', 'ß'
+
+    // explicitly just testing the special chars mentioned in raised Issue
+    model.setFullname("ä ö Ä ß");
+    violations = validator.validate(model);
+    assertThat(violations.isEmpty()).isTrue();
+  }
+
+  @Test
+  public void validateIrishSurnamesAllowed() {
+    UserInfoModel model = getUserInfoModelForTeamContactValidation();
+    model.setFullname("Aindriú O'Maolfábhail");
+    Set<ConstraintViolation<UserInfoModel>> violations = validator.validate(model);
+    assertThat(violations.isEmpty()).isTrue();
+    model.setFullname("Seán O'Neill");
+    violations = validator.validate(model);
+    assertThat(violations.isEmpty()).isTrue();
+  }
+
+  private UserInfoModel getUserInfoModelForTeamContactValidation() {
+    UserInfoModel model = new UserInfoModel();
+    model.setUsername("DORRIS");
+    model.setMailid("bob@bob.com");
+    return model;
+  }
+}


### PR DESCRIPTION
Issue 577 team contact too strict accents and international dialing numbers.

About this change - What it does
This change caters for most accents, umlauts as well as international dialing codes.
Resolves: #577 
Why this way
This while not an exhaustive fix allows for more inclusive development and usage of Klaw allowing people to correctly spell their names more accurately.