### PR TITLE
feat(coral): Extend ApprovalLayout

### DIFF
--- a/coral/src/app/features/approvals/acls/AclApprovals.test.tsx
+++ b/coral/src/app/features/approvals/acls/AclApprovals.test.tsx
@@ -100,27 +100,41 @@ describe("AclApprovals", () => {
     jest.resetAllMocks();
   });
 
-  describe("Skeleton", () => {
-    beforeAll(() => {
+  describe("shows loading or error state for fetching acls requests", () => {
+    afterEach(cleanup);
+
+    afterAll(() => {
+      useQuerySpy.mockRestore();
+    });
+
+    it("shows a skeleton table while loading", () => {
       // eslint-disable-next-line @typescript-eslint/ban-ts-comment
       //@ts-ignore
-      useQuerySpy.mockReturnValue({ data: [], isLoading: true });
+      useQuerySpy.mockReturnValue({ data: { entries: [] }, isLoading: true });
 
       customRender(<AclApprovals />, {
         queryClient: true,
         memoryRouter: true,
       });
-    });
-
-    afterAll(() => {
-      cleanup();
-      useQuerySpy.mockRestore();
-    });
-
-    it("shows a skeleton table", () => {
       const skeleton = screen.getByTestId("skeleton-table");
 
       expect(skeleton).toBeVisible();
+    });
+
+    it("shows an error message when an error occurs", () => {
+      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+      //@ts-ignore
+      useQuerySpy.mockReturnValue({ data: { entries: [] }, isError: true });
+
+      customRender(<AclApprovals />, {
+        queryClient: true,
+        memoryRouter: true,
+      });
+      const error = screen.getByText(
+        "Unexpected error. Please try again later!"
+      );
+
+      expect(error).toBeVisible();
     });
   });
 

--- a/coral/src/app/features/approvals/acls/AclApprovals.tsx
+++ b/coral/src/app/features/approvals/acls/AclApprovals.tsx
@@ -42,6 +42,37 @@ interface AclRequestTableRows {
   requesttimestring: string;
 }
 
+const getRows = (entries: AclRequest[] | undefined): AclRequestTableRows[] => {
+  if (entries === undefined) {
+    return [];
+  }
+  return entries.map(
+    ({
+      req_no,
+      acl_ssl,
+      acl_ip,
+      topicname,
+      aclPatternType,
+      environmentName,
+      teamname,
+      topictype,
+      username,
+      requesttimestring,
+    }) => ({
+      id: Number(req_no),
+      acl_ssl: acl_ssl ?? [],
+      acl_ip: acl_ip ?? [],
+      topicname: topicname,
+      prefixed: aclPatternType === "PREFIXED",
+      environmentName: environmentName ?? "-",
+      teamname,
+      topictype,
+      username: username ?? "-",
+      requesttimestring: requesttimestring ?? "-",
+    })
+  );
+};
+
 function AclApprovals() {
   const queryClient = useQueryClient();
   const [searchParams, setSearchParams] = useSearchParams();
@@ -276,33 +307,6 @@ function AclApprovals() {
     },
   ];
 
-  const rows: AclRequestTableRows[] =
-    data?.entries.map(
-      ({
-        req_no,
-        acl_ssl,
-        acl_ip,
-        topicname,
-        aclPatternType,
-        environmentName,
-        teamname,
-        topictype,
-        username,
-        requesttimestring,
-      }) => ({
-        id: Number(req_no),
-        acl_ssl: acl_ssl ?? [],
-        acl_ip: acl_ip ?? [],
-        topicname: topicname,
-        prefixed: aclPatternType === "PREFIXED",
-        environmentName: environmentName ?? "-",
-        teamname,
-        topictype,
-        username: username ?? "-",
-        requesttimestring: requesttimestring ?? "-",
-      })
-    ) || [];
-
   const handleChangePage = (activePage: number) => {
     setActivePage(activePage);
     searchParams.set("page", activePage.toString());
@@ -402,7 +406,7 @@ function AclApprovals() {
           <DataTable
             ariaLabel={"Acl requests"}
             columns={columns}
-            rows={rows}
+            rows={getRows(data?.entries)}
             noWrap={false}
           />
         }

--- a/coral/src/app/features/approvals/components/ApprovalsLayout.test.tsx
+++ b/coral/src/app/features/approvals/components/ApprovalsLayout.test.tsx
@@ -68,6 +68,45 @@ describe("ApprovalsLayout", () => {
     });
   });
 
+  describe("renders states dependent on props", () => {
+    afterEach(cleanup);
+
+    it("shows a loading state instead of the table", () => {
+      render(
+        <ApprovalsLayout
+          filters={mockFilter}
+          table={mockTable}
+          isLoading={true}
+        />
+      );
+
+      const table = screen.queryByRole("table");
+      const skeleton = screen.getByTestId("skeleton-table");
+
+      expect(table).not.toBeInTheDocument();
+      expect(skeleton).toBeVisible();
+    });
+
+    it("shows an error message instead of the table", () => {
+      render(
+        <ApprovalsLayout
+          filters={mockFilter}
+          table={mockTable}
+          isErrorLoading={true}
+          errorMessage={{ data: { message: "Oh no, this is an error" } }}
+        />
+      );
+
+      const table = screen.queryByRole("table");
+      const errorMessage = screen.getByText(
+        "Oh no, this is an error. Please try again later!"
+      );
+
+      expect(table).not.toBeInTheDocument();
+      expect(errorMessage).toBeVisible();
+    });
+  });
+
   describe("renders the necessary DOM and CSS to create layout", () => {
     afterEach(cleanup);
 

--- a/coral/src/app/features/approvals/components/ApprovalsLayout.tsx
+++ b/coral/src/app/features/approvals/components/ApprovalsLayout.tsx
@@ -1,14 +1,22 @@
-import { Box } from "@aivenio/aquarium";
+import { Alert, Box } from "@aivenio/aquarium";
 import { ReactElement } from "react";
+import SkeletonTable from "src/app/features/approvals/SkeletonTable";
+import { parseErrorMsg } from "src/services/mutation-utils";
 
 type ApprovalsLayoutProps = {
+  isLoading?: boolean;
+  isErrorLoading?: boolean;
+  errorMessage?: unknown;
   filters: ReactElement[];
   table: ReactElement;
   pagination?: ReactElement;
 };
 
 function ApprovalsLayout(props: ApprovalsLayoutProps) {
-  const { filters, table, pagination } = props;
+  const { filters, table, pagination, isLoading, isErrorLoading } = props;
+
+  const errorMessage = parseErrorMsg(props.errorMessage);
+
   return (
     <>
       <Box
@@ -27,17 +35,22 @@ function ApprovalsLayout(props: ApprovalsLayoutProps) {
           );
         })}
       </Box>
-
-      <Box
-        display={"flex"}
-        flexDirection={"column"}
-        alignItems={"center"}
-        rowGap={"l4"}
-        className={"a11y-enhancement-data-table"}
-      >
-        {table}
-        {pagination}
-      </Box>
+      {isLoading && <SkeletonTable />}
+      {isErrorLoading && (
+        <Alert type={"error"}>{errorMessage}. Please try again later!</Alert>
+      )}
+      {!isLoading && !isErrorLoading && (
+        <Box
+          display={"flex"}
+          flexDirection={"column"}
+          alignItems={"center"}
+          rowGap={"l4"}
+          className={"a11y-enhancement-data-table"}
+        >
+          {table}
+          {pagination}
+        </Box>
+      )}
     </>
   );
 }


### PR DESCRIPTION
# About this change - What it does

All approvals table can reuse the UI for loading and error-cases for fetching their requests 

- extends ApprovalsLayout with loading and error UI
- uses updated ApprovalsLayout component in ACL approvals