### PR TITLE
DRAFT commit as POC for Pagination.

### DIFF
--- a/coral/src/app/components/PaginationBase.test.tsx
+++ b/coral/src/app/components/PaginationBase.test.tsx
@@ -1,12 +1,12 @@
 import { cleanup, render, within, screen } from "@testing-library/react";
-import { Pagination } from "src/app/components/Pagination";
+import { PaginationBase } from "src/app/components/PaginationBase";
 import userEvent from "@testing-library/user-event";
 
 function getNavigationElement() {
   return screen.getByRole("navigation", { name: /Pagination/ });
 }
 
-describe("Pagination.tsx", () => {
+describe("PaginationBase.tsx", () => {
   describe("renders the pagination by default with active page `1`", () => {
     const activePage = 1;
     const totalPages = 5;
@@ -14,7 +14,7 @@ describe("Pagination.tsx", () => {
     describe("shows all necessary elements", () => {
       beforeAll(() => {
         render(
-          <Pagination
+          <PaginationBase
             activePage={activePage}
             totalPages={totalPages}
             setActivePage={jest.fn()}
@@ -111,7 +111,7 @@ describe("Pagination.tsx", () => {
       const mockedSetActivePage = jest.fn();
       beforeEach(() => {
         render(
-          <Pagination
+          <PaginationBase
             activePage={activePage}
             totalPages={totalPages}
             setActivePage={mockedSetActivePage}
@@ -167,7 +167,7 @@ describe("Pagination.tsx", () => {
       const mockSetActivePage = jest.fn();
       beforeEach(() => {
         render(
-          <Pagination
+          <PaginationBase
             activePage={activePage}
             totalPages={totalPages}
             setActivePage={mockSetActivePage}
@@ -221,7 +221,7 @@ describe("Pagination.tsx", () => {
     describe("shows all necessary elements", () => {
       beforeAll(() => {
         render(
-          <Pagination
+          <PaginationBase
             activePage={activePage}
             totalPages={totalPages}
             setActivePage={jest.fn()}
@@ -283,7 +283,7 @@ describe("Pagination.tsx", () => {
       const mockedSetActivePage = jest.fn();
       beforeEach(() => {
         render(
-          <Pagination
+          <PaginationBase
             activePage={activePage}
             totalPages={totalPages}
             setActivePage={mockedSetActivePage}
@@ -337,7 +337,7 @@ describe("Pagination.tsx", () => {
       const mockSetActivePage = jest.fn();
       beforeEach(() => {
         render(
-          <Pagination
+          <PaginationBase
             activePage={activePage}
             totalPages={totalPages}
             setActivePage={mockSetActivePage}
@@ -431,7 +431,7 @@ describe("Pagination.tsx", () => {
     describe("shows all necessary elements", () => {
       beforeAll(() => {
         render(
-          <Pagination
+          <PaginationBase
             activePage={activePage}
             totalPages={totalPages}
             setActivePage={jest.fn()}
@@ -511,7 +511,7 @@ describe("Pagination.tsx", () => {
       const mockedSetActivePage = jest.fn();
       beforeEach(() => {
         render(
-          <Pagination
+          <PaginationBase
             activePage={activePage}
             totalPages={totalPages}
             setActivePage={mockedSetActivePage}
@@ -567,7 +567,7 @@ describe("Pagination.tsx", () => {
       const mockSetActivePage = jest.fn();
       beforeEach(() => {
         render(
-          <Pagination
+          <PaginationBase
             activePage={activePage}
             totalPages={totalPages}
             setActivePage={mockSetActivePage}

--- a/coral/src/app/components/PaginationBase.tsx
+++ b/coral/src/app/components/PaginationBase.tsx
@@ -10,7 +10,7 @@ type PaginationProps = {
   setActivePage: (pageNumber: number) => void;
 };
 
-function Pagination(props: PaginationProps) {
+function PaginationBase(props: PaginationProps) {
   const { activePage, totalPages, setActivePage } = props;
 
   function onUpdatePage(nextPageNumber: number) {
@@ -81,4 +81,4 @@ function Pagination(props: PaginationProps) {
   );
 }
 
-export { Pagination };
+export { PaginationBase };

--- a/coral/src/app/features/approvals/acls/AclApprovals.tsx
+++ b/coral/src/app/features/approvals/acls/AclApprovals.tsx
@@ -14,7 +14,7 @@ import tickCircle from "@aivenio/aquarium/dist/src/icons/tickCircle";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { useState } from "react";
 import { useSearchParams } from "react-router-dom";
-import { Pagination } from "src/app/components/Pagination";
+import { PaginationBase } from "src/app/components/PaginationBase";
 import DetailsModalContent from "src/app/features/approvals/acls/components/DetailsModalContent";
 import useTableFilters from "src/app/features/approvals/acls/hooks/useTableFilters";
 import { ApprovalsLayout } from "src/app/features/approvals/components/ApprovalsLayout";
@@ -334,7 +334,7 @@ function AclApprovals() {
 
   const pagination =
     data?.totalPages && data.totalPages > 1 ? (
-      <Pagination
+      <PaginationBase
         activePage={data.currentPage}
         totalPages={data.totalPages}
         setActivePage={handleChangePage}

--- a/coral/src/app/features/approvals/components/ApprovalsLayout.tsx
+++ b/coral/src/app/features/approvals/components/ApprovalsLayout.tsx
@@ -39,18 +39,17 @@ function ApprovalsLayout(props: ApprovalsLayoutProps) {
       {isErrorLoading && (
         <Alert type={"error"}>{errorMessage}. Please try again later!</Alert>
       )}
-      {!isLoading && !isErrorLoading && (
-        <Box
-          display={"flex"}
-          flexDirection={"column"}
-          alignItems={"center"}
-          rowGap={"l4"}
-          className={"a11y-enhancement-data-table"}
-        >
-          {table}
-          {pagination}
-        </Box>
-      )}
+
+      <Box
+        display={"flex"}
+        flexDirection={"column"}
+        alignItems={"center"}
+        rowGap={"l4"}
+        className={"a11y-enhancement-data-table"}
+      >
+        {!isLoading && !isErrorLoading && table}
+        {pagination}
+      </Box>
     </>
   );
 }

--- a/coral/src/app/features/approvals/schemas/SchemaApprovals.tsx
+++ b/coral/src/app/features/approvals/schemas/SchemaApprovals.tsx
@@ -1,5 +1,5 @@
 import { SearchInput, NativeSelect } from "@aivenio/aquarium";
-import { Pagination } from "src/app/components/Pagination";
+import { PaginationBase } from "src/app/components/PaginationBase";
 import SchemaApprovalsTable from "src/app/features/approvals/schemas/components/SchemaApprovalsTable";
 import { ApprovalsLayout } from "src/app/features/approvals/components/ApprovalsLayout";
 import { SchemaRequest } from "src/domain/schema-request";
@@ -101,7 +101,7 @@ function SchemaApprovals() {
 
   const table = <SchemaApprovalsTable requests={mockedResponse} />;
   const pagination = (
-    <Pagination activePage={1} totalPages={2} setActivePage={changePage} />
+    <PaginationBase activePage={1} totalPages={2} setActivePage={changePage} />
   );
 
   return (

--- a/coral/src/app/features/approvals/topics/TopicApprovals.tsx
+++ b/coral/src/app/features/approvals/topics/TopicApprovals.tsx
@@ -1,6 +1,6 @@
 import { NativeSelect, SearchInput } from "@aivenio/aquarium";
 import { ApprovalsLayout } from "src/app/features/approvals/components/ApprovalsLayout";
-import { Pagination } from "src/app/components/Pagination";
+import { PaginationBase } from "src/app/components/PaginationBase";
 import { TopicApprovalsTable } from "src/app/features/approvals/topics/components/TopicApprovalsTable";
 import { TopicRequestTypes, TopicRequestStatus } from "src/domain/topic";
 
@@ -106,7 +106,7 @@ function TopicApprovals() {
 
   const table = <TopicApprovalsTable requests={mockedRequests} />;
   const pagination = (
-    <Pagination activePage={1} totalPages={2} setActivePage={changePage} />
+    <PaginationBase activePage={1} totalPages={2} setActivePage={changePage} />
   );
 
   return (

--- a/coral/src/app/features/components/Pagination.tsx
+++ b/coral/src/app/features/components/Pagination.tsx
@@ -1,23 +1,26 @@
 import { PaginationBase } from "src/app/components/PaginationBase";
-import { Dispatch, SetStateAction, useState } from "react";
+import { Dispatch, SetStateAction, useEffect } from "react";
 import { useSearchParams } from "react-router-dom";
 
 type PaginationTestProps = {
   totalPages: number | undefined;
-  initialPage: number;
+  page: number | undefined;
   setPage: Dispatch<SetStateAction<number>>;
 };
 
 function Pagination(props: PaginationTestProps) {
-  const { initialPage, totalPages, setPage } = props;
+  const { totalPages, page, setPage } = props;
+
   const [searchParams, setSearchParams] = useSearchParams();
-  const [currentPage, setCurrentPage] = useState(
-    Number(searchParams.get("page")) || initialPage
-  );
+  const initialPage = searchParams.get("page");
+
+  useEffect(() => {
+    const pageToSet = initialPage ? Number(initialPage) : 1;
+    setPage(pageToSet);
+  }, [initialPage]);
 
   function changePage(activePage: number) {
     setPage(activePage);
-    setCurrentPage(activePage);
     searchParams.set("page", activePage.toString());
     setSearchParams(searchParams);
   }
@@ -25,7 +28,7 @@ function Pagination(props: PaginationTestProps) {
   if (!totalPages || totalPages <= 1) return null;
   return (
     <PaginationBase
-      activePage={currentPage}
+      activePage={page || 1}
       totalPages={totalPages}
       setActivePage={changePage}
     />

--- a/coral/src/app/features/components/Pagination.tsx
+++ b/coral/src/app/features/components/Pagination.tsx
@@ -1,0 +1,35 @@
+import { PaginationBase } from "src/app/components/PaginationBase";
+import { Dispatch, SetStateAction, useState } from "react";
+import { useSearchParams } from "react-router-dom";
+
+type PaginationTestProps = {
+  totalPages: number | undefined;
+  initialPage: number;
+  setPage: Dispatch<SetStateAction<number>>;
+};
+
+function Pagination(props: PaginationTestProps) {
+  const { initialPage, totalPages, setPage } = props;
+  const [searchParams, setSearchParams] = useSearchParams();
+  const [currentPage, setCurrentPage] = useState(
+    Number(searchParams.get("page")) || initialPage
+  );
+
+  function changePage(activePage: number) {
+    setPage(activePage);
+    setCurrentPage(activePage);
+    searchParams.set("page", activePage.toString());
+    setSearchParams(searchParams);
+  }
+
+  if (!totalPages || totalPages <= 1) return null;
+  return (
+    <PaginationBase
+      activePage={currentPage}
+      totalPages={totalPages}
+      setActivePage={changePage}
+    />
+  );
+}
+
+export { Pagination };

--- a/coral/src/app/features/topics/browse/BrowseTopics.test.tsx
+++ b/coral/src/app/features/topics/browse/BrowseTopics.test.tsx
@@ -201,7 +201,7 @@ describe("BrowseTopics.tsx", () => {
 
     it("renders the topic table with information about the pages", () => {
       const table = screen.getByRole("table", {
-        name: "Topics overview, page 2 of 4",
+        name: "Topics overview, page 1 of 4",
       });
 
       expect(table).toBeVisible();
@@ -215,11 +215,11 @@ describe("BrowseTopics.tsx", () => {
       expect(pagination).toBeVisible();
     });
 
-    it("shows page 2 as currently active page and the total page number", () => {
+    it("shows page 1 as currently active page and the total page number", () => {
       const pagination = screen.getByRole("navigation", { name: /Pagination/ });
 
       expect(pagination).toHaveAccessibleName(
-        "Pagination navigation, you're on page 2 of 4"
+        "Pagination navigation, you're on page 1 of 4"
       );
     });
   });
@@ -239,25 +239,25 @@ describe("BrowseTopics.tsx", () => {
       cleanup();
     });
 
-    it("shows page 2 as currently active page and the total page number", () => {
+    it("shows page 1 as currently active page and the total page number", () => {
       const pagination = screen.getByRole("navigation", {
         name: /Pagination/,
       });
 
       expect(pagination).toHaveAccessibleName(
-        "Pagination navigation, you're on page 2 of 4"
+        "Pagination navigation, you're on page 1 of 4"
       );
     });
 
     it("fetches new data when user clicks on next page", async () => {
       const pageTwoButton = screen.getByRole("button", {
-        name: "Go to next page, page 3",
+        name: "Go to next page, page 2",
       });
 
       await userEvent.click(pageTwoButton);
 
       expect(mockGetTopics).toHaveBeenNthCalledWith(2, {
-        currentPage: 3,
+        currentPage: 2,
         environment: "ALL",
         searchTerm: undefined,
         teamName: "f5ed03b4-c0da-4b18-a534-c7e9a13d1342",

--- a/coral/src/app/features/topics/browse/BrowseTopics.tsx
+++ b/coral/src/app/features/topics/browse/BrowseTopics.tsx
@@ -1,5 +1,4 @@
 import { useGetTopics } from "src/app/features/topics/browse/hooks/topic-list/useGetTopics";
-import { Pagination } from "src/app/components/Pagination";
 import SelectTeam from "src/app/features/topics/browse/components/select-team/SelectTeam";
 import TopicTable from "src/app/features/topics/browse/components/topic-table/TopicTable";
 import { useState } from "react";
@@ -9,15 +8,15 @@ import SelectEnvironment from "src/app/features/topics/browse/components/select-
 import { SearchTopics } from "src/app/features/topics/browse/components/search/SearchTopics";
 import { Team, TEAM_NOT_INITIALIZED } from "src/domain/team";
 import { ENVIRONMENT_NOT_INITIALIZED } from "src/domain/environment/environment-types";
+import { Pagination } from "src/app/features/components/Pagination";
 
 function BrowseTopics() {
+  const [page, setPage] = useState(1);
   const [searchParams, setSearchParams] = useSearchParams();
   const [teamName, setTeamName] = useState<Team>(TEAM_NOT_INITIALIZED);
   const [environment, setEnvironment] = useState(ENVIRONMENT_NOT_INITIALIZED);
 
-  const initialPage = searchParams.get("page");
   const initialSearchTerm = searchParams.get("search");
-  const [page, setPage] = useState(Number(initialPage) || 1);
   const [searchTerm, setSearchTerm] = useState<string>(initialSearchTerm || "");
 
   const {
@@ -33,7 +32,6 @@ function BrowseTopics() {
   });
 
   const hasTopics = topics && topics.entries.length > 0;
-  const hasMultiplePages = topics && topics.totalPages > 1;
 
   return (
     <>
@@ -71,19 +69,18 @@ function BrowseTopics() {
 
           {!isLoading && !hasTopics && <div>No topics found</div>}
           {hasTopics && (
-            <TopicTable
-              topics={topics.entries}
-              activePage={topics.currentPage}
-              totalPages={topics.totalPages}
-            />
-          )}
-
-          {hasMultiplePages && (
-            <Pagination
-              activePage={topics.currentPage}
-              totalPages={topics.totalPages}
-              setActivePage={changePage}
-            />
+            <>
+              <TopicTable
+                topics={topics.entries}
+                activePage={page}
+                totalPages={topics.totalPages}
+              />
+              <Pagination
+                totalPages={topics?.totalPages}
+                initialPage={page}
+                setPage={setPage}
+              />
+            </>
           )}
         </Box>
       </Box>
@@ -98,12 +95,6 @@ function BrowseTopics() {
       searchParams.set("search", newSearchTerm);
     }
 
-    setSearchParams(searchParams);
-  }
-
-  function changePage(activePage: number) {
-    setPage(activePage);
-    searchParams.set("page", activePage.toString());
     setSearchParams(searchParams);
   }
 }

--- a/coral/src/domain/acl/acl-api.ts
+++ b/coral/src/domain/acl/acl-api.ts
@@ -24,6 +24,7 @@ const createAclRequest = (
 };
 
 const getAclRequestsForApprover = (params: GetCreatedAclRequestParameters) => {
+  console.log("api call");
   const filteredParams = omitBy(params, (value, property) => {
     const omitEnv = property === "env" && value === "ALL";
     const omitAclType = property === "aclType" && value === "ALL";


### PR DESCRIPTION
# About this change - What it does

## Current state (POC)

Adds a `Pagination` component that handles getting and setting it's values from searchParams.

## Notes
Custom hook is not a good solution, since returning a component from a hook can lead to unnecessary renders. Also, we want to pass data to the hook that we're getting from an API call but also use date from the hook to do the API call and that get's messed up. So I thought this is a nice solution. 

I noticed that we're unclear about what value of `currentPage` is the truth. We're getting this value from the API (our transformer set's it explicitly) and in tests for `BrowseTopics` we assume that this is the source of truth (that's why the tests checked for "page 2 of 4" -> "2" is the "currentPage" value from the mocked API response). 

We could agree to always use the `currentPage` from the api-call as the initial current page in our views - that way, we would respect the API value. That could get a bit more messy, because if we treat the API as source of truth, we would have to sync the `currentPage` back to our state after an update -> e.g.:
- usePagination is initialised with `data.currentPage`
- `setPage` gets called through `Pagination` with "2" because user clicks page
- we're doing a new api call and call `setPage` onSuccess with `currentPage` from the API

(does not even feel so messy tbh)

Alternative would be to remove `currentPage` from our side of the API (transformer) and threat our definition of `currentPage` as source of truth. Which would be more accurate, but it feels a bit icky to just ignore the API value. 


