### PR TITLE
Add additional documentation on how to utliise dockerized Klaw

### DIFF
--- a/docker-scripts/README.md
+++ b/docker-scripts/README.md
@@ -42,8 +42,8 @@ The keystore and truststore should be copied to the klaw data volume so that it 
 \\wsl$\docker-desktop-data\data\docker\volumes\docker-scripts_klaw_data\_data
 
 
-#### How to configure the keystores
-Once the Keystores have been copied to the Klaw docker volume the keystore location is simply set to ./client.keystore.p12 and ./client.truststore.jks
+#### How to configure the docker images
+Once the Keystores have been copied to the Klaw docker volume the keystore location is simply set to /klaw/client.keystore.p12 and /klaw/client.truststore.jks
 
 This can be configured in two ways.
 
@@ -77,3 +77,7 @@ This can be configured in two ways.
       SPRING_DATASOURCE_URL: "jdbc:h2:file:/klaw/klawprodb;DB_CLOSE_ON_EXIT=FALSE;DB_CLOSE_DELAY=-1;MODE=MySQL;CASE_INSENSITIVE_IDENTIFIERS=TRUE;"
       SPRING_CONFIG_LOCATION: "/klaw/klaw-application.properties"
 ````
+
+#### How to use an existing H2 Database
+If you already have a configured environment with users etc those can also be transferred over to the docker image by copying the klawprodb files into the docker volume.
+It is recommended that any existing prodb files in the docker volume be backed up in case of any need to revert in the future.

--- a/docker-scripts/README.md
+++ b/docker-scripts/README.md
@@ -28,3 +28,52 @@ How to use klaw-docker:
 * --all will execute both the --build and --deploy options but will **not** execute the testEnv option.
 * --destroy will tear down **both** Klaw containers and Kafka containers.
 
+
+
+### Enabling HTTPS
+A volume is created to store Klaw data this is where you can store your keystore and truststore for both enabling https but also for enabling secure connections between Klaw and Kafka.
+The keystore and truststore should be copied to the klaw data volume so that it may be accessed at run time.
+
+#### Where to find the Klaw docker volume
+
+#### Linux
+/var/lib/docker/volumes/docker-scripts_klaw_data/_data
+##### Windows
+\\wsl$\docker-desktop-data\data\docker\volumes\docker-scripts_klaw_data\_data
+
+
+#### How to configure the keystores
+Once the Keystores have been copied to the Klaw docker volume the keystore location is simply set to ./client.keystore.p12 and ./client.truststore.jks
+
+This can be configured in two ways.
+
+1. Configure the application.properties as normal and execute ```./klaw-docker.sh --all``` that will build and redeploy Klaw with the updated configuration settings
+2. Configure the docker-compose-klaw.yaml environment variables to add to the environment settings and execute ```./klaw-docker.sh --deploy``` to redeploy the environmental changes and restart Klaw
+ i. Here is an example of updating the docker-compose-klaw.yaml
+```
+    environment:
+      KLAW_CLUSTERAPI_ACCESS_BASE64_SECRET: dGhpcyBpcyBhIHNlY3JldCB0byBhY2Nlc3MgY2x1c3RlcmFwaQ==
+      SPRING_DATASOURCE_URL: "jdbc:h2:file:/klaw/klawprodb;DB_CLOSE_ON_EXIT=FALSE;DB_CLOSE_DELAY=-1;MODE=MySQL;CASE_INSENSITIVE_IDENTIFIERS=TRUE;"
+      DEV1_KAFKASSL_KEYSTORE_LOCATION: "/klaw/client.keystore.p12"
+      DEV1_KAFKASSL_KEYSTORE_PWD: "klaw1234"
+      DEV1_KAFKASSL_KEY_PWD: "klaw1234"
+      DEV1_KAFKASSL_KEYSTORE_TYPE: "pkcs12"
+      DEV1_KAFKASSL_TRUSTSTORE_LOCATION: "/klaw/client.truststore.jks"
+      DEV1_KAFKASSL_TRUSTSTORE_PWD: "klaw1234"
+      DEV1_KAFKASSL_TRUSTSTORE_TYPE: "JKS"
+      SERVER_SSL_KEY-STORE: "/klaw/client.keystore.p12"
+      SERVER_SSL_TRUSTSTORE: "/klaw/client.truststore.jks"
+      SERVER_SSL_KEY-STOREPASSWORD: "klaw1234"
+      SERVER_SSL_KEYPASSWORD: "klaw1234"
+      SERVER_SSL_TRUSTSTOREPASSWORD: "klaw1234"
+      SERVER_SSL_KEYSTORETYPE: "pkcs12"
+```
+3. You can also externalize the application.properties to the volume and set the environment value in the docker-compose for it to use the local copy of application.properties.
+   i. Ensure that the klaw.version property is updated correctly on the version copied over to the volume as this is normally updated during the build to keep the api versions in line with the pom version.
+      Also ensure that the application.properties is renamed to a unique properties file name so you don't accidentally copy over the Core properties with the cluster properties and vice versa. 
+````
+    environment:
+      KLAW_CLUSTERAPI_ACCESS_BASE64_SECRET: dGhpcyBpcyBhIHNlY3JldCB0byBhY2Nlc3MgY2x1c3RlcmFwaQ==
+      SPRING_DATASOURCE_URL: "jdbc:h2:file:/klaw/klawprodb;DB_CLOSE_ON_EXIT=FALSE;DB_CLOSE_DELAY=-1;MODE=MySQL;CASE_INSENSITIVE_IDENTIFIERS=TRUE;"
+      SPRING_CONFIG_LOCATION: "/klaw/klaw-application.properties"
+````


### PR DESCRIPTION
About this change - What it does
Updates a README file to expand on how to utilize docker and Klaw.
Resolves: #xxxxx
Why this way
This provides a nice utility for those who want to test or demo or trial Klaw with minimal commitment.