### PR TITLE
feat(coral): add cancel workflow to "Request new x" workflows

### DIFF
--- a/coral/src/app/components/Dialog.test.tsx
+++ b/coral/src/app/components/Dialog.test.tsx
@@ -6,7 +6,7 @@ import error from "@aivenio/aquarium/dist/src/icons/error";
 
 describe("Dialog.tsx", () => {
   const testTitle = "Dialog title";
-  const mockChildren = <div>This is child content</div>;
+  const textContent = "This is the content given!";
   const mockPrimary = {
     text: "Primary action 1",
     onClick: jest.fn(),
@@ -29,7 +29,7 @@ describe("Dialog.tsx", () => {
             primaryAction={mockPrimary}
             secondaryAction={mockSecondary}
           >
-            {mockChildren}
+            {textContent}
           </Dialog>
         </>
       );
@@ -51,7 +51,7 @@ describe("Dialog.tsx", () => {
     });
 
     it("shows the given content", () => {
-      const text = screen.getByText("This is child content");
+      const text = screen.getByText(textContent);
 
       expect(text).toBeVisible();
     });
@@ -90,7 +90,7 @@ describe("Dialog.tsx", () => {
             primaryAction={mockPrimary}
             secondaryAction={mockSecondary}
           >
-            {mockChildren}
+            {textContent}
           </Dialog>
         </>
       );
@@ -112,7 +112,7 @@ describe("Dialog.tsx", () => {
             primaryAction={mockPrimary}
             secondaryAction={mockSecondary}
           >
-            {mockChildren}
+            {textContent}
           </Dialog>
         </>
       );
@@ -134,7 +134,7 @@ describe("Dialog.tsx", () => {
             primaryAction={mockPrimary}
             secondaryAction={mockSecondary}
           >
-            {mockChildren}
+            {textContent}
           </Dialog>
         </>
       );

--- a/coral/src/app/components/Dialog.tsx
+++ b/coral/src/app/components/Dialog.tsx
@@ -8,9 +8,11 @@ import { Box, Icon, Typography } from "@aivenio/aquarium";
 import { ResolveIntersectionTypes } from "types/utils";
 
 type DialogProps = ResolveIntersectionTypes<
-  Omit<ModalProps, "isDialog" | "dialogTitle" | "close"> &
+  Omit<ModalProps, "isDialog" | "dialogTitle" | "close" | "children"> &
     Required<Pick<ModalProps, "secondaryAction">> & {
       type: DialogType;
+    } & {
+      children: string;
     }
 >;
 

--- a/coral/src/app/features/topics/acl-request/TopicAclRequest.test.tsx
+++ b/coral/src/app/features/topics/acl-request/TopicAclRequest.test.tsx
@@ -1,4 +1,4 @@
-import { cleanup, screen, waitFor } from "@testing-library/react";
+import { cleanup, screen, waitFor, within } from "@testing-library/react";
 import { waitForElementToBeRemoved } from "@testing-library/react/pure";
 import userEvent from "@testing-library/user-event";
 import { Route, Routes } from "react-router-dom";
@@ -826,6 +826,107 @@ describe("<TopicAclRequest />", () => {
       jest.clearAllMocks();
     });
 
+    describe("when user cancels form input", () => {
+      beforeEach(async () => {
+        await assertSkeleton();
+        const aclConsumerTypeInput = screen.getByRole("radio", {
+          name: "Producer",
+        });
+        await userEvent.click(aclConsumerTypeInput);
+      });
+
+      const getForm = () => {
+        return screen.getByRole("form", {
+          name: `Request producer ACL`,
+        });
+      };
+
+      it("redirects user to the previous page if they click 'Cancel' on empty form", async () => {
+        const form = getForm();
+
+        const button = within(form).getByRole("button", {
+          name: "Cancel",
+        });
+
+        await userEvent.click(button);
+
+        expect(mockedNavigate).toHaveBeenCalledWith(-1);
+      });
+
+      it('shows a warning dialog if user clicks "Cancel" and has inputs in form', async () => {
+        const form = getForm();
+
+        const remarkInput = screen.getByRole("textbox", {
+          name: "Remarks",
+        });
+        await userEvent.type(remarkInput, "Important information");
+
+        const button = within(form).getByRole("button", {
+          name: "Cancel",
+        });
+
+        await userEvent.click(button);
+        const dialog = screen.getByRole("dialog");
+
+        expect(dialog).toBeVisible();
+        expect(dialog).toHaveTextContent("Cancel ACL request");
+        expect(dialog).toHaveTextContent(
+          "Do you want to cancel this request? The data added will be lost."
+        );
+
+        expect(mockedNavigate).not.toHaveBeenCalled();
+      });
+
+      it("brings the user back to the form when they do not cancel", async () => {
+        const form = getForm();
+
+        const remarkInput = screen.getByRole("textbox", {
+          name: "Remarks",
+        });
+        await userEvent.type(remarkInput, "Important information");
+
+        const button = within(form).getByRole("button", {
+          name: "Cancel",
+        });
+
+        await userEvent.click(button);
+        const dialog = screen.getByRole("dialog");
+
+        const returnButton = screen.getByRole("button", {
+          name: "Continue with request",
+        });
+
+        await userEvent.click(returnButton);
+
+        expect(mockedNavigate).not.toHaveBeenCalled();
+
+        expect(dialog).not.toBeInTheDocument();
+      });
+
+      it("redirects user to previous page if they cancel the request", async () => {
+        const form = getForm();
+
+        const remarkInput = screen.getByRole("textbox", {
+          name: "Remarks",
+        });
+        await userEvent.type(remarkInput, "Important information");
+
+        const button = within(form).getByRole("button", {
+          name: "Cancel",
+        });
+
+        await userEvent.click(button);
+
+        const returnButton = screen.getByRole("button", {
+          name: "Cancel request",
+        });
+
+        await userEvent.click(returnButton);
+
+        expect(mockedNavigate).toHaveBeenCalledWith(-1);
+      });
+    });
+
     describe("when API returns an error", () => {
       beforeEach(async () => {
         mockCreateAclRequest({
@@ -840,7 +941,9 @@ describe("<TopicAclRequest />", () => {
       it("renders an error message", async () => {
         const spyPost = jest.spyOn(api, "post");
         await assertSkeleton();
-        const submitButton = screen.getByRole("button", { name: "Submit" });
+        const submitButton = screen.getByRole("button", {
+          name: "Submit request",
+        });
 
         // Fill form with valid data
         await selectTestEnvironment();
@@ -894,7 +997,9 @@ describe("<TopicAclRequest />", () => {
       it("redirects user to /myAclRequests?reqsType=created&aclCreated=true", async () => {
         const spyPost = jest.spyOn(api, "post");
         await assertSkeleton();
-        const submitButton = screen.getByRole("button", { name: "Submit" });
+        const submitButton = screen.getByRole("button", {
+          name: "Submit request",
+        });
 
         // Fill form with valid data
         await selectTestEnvironment();
@@ -983,6 +1088,107 @@ describe("<TopicAclRequest />", () => {
       jest.clearAllMocks();
     });
 
+    describe("when user cancels form input", () => {
+      beforeEach(async () => {
+        await assertSkeleton();
+        const aclConsumerTypeInput = screen.getByRole("radio", {
+          name: "Consumer",
+        });
+        await userEvent.click(aclConsumerTypeInput);
+      });
+
+      const getForm = () => {
+        return screen.getByRole("form", {
+          name: `Request consumer ACL`,
+        });
+      };
+
+      it("redirects user to the previous page if they click 'Cancel' on empty form", async () => {
+        const form = getForm();
+
+        const button = within(form).getByRole("button", {
+          name: "Cancel",
+        });
+
+        await userEvent.click(button);
+
+        expect(mockedNavigate).toHaveBeenCalledWith(-1);
+      });
+
+      it('shows a warning dialog if user clicks "Cancel" and has inputs in form', async () => {
+        const form = getForm();
+
+        const remarkInput = screen.getByRole("textbox", {
+          name: "Remarks",
+        });
+        await userEvent.type(remarkInput, "Important information");
+
+        const button = within(form).getByRole("button", {
+          name: "Cancel",
+        });
+
+        await userEvent.click(button);
+        const dialog = screen.getByRole("dialog");
+
+        expect(dialog).toBeVisible();
+        expect(dialog).toHaveTextContent("Cancel ACL request");
+        expect(dialog).toHaveTextContent(
+          "Do you want to cancel this request? The data added will be lost."
+        );
+
+        expect(mockedNavigate).not.toHaveBeenCalled();
+      });
+
+      it("brings the user back to the form when they do not cancel", async () => {
+        const form = getForm();
+
+        const remarkInput = screen.getByRole("textbox", {
+          name: "Remarks",
+        });
+        await userEvent.type(remarkInput, "Important information");
+
+        const button = within(form).getByRole("button", {
+          name: "Cancel",
+        });
+
+        await userEvent.click(button);
+        const dialog = screen.getByRole("dialog");
+
+        const returnButton = screen.getByRole("button", {
+          name: "Continue with request",
+        });
+
+        await userEvent.click(returnButton);
+
+        expect(mockedNavigate).not.toHaveBeenCalled();
+
+        expect(dialog).not.toBeInTheDocument();
+      });
+
+      it("redirects user to previous page if they cancel the request", async () => {
+        const form = getForm();
+
+        const remarkInput = screen.getByRole("textbox", {
+          name: "Remarks",
+        });
+        await userEvent.type(remarkInput, "Important information");
+
+        const button = within(form).getByRole("button", {
+          name: "Cancel",
+        });
+
+        await userEvent.click(button);
+
+        const returnButton = screen.getByRole("button", {
+          name: "Cancel request",
+        });
+
+        await userEvent.click(returnButton);
+
+        expect(mockedNavigate).toHaveBeenCalledWith(-1);
+      });
+    });
+
     describe("when API returns an error", () => {
       beforeEach(async () => {
         mockCreateAclRequest({
@@ -1004,7 +1210,7 @@ describe("<TopicAclRequest />", () => {
         await userEvent.click(aclConsumerTypeInput);
 
         const submitButton = screen.getByRole("button", {
-          name: "Submit",
+          name: "Submit request",
         });
 
         // Fill form with valid data
@@ -1074,7 +1280,7 @@ describe("<TopicAclRequest />", () => {
         await userEvent.click(aclConsumerTypeInput);
 
         const submitButton = screen.getByRole("button", {
-          name: "Submit",
+          name: "Submit request",
         });
 
         // Fill form with valid data

--- a/coral/src/app/features/topics/acl-request/TopicAclRequest.test.tsx
+++ b/coral/src/app/features/topics/acl-request/TopicAclRequest.test.tsx
@@ -928,7 +928,9 @@ describe("<TopicAclRequest />", () => {
     });
 
     describe("when API returns an error", () => {
+      const originalConsoleError = console.error;
       beforeEach(async () => {
+        console.error = jest.fn();
         mockCreateAclRequest({
           mswInstance: server,
           response: {
@@ -936,6 +938,10 @@ describe("<TopicAclRequest />", () => {
             status: 400,
           },
         });
+      });
+
+      afterEach(() => {
+        console.error = originalConsoleError;
       });
 
       it("renders an error message", async () => {
@@ -983,6 +989,20 @@ describe("<TopicAclRequest />", () => {
 
         const alert = await screen.findByRole("alert");
         expect(alert).toHaveTextContent("Error message example");
+
+        // it's not important that the console.error is called,
+        // but it makes sure that 1) the console.error does not
+        // show up in the test logs while 2) flagging an error
+        // in case a console.error with a different message
+        // gets called - which could be hinting to a problem
+        expect(console.error).toHaveBeenCalledWith({
+          data: { message: "Error message example" },
+          status: 400,
+          statusText: "Bad Request",
+          headers: {
+            map: { "x-powered-by": "msw", "content-type": "application/json" },
+          },
+        });
       });
     });
 
@@ -1190,7 +1210,9 @@ describe("<TopicAclRequest />", () => {
     });
 
     describe("when API returns an error", () => {
+      const originalConsoleError = console.error;
       beforeEach(async () => {
+        console.error = jest.fn();
         mockCreateAclRequest({
           mswInstance: server,
           response: {
@@ -1198,6 +1220,10 @@ describe("<TopicAclRequest />", () => {
             status: 400,
           },
         });
+      });
+
+      afterEach(() => {
+        console.error = originalConsoleError;
       });
 
       it("renders an error message", async () => {
@@ -1259,6 +1285,20 @@ describe("<TopicAclRequest />", () => {
 
         const alert = await screen.findByRole("alert");
         expect(alert).toHaveTextContent("Error message example");
+
+        // it's not important that the console.error is called,
+        // but it makes sure that 1) the console.error does not
+        // show up in the test logs while 2) flagging an error
+        // in case a console.error with a different message
+        // gets called - which could be hinting to a problem
+        expect(console.error).toHaveBeenCalledWith({
+          data: { message: "Error message example" },
+          status: 400,
+          statusText: "Bad Request",
+          headers: {
+            map: { "x-powered-by": "msw", "content-type": "application/json" },
+          },
+        });
       });
     });
 

--- a/coral/src/app/features/topics/acl-request/TopicAclRequest.test.tsx
+++ b/coral/src/app/features/topics/acl-request/TopicAclRequest.test.tsx
@@ -869,7 +869,7 @@ describe("<TopicAclRequest />", () => {
         const dialog = screen.getByRole("dialog");
 
         expect(dialog).toBeVisible();
-        expect(dialog).toHaveTextContent("Cancel ACL request");
+        expect(dialog).toHaveTextContent("Cancel ACL request?");
         expect(dialog).toHaveTextContent(
           "Do you want to cancel this request? The data added will be lost."
         );
@@ -1151,7 +1151,7 @@ describe("<TopicAclRequest />", () => {
         const dialog = screen.getByRole("dialog");
 
         expect(dialog).toBeVisible();
-        expect(dialog).toHaveTextContent("Cancel ACL request");
+        expect(dialog).toHaveTextContent("Cancel ACL request?");
         expect(dialog).toHaveTextContent(
           "Do you want to cancel this request? The data added will be lost."
         );

--- a/coral/src/app/features/topics/acl-request/TopicAclRequest.tsx
+++ b/coral/src/app/features/topics/acl-request/TopicAclRequest.tsx
@@ -110,7 +110,7 @@ const TopicAclRequest = () => {
   const currentTopicNames = selectedEnvironment?.topicNames || [];
 
   return (
-    <Box style={{ maxWidth: 1200 }}>
+    <Box maxWidth={"7xl"}>
       {topicType === "Consumer" ? (
         <TopicConsumerForm
           renderAclTypeField={() => (

--- a/coral/src/app/features/topics/acl-request/TopicAclRequest.tsx
+++ b/coral/src/app/features/topics/acl-request/TopicAclRequest.tsx
@@ -110,7 +110,7 @@ const TopicAclRequest = () => {
   const currentTopicNames = selectedEnvironment?.topicNames || [];
 
   return (
-    <Box maxWidth={"4xl"}>
+    <Box style={{ maxWidth: 1200 }}>
       {topicType === "Consumer" ? (
         <TopicConsumerForm
           renderAclTypeField={() => (

--- a/coral/src/app/features/topics/acl-request/forms/SkeletonForm.tsx
+++ b/coral/src/app/features/topics/acl-request/forms/SkeletonForm.tsx
@@ -15,7 +15,7 @@ import {
 
 const SkeletonForm = () => {
   return (
-    <Box data-testid={"skeleton"} maxWidth={"4xl"}>
+    <Box data-testid={"skeleton"} maxWidth={"7xl"}>
       <Grid cols="2" minWidth={"fit"} colGap={"9"}>
         <GridItem>
           <Flexbox gap={"4"}>

--- a/coral/src/app/features/topics/acl-request/forms/TopicConsumerForm.test.tsx
+++ b/coral/src/app/features/topics/acl-request/forms/TopicConsumerForm.test.tsx
@@ -146,7 +146,9 @@ describe("<TopicConsumerForm />", () => {
     });
 
     it("renders Submit and Cancel buttons", () => {
-      const submitButton = screen.getByRole("button", { name: "Submit" });
+      const submitButton = screen.getByRole("button", {
+        name: "Submit request",
+      });
       const cancelButton = screen.getByRole("button", { name: "Cancel" });
 
       expect(submitButton).toBeVisible();
@@ -260,7 +262,9 @@ describe("<TopicConsumerForm />", () => {
     });
 
     it("renders Submit and Cancel buttons", () => {
-      const submitButton = screen.getByRole("button", { name: "Submit" });
+      const submitButton = screen.getByRole("button", {
+        name: "Submit request",
+      });
       const cancelButton = screen.getByRole("button", { name: "Cancel" });
 
       expect(submitButton).toBeVisible();
@@ -374,7 +378,9 @@ describe("<TopicConsumerForm />", () => {
     });
 
     it("renders Submit and Cancel buttons", () => {
-      const submitButton = screen.getByRole("button", { name: "Submit" });
+      const submitButton = screen.getByRole("button", {
+        name: "Submit request",
+      });
       const cancelButton = screen.getByRole("button", { name: "Cancel" });
 
       expect(submitButton).toBeVisible();

--- a/coral/src/app/features/topics/acl-request/forms/TopicConsumerForm.tsx
+++ b/coral/src/app/features/topics/acl-request/forms/TopicConsumerForm.tsx
@@ -7,7 +7,7 @@ import {
   SecondaryButton,
 } from "@aivenio/aquarium";
 import { useMutation } from "@tanstack/react-query";
-import { useEffect, useRef } from "react";
+import { useEffect, useRef, useState } from "react";
 import { UseFormReturn } from "react-hook-form";
 import { useNavigate } from "react-router-dom";
 import {
@@ -25,6 +25,7 @@ import { TopicConsumerFormSchema } from "src/app/features/topics/acl-request/sch
 import { createAclRequest } from "src/domain/acl/acl-api";
 import { Environment } from "src/domain/environment";
 import { parseErrorMsg } from "src/services/mutation-utils";
+import { Dialog } from "src/app/components/Dialog";
 
 // eslint-disable-next-line import/exports-last
 export interface TopicConsumerFormProps {
@@ -42,6 +43,8 @@ const TopicConsumerForm = ({
   renderAclTypeField,
   isAivenCluster,
 }: TopicConsumerFormProps) => {
+  const [cancelDialogVisible, setCancelDialogVisible] = useState(false);
+
   const navigate = useNavigate();
   const { aclIpPrincipleType } = topicConsumerForm.getValues();
   const { current: initialAclIpPrincipleType } = useRef(aclIpPrincipleType);
@@ -71,6 +74,11 @@ const TopicConsumerForm = ({
     mutate(formData);
   };
 
+  function cancelRequest() {
+    topicConsumerForm.reset();
+    navigate(-1);
+  }
+
   // The consumer group field is irrelevant if the Environment is an Aiven cluster
   // So we hide it when:
   // - we don't know if the Environment is an Aiven cluster (user has not selected an environment yet)
@@ -98,7 +106,11 @@ const TopicConsumerForm = ({
           <Alert type="warning">{parseErrorMsg(error)}</Alert>
         </Box>
       )}
-      <Form {...topicConsumerForm} onSubmit={onSubmitTopicConsumer}>
+      <Form
+        {...topicConsumerForm}
+        ariaLabel={"Request consumer ACL"}
+        onSubmit={onSubmitTopicConsumer}
+      >
         <Grid cols="2" minWidth={"fit"} colGap={"9"}>
           <GridItem>{renderAclTypeField()}</GridItem>
           <GridItem>
@@ -146,15 +158,39 @@ const TopicConsumerForm = ({
 
         <Grid cols={"2"} colGap={"4"} width={"fit"}>
           <GridItem>
-            <SubmitButton loading={isLoading}>Submit</SubmitButton>
+            <SubmitButton loading={isLoading}>Submit request</SubmitButton>
           </GridItem>
           <GridItem>
-            <SecondaryButton disabled={isLoading} onClick={() => navigate(-1)}>
+            <SecondaryButton
+              disabled={isLoading}
+              type="button"
+              onClick={
+                topicConsumerForm.formState.isDirty
+                  ? () => setCancelDialogVisible(true)
+                  : () => cancelRequest()
+              }
+            >
               Cancel
             </SecondaryButton>
           </GridItem>
         </Grid>
       </Form>
+      {cancelDialogVisible && (
+        <Dialog
+          title={"Cancel ACL request"}
+          primaryAction={{
+            text: "Cancel request",
+            onClick: () => cancelRequest(),
+          }}
+          secondaryAction={{
+            text: "Continue with request",
+            onClick: () => setCancelDialogVisible(false),
+          }}
+          type={"warning"}
+        >
+          <>Do you want to cancel this request? The data added will be lost.</>
+        </Dialog>
+      )}
     </>
   );
 };

--- a/coral/src/app/features/topics/acl-request/forms/TopicConsumerForm.tsx
+++ b/coral/src/app/features/topics/acl-request/forms/TopicConsumerForm.tsx
@@ -188,7 +188,7 @@ const TopicConsumerForm = ({
           }}
           type={"warning"}
         >
-          <>Do you want to cancel this request? The data added will be lost.</>
+          Do you want to cancel this request? The data added will be lost.
         </Dialog>
       )}
     </>

--- a/coral/src/app/features/topics/acl-request/forms/TopicConsumerForm.tsx
+++ b/coral/src/app/features/topics/acl-request/forms/TopicConsumerForm.tsx
@@ -177,7 +177,7 @@ const TopicConsumerForm = ({
       </Form>
       {cancelDialogVisible && (
         <Dialog
-          title={"Cancel ACL request"}
+          title={"Cancel ACL request?"}
           primaryAction={{
             text: "Cancel request",
             onClick: () => cancelRequest(),

--- a/coral/src/app/features/topics/acl-request/forms/TopicProducerForm.test.tsx
+++ b/coral/src/app/features/topics/acl-request/forms/TopicProducerForm.test.tsx
@@ -147,7 +147,9 @@ describe("<TopicProducerForm />", () => {
     });
 
     it("renders Submit and Cancel buttons", () => {
-      const submitButton = screen.getByRole("button", { name: "Submit" });
+      const submitButton = screen.getByRole("button", {
+        name: "Submit request",
+      });
       const cancelButton = screen.getByRole("button", { name: "Cancel" });
 
       expect(submitButton).toBeVisible();
@@ -273,7 +275,9 @@ describe("<TopicProducerForm />", () => {
     });
 
     it("renders Submit and Cancel buttons", () => {
-      const submitButton = screen.getByRole("button", { name: "Submit" });
+      const submitButton = screen.getByRole("button", {
+        name: "Submit request",
+      });
       const cancelButton = screen.getByRole("button", { name: "Cancel" });
 
       expect(submitButton).toBeVisible();
@@ -399,7 +403,9 @@ describe("<TopicProducerForm />", () => {
     });
 
     it("renders Submit and Cancel buttons", () => {
-      const submitButton = screen.getByRole("button", { name: "Submit" });
+      const submitButton = screen.getByRole("button", {
+        name: "Submit request",
+      });
       const cancelButton = screen.getByRole("button", { name: "Cancel" });
 
       expect(submitButton).toBeVisible();

--- a/coral/src/app/features/topics/acl-request/forms/TopicProducerForm.tsx
+++ b/coral/src/app/features/topics/acl-request/forms/TopicProducerForm.tsx
@@ -205,7 +205,7 @@ const TopicProducerForm = ({
           }}
           type={"warning"}
         >
-          <>Do you want to cancel this request? The data added will be lost.</>
+          Do you want to cancel this request? The data added will be lost.
         </Dialog>
       )}
     </>

--- a/coral/src/app/features/topics/acl-request/forms/TopicProducerForm.tsx
+++ b/coral/src/app/features/topics/acl-request/forms/TopicProducerForm.tsx
@@ -194,7 +194,7 @@ const TopicProducerForm = ({
       </Form>
       {cancelDialogVisible && (
         <Dialog
-          title={"Cancel ACL request"}
+          title={"Cancel ACL request?"}
           primaryAction={{
             text: "Cancel request",
             onClick: () => cancelRequest(),

--- a/coral/src/app/features/topics/browse/BrowseTopics.tsx
+++ b/coral/src/app/features/topics/browse/BrowseTopics.tsx
@@ -42,7 +42,7 @@ function BrowseTopics() {
           display={"flex"}
           justifyContent={"end"}
           colGap={"l1"}
-          maxWidth={"6xl"}
+          maxWidth={"7xl"}
         >
           <SearchTopics onChange={searchTopics} value={searchTerm} />
         </Box>
@@ -50,7 +50,7 @@ function BrowseTopics() {
           display={"flex"}
           flexDirection={"row"}
           colGap={"l1"}
-          maxWidth={"6xl"}
+          maxWidth={"7xl"}
         >
           <Box grow={1}>
             <SelectTeam onChange={setTeamName} />

--- a/coral/src/app/features/topics/request/TopicRequest.test.tsx
+++ b/coral/src/app/features/topics/request/TopicRequest.test.tsx
@@ -900,7 +900,7 @@ describe("<TopicRequest />", () => {
       const dialog = screen.getByRole("dialog");
 
       expect(dialog).toBeVisible();
-      expect(dialog).toHaveTextContent("Cancel topic request");
+      expect(dialog).toHaveTextContent("Cancel topic request?");
       expect(dialog).toHaveTextContent(
         "Do you want to cancel this request? The data added will be lost."
       );

--- a/coral/src/app/features/topics/request/TopicRequest.test.tsx
+++ b/coral/src/app/features/topics/request/TopicRequest.test.tsx
@@ -19,6 +19,12 @@ import {
 } from "src/domain/topic/topic-api.msw";
 import api from "src/services/api";
 
+const mockedUsedNavigate = jest.fn();
+jest.mock("react-router-dom", () => ({
+  ...jest.requireActual("react-router-dom"),
+  useNavigate: () => mockedUsedNavigate,
+}));
+
 describe("<TopicRequest />", () => {
   const originalConsoleError = console.error;
   let user: ReturnType<typeof userEvent.setup>;
@@ -744,10 +750,12 @@ describe("<TopicRequest />", () => {
       it("renders an error message", async () => {
         const spyPost = jest.spyOn(api, "post");
 
-        await user.click(screen.getByRole("button", { name: "Request topic" }));
+        await user.click(
+          screen.getByRole("button", { name: "Submit request" })
+        );
 
         await waitFor(() => {
-          const btn = screen.getByRole("button", { name: "Request topic" });
+          const btn = screen.getByRole("button", { name: "Submit request" });
           expect(btn).toBeDisabled();
         });
 
@@ -794,10 +802,12 @@ describe("<TopicRequest />", () => {
       it("redirects user to previous page", async () => {
         const spyPost = jest.spyOn(api, "post");
 
-        await user.click(screen.getByRole("button", { name: "Request topic" }));
+        await user.click(
+          screen.getByRole("button", { name: "Submit request" })
+        );
 
         await waitFor(() => {
-          const btn = screen.getByRole("button", { name: "Request topic" });
+          const btn = screen.getByRole("button", { name: "Submit request" });
           expect(btn).toBeDisabled();
         });
 
@@ -820,6 +830,131 @@ describe("<TopicRequest />", () => {
           );
         });
       });
+    });
+  });
+
+  describe("enables user to cancel the form input", () => {
+    const getForm = () => {
+      return screen.getByRole("form", {
+        name: `Request a new topic`,
+      });
+    };
+
+    beforeEach(async () => {
+      mockGetEnvironmentsForTeam({
+        mswInstance: server,
+        response: {
+          data: [createMockEnvironmentDTO({ name: "DEV", id: "1" })],
+        },
+      });
+
+      mockgetTopicAdvancedConfigOptions({
+        mswInstance: server,
+        response: {
+          data: defaultgetTopicAdvancedConfigOptionsResponse,
+        },
+      });
+
+      customRender(
+        <AquariumContext>
+          <TopicRequest />
+        </AquariumContext>,
+        { queryClient: true }
+      );
+
+      // Wait all API calls to resolve, which are required for the render
+      await screen.findByLabelText("Environment");
+      await screen.findByRole("option", { name: "DEV" });
+    });
+
+    afterEach(() => {
+      jest.clearAllMocks();
+      cleanup();
+    });
+
+    it("redirects user to the previous page if they click 'Cancel' on empty form", async () => {
+      const form = getForm();
+
+      const button = within(form).getByRole("button", {
+        name: "Cancel",
+      });
+
+      await userEvent.click(button);
+
+      expect(mockedUsedNavigate).toHaveBeenCalledWith(-1);
+    });
+
+    it('shows a warning dialog if user clicks "Cancel" and has inputs in form', async () => {
+      const form = getForm();
+
+      const nameInput = screen.getByRole("textbox", {
+        name: "Topic name *",
+      });
+      await userEvent.type(nameInput, "Some name");
+
+      const button = within(form).getByRole("button", {
+        name: "Cancel",
+      });
+
+      await userEvent.click(button);
+      const dialog = screen.getByRole("dialog");
+
+      expect(dialog).toBeVisible();
+      expect(dialog).toHaveTextContent("Cancel topic request");
+      expect(dialog).toHaveTextContent(
+        "Do you want to cancel this request? The data added will be lost."
+      );
+
+      expect(mockedUsedNavigate).not.toHaveBeenCalled();
+    });
+
+    it("brings the user back to the form when they do not cancel", async () => {
+      const form = getForm();
+
+      const nameInput = screen.getByRole("textbox", {
+        name: "Topic name *",
+      });
+      await userEvent.type(nameInput, "Some name");
+
+      const button = within(form).getByRole("button", {
+        name: "Cancel",
+      });
+
+      await userEvent.click(button);
+      const dialog = screen.getByRole("dialog");
+
+      const returnButton = screen.getByRole("button", {
+        name: "Continue with request",
+      });
+
+      await userEvent.click(returnButton);
+
+      expect(mockedUsedNavigate).not.toHaveBeenCalled();
+
+      expect(dialog).not.toBeInTheDocument();
+    });
+
+    it("redirects user to previous page if they cancel the request", async () => {
+      const form = getForm();
+
+      const nameInput = screen.getByRole("textbox", {
+        name: "Topic name *",
+      });
+      await userEvent.type(nameInput, "Some name");
+
+      const button = within(form).getByRole("button", {
+        name: "Cancel",
+      });
+
+      await userEvent.click(button);
+
+      const returnButton = screen.getByRole("button", {
+        name: "Cancel request",
+      });
+
+      await userEvent.click(returnButton);
+
+      expect(mockedUsedNavigate).toHaveBeenCalledWith(-1);
     });
   });
 });

--- a/coral/src/app/features/topics/request/TopicRequest.tsx
+++ b/coral/src/app/features/topics/request/TopicRequest.tsx
@@ -183,7 +183,7 @@ function TopicRequest() {
       </Box>
       {cancelDialogVisible && (
         <Dialog
-          title={"Cancel topic request"}
+          title={"Cancel topic request?"}
           primaryAction={{
             text: "Cancel request",
             onClick: () => cancelRequest(),

--- a/coral/src/app/features/topics/request/TopicRequest.tsx
+++ b/coral/src/app/features/topics/request/TopicRequest.tsx
@@ -79,7 +79,8 @@ function TopicRequest() {
 
   return (
     <>
-      <Box style={{ maxWidth: 1200 }}>
+      {/*<Box style={{ maxWidth: 1200 }}>*/}
+      <Box maxWidth={"4xl"}>
         {isError && (
           <Box marginBottom={"l1"} role="alert">
             <Alert type="warning">{parseErrorMsg(error)}</Alert>
@@ -194,7 +195,7 @@ function TopicRequest() {
           }}
           type={"warning"}
         >
-          <>Do you want to cancel this request? The data added will be lost.</>
+          Do you want to cancel this request? The data added will be lost.
         </Dialog>
       )}
     </>

--- a/coral/src/app/features/topics/request/TopicRequest.tsx
+++ b/coral/src/app/features/topics/request/TopicRequest.tsx
@@ -79,8 +79,7 @@ function TopicRequest() {
 
   return (
     <>
-      {/*<Box style={{ maxWidth: 1200 }}>*/}
-      <Box maxWidth={"4xl"}>
+      <Box maxWidth={"7xl"}>
         {isError && (
           <Box marginBottom={"l1"} role="alert">
             <Alert type="warning">{parseErrorMsg(error)}</Alert>

--- a/coral/src/app/features/topics/request/TopicRequest.tsx
+++ b/coral/src/app/features/topics/request/TopicRequest.tsx
@@ -1,6 +1,13 @@
 import { useMutation, useQuery } from "@tanstack/react-query";
 import { FieldErrorsImpl, SubmitHandler } from "react-hook-form";
-import { Alert, Box, Divider, Flexbox, FlexboxItem } from "@aivenio/aquarium";
+import {
+  Alert,
+  Box,
+  Button,
+  Divider,
+  Flexbox,
+  FlexboxItem,
+} from "@aivenio/aquarium";
 import {
   Form,
   SubmitButton,
@@ -21,8 +28,14 @@ import AdvancedConfiguration from "src/app/features/topics/request/components/Ad
 import { requestTopic } from "src/domain/topic/topic-api";
 import { parseErrorMsg } from "src/services/mutation-utils";
 import { createTopicRequestPayload } from "src/app/features/topics/request/utils";
+import { Dialog } from "src/app/components/Dialog";
+import { useState } from "react";
+import { useNavigate } from "react-router-dom";
 
 function TopicRequest() {
+  const [cancelDialogVisible, setCancelDialogVisible] = useState(false);
+  const navigate = useNavigate();
+
   const { data: environments } = useQuery<Environment[], Error>(
     ["environments-for-team"],
     getEnvironmentsForTeam
@@ -59,91 +72,132 @@ function TopicRequest() {
     isInitialized: defaultValues !== undefined,
   });
 
+  function cancelRequest() {
+    form.reset();
+    navigate(-1);
+  }
+
   return (
-    <Box style={{ maxWidth: 1200 }}>
-      {isError && (
-        <Box marginBottom={"l1"} role="alert">
-          <Alert type="warning">{parseErrorMsg(error)}</Alert>
-        </Box>
-      )}
-      <Form {...form} onSubmit={onSubmit} onError={onError}>
-        <Box width={"full"}>
-          {Array.isArray(environments) ? (
-            <ComplexNativeSelect<Schema, Environment>
-              name="environment"
-              labelText={"Environment"}
-              placeholder={"-- Please select --"}
-              options={environments}
-              identifierValue={"id"}
-              identifierName={"name"}
+    <>
+      <Box style={{ maxWidth: 1200 }}>
+        {isError && (
+          <Box marginBottom={"l1"} role="alert">
+            <Alert type="warning">{parseErrorMsg(error)}</Alert>
+          </Box>
+        )}
+        <Form
+          {...form}
+          ariaLabel={"Request a new topic"}
+          onSubmit={onSubmit}
+          onError={onError}
+        >
+          <Box width={"full"}>
+            {Array.isArray(environments) ? (
+              <ComplexNativeSelect<Schema, Environment>
+                name="environment"
+                labelText={"Environment"}
+                placeholder={"-- Please select --"}
+                options={environments}
+                identifierValue={"id"}
+                identifierName={"name"}
+              />
+            ) : (
+              <NativeSelect.Skeleton></NativeSelect.Skeleton>
+            )}
+          </Box>
+          <Box>
+            <Box paddingY={"l1"}>
+              <Divider />
+            </Box>
+            <TextInput<Schema>
+              name={"topicname"}
+              labelText="Topic name"
+              placeholder="e.g. my-topic"
+              required={true}
             />
-          ) : (
-            <NativeSelect.Skeleton></NativeSelect.Skeleton>
-          )}
-        </Box>
-        <Box>
-          <Box paddingY={"l1"}>
-            <Divider />
-          </Box>
-          <TextInput<Schema>
-            name={"topicname"}
-            labelText="Topic name"
-            placeholder="e.g. my-topic"
-            required={true}
-          />
-          <Box component={Flexbox} gap={"l1"}>
-            <Box component={FlexboxItem} grow={1} width={"1/2"}>
-              <SelectOrNumberInput
-                name={"topicpartitions"}
-                label={"Topic partitions"}
-                max={selectedEnvironment?.maxPartitions}
-                required={true}
-              />
-            </Box>
-            <Box component={FlexboxItem} grow={1} width={"1/2"}>
-              <SelectOrNumberInput
-                name={"replicationfactor"}
-                label={"Replication factor"}
-                max={selectedEnvironment?.maxReplicationFactor}
-                required={true}
-              />
+            <Box component={Flexbox} gap={"l1"}>
+              <Box component={FlexboxItem} grow={1} width={"1/2"}>
+                <SelectOrNumberInput
+                  name={"topicpartitions"}
+                  label={"Topic partitions"}
+                  max={selectedEnvironment?.maxPartitions}
+                  required={true}
+                />
+              </Box>
+              <Box component={FlexboxItem} grow={1} width={"1/2"}>
+                <SelectOrNumberInput
+                  name={"replicationfactor"}
+                  label={"Replication factor"}
+                  max={selectedEnvironment?.maxReplicationFactor}
+                  required={true}
+                />
+              </Box>
             </Box>
           </Box>
-        </Box>
-        <Box>
-          <Box paddingY={"l1"}>
-            <Divider />
+          <Box>
+            <Box paddingY={"l1"}>
+              <Divider />
+            </Box>
+            <AdvancedConfiguration name={"advancedConfiguration"} />
           </Box>
-          <AdvancedConfiguration name={"advancedConfiguration"} />
-        </Box>
 
-        <Box>
-          <Box paddingY={"l1"}>
-            <Divider />
-          </Box>
-          <Box component={Flexbox} gap={"l1"}>
-            <Box component={FlexboxItem} grow={1} width={"1/2"}>
-              <Textarea<Schema>
-                name="description"
-                labelText="Description"
-                rows={5}
-                required={true}
-              />
+          <Box>
+            <Box paddingY={"l1"}>
+              <Divider />
             </Box>
-            <Box component={FlexboxItem} grow={1} width={"1/2"}>
-              {" "}
-              <Textarea<Schema>
-                name="remarks"
-                labelText="Message for approval"
-                rows={5}
-              />
+            <Box component={Flexbox} gap={"l1"}>
+              <Box component={FlexboxItem} grow={1} width={"1/2"}>
+                <Textarea<Schema>
+                  name="description"
+                  labelText="Description"
+                  rows={5}
+                  required={true}
+                />
+              </Box>
+              <Box component={FlexboxItem} grow={1} width={"1/2"}>
+                {" "}
+                <Textarea<Schema>
+                  name="remarks"
+                  labelText="Message for approval"
+                  rows={5}
+                />
+              </Box>
             </Box>
           </Box>
-        </Box>
 
-        <SubmitButton loading={isLoading}>Request topic</SubmitButton>
-      </Form>
-    </Box>
+          <Box display={"flex"} colGap={"l1"} marginTop={"3"}>
+            <SubmitButton loading={isLoading}>Submit request</SubmitButton>
+            <Button
+              type="button"
+              kind={"secondary"}
+              onClick={
+                form.formState.isDirty
+                  ? () => setCancelDialogVisible(true)
+                  : () => cancelRequest()
+              }
+            >
+              Cancel
+            </Button>
+          </Box>
+        </Form>
+      </Box>
+      {cancelDialogVisible && (
+        <Dialog
+          title={"Cancel topic request"}
+          primaryAction={{
+            text: "Cancel request",
+            onClick: () => cancelRequest(),
+          }}
+          secondaryAction={{
+            text: "Continue with request",
+            onClick: () => setCancelDialogVisible(false),
+          }}
+          type={"warning"}
+        >
+          <>Do you want to cancel this request? The data added will be lost.</>
+        </Dialog>
+      )}
+    </>
   );
 
   function onError(err: Partial<FieldErrorsImpl<Schema>>) {

--- a/coral/src/app/features/topics/request/schemas/topic-request-form.ts
+++ b/coral/src/app/features/topics/request/schemas/topic-request-form.ts
@@ -177,7 +177,7 @@ const useExtendedFormValidationAndTriggers = (
   }, [topicPartitions]);
 
   useEffect(() => {
-    if (isInitialized && topicName.length > 0) {
+    if (isInitialized && topicName?.length > 0) {
       form.trigger("topicname");
     }
   }, [topicName]);

--- a/coral/src/app/features/topics/schema-request/TopicSchemaRequest.test.tsx
+++ b/coral/src/app/features/topics/schema-request/TopicSchemaRequest.test.tsx
@@ -398,7 +398,7 @@ describe("TopicSchemaRequest", () => {
       const dialog = screen.getByRole("dialog");
 
       expect(dialog).toBeVisible();
-      expect(dialog).toHaveTextContent("Cancel schema request");
+      expect(dialog).toHaveTextContent("Cancel schema request?");
       expect(dialog).toHaveTextContent(
         "Do you want to cancel this request? The data added will be lost."
       );

--- a/coral/src/app/features/topics/schema-request/TopicSchemaRequest.tsx
+++ b/coral/src/app/features/topics/schema-request/TopicSchemaRequest.tsx
@@ -171,7 +171,7 @@ function TopicSchemaRequest(props: TopicSchemaRequestProps) {
           }}
           type={"warning"}
         >
-          <>Do you want to cancel this request? The data added will be lost.</>
+          Do you want to cancel this request? The data added will be lost.
         </Dialog>
       )}
     </>

--- a/coral/src/app/features/topics/schema-request/TopicSchemaRequest.tsx
+++ b/coral/src/app/features/topics/schema-request/TopicSchemaRequest.tsx
@@ -87,7 +87,7 @@ function TopicSchemaRequest(props: TopicSchemaRequestProps) {
 
   return (
     <>
-      <Box style={{ maxWidth: 1200 }}>
+      <Box maxWidth={"7xl"}>
         {schemaRequestMutation.isError && (
           <Box marginBottom={"l1"} role="alert">
             <Alert type="warning">

--- a/coral/src/app/features/topics/schema-request/TopicSchemaRequest.tsx
+++ b/coral/src/app/features/topics/schema-request/TopicSchemaRequest.tsx
@@ -160,7 +160,7 @@ function TopicSchemaRequest(props: TopicSchemaRequestProps) {
       </Box>
       {cancelDialogVisible && (
         <Dialog
-          title={"Cancel schema request"}
+          title={"Cancel schema request?"}
           primaryAction={{
             text: "Cancel request",
             onClick: () => cancelRequest(),


### PR DESCRIPTION
# About this change - What it does

- adds a "Cancel request" flow to
    -  Request a new schema
    -  Request a new topic        
    -  Request a new ACL
- makes naming for buttons consistent in forms


Resolves: #582

## technical note
Since the workflows and skeleton of the forms are very similar, I thought about adding a layout component that may also take care of the dialogs (will add a success next). Since they are using `<Form />` and all it's less straightforward than I hoped, so I added the dialogs like this and will do the same for success handlings. It's a bit redundant, but way faster for now. 
