### PR TITLE
feat(coral): Add api definition and types for getSchemaRequestsForApprover

### DIFF
--- a/coral/src/app/features/approvals/schemas/SchemaApprovals.tsx
+++ b/coral/src/app/features/approvals/schemas/SchemaApprovals.tsx
@@ -2,8 +2,9 @@ import { SearchInput, NativeSelect } from "@aivenio/aquarium";
 import { Pagination } from "src/app/components/Pagination";
 import SchemaApprovalsTable from "src/app/features/approvals/schemas/components/SchemaApprovalsTable";
 import { ApprovalsLayout } from "src/app/features/approvals/components/ApprovalsLayout";
+import { SchemaRequest } from "src/domain/schema-request";
 
-const responseMock = [
+const mockedResponse: SchemaRequest[] = [
   {
     req_no: 1014,
     topicname: "testtopic-first",
@@ -19,15 +20,16 @@ const responseMock = [
     requesttimestring: "28-Sep-1987 13:37:00",
     topicstatus: "created",
     requesttype: "Create",
-    forceRegister: false,
     remarks: "asap",
-    approver: null,
-    approvingtime: null,
     approvingTeamDetails:
       "Team : NCC1701D, Users : jlpicard, worf, bcrusher, geordilf",
-    totalNoPages: "1",
+    approvingtime: "2022-11-04T14:54:13.414+00:00",
+    totalNoPages: "4",
     allPageNos: ["1"],
     currentPage: "1",
+    deletable: false,
+    editable: false,
+    forceRegister: false,
   },
   {
     req_no: 1013,
@@ -43,16 +45,17 @@ const responseMock = [
     requesttime: "1994-23-05T13:37:00.001+00:00",
     requesttimestring: "23-May-1994 13:37:00",
     topicstatus: "created",
-    requesttype: "Create",
-    forceRegister: false,
+    requesttype: "Delete",
     remarks: "asap",
-    approver: null,
-    approvingtime: null,
     approvingTeamDetails:
       "Team : NCC1701D, Users : jlpicard, worf, bcrusher, geordilf",
-    totalNoPages: "1",
+    approvingtime: "2022-11-04T14:54:13.414+00:00",
+    totalNoPages: "4",
     allPageNos: ["1"],
     currentPage: "1",
+    deletable: false,
+    editable: false,
+    forceRegister: false,
   },
 ];
 
@@ -96,7 +99,7 @@ function SchemaApprovals() {
     </div>,
   ];
 
-  const table = <SchemaApprovalsTable requests={responseMock} />;
+  const table = <SchemaApprovalsTable requests={mockedResponse} />;
   const pagination = (
     <Pagination activePage={1} totalPages={2} setActivePage={changePage} />
   );

--- a/coral/src/app/features/approvals/schemas/components/SchemaApprovalsTable.test.tsx
+++ b/coral/src/app/features/approvals/schemas/components/SchemaApprovalsTable.test.tsx
@@ -1,8 +1,9 @@
 import SchemaApprovalsTable from "src/app/features/approvals/schemas/components/SchemaApprovalsTable";
 import { cleanup, render, screen, within } from "@testing-library/react";
 import { mockIntersectionObserver } from "src/services/test-utils/mock-intersection-observer";
+import { SchemaRequest } from "src/domain/schema-request";
 
-const mockedRequests = [
+const mockedRequests: SchemaRequest[] = [
   {
     req_no: 1014,
     topicname: "testtopic-first",
@@ -18,15 +19,16 @@ const mockedRequests = [
     requesttimestring: "28-Sep-1987 13:37:00",
     topicstatus: "created",
     requesttype: "Create",
-    forceRegister: false,
     remarks: "asap",
-    approver: null,
-    approvingtime: null,
     approvingTeamDetails:
       "Team : NCC1701D, Users : jlpicard, worf, bcrusher, geordilf",
-    totalNoPages: "1",
+    approvingtime: "2022-11-04T14:54:13.414+00:00",
+    totalNoPages: "4",
     allPageNos: ["1"],
     currentPage: "1",
+    deletable: false,
+    editable: false,
+    forceRegister: false,
   },
   {
     req_no: 1013,
@@ -42,16 +44,17 @@ const mockedRequests = [
     requesttime: "1994-23-05T13:37:00.001+00:00",
     requesttimestring: "23-May-1994 13:37:00",
     topicstatus: "created",
-    requesttype: "Create",
-    forceRegister: false,
+    requesttype: "Delete",
     remarks: "asap",
-    approver: null,
-    approvingtime: null,
     approvingTeamDetails:
       "Team : NCC1701D, Users : jlpicard, worf, bcrusher, geordilf",
-    totalNoPages: "1",
+    approvingtime: "2022-11-04T14:54:13.414+00:00",
+    totalNoPages: "4",
     allPageNos: ["1"],
     currentPage: "1",
+    deletable: false,
+    editable: false,
+    forceRegister: false,
   },
 ];
 

--- a/coral/src/app/features/approvals/schemas/components/SchemaApprovalsTable.tsx
+++ b/coral/src/app/features/approvals/schemas/components/SchemaApprovalsTable.tsx
@@ -1,5 +1,5 @@
 import { DataTable, DataTableColumn, GhostButton } from "@aivenio/aquarium";
-import { CreatedSchemaRequests } from "src/domain/schema-request/schema-request-types";
+import { SchemaRequest } from "src/domain/schema-request";
 import infoSign from "@aivenio/aquarium/icons/infoSign";
 import tickCircle from "@aivenio/aquarium/icons/tickCircle";
 import deleteIcon from "@aivenio/aquarium/icons/delete";
@@ -85,13 +85,13 @@ const columns: Array<DataTableColumn<SchemaRequestTableData>> = [
 ];
 
 type SchemaApprovalsTableProps = {
-  requests: CreatedSchemaRequests[];
+  requests: SchemaRequest[];
 };
 function SchemaApprovalsTable(props: SchemaApprovalsTableProps) {
   const { requests } = props;
 
   const rows: SchemaRequestTableData[] = requests.map(
-    (request: CreatedSchemaRequests) => {
+    (request: SchemaRequest) => {
       return {
         id: request.req_no,
         topicname: request.topicname,

--- a/coral/src/domain/acl/acl-types.ts
+++ b/coral/src/domain/acl/acl-types.ts
@@ -3,6 +3,7 @@ import {
   KlawApiRequestQueryParameters,
   KlawApiModel,
   ResolveIntersectionTypes,
+  Paginated,
 } from "types/utils";
 
 // Several types are dependent on topictype when it is "Consumer":
@@ -47,13 +48,7 @@ type GetCreatedAclRequestParameters =
 
 type AclRequest = KlawApiModel<"aclRequest">;
 
-type Paginated<T> = {
-  totalPages: number;
-  currentPage: number;
-  entries: T;
-};
-
-type AclRequestsForApprover = Paginated<AclRequest[]>;
+type AclRequestsForApprover = ResolveIntersectionTypes<Paginated<AclRequest[]>>;
 
 export type {
   CreateAclRequestTopicTypeProducer,

--- a/coral/src/domain/schema-request/index.ts
+++ b/coral/src/domain/schema-request/index.ts
@@ -1,5 +1,11 @@
-import { createSchemaRequest } from "src/domain/schema-request/schema-request-api";
-import { CreatedSchemaRequests } from "src/domain/schema-request/schema-request-types";
+import {
+  createSchemaRequest,
+  getSchemaRequestsForApprover,
+} from "src/domain/schema-request/schema-request-api";
+import {
+  CreatedSchemaRequests,
+  SchemaRequest,
+} from "src/domain/schema-request/schema-request-types";
 
-export type { CreatedSchemaRequests };
-export { createSchemaRequest };
+export type { CreatedSchemaRequests, SchemaRequest };
+export { createSchemaRequest, getSchemaRequestsForApprover };

--- a/coral/src/domain/schema-request/schema-request-api.ts
+++ b/coral/src/domain/schema-request/schema-request-api.ts
@@ -1,6 +1,16 @@
-import { KlawApiRequest, KlawApiResponse } from "types/utils";
+import {
+  KlawApiRequest,
+  KlawApiResponse,
+  ResolveIntersectionTypes,
+} from "types/utils";
 import api from "src/services/api";
-import { SchemaRequestPayload } from "src/domain/schema-request/schema-request-types";
+import {
+  SchemaRequestApiResponse,
+  SchemaRequestPayload,
+  SchemaRequestStatus,
+} from "src/domain/schema-request/schema-request-types";
+import { operations } from "types/api";
+import { transformGetSchemaRequestsForApproverResponse } from "src/domain/schema-request/schema-request-transformer";
 
 const createSchemaRequest = (
   params: SchemaRequestPayload
@@ -17,4 +27,37 @@ const createSchemaRequest = (
   >(`/uploadSchema`, payload);
 };
 
-export { createSchemaRequest };
+type GetSchemaRequestsArgs = {
+  pageNumber?: number;
+  requestStatus: SchemaRequestStatus;
+};
+
+type GetSchemaRequestsQueryParams = ResolveIntersectionTypes<
+  Required<
+    Pick<
+      operations["getSchemaRequestsForApprover"]["parameters"]["query"],
+      "pageNo" | "requestsType"
+    >
+  >
+>;
+
+const getSchemaRequestsForApprover = ({
+  requestStatus,
+  pageNumber = 1,
+}: GetSchemaRequestsArgs): Promise<SchemaRequestApiResponse> => {
+  const queryObject: GetSchemaRequestsQueryParams = {
+    pageNo: pageNumber.toString(),
+    // This is a naming mix up in backend, we want to query
+    // for the status, not the type. Will be changed there soon.
+    requestsType: requestStatus,
+  };
+  return api
+    .get<KlawApiResponse<"getSchemaRequestsForApprover">>(
+      `/getSchemaRequestsForApprover?${new URLSearchParams(
+        queryObject
+      ).toString()}`
+    )
+    .then(transformGetSchemaRequestsForApproverResponse);
+};
+
+export { createSchemaRequest, getSchemaRequestsForApprover };

--- a/coral/src/domain/schema-request/schema-request-transformer.test.ts
+++ b/coral/src/domain/schema-request/schema-request-transformer.test.ts
@@ -1,0 +1,93 @@
+import { transformGetSchemaRequestsForApproverResponse } from "src/domain/schema-request/schema-request-transformer";
+import {
+  SchemaRequest,
+  SchemaRequestApiResponse,
+  SchemaRequestStatus,
+  SchemaRequestType,
+} from "src/domain/schema-request/schema-request-types";
+
+describe("schema-request-transformer.ts", () => {
+  describe("transformGetSchemaRequestsForApproverResponse", () => {
+    it("transforms empty payload into empty array", () => {
+      const transformedResponse = transformGetSchemaRequestsForApproverResponse(
+        []
+      );
+
+      const result: SchemaRequestApiResponse = {
+        totalPages: 0,
+        currentPage: 0,
+        entries: [],
+      };
+
+      expect(transformedResponse).toEqual(result);
+    });
+
+    it("transforms all response items into expected type", () => {
+      const mockedResponse: SchemaRequest[] = [
+        {
+          req_no: 1014,
+          topicname: "testtopic-first",
+          environment: "1",
+          environmentName: "BRG",
+          schemaversion: "1.0",
+          teamname: "NCC1701D",
+          teamId: 1701,
+          appname: "App",
+          schemafull: "",
+          username: "jlpicard",
+          requesttime: "1987-09-28T13:37:00.001+00:00",
+          requesttimestring: "28-Sep-1987 13:37:00",
+          topicstatus: "created" as SchemaRequestStatus,
+          requesttype: "Create" as SchemaRequestType,
+          remarks: "asap",
+          approvingTeamDetails:
+            "Team : NCC1701D, Users : jlpicard, worf, bcrusher, geordilf",
+          approvingtime: "2022-11-04T14:54:13.414+00:00",
+          totalNoPages: "4",
+          allPageNos: ["1"],
+          currentPage: "1",
+          deletable: false,
+          editable: false,
+          forceRegister: false,
+        },
+        {
+          req_no: 1013,
+          topicname: "testtopic-second",
+          environment: "2",
+          environmentName: "SEC",
+          schemaversion: "1.0",
+          teamname: "NCC1701D",
+          teamId: 1701,
+          appname: "App",
+          schemafull: "",
+          username: "bcrusher",
+          requesttime: "1994-23-05T13:37:00.001+00:00",
+          requesttimestring: "23-May-1994 13:37:00",
+          topicstatus: "created" as SchemaRequestStatus,
+          requesttype: "Delete" as SchemaRequestType,
+          remarks: "asap",
+          approvingTeamDetails:
+            "Team : NCC1701D, Users : jlpicard, worf, bcrusher, geordilf",
+          approvingtime: "2022-11-04T14:54:13.414+00:00",
+          totalNoPages: "4",
+          allPageNos: ["1"],
+          currentPage: "1",
+          deletable: false,
+          editable: false,
+          forceRegister: false,
+        },
+      ];
+      const transformedResponse =
+        transformGetSchemaRequestsForApproverResponse(mockedResponse);
+
+      const result: SchemaRequestApiResponse = {
+        totalPages: 4,
+        currentPage: 1,
+        entries: mockedResponse,
+      };
+
+      expect(transformedResponse.entries).toHaveLength(2);
+      expect(transformedResponse).toEqual(result);
+    });
+  });
+});

--- a/coral/src/domain/schema-request/schema-request-transformer.ts
+++ b/coral/src/domain/schema-request/schema-request-transformer.ts
@@ -1,0 +1,22 @@
+import { KlawApiResponse } from "types/utils";
+import { SchemaRequestApiResponse } from "src/domain/schema-request/schema-request-types";
+
+function transformGetSchemaRequestsForApproverResponse(
+  apiResponse: KlawApiResponse<"getSchemaRequestsForApprover">
+): SchemaRequestApiResponse {
+  if (apiResponse.length === 0) {
+    return {
+      totalPages: 0,
+      currentPage: 0,
+      entries: [],
+    };
+  }
+
+  return {
+    totalPages: Number(apiResponse[0].totalNoPages),
+    currentPage: Number(apiResponse[0].currentPage),
+    entries: apiResponse,
+  };
+}
+
+export { transformGetSchemaRequestsForApproverResponse };

--- a/coral/src/domain/schema-request/schema-request-types.ts
+++ b/coral/src/domain/schema-request/schema-request-types.ts
@@ -1,4 +1,5 @@
-import { KlawApiModel, ResolveIntersectionTypes } from "types/utils";
+import { KlawApiModel, Paginated, ResolveIntersectionTypes } from "types/utils";
+import { RequestStatus, RequestType } from "src/domain/requests";
 
 type CreatedSchemaRequests = ResolveIntersectionTypes<
   Required<
@@ -23,4 +24,37 @@ type SchemaRequestPayload = ResolveIntersectionTypes<
     Pick<KlawApiModel<"SchemaRequest">, "remarks" | "schemaversion" | "appname">
 >;
 
-export type { SchemaRequestPayload, CreatedSchemaRequests };
+type SchemaRequestType = RequestType;
+type SchemaRequestStatus = RequestStatus;
+
+type SchemaRequest = ResolveIntersectionTypes<
+  Required<
+    Pick<
+      KlawApiModel<"SchemaRequest">,
+      | "req_no"
+      | "topicname"
+      | "environment"
+      | "environmentName"
+      | "teamname"
+      | "username"
+      | "requesttimestring"
+      | "requesttype"
+      | "remarks"
+      | "approvingTeamDetails"
+    >
+  > &
+    KlawApiModel<"SchemaRequest">
+>;
+
+type SchemaRequestApiResponse = ResolveIntersectionTypes<
+  Paginated<SchemaRequest[]>
+>;
+
+export type {
+  SchemaRequestPayload,
+  CreatedSchemaRequests,
+  SchemaRequest,
+  SchemaRequestType,
+  SchemaRequestStatus,
+  SchemaRequestApiResponse,
+};

--- a/coral/src/domain/topic/topic-types.ts
+++ b/coral/src/domain/topic/topic-types.ts
@@ -1,11 +1,9 @@
-import type { KlawApiModel, ResolveIntersectionTypes } from "types/utils";
+import type {
+  KlawApiModel,
+  Paginated,
+  ResolveIntersectionTypes,
+} from "types/utils";
 import { RequestStatus, RequestType } from "src/domain/requests";
-
-type Paginated<T> = {
-  totalPages: number;
-  currentPage: number;
-  entries: T;
-};
 
 type TopicApiResponse = ResolveIntersectionTypes<Paginated<Topic[]>>;
 

--- a/coral/types/api.d.ts
+++ b/coral/types/api.d.ts
@@ -66,6 +66,9 @@ export type paths = {
   "/request/decline": {
     post: operations["declineRequest"];
   };
+  "/getSchemaRequestsForApprover": {
+    get: operations["getSchemaRequestsForApprover"];
+  };
 };
 
 export type components = {
@@ -1320,6 +1323,29 @@ export type operations = {
       };
     };
   };
+  getSchemaRequestsForApprover: {
+    parameters: {
+      query: {
+        pageNo: string;
+        currentPage?: string;
+        /** Naming is a mistake (will change), this relates to the status of a request */
+        requestsType?: components["schemas"]["RequestStatus"];
+        /** Name of a topic */
+        topic?: string;
+        /** Environment identifier */
+        env?: string;
+        search?: string;
+      };
+    };
+    responses: {
+      /** successful operation */
+      200: {
+        content: {
+          "application/json": components["schemas"]["SchemaRequestModel"][];
+        };
+      };
+    };
+  };
 };
 
 export type external = {};
@@ -1345,4 +1371,5 @@ export enum ApiPaths {
   getAuth = "/getAuth",
   approveRequest = "/request/approve",
   declineRequest = "/request/decline",
+  getSchemaRequestsForApprover = "/getSchemaRequestsForApprover",
 }

--- a/coral/types/api.d.ts
+++ b/coral/types/api.d.ts
@@ -804,6 +804,7 @@ export type components = {
       requesttimestring?: string;
       topicstatus?: components["schemas"]["RequestStatus"];
       requesttype?: components["schemas"]["RequestType"];
+      forceRegister?: boolean;
       /**
        * Remarks
        * @description SchemaRequest specific comment
@@ -843,6 +844,8 @@ export type components = {
        * @example 2
        */
       currentPage?: string;
+      editable?: boolean;
+      deletable?: boolean;
     };
     TopicRequest: {
       /**

--- a/coral/types/utils.d.ts
+++ b/coral/types/utils.d.ts
@@ -16,10 +16,17 @@ type ResolveIntersectionTypes<T> = {
   // eslint-disable-next-line @typescript-eslint/ban-types
 } & {};
 
+type Paginated<T> = {
+  totalPages: number;
+  currentPage: number;
+  entries: T;
+};
+
 export type {
   KlawApiResponse,
   KlawApiModel,
   KlawApiRequest,
   KlawApiRequestQueryParameters,
   ResolveIntersectionTypes,
+  Paginated,
 };

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1334,6 +1334,8 @@ components:
           $ref: "#/components/schemas/RequestStatus"
         requesttype:
           $ref: "#/components/schemas/RequestType"
+        forceRegister:
+          type: boolean
         remarks:
           title: Remarks
           description: SchemaRequest specific comment
@@ -1367,6 +1369,10 @@ components:
           title: Current page number
           type: string
           example: "2"
+        editable:
+          type: boolean
+        deletable:
+          type: boolean
     TopicRequest:
       type: object
       properties:

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -442,6 +442,7 @@ paths:
         - name: requestsType
           in: query
           description: Naming is a mistake (will change), this relates to the status of a request
+          example: created
           schema:
             $ref: "#/components/schemas/RequestStatus"
         - name: teamId
@@ -515,6 +516,51 @@ paths:
                 items:
                   $ref: "#/components/schemas/ApiResponse"
       x-codegen-request-body-name: body
+  /getSchemaRequestsForApprover:
+    get:
+      operationId: getSchemaRequestsForApprover
+      parameters:
+        - name: pageNo
+          in: query
+          required: true
+          example: "1"
+          schema:
+            type: string
+        - name: currentPage
+          in: query
+          example: "1"
+          schema:
+            type: string
+        - name: requestsType
+          in: query
+          description: Naming is a mistake (will change), this relates to the status of a request
+          schema:
+            $ref: "#/components/schemas/RequestStatus"
+        - name: topic
+          description: Name of a topic
+          example: "testtopic1"
+          in: query
+          schema:
+            type: string
+        - name: env
+          in: query
+          description: Environment identifier
+          example: "3"
+          schema:
+            type: string
+        - name: search
+          in: query
+          schema:
+            type: string
+      responses:
+        200:
+          description: successful operation
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/SchemaRequestModel"
 components:
   schemas:
     CommonError:


### PR DESCRIPTION
# About this change - What it does
- adds api definition for `/getSchemaRequestsForApprover.`
- updates api definition for `SchemaRequest` (there was an update)
- generate types
- adds types to `/domain`
- adds api call with transformer to `/domain`

Resolves: #639 
