### PR TITLE
fix: Remove `pnpm:devPreinstall` in favour for custom script

### DIFF
--- a/coral/README.md
+++ b/coral/README.md
@@ -40,6 +40,7 @@
 ### Usage: How to run Coral in development
 
 - navigate to this directory
+- run `pnpm add-precommit` the first time you install the repository to set the custom directory for our pre commit hooks.
 - run `pnpm install`
 - to start development mode, run:
   - `pnpm dev`sto start the frontend app for development in development mode **with remote API**

--- a/coral/package.json
+++ b/coral/package.json
@@ -24,7 +24,7 @@
     "tsc": "tsc",
     "bundle-analyze": "BUNDLE_ANALYZE=1 vite build",
     "extract-api-types": "openapi-typescript ../openapi.yaml --output types/api.d.ts --make-paths-enum --export-type",
-    "pnpm:devPreinstall": "git config --local core.hooksPath .githooks/"
+    "add-precommit": "git config --local core.hooksPath .githooks/"
   },
   "lint-staged": {
     "**/*.ts?(x)": [


### PR DESCRIPTION
# Problem
- `pnpm:devPreinstall` script fails on running build on Windows 10. 
(it runs before every `pnpm install`)

## About this change - What it does
- removes `pnpm:devPreinstall` 
- add custom script for adding directory for pre-commit hooks
- adds info for that in setup for development in corals README

Resolves: 🐛 #641

