### PR TITLE
Update openapi definition and types in coral.

### DIFF
--- a/coral/src/app/features/approvals/acls/AclApprovals.test.tsx
+++ b/coral/src/app/features/approvals/acls/AclApprovals.test.tsx
@@ -40,7 +40,6 @@ const mockedAclRequestsForApproverApiResponse: AclRequest[] = [
     topicname: "aivtopic1",
     environment: "1",
     teamname: "Ospo",
-    topictype: "Consumer",
     aclIpPrincipleType: "PRINCIPAL",
     environmentName: "DEV",
     teamId: 1003,
@@ -50,10 +49,10 @@ const mockedAclRequestsForApproverApiResponse: AclRequest[] = [
     username: "amathieu",
     requesttime: "2023-01-06T14:50:37.912+00:00",
     requesttimestring: "06-Jan-2023 14:50:37",
-    aclstatus: "created",
+    requestStatus: "CREATED",
     approver: undefined,
     approvingtime: undefined,
-    aclType: "Consumer",
+    aclType: "CONSUMER",
     aclResourceType: undefined,
     currentPage: "1",
     otherParams: undefined,
@@ -73,7 +72,7 @@ const mockedAclRequestsForApproverApiResponse: AclRequest[] = [
     topicname: "newaudittopic",
     environment: "2",
     teamname: "Ospo",
-    topictype: "Producer",
+    aclType: "PRODUCER",
     aclIpPrincipleType: "IP_ADDRESS",
     environmentName: "TST",
     teamId: 1003,
@@ -82,10 +81,9 @@ const mockedAclRequestsForApproverApiResponse: AclRequest[] = [
     username: "amathieu",
     requesttime: "2023-01-10T13:19:10.757+00:00",
     requesttimestring: "10-Jan-2023 13:19:10",
-    aclstatus: "created",
+    requestStatus: "CREATED",
     approver: undefined,
     approvingtime: undefined,
-    aclType: "Producer",
     aclResourceType: undefined,
     currentPage: "1",
     otherParams: undefined,
@@ -274,7 +272,7 @@ describe("AclApprovals", () => {
           aclType: "ALL",
           env: "1",
           pageNo: "1",
-          requestsType: "created",
+          requestStatus: "CREATED",
           topic: "",
         });
       });
@@ -284,21 +282,21 @@ describe("AclApprovals", () => {
       const select = screen.getByLabelText("Filter by status");
 
       const option = within(select).getByRole("option", {
-        name: "declined",
+        name: "DECLINED",
       });
 
       expect(option).toBeEnabled();
 
       await userEvent.selectOptions(select, option);
 
-      expect(select).toHaveDisplayValue("declined");
+      expect(select).toHaveDisplayValue("DECLINED");
 
       await waitFor(() =>
         expect(mockGetAclRequestsForApprover).toHaveBeenCalledWith({
           aclType: "ALL",
           env: "ALL",
           pageNo: "1",
-          requestsType: "declined",
+          requestStatus: "DECLINED",
           topic: "",
         })
       );
@@ -322,7 +320,7 @@ describe("AclApprovals", () => {
           aclType: "PRODUCER",
           env: "ALL",
           pageNo: "1",
-          requestsType: "created",
+          requestStatus: "CREATED",
           topic: "",
         })
       );
@@ -342,7 +340,7 @@ describe("AclApprovals", () => {
           aclType: "ALL",
           env: "ALL",
           pageNo: "1",
-          requestsType: "created",
+          requestStatus: "CREATED",
           topic: "topicname",
         })
       );
@@ -367,7 +365,7 @@ describe("AclApprovals", () => {
           aclType: "PRODUCER",
           env: "ALL",
           pageNo: "1",
-          requestsType: "created",
+          requestStatus: "CREATED",
           topic: "topicname",
         })
       );

--- a/coral/src/app/features/approvals/acls/AclApprovals.tsx
+++ b/coral/src/app/features/approvals/acls/AclApprovals.tsx
@@ -36,7 +36,7 @@ interface AclRequestTableRows {
   prefixed: boolean;
   environmentName: string;
   teamname: AclRequest["teamname"];
-  topictype: AclRequest["topictype"];
+  aclType: AclRequest["aclType"];
   username: string;
   requesttimestring: string;
 }
@@ -54,7 +54,7 @@ const getRows = (entries: AclRequest[] | undefined): AclRequestTableRows[] => {
       aclPatternType,
       environmentName,
       teamname,
-      topictype,
+      aclType,
       username,
       requesttimestring,
     }) => ({
@@ -65,7 +65,7 @@ const getRows = (entries: AclRequest[] | undefined): AclRequestTableRows[] => {
       prefixed: aclPatternType === "PREFIXED",
       environmentName: environmentName ?? "-",
       teamname,
-      topictype,
+      aclType,
       username: username ?? "-",
       requesttimestring: requesttimestring ?? "-",
     })
@@ -103,7 +103,7 @@ function AclApprovals() {
       getAclRequestsForApprover({
         pageNo: String(activePage),
         env: environment,
-        requestsType: status,
+        requestStatus: status,
         aclType,
         topic,
       }),
@@ -249,11 +249,11 @@ function AclApprovals() {
     },
     {
       type: "status",
-      field: "topictype",
+      field: "aclType",
       headerName: "ACL type",
-      status: ({ topictype }) => ({
-        status: topictype === "Consumer" ? "success" : "info",
-        text: topictype,
+      status: ({ aclType }) => ({
+        status: aclType === "CONSUMER" ? "success" : "info",
+        text: aclType,
       }),
     },
     {

--- a/coral/src/app/features/approvals/acls/components/DetailsModalContent.test.tsx
+++ b/coral/src/app/features/approvals/acls/components/DetailsModalContent.test.tsx
@@ -13,7 +13,6 @@ const mockedIpsAclRequest: AclRequest = {
   topicname: "newaudittopic",
   environment: "2",
   teamname: "Ospo",
-  topictype: "Producer",
   aclIpPrincipleType: "IP_ADDRESS",
   environmentName: "TST",
   teamId: 1003,
@@ -23,10 +22,10 @@ const mockedIpsAclRequest: AclRequest = {
   username: "amathieu",
   requesttime: "2023-01-10T13:19:10.757+00:00",
   requesttimestring: "10-Jan-2023 13:19:10",
-  aclstatus: "created",
+  requestStatus: "CREATED",
   approver: undefined,
   approvingtime: undefined,
-  aclType: "Producer",
+  aclType: "PRODUCER",
   aclResourceType: undefined,
   currentPage: "1",
   otherParams: undefined,
@@ -47,7 +46,6 @@ const mockedPrincipalsAclrequest: AclRequest = {
   topicname: "aivtopic1",
   environment: "1",
   teamname: "Ospo",
-  topictype: "Consumer",
   aclIpPrincipleType: "PRINCIPAL",
   environmentName: "DEV",
   teamId: 1003,
@@ -57,10 +55,10 @@ const mockedPrincipalsAclrequest: AclRequest = {
   username: "amathieu",
   requesttime: "2023-01-06T14:50:37.912+00:00",
   requesttimestring: "06-Jan-2023 14:50:37",
-  aclstatus: "created",
+  requestStatus: "CREATED",
   approver: undefined,
   approvingtime: undefined,
-  aclType: "Consumer",
+  aclType: "CONSUMER",
   aclResourceType: undefined,
   currentPage: "1",
   otherParams: undefined,
@@ -91,7 +89,7 @@ describe("DetailsModalContent", () => {
 
     it("renders ACL type", () => {
       expect(findTerm("ACL type")).toBeVisible();
-      expect(findDefinition(mockedIpsAclRequest.topictype)).toBeVisible();
+      expect(findDefinition(mockedIpsAclRequest.aclType)).toBeVisible();
     });
     it("renders Requesting team", () => {
       expect(findTerm("Requesting team")).toBeVisible();
@@ -140,9 +138,7 @@ describe("DetailsModalContent", () => {
 
     it("renders ACL type", () => {
       expect(findTerm("ACL type")).toBeVisible();
-      expect(
-        findDefinition(mockedPrincipalsAclrequest.topictype)
-      ).toBeVisible();
+      expect(findDefinition(mockedPrincipalsAclrequest.aclType)).toBeVisible();
     });
     it("renders Requesting team", () => {
       expect(findTerm("Requesting team")).toBeVisible();

--- a/coral/src/app/features/approvals/acls/components/DetailsModalContent.tsx
+++ b/coral/src/app/features/approvals/acls/components/DetailsModalContent.tsx
@@ -17,7 +17,7 @@ const DetailsModalContent = ({ aclRequest }: DetailsModalContentProps) => {
   }
 
   const {
-    topictype,
+    aclType,
     environmentName = "Environment not found",
     topicname,
     acl_ssl,
@@ -38,8 +38,8 @@ const DetailsModalContent = ({ aclRequest }: DetailsModalContentProps) => {
         <Label>ACL type</Label>
         <dd>
           <StatusChip
-            status={topictype === "Producer" ? "info" : "success"}
-            text={topictype}
+            status={aclType === "PRODUCER" ? "info" : "success"}
+            text={aclType}
           />
         </dd>
       </Flexbox>
@@ -91,7 +91,7 @@ const DetailsModalContent = ({ aclRequest }: DetailsModalContentProps) => {
         <Flexbox direction={"column"}>
           <Label>Consumer group</Label>
           <dd>
-            {topictype === "Consumer" ? consumergroup : <i>Not applicable</i>}
+            {aclType === "CONSUMER" ? consumergroup : <i>Not applicable</i>}
           </dd>
         </Flexbox>
       </GridItem>

--- a/coral/src/app/features/approvals/acls/hooks/useTableFilters.test.tsx
+++ b/coral/src/app/features/approvals/acls/hooks/useTableFilters.test.tsx
@@ -39,7 +39,7 @@ describe("useTableFilters.tsx", () => {
         wrapper,
       });
 
-      expect(result.current.status).toBe("created");
+      expect(result.current.status).toBe("CREATED");
     });
     it("returns 'ALL' value by default for environment state", () => {
       const { result } = renderHook(() => useTableFilters(), {

--- a/coral/src/app/features/approvals/acls/hooks/useTableFilters.tsx
+++ b/coral/src/app/features/approvals/acls/hooks/useTableFilters.tsx
@@ -6,11 +6,11 @@ import SelectEnvironment from "src/app/features/topics/browse/components/select-
 import { RequestStatus } from "src/domain/requests";
 
 const statusList: RequestStatus[] = [
-  "all",
-  "created",
-  "approved",
-  "declined",
-  "deleted",
+  "ALL",
+  "CREATED",
+  "APPROVED",
+  "DECLINED",
+  "DELETED",
 ];
 type AclType = "ALL" | "CONSUMER" | "PRODUCER";
 const aclTypes: AclType[] = ["ALL", "CONSUMER", "PRODUCER"];
@@ -22,7 +22,7 @@ const useTableFilters = () => {
   const aclTypeParam = searchParams.get("aclType") as AclType | null;
 
   const [environment, setEnvironment] = useState(envParam ?? "ALL");
-  const [status, setStatus] = useState<RequestStatus>(statusParam ?? "created");
+  const [status, setStatus] = useState<RequestStatus>(statusParam ?? "CREATED");
   const [aclType, setAclType] = useState<AclType>(aclTypeParam ?? "ALL");
   const [topic, setTopic] = useState(searchParams.get("topic") ?? "");
 
@@ -40,7 +40,7 @@ const useTableFilters = () => {
       }}
     >
       {statusList.map((status) => {
-        if (status === "all") {
+        if (status === "ALL") {
           return (
             <option key={status} value={"ALL"}>
               All statuses

--- a/coral/src/app/features/approvals/schemas/SchemaApprovals.tsx
+++ b/coral/src/app/features/approvals/schemas/SchemaApprovals.tsx
@@ -18,8 +18,8 @@ const mockedResponse: SchemaRequest[] = [
     username: "jlpicard",
     requesttime: "1987-09-28T13:37:00.001+00:00",
     requesttimestring: "28-Sep-1987 13:37:00",
-    topicstatus: "created",
-    requesttype: "Create",
+    requestStatus: "CREATED",
+    requestOperationType: "CREATE",
     remarks: "asap",
     approvingTeamDetails:
       "Team : NCC1701D, Users : jlpicard, worf, bcrusher, geordilf",
@@ -44,8 +44,8 @@ const mockedResponse: SchemaRequest[] = [
     username: "bcrusher",
     requesttime: "1994-23-05T13:37:00.001+00:00",
     requesttimestring: "23-May-1994 13:37:00",
-    topicstatus: "created",
-    requesttype: "Delete",
+    requestStatus: "CREATED",
+    requestOperationType: "DELETE",
     remarks: "asap",
     approvingTeamDetails:
       "Team : NCC1701D, Users : jlpicard, worf, bcrusher, geordilf",

--- a/coral/src/app/features/approvals/schemas/components/SchemaApprovalsTable.test.tsx
+++ b/coral/src/app/features/approvals/schemas/components/SchemaApprovalsTable.test.tsx
@@ -17,8 +17,8 @@ const mockedRequests: SchemaRequest[] = [
     username: "jlpicard",
     requesttime: "1987-09-28T13:37:00.001+00:00",
     requesttimestring: "28-Sep-1987 13:37:00",
-    topicstatus: "created",
-    requesttype: "Create",
+    requestStatus: "CREATED",
+    requestOperationType: "CREATE",
     remarks: "asap",
     approvingTeamDetails:
       "Team : NCC1701D, Users : jlpicard, worf, bcrusher, geordilf",
@@ -43,8 +43,8 @@ const mockedRequests: SchemaRequest[] = [
     username: "bcrusher",
     requesttime: "1994-23-05T13:37:00.001+00:00",
     requesttimestring: "23-May-1994 13:37:00",
-    topicstatus: "created",
-    requesttype: "Delete",
+    requestStatus: "CREATED",
+    requestOperationType: "DELETE",
     remarks: "asap",
     approvingTeamDetails:
       "Team : NCC1701D, Users : jlpicard, worf, bcrusher, geordilf",

--- a/coral/src/app/features/approvals/topics/TopicApprovals.tsx
+++ b/coral/src/app/features/approvals/topics/TopicApprovals.tsx
@@ -2,9 +2,9 @@ import { NativeSelect, SearchInput } from "@aivenio/aquarium";
 import { ApprovalsLayout } from "src/app/features/approvals/components/ApprovalsLayout";
 import { Pagination } from "src/app/components/Pagination";
 import { TopicApprovalsTable } from "src/app/features/approvals/topics/components/TopicApprovalsTable";
-import { TopicRequestTypes, TopicRequestStatus } from "src/domain/topic";
+import { TopicRequest } from "src/domain/topic";
 
-const mockedRequests = [
+const mockedRequests: TopicRequest[] = [
   {
     topicname: "test-topic-1",
     environment: "1",
@@ -21,17 +21,19 @@ const mockedRequests = [
         configValue: "delete",
       },
     ],
-    topictype: "Create" as TopicRequestTypes,
+    requestOperationType: "CREATE",
     requestor: "jlpicard",
     requesttime: "1987-09-28T13:37:00.001+00:00",
     requesttimestring: "28-Sep-1987 13:37:00",
-    topicstatus: "created" as TopicRequestStatus,
+    requestStatus: "CREATED",
     totalNoPages: "1",
     approvingTeamDetails:
       "Team : NCC1701D, Users : jlpicard, worf, bcrusher, geordilf,",
     teamId: 1003,
     allPageNos: ["1"],
     currentPage: "1",
+    deletable: true,
+    editable: true,
   },
   {
     topicname: "test-topic-2",
@@ -50,17 +52,19 @@ const mockedRequests = [
       },
     ],
 
-    topictype: "Update" as TopicRequestTypes,
+    requestOperationType: "UPDATE",
     requestor: "bcrusher",
     requesttime: "1994-23-05T13:37:00.001+00:00",
     requesttimestring: "23-May-1994 13:37:00",
-    topicstatus: "approved" as TopicRequestStatus,
+    requestStatus: "APPROVED",
     totalNoPages: "1",
     approvingTeamDetails:
       "Team : NCC1701D, Users : jlpicard, worf, bcrusher, geordilf,",
     teamId: 1003,
     allPageNos: ["1"],
     currentPage: "1",
+    deletable: true,
+    editable: true,
   },
 ];
 

--- a/coral/src/app/features/approvals/topics/components/TopicApprovalsTable.test.tsx
+++ b/coral/src/app/features/approvals/topics/components/TopicApprovalsTable.test.tsx
@@ -1,9 +1,9 @@
 import { cleanup, render, screen, within } from "@testing-library/react";
 import { mockIntersectionObserver } from "src/services/test-utils/mock-intersection-observer";
 import { TopicApprovalsTable } from "src/app/features/approvals/topics/components/TopicApprovalsTable";
-import { TopicRequestStatus, TopicRequestTypes } from "src/domain/topic";
+import { TopicRequest } from "src/domain/topic";
 
-const mockedRequests = [
+const mockedRequests: TopicRequest[] = [
   {
     topicname: "test-topic-1",
     environment: "1",
@@ -20,17 +20,19 @@ const mockedRequests = [
         configValue: "delete",
       },
     ],
-    topictype: "Create" as TopicRequestTypes,
+    requestOperationType: "CREATE",
     requestor: "jlpicard",
     requesttime: "1987-09-28T13:37:00.001+00:00",
     requesttimestring: "28-Sep-1987 13:37:00",
-    topicstatus: "created" as TopicRequestStatus,
+    requestStatus: "CREATED",
     totalNoPages: "1",
     approvingTeamDetails:
       "Team : NCC1701D, Users : jlpicard, worf, bcrusher, geordilf,",
     teamId: 1003,
     allPageNos: ["1"],
     currentPage: "1",
+    editable: true,
+    deletable: true,
   },
   {
     topicname: "test-topic-2",
@@ -49,17 +51,19 @@ const mockedRequests = [
       },
     ],
 
-    topictype: "Update" as TopicRequestTypes,
+    requestOperationType: "UPDATE",
     requestor: "bcrusher",
     requesttime: "1994-23-05T13:37:00.001+00:00",
     requesttimestring: "23-May-1994 13:37:00",
-    topicstatus: "approved" as TopicRequestStatus,
+    requestStatus: "APPROVED",
     totalNoPages: "1",
     approvingTeamDetails:
       "Team : NCC1701D, Users : jlpicard, worf, bcrusher, geordilf,",
     teamId: 1003,
     allPageNos: ["1"],
     currentPage: "1",
+    editable: true,
+    deletable: true,
   },
 ];
 
@@ -67,7 +71,7 @@ describe("TopicApprovalsTable", () => {
   const columnsFieldMap = [
     { columnHeader: "Topic", relatedField: "topicname" },
     { columnHeader: "Environment", relatedField: "environmentName" },
-    { columnHeader: "Type", relatedField: "topictype" },
+    { columnHeader: "Status", relatedField: "requestStatus" },
     { columnHeader: "Claim by team", relatedField: "teamname" },
     { columnHeader: "Requested by", relatedField: "requestor" },
     { columnHeader: "Date requested", relatedField: "requesttimestring" },

--- a/coral/src/app/features/approvals/topics/components/TopicApprovalsTable.tsx
+++ b/coral/src/app/features/approvals/topics/components/TopicApprovalsTable.tsx
@@ -8,7 +8,7 @@ interface TopicRequestTableData {
   id: number; // unclear
   topicname: string;
   environmentName: string;
-  topictype: string;
+  requestStatus: string;
   teamname: string; // unclear
   requestor: string;
   requesttimestring: string;
@@ -17,7 +17,7 @@ interface TopicRequestTableData {
 const columns: Array<DataTableColumn<TopicRequestTableData>> = [
   { type: "text", field: "topicname", headerName: "Topic" },
   { type: "text", field: "environmentName", headerName: "Environment" },
-  { type: "text", field: "topictype", headerName: "Type" },
+  { type: "text", field: "requestStatus", headerName: "Status" },
   { type: "text", field: "teamname", headerName: "Claim by team" },
   { type: "text", field: "requestor", headerName: "Requested by" },
   {
@@ -100,7 +100,7 @@ function TopicApprovalsTable(props: TopicApprovalsTableProp) {
         id: request.topicid,
         topicname: request.topicname,
         environmentName: request.environmentName,
-        topictype: request.topictype,
+        requestStatus: request.requestStatus,
         teamname: request.teamname,
         requestor: request.requestor,
         requesttimestring: request.requesttimestring,

--- a/coral/src/app/features/topics/acl-request/TopicAclRequest.test.tsx
+++ b/coral/src/app/features/topics/acl-request/TopicAclRequest.test.tsx
@@ -983,7 +983,7 @@ describe("<TopicAclRequest />", () => {
           aclPatternType: "LITERAL",
           topicname: "aivtopic1",
           environment: "1",
-          topictype: "Producer",
+          aclType: "PRODUCER",
           teamname: "Ospo",
         });
 
@@ -1053,7 +1053,7 @@ describe("<TopicAclRequest />", () => {
           aclPatternType: "LITERAL",
           topicname: "aivtopic1",
           environment: "1",
-          topictype: "Producer",
+          aclType: "PRODUCER",
           teamname: "Ospo",
         });
 
@@ -1278,7 +1278,7 @@ describe("<TopicAclRequest />", () => {
           aclPatternType: "LITERAL",
           topicname: "aivtopic1",
           environment: "1",
-          topictype: "Consumer",
+          aclType: "CONSUMER",
           teamname: "Ospo",
           consumergroup: "group",
         });
@@ -1365,7 +1365,7 @@ describe("<TopicAclRequest />", () => {
           aclPatternType: "LITERAL",
           topicname: "aivtopic1",
           environment: "1",
-          topictype: "Consumer",
+          aclType: "CONSUMER",
           teamname: "Ospo",
           consumergroup: "group",
         });

--- a/coral/src/app/features/topics/acl-request/TopicAclRequest.tsx
+++ b/coral/src/app/features/topics/acl-request/TopicAclRequest.tsx
@@ -15,16 +15,17 @@ import topicProducerFormSchema, {
   TopicProducerFormSchema,
 } from "src/app/features/topics/acl-request/schemas/topic-acl-request-producer";
 import { getTopicTeam, TopicTeam } from "src/domain/topic";
+import { AclType } from "src/domain/acl";
 
 const TopicAclRequest = () => {
   const { topicName } = useParams();
-  const [topicType, setTopicType] = useState("Producer");
+  const [aclType, setAclType] = useState<AclType>("PRODUCER");
 
   const topicProducerForm = useForm<TopicProducerFormSchema>({
     schema: topicProducerFormSchema,
     defaultValues: {
       topicname: topicName,
-      topictype: "Producer",
+      aclType: "PRODUCER",
     },
   });
 
@@ -33,7 +34,7 @@ const TopicAclRequest = () => {
     defaultValues: {
       aclPatternType: "LITERAL",
       topicname: topicName,
-      topictype: "Consumer",
+      aclType: "CONSUMER",
       consumergroup: "",
     },
   });
@@ -44,7 +45,7 @@ const TopicAclRequest = () => {
   // Will trigger infinite rerender when selecting an environment if not memoized
   const selectedEnvironment = useMemo(
     () =>
-      topicType === "Producer"
+      aclType === "PRODUCER"
         ? extendedEnvironments.find(
             (env) => env.id === topicProducerForm.watch("environment")
           )
@@ -52,22 +53,22 @@ const TopicAclRequest = () => {
             (env) => env.id === topicConsumerForm.watch("environment")
           ),
     [
-      topicType,
+      aclType,
       topicProducerForm.watch("environment"),
       topicConsumerForm.watch("environment"),
     ]
   );
 
   const selectedPatternType =
-    topicType === "Producer"
+    aclType === "PRODUCER"
       ? topicProducerForm.watch("aclPatternType")
       : "LITERAL";
   const selectedTopicName =
-    topicType === "Producer"
+    aclType === "PRODUCER"
       ? topicProducerForm.watch("topicname")
       : topicConsumerForm.watch("topicname");
   useQuery<TopicTeam, Error>({
-    queryKey: ["topicTeam", selectedTopicName, selectedPatternType, topicType],
+    queryKey: ["topicTeam", selectedTopicName, selectedPatternType, aclType],
     queryFn: () =>
       getTopicTeam({
         topicName: selectedTopicName,
@@ -77,7 +78,7 @@ const TopicAclRequest = () => {
       if (data === undefined) {
         throw new Error("Could not fetch team for current Topic");
       }
-      return topicType === "Producer"
+      return aclType === "PRODUCER"
         ? topicProducerForm.setValue("teamname", data.team)
         : topicConsumerForm.setValue("teamname", data.team);
     },
@@ -92,12 +93,12 @@ const TopicAclRequest = () => {
       selectedEnvironment !== undefined &&
       selectedEnvironment.isAivenCluster
     ) {
-      if (topicType === "Producer") {
+      if (aclType === "PRODUCER") {
         topicProducerForm.setValue("aclPatternType", "LITERAL");
         topicProducerForm.setValue("aclIpPrincipleType", "PRINCIPAL");
         topicProducerForm.resetField("transactionalId");
       }
-      if (topicType === "Consumer") {
+      if (aclType === "CONSUMER") {
         topicConsumerForm.setValue("aclIpPrincipleType", "PRINCIPAL");
       }
     }
@@ -111,10 +112,10 @@ const TopicAclRequest = () => {
 
   return (
     <Box maxWidth={"7xl"}>
-      {topicType === "Consumer" ? (
+      {aclType === "CONSUMER" ? (
         <TopicConsumerForm
           renderAclTypeField={() => (
-            <AclTypeField topicType={topicType} handleChange={setTopicType} />
+            <AclTypeField aclType={aclType} handleChange={setAclType} />
           )}
           topicConsumerForm={topicConsumerForm}
           topicNames={currentTopicNames}
@@ -124,7 +125,7 @@ const TopicAclRequest = () => {
       ) : (
         <TopicProducerForm
           renderAclTypeField={() => (
-            <AclTypeField topicType={topicType} handleChange={setTopicType} />
+            <AclTypeField aclType={aclType} handleChange={setAclType} />
           )}
           topicProducerForm={topicProducerForm}
           topicNames={currentTopicNames}

--- a/coral/src/app/features/topics/acl-request/fields/AclTypeField.test.tsx
+++ b/coral/src/app/features/topics/acl-request/fields/AclTypeField.test.tsx
@@ -15,7 +15,7 @@ describe("AclTypeField", () => {
 
   it("renders AclTypeField with two options", () => {
     const result = render(
-      <AclTypeField handleChange={handleChange} topicType={"Producer"} />
+      <AclTypeField handleChange={handleChange} aclType={"PRODUCER"} />
     );
     const radioButtons = result.getAllByRole("radio");
     expect(radioButtons).toHaveLength(2);
@@ -23,7 +23,7 @@ describe("AclTypeField", () => {
 
   it("should render AclTypeField with Consumer option checked by default", () => {
     const result = render(
-      <AclTypeField handleChange={handleChange} topicType={"Consumer"} />
+      <AclTypeField handleChange={handleChange} aclType={"CONSUMER"} />
     );
     const consumerRadioButton = result.getByLabelText("Consumer");
     const producerRadioButton = result.getByLabelText("Producer");
@@ -33,7 +33,7 @@ describe("AclTypeField", () => {
 
   it("should render AclTypeField with Producer option checked by default", () => {
     const result = render(
-      <AclTypeField handleChange={handleChange} topicType={"Producer"} />
+      <AclTypeField handleChange={handleChange} aclType={"PRODUCER"} />
     );
     const consumerRadioButton = result.getByLabelText("Consumer");
     const producerRadioButton = result.getByLabelText("Producer");
@@ -43,7 +43,7 @@ describe("AclTypeField", () => {
 
   it("should call handleChange when options are clicked", async () => {
     const result = render(
-      <AclTypeField handleChange={handleChange} topicType={"Producer"} />
+      <AclTypeField handleChange={handleChange} aclType={"PRODUCER"} />
     );
     const consumerRadioButton = result.getByLabelText("Consumer");
 

--- a/coral/src/app/features/topics/acl-request/fields/AclTypeField.tsx
+++ b/coral/src/app/features/topics/acl-request/fields/AclTypeField.tsx
@@ -2,23 +2,24 @@ import {
   RadioButton as BaseRadioButton,
   RadioButtonGroup as BaseRadioButtonGroup,
 } from "@aivenio/aquarium";
+import { AclType } from "src/domain/acl";
 
 interface AclTypeFieldProps {
-  handleChange: (value: string) => void;
-  topicType: string;
+  handleChange: (value: AclType) => void;
+  aclType: AclType;
 }
 
-const AclTypeField = ({ handleChange, topicType }: AclTypeFieldProps) => (
+const AclTypeField = ({ handleChange, aclType }: AclTypeFieldProps) => (
   <BaseRadioButtonGroup
     labelText="ACL type"
-    name="topicType"
-    onChange={handleChange}
+    name="aclType"
+    onChange={(value) => handleChange(value as AclType)}
     required
   >
-    <BaseRadioButton value="Producer" checked={topicType === "Producer"}>
+    <BaseRadioButton value={"PRODUCER"} checked={aclType === "PRODUCER"}>
       Producer
     </BaseRadioButton>
-    <BaseRadioButton value="Consumer" checked={topicType === "Consumer"}>
+    <BaseRadioButton value={"CONSUMER"} checked={aclType === "CONSUMER"}>
       Consumer
     </BaseRadioButton>
   </BaseRadioButtonGroup>

--- a/coral/src/app/features/topics/acl-request/forms/TopicConsumerForm.test.tsx
+++ b/coral/src/app/features/topics/acl-request/forms/TopicConsumerForm.test.tsx
@@ -24,7 +24,7 @@ const baseProps = {
     }),
   ],
   renderAclTypeField: () => (
-    <AclTypeField topicType={"Producer"} handleChange={() => null} />
+    <AclTypeField aclType={"PRODUCER"} handleChange={() => null} />
   ),
 } as TopicConsumerFormProps;
 
@@ -46,7 +46,7 @@ describe("<TopicConsumerForm />", () => {
           schema: topicConsumerFormSchema,
           defaultValues: {
             topicname: "aiventopic1",
-            topictype: "Consumer",
+            aclType: "CONSUMER",
           },
         })
       );
@@ -168,7 +168,7 @@ describe("<TopicConsumerForm />", () => {
           defaultValues: {
             topicname: "aiventopic1",
             environment: "1",
-            topictype: "Consumer",
+            aclType: "CONSUMER",
             aclIpPrincipleType: "PRINCIPAL",
           },
         })
@@ -284,7 +284,7 @@ describe("<TopicConsumerForm />", () => {
           defaultValues: {
             topicname: "aiventopic1",
             environment: "2",
-            topictype: "Consumer",
+            aclType: "CONSUMER",
           },
         })
       );

--- a/coral/src/app/features/topics/acl-request/forms/TopicProducerForm.test.tsx
+++ b/coral/src/app/features/topics/acl-request/forms/TopicProducerForm.test.tsx
@@ -24,7 +24,7 @@ const baseProps = {
     }),
   ],
   renderAclTypeField: () => (
-    <AclTypeField topicType={"Producer"} handleChange={() => null} />
+    <AclTypeField aclType={"PRODUCER"} handleChange={() => null} />
   ),
 } as TopicProducerFormProps;
 
@@ -47,7 +47,7 @@ describe("<TopicProducerForm />", () => {
           defaultValues: {
             topicname: "aiventopic1",
             environment: ENVIRONMENT_NOT_INITIALIZED,
-            topictype: "Producer",
+            aclType: "PRODUCER",
           },
         })
       );
@@ -169,7 +169,7 @@ describe("<TopicProducerForm />", () => {
           defaultValues: {
             topicname: "aiventopic1",
             environment: "1",
-            topictype: "Producer",
+            aclType: "PRODUCER",
             aclIpPrincipleType: "PRINCIPAL",
           },
         })
@@ -297,7 +297,7 @@ describe("<TopicProducerForm />", () => {
           defaultValues: {
             topicname: "aiventopic1",
             environment: "2",
-            topictype: "Producer",
+            aclType: "PRODUCER",
           },
         })
       );

--- a/coral/src/app/features/topics/acl-request/schemas/topic-acl-request-consumer.ts
+++ b/coral/src/app/features/topics/acl-request/schemas/topic-acl-request-consumer.ts
@@ -21,7 +21,7 @@ const consumergroup = z
     message: "Only characters allowed: a-z, A-Z, 0-9, ., _,-.",
   });
 const aclPatternType = z.literal("LITERAL");
-const topictype = z.literal("Consumer");
+const aclType = z.literal("CONSUMER");
 
 const topicConsumerFormSchema = z
   .object({
@@ -33,7 +33,7 @@ const topicConsumerFormSchema = z
     aclPatternType,
     topicname,
     environment,
-    topictype,
+    aclType,
     teamname,
   })
   // We check if the user has entered valid values for acl_ssl or acl_ip

--- a/coral/src/app/features/topics/acl-request/schemas/topic-acl-request-producer.ts
+++ b/coral/src/app/features/topics/acl-request/schemas/topic-acl-request-producer.ts
@@ -14,7 +14,7 @@ import {
 import { z } from "zod";
 
 const aclPatternType = z.union([z.literal("LITERAL"), z.literal("PREFIXED")]);
-const topictype = z.literal("Producer");
+const aclType = z.literal("PRODUCER");
 const transactionalId = z
   .string()
   .regex(hasOnlyValidCharacters, {
@@ -32,7 +32,7 @@ const topicProducerFormSchema = z
     aclPatternType,
     topicname,
     environment,
-    topictype,
+    aclType,
     transactionalId,
     teamname,
   })

--- a/coral/src/app/features/topics/request/TopicRequest.test.tsx
+++ b/coral/src/app/features/topics/request/TopicRequest.test.tsx
@@ -768,7 +768,7 @@ describe("<TopicRequest />", () => {
           advancedTopicConfigEntries: [],
           description: "test",
           remarks: "",
-          topictype: "Create",
+          requestOperationType: "CREATE",
         });
 
         const alert = await screen.findByRole("alert");
@@ -820,7 +820,7 @@ describe("<TopicRequest />", () => {
           advancedTopicConfigEntries: [],
           description: "test",
           remarks: "",
-          topictype: "Create",
+          requestOperationType: "CREATE",
         });
 
         await waitFor(() => {

--- a/coral/src/app/features/topics/request/TopicRequest.tsx
+++ b/coral/src/app/features/topics/request/TopicRequest.tsx
@@ -64,6 +64,7 @@ function TopicRequest() {
         "/myTopicRequests?reqsType=created&topicCreated=true"
       ),
   });
+
   const onSubmit: SubmitHandler<Schema> = (data) =>
     mutate(createTopicRequestPayload(data));
 

--- a/coral/src/app/features/topics/request/utils.test.ts
+++ b/coral/src/app/features/topics/request/utils.test.ts
@@ -32,7 +32,7 @@ describe("TopicRequest utils", () => {
         advancedTopicConfigEntries: [],
         description: "example description",
         remarks: "please approve this topic asap",
-        topictype: "Create",
+        requestOperationType: "CREATE",
       });
     });
   });

--- a/coral/src/app/features/topics/request/utils.ts
+++ b/coral/src/app/features/topics/request/utils.ts
@@ -15,7 +15,7 @@ function createTopicRequestPayload(
     advancedTopicConfigEntries: transformAdvancedConfigEntries(
       formData.advancedConfiguration
     ),
-    topictype: "Create" as const,
+    requestOperationType: "CREATE",
   };
 }
 function coerceToString(value: unknown): string | undefined {

--- a/coral/src/domain/acl/acl-types.ts
+++ b/coral/src/domain/acl/acl-types.ts
@@ -19,7 +19,7 @@ type BaseCreateAclRequest = Pick<
   KlawApiRequest<"createAclRequest">,
   | "remarks"
   | "aclPatternType"
-  | "topictype"
+  | "aclType"
   | "topicname"
   | "environment"
   | "teamname"
@@ -30,14 +30,14 @@ type BaseCreateAclRequest = Pick<
 
 type CreateAclRequestTopicTypeProducer = ResolveIntersectionTypes<
   BaseCreateAclRequest & {
-    topictype: "Producer";
+    aclType: "PRODUCER";
   }
 >;
 
 type CreateAclRequestTopicTypeConsumer = ResolveIntersectionTypes<
   BaseCreateAclRequest & {
     transactionalId?: string;
-    topictype: "Consumer";
+    aclType: "CONSUMER";
     aclPatternType: "LITERAL";
     consumergroup: string;
   }
@@ -53,10 +53,13 @@ type AclRequest = KlawApiModel<"aclRequest">;
 
 type AclRequestsForApprover = ResolveIntersectionTypes<Paginated<AclRequest[]>>;
 
+type AclType = KlawApiModel<"aclRequest">["aclType"];
+
 export type {
   CreateAclRequestTopicTypeProducer,
   CreateAclRequestTopicTypeConsumer,
   GetCreatedAclRequestParameters,
   AclRequest,
   AclRequestsForApprover,
+  AclType,
 };

--- a/coral/src/domain/acl/index.ts
+++ b/coral/src/domain/acl/index.ts
@@ -1,9 +1,11 @@
 import {
   CreateAclRequestTopicTypeProducer,
   CreateAclRequestTopicTypeConsumer,
+  AclType,
 } from "src/domain/acl/acl-types";
 
 export type {
   CreateAclRequestTopicTypeProducer,
   CreateAclRequestTopicTypeConsumer,
+  AclType,
 };

--- a/coral/src/domain/requests.ts
+++ b/coral/src/domain/requests.ts
@@ -1,7 +1,7 @@
 import { components } from "types/api";
 
-type RequestType = components["schemas"]["RequestType"];
+type RequestOperationType = components["schemas"]["RequestOperationType"];
 type RequestStatus = components["schemas"]["RequestStatus"];
 type RequestVerdict = components["schemas"]["RequestVerdict"];
 
-export type { RequestType, RequestStatus, RequestVerdict };
+export type { RequestOperationType, RequestStatus, RequestVerdict };

--- a/coral/src/domain/schema-request/schema-request-api.ts
+++ b/coral/src/domain/schema-request/schema-request-api.ts
@@ -1,19 +1,15 @@
-import {
-  KlawApiRequest,
-  KlawApiResponse,
-  ResolveIntersectionTypes,
-} from "types/utils";
+import { KlawApiResponse, ResolveIntersectionTypes } from "types/utils";
 import api from "src/services/api";
 import {
   SchemaRequestApiResponse,
-  SchemaRequestPayload,
+  CreateSchemaRequestPayload,
   SchemaRequestStatus,
 } from "src/domain/schema-request/schema-request-types";
 import { operations } from "types/api";
 import { transformGetSchemaRequestsForApproverResponse } from "src/domain/schema-request/schema-request-transformer";
 
 const createSchemaRequest = (
-  params: SchemaRequestPayload
+  params: CreateSchemaRequestPayload
 ): Promise<KlawApiResponse<"schemaUpload">> => {
   const payload = {
     ...params,
@@ -21,10 +17,10 @@ const createSchemaRequest = (
     appname: "App",
   };
 
-  return api.post<
-    KlawApiResponse<"schemaUpload">,
-    KlawApiRequest<"schemaUpload">
-  >(`/uploadSchema`, payload);
+  return api.post<KlawApiResponse<"schemaUpload">, CreateSchemaRequestPayload>(
+    `/uploadSchema`,
+    payload
+  );
 };
 
 type GetSchemaRequestsArgs = {
@@ -36,7 +32,7 @@ type GetSchemaRequestsQueryParams = ResolveIntersectionTypes<
   Required<
     Pick<
       operations["getSchemaRequestsForApprover"]["parameters"]["query"],
-      "pageNo" | "requestsType"
+      "pageNo" | "requestStatus"
     >
   >
 >;
@@ -47,9 +43,7 @@ const getSchemaRequestsForApprover = ({
 }: GetSchemaRequestsArgs): Promise<SchemaRequestApiResponse> => {
   const queryObject: GetSchemaRequestsQueryParams = {
     pageNo: pageNumber.toString(),
-    // This is a naming mix up in backend, we want to query
-    // for the status, not the type. Will be changed there soon.
-    requestsType: requestStatus,
+    requestStatus: requestStatus,
   };
   return api
     .get<KlawApiResponse<"getSchemaRequestsForApprover">>(

--- a/coral/src/domain/schema-request/schema-request-transformer.test.ts
+++ b/coral/src/domain/schema-request/schema-request-transformer.test.ts
@@ -2,8 +2,6 @@ import { transformGetSchemaRequestsForApproverResponse } from "src/domain/schema
 import {
   SchemaRequest,
   SchemaRequestApiResponse,
-  SchemaRequestStatus,
-  SchemaRequestType,
 } from "src/domain/schema-request/schema-request-types";
 
 describe("schema-request-transformer.ts", () => {
@@ -37,8 +35,8 @@ describe("schema-request-transformer.ts", () => {
           username: "jlpicard",
           requesttime: "1987-09-28T13:37:00.001+00:00",
           requesttimestring: "28-Sep-1987 13:37:00",
-          topicstatus: "created" as SchemaRequestStatus,
-          requesttype: "Create" as SchemaRequestType,
+          requestStatus: "CREATED",
+          requestOperationType: "CREATE",
           remarks: "asap",
           approvingTeamDetails:
             "Team : NCC1701D, Users : jlpicard, worf, bcrusher, geordilf",
@@ -63,8 +61,8 @@ describe("schema-request-transformer.ts", () => {
           username: "bcrusher",
           requesttime: "1994-23-05T13:37:00.001+00:00",
           requesttimestring: "23-May-1994 13:37:00",
-          topicstatus: "created" as SchemaRequestStatus,
-          requesttype: "Delete" as SchemaRequestType,
+          requestStatus: "CREATED",
+          requestOperationType: "DELETE",
           remarks: "asap",
           approvingTeamDetails:
             "Team : NCC1701D, Users : jlpicard, worf, bcrusher, geordilf",

--- a/coral/src/domain/schema-request/schema-request-types.ts
+++ b/coral/src/domain/schema-request/schema-request-types.ts
@@ -1,5 +1,5 @@
 import { KlawApiModel, Paginated, ResolveIntersectionTypes } from "types/utils";
-import { RequestStatus, RequestType } from "src/domain/requests";
+import { RequestStatus, RequestOperationType } from "src/domain/requests";
 
 type CreatedSchemaRequests = ResolveIntersectionTypes<
   Required<
@@ -14,47 +14,30 @@ type CreatedSchemaRequests = ResolveIntersectionTypes<
   >
 >;
 
-type SchemaRequestPayload = ResolveIntersectionTypes<
+type CreateSchemaRequestPayload = ResolveIntersectionTypes<
   Required<
     Pick<
       KlawApiModel<"SchemaRequest">,
       "environment" | "schemafull" | "topicname"
     >
   > &
-    Pick<KlawApiModel<"SchemaRequest">, "remarks" | "schemaversion" | "appname">
+    Partial<KlawApiModel<"SchemaRequest">>
 >;
 
-type SchemaRequestType = RequestType;
+type SchemaRequestOperationType = RequestOperationType;
 type SchemaRequestStatus = RequestStatus;
 
-type SchemaRequest = ResolveIntersectionTypes<
-  Required<
-    Pick<
-      KlawApiModel<"SchemaRequest">,
-      | "req_no"
-      | "topicname"
-      | "environment"
-      | "environmentName"
-      | "teamname"
-      | "username"
-      | "requesttimestring"
-      | "requesttype"
-      | "remarks"
-      | "approvingTeamDetails"
-    >
-  > &
-    KlawApiModel<"SchemaRequest">
->;
+type SchemaRequest = ResolveIntersectionTypes<KlawApiModel<"SchemaRequest">>;
 
 type SchemaRequestApiResponse = ResolveIntersectionTypes<
   Paginated<SchemaRequest[]>
 >;
 
 export type {
-  SchemaRequestPayload,
+  CreateSchemaRequestPayload,
   CreatedSchemaRequests,
   SchemaRequest,
-  SchemaRequestType,
+  SchemaRequestOperationType,
   SchemaRequestStatus,
   SchemaRequestApiResponse,
 };

--- a/coral/src/domain/topic/index.ts
+++ b/coral/src/domain/topic/index.ts
@@ -6,7 +6,7 @@ import {
 import {
   Topic,
   TopicNames,
-  TopicRequestTypes,
+  TopicRequestOperationTypes,
   TopicTeam,
   TopicRequestStatus,
   TopicRequest,
@@ -17,7 +17,7 @@ export type {
   TopicNames,
   TopicTeam,
   TopicRequest,
-  TopicRequestTypes,
+  TopicRequestOperationTypes,
   TopicRequestStatus,
 };
 export { getTopics, getTopicNames, getTopicTeam };

--- a/coral/src/domain/topic/topic-api.msw.ts
+++ b/coral/src/domain/topic/topic-api.msw.ts
@@ -210,7 +210,7 @@ const mockedResponseTopicTeamPrefixed: KlawApiResponse<"topicGetTeam"> = {
   team: "prefixed-Ospo",
 };
 
-function mockGetTopicRequests({
+function mockGetTopicRequestsForApprover({
   mswInstance,
   response,
 }: {
@@ -245,5 +245,5 @@ export {
   mockGetTopicTeam,
   mockedResponseTopicTeamLiteral,
   mockedResponseTopicTeamPrefixed,
-  mockGetTopicRequests,
+  mockGetTopicRequestsForApprover,
 };

--- a/coral/src/domain/topic/topic-api.test.ts
+++ b/coral/src/domain/topic/topic-api.test.ts
@@ -5,10 +5,9 @@ import {
 import { server } from "src/services/api-mocks/server";
 import api from "src/services/api";
 import {
-  mockGetTopicRequests,
+  mockGetTopicRequestsForApprover,
   mockRequestTopic,
 } from "src/domain/topic/topic-api.msw";
-import { createMockTopicRequestApiResource } from "src/domain/topic/topic-test-helper";
 
 describe("topic-api", () => {
   beforeAll(() => {
@@ -50,19 +49,19 @@ describe("topic-api", () => {
 
   describe("getTopicRequests", () => {
     beforeEach(() => {
-      mockGetTopicRequests({
+      mockGetTopicRequestsForApprover({
         mswInstance: server,
         response: {
-          data: [createMockTopicRequestApiResource()],
+          data: [],
         },
       });
     });
     it("calls api.get with correct URL", async () => {
       const getSpy = jest.spyOn(api, "get");
-      await getTopicRequestsForApprover({ requestStatus: "created" });
+      await getTopicRequestsForApprover({ requestStatus: "CREATED" });
       expect(getSpy).toHaveBeenCalledTimes(1);
       expect(getSpy).toHaveBeenCalledWith(
-        "/getTopicRequestsForApprover?pageNo=1&currentPage=1&requestsType=created"
+        "/getTopicRequestsForApprover?pageNo=1&currentPage=1&requestStatus=CREATED"
       );
     });
   });

--- a/coral/src/domain/topic/topic-api.ts
+++ b/coral/src/domain/topic/topic-api.ts
@@ -113,7 +113,7 @@ type GetTopicRequestsQueryParams = ResolveIntersectionTypes<
   Required<
     Pick<
       operations["getTopicRequestsForApprover"]["parameters"]["query"],
-      "pageNo" | "currentPage" | "requestsType"
+      "pageNo" | "currentPage" | "requestStatus"
     >
   >
 >;
@@ -126,9 +126,7 @@ const getTopicRequestsForApprover = ({
   const queryObject: GetTopicRequestsQueryParams = {
     pageNo: pageNumber.toString(),
     currentPage: currentPage.toString(),
-    // This is a naming mix up in backend, we want to query
-    // for the status, not the type. Will be changed there soon.
-    requestsType: requestStatus,
+    requestStatus: requestStatus,
   };
   return api
     .get<KlawApiResponse<"getTopicRequestsForApprover">>(

--- a/coral/src/domain/topic/topic-test-helper.ts
+++ b/coral/src/domain/topic/topic-test-helper.ts
@@ -1,10 +1,5 @@
-import {
-  Topic,
-  TopicRequest,
-  TopicRequestStatus,
-  TopicRequestTypes,
-} from "src/domain/topic/topic-types";
-import { KlawApiModel, KlawApiResponse } from "types/utils";
+import { Topic, TopicRequest } from "src/domain/topic/topic-types";
+import { KlawApiResponse } from "types/utils";
 
 // currently this file is used in code (topcis-api.msw.ts)
 // so "expect" is not defined there
@@ -133,29 +128,23 @@ const defaultTopicRequest: TopicRequest = {
       configValue: "delete",
     },
   ],
-  topictype: "Create" as TopicRequestTypes,
+  requestOperationType: "CREATE",
   requestor: "jlpicard",
   requesttime: "1987-09-28T13:37:00.001+00:00",
   requesttimestring: "28-Sep-1987 13:37:00",
-  topicstatus: "created" as TopicRequestStatus,
+  requestStatus: "CREATED",
   totalNoPages: "1",
   approvingTeamDetails:
     "Team : NCC1701D, Users : jlpicard, worf, bcrusher, geordilf,",
   teamId: 1003,
   allPageNos: ["1"],
   currentPage: "1",
+  editable: true,
+  deletable: true,
 };
 
 function createMockTopicRequest(request?: Partial<TopicRequest>): TopicRequest {
   return { ...defaultTopicRequest, ...request };
-}
-
-const defaultTopicRequestApiResource = {};
-
-function createMockTopicRequestApiResource(
-  request?: Partial<KlawApiModel<"TopicRequest">>
-): KlawApiModel<"TopicRequest"> {
-  return { ...defaultTopicRequestApiResource, ...request };
 }
 
 export {
@@ -163,5 +152,4 @@ export {
   createMockTopicApiResponse,
   baseTestObjectMockedTopic,
   createMockTopicRequest,
-  createMockTopicRequestApiResource,
 };

--- a/coral/src/domain/topic/topic-transformer.test.ts
+++ b/coral/src/domain/topic/topic-transformer.test.ts
@@ -7,8 +7,7 @@ import {
   Topic,
   TopicApiResponse,
   TopicRequestApiResponse,
-  TopicRequestStatus,
-  TopicRequestTypes,
+  TopicRequest,
 } from "src/domain/topic/topic-types";
 import {
   baseTestObjectMockedTopic,
@@ -110,7 +109,7 @@ describe("topic-transformer.ts", () => {
     });
 
     it("transforms all response items into expected type", () => {
-      const mockedResponse = [
+      const mockedResponse: TopicRequest[] = [
         {
           topicname: "test-topic-1",
           environment: "1",
@@ -127,17 +126,19 @@ describe("topic-transformer.ts", () => {
               configValue: "delete",
             },
           ],
-          topictype: "Create" as TopicRequestTypes,
+          requestOperationType: "CREATE",
           requestor: "jlpicard",
           requesttime: "1987-09-28T13:37:00.001+00:00",
           requesttimestring: "28-Sep-1987 13:37:00",
-          topicstatus: "created" as TopicRequestStatus,
+          requestStatus: "CREATED",
           totalNoPages: "3",
           approvingTeamDetails:
             "Team : NCC1701D, Users : jlpicard, worf, bcrusher, geordilf,",
           teamId: 1003,
           allPageNos: ["1"],
           currentPage: "1",
+          editable: true,
+          deletable: true,
         },
         {
           topicname: "test-topic-2",
@@ -156,17 +157,19 @@ describe("topic-transformer.ts", () => {
             },
           ],
 
-          topictype: "Update" as TopicRequestTypes,
+          requestOperationType: "UPDATE",
           requestor: "bcrusher",
           requesttime: "1994-23-05T13:37:00.001+00:00",
           requesttimestring: "23-May-1994 13:37:00",
-          topicstatus: "approved" as TopicRequestStatus,
+          requestStatus: "APPROVED",
           totalNoPages: "3",
           approvingTeamDetails:
             "Team : NCC1701D, Users : jlpicard, worf, bcrusher, geordilf,",
           teamId: 1003,
           allPageNos: ["1"],
           currentPage: "1",
+          editable: true,
+          deletable: true,
         },
       ];
       const transformedResponse =

--- a/coral/src/domain/topic/topic-types.ts
+++ b/coral/src/domain/topic/topic-types.ts
@@ -3,7 +3,7 @@ import type {
   Paginated,
   ResolveIntersectionTypes,
 } from "types/utils";
-import { RequestStatus, RequestType } from "src/domain/requests";
+import { RequestStatus, RequestOperationType } from "src/domain/requests";
 
 type TopicApiResponse = ResolveIntersectionTypes<Paginated<Topic[]>>;
 
@@ -22,24 +22,10 @@ type TopicAdvancedConfigurationOptions = {
   };
 };
 
-type TopicRequestTypes = RequestType;
+type TopicRequestOperationTypes = RequestOperationType;
 type TopicRequestStatus = RequestStatus;
 
-type TopicRequest = ResolveIntersectionTypes<
-  Required<
-    Pick<
-      KlawApiModel<"TopicRequest">,
-      | "topicid"
-      | "topicname"
-      | "environmentName"
-      | "topictype"
-      | "teamname"
-      | "requestor"
-      | "requesttimestring"
-    >
-  > &
-    KlawApiModel<"TopicRequest">
->;
+type TopicRequest = ResolveIntersectionTypes<KlawApiModel<"TopicRequest">>;
 
 type TopicRequestApiResponse = ResolveIntersectionTypes<
   Paginated<TopicRequest[]>
@@ -52,7 +38,7 @@ export type {
   TopicApiResponse,
   TopicAdvancedConfigurationOptions,
   TopicRequest,
-  TopicRequestTypes,
+  TopicRequestOperationTypes,
   TopicRequestStatus,
   TopicRequestApiResponse,
 };

--- a/coral/types/api.d.ts
+++ b/coral/types/api.d.ts
@@ -614,7 +614,7 @@ export type components = {
        */
       acl_ssl?: string[];
       /**
-       * @description If topictype is consumer, this field can only be LITERAL. If topictype is producer, this field can be LITERAL or PREFIXED
+       * @description If aclType is consumer, this field can only be LITERAL. If aclType is producer, this field can be LITERAL or PREFIXED
        * @example LITERAL
        * @enum {string}
        */
@@ -665,7 +665,7 @@ export type components = {
        * @example PRODUCER
        * @enum {string}
        */
-      aclType?: "PRODUCER" | "CONSUMER";
+      aclType: "PRODUCER" | "CONSUMER";
       /** @example User */
       username?: string;
       /**
@@ -675,7 +675,6 @@ export type components = {
       requesttime?: string;
       /** @example 10-11-2020 10:45:30 */
       requesttimestring?: string;
-      /** @example created */
       requestStatus?: components["schemas"]["RequestStatus"];
       approver?: string;
       /**
@@ -707,8 +706,6 @@ export type components = {
       allPageNos?: string[];
       /** @example DevRel */
       approvingTeamDetails?: string;
-    } & {
-      topictype: unknown;
     };
     /** SchemaRequest */
     SchemaRequest: {

--- a/coral/types/api.d.ts
+++ b/coral/types/api.d.ts
@@ -716,49 +716,49 @@ export type components = {
        * unique identifier
        * Format: int32
        */
-      req_no?: number;
+      req_no: number;
       /**
        * Topic name
        * @description Kafka Topic name
        * @example testtopic
        */
-      topicname?: string;
+      topicname: string;
       /**
        * environment
        * @description Id of the environment
        * @example 3
        */
-      environment?: string;
+      environment: string;
       /**
        * environmentName
        * @description Name of the environment
        * @example DEV
        */
-      environmentName?: string;
+      environmentName: string;
       /**
        * schemaversion
        * @description SchemaRequest version
        * @example 1.0
        */
-      schemaversion?: string;
+      schemaversion: string;
       /**
        * Team name
        * @description Topic owner team name
        * @example Infra
        */
-      teamname?: string;
+      teamname: string;
       /**
        * Team ID
        * Format: int32
        * @description Team identifier
        * @example 1010
        */
-      teamId?: number;
+      teamId: number;
       /**
        * App name
        * @example App
        */
-      appname?: string;
+      appname: string;
       /**
        * schemafull
        * @description A valid json/avro schema
@@ -784,20 +784,20 @@ export type components = {
        * @description Username
        * @example jon.snow@klaw-project.io
        */
-      username?: string;
+      username: string;
       /**
        * Request time
        * Format: date-time
        * @example 2018-11-13T20:20:39.000Z
        */
-      requesttime?: string;
+      requesttime: string;
       /**
        * Request time string representation
        * @example 28-Dec-2022 14:54:57
        */
-      requesttimestring?: string;
-      requestStatus?: components["schemas"]["RequestStatus"];
-      requestOperationType?: components["schemas"]["RequestOperationType"];
+      requesttimestring: string;
+      requestStatus: components["schemas"]["RequestStatus"];
+      requestOperationType: components["schemas"]["RequestOperationType"];
       forceRegister?: boolean;
       /**
        * Remarks
@@ -817,7 +817,7 @@ export type components = {
        * Approving team details
        * @example Team : Stark, Users : jonsnow,sansastark,aryastark,branstark
        */
-      approvingTeamDetails?: string;
+      approvingTeamDetails: string;
       /**
        * Total number of pages
        * @example 3
@@ -838,8 +838,8 @@ export type components = {
        * @example 2
        */
       currentPage?: string;
-      editable?: boolean;
-      deletable?: boolean;
+      editable: boolean;
+      deletable: boolean;
     };
     TopicRequest: {
       /**
@@ -853,12 +853,12 @@ export type components = {
        * @description ID of environment
        * @example 1
        */
-      environment?: string;
+      environment: string;
       /**
        * Topic partitions
        * Format: int32
        */
-      topicpartitions?: number;
+      topicpartitions: number;
       /**
        * Team name
        * @description Topic owner team name
@@ -880,7 +880,7 @@ export type components = {
        * Replication factor
        * @example 1
        */
-      replicationfactor?: string;
+      replicationfactor: string;
       /**
        * Environment name
        * @example DEV
@@ -908,10 +908,10 @@ export type components = {
        * Format: date-time
        * @example 2018-11-13T20:20:39.000Z
        */
-      requesttime?: string;
+      requesttime: string;
       /** Request time string */
       requesttimestring: string;
-      requestStatus?: components["schemas"]["RequestStatus"];
+      requestStatus: components["schemas"]["RequestStatus"];
       /**
        * Approver
        * @example jon.snow@klaw-project.io
@@ -943,7 +943,7 @@ export type components = {
        * Approving team details
        * @example Team : Stark, Users : jonsnow,sansastark,aryastark,branstark
        */
-      approvingTeamDetails?: string;
+      approvingTeamDetails: string;
       /**
        * Other parameters
        * @description Topic configuration parameters
@@ -955,7 +955,7 @@ export type components = {
        * Format: int32
        * @example 1010
        */
-      teamId?: number;
+      teamId: number;
       /**
        * All page numbers
        * @description List of all page numbers
@@ -971,6 +971,10 @@ export type components = {
        * @example 1
        */
       currentPage?: string;
+      /** Topic can be edited */
+      editable: boolean;
+      /** Topic can be deleted */
+      deletable: boolean;
     };
     /** GetAuthResponse */
     GetAuthResponse: {

--- a/coral/types/api.d.ts
+++ b/coral/types/api.d.ts
@@ -706,6 +706,8 @@ export type components = {
       allPageNos?: string[];
       /** @example DevRel */
       approvingTeamDetails?: string;
+      editable?: boolean;
+      deletable?: boolean;
     };
     /** SchemaRequest */
     SchemaRequest: {

--- a/coral/types/api.d.ts
+++ b/coral/types/api.d.ts
@@ -164,17 +164,17 @@ export type components = {
       data?: { [key: string]: unknown };
     };
     /**
-     * Type of request related to topic
-     * @example Update
+     * Type of request operation
+     * @example UPDATE
      * @enum {string}
      */
-    RequestType: "Create" | "Update" | "Delete" | "Claim" | "Promote";
+    RequestOperationType: "CREATE" | "UPDATE" | "DELETE" | "CLAIM" | "PROMOTE";
     /**
      * Status of a request
-     * @example created
+     * @example CREATED
      * @enum {string}
      */
-    RequestStatus: "created" | "deleted" | "declined" | "approved" | "all";
+    RequestStatus: "CREATED" | "DELETED" | "DECLINED" | "APPROVED" | "ALL";
     UserAuthenticationRequest: {
       /**
        * username
@@ -526,11 +526,7 @@ export type components = {
       }[];
       /** App name */
       appname?: string;
-      /**
-       * Topic type
-       * @enum {string}
-       */
-      topictype?: "Create" | "Update" | "Delete" | "Claim";
+      requestOperationType?: components["schemas"]["RequestOperationType"];
       /** Requestor */
       requestor?: string;
       /**
@@ -541,7 +537,7 @@ export type components = {
       requesttime?: string;
       /** Request time string */
       requesttimestring?: string;
-      topicstatus?: components["schemas"]["RequestStatus"];
+      requestStatus?: components["schemas"]["RequestStatus"];
       /**
        * Approver
        * @example jon.snow@klaw-project.io
@@ -599,7 +595,7 @@ export type components = {
        */
       remarks?: string;
       /**
-       * @description This is mandatory if topictype is consumer
+       * @description This is mandatory if acl type is consumer
        * @example Group-one
        */
       consumergroup?: string;
@@ -666,10 +662,10 @@ export type components = {
       /** @example App */
       appname?: string;
       /**
-       * @example Producer
+       * @example PRODUCER
        * @enum {string}
        */
-      topictype: "Producer" | "Consumer";
+      aclType?: "PRODUCER" | "CONSUMER";
       /** @example User */
       username?: string;
       /**
@@ -680,18 +676,13 @@ export type components = {
       /** @example 10-11-2020 10:45:30 */
       requesttimestring?: string;
       /** @example created */
-      aclstatus?: components["schemas"]["RequestStatus"];
+      requestStatus?: components["schemas"]["RequestStatus"];
       approver?: string;
       /**
        * Format: date-time
        * @example 2018-03-20T09:12:28Z
        */
       approvingtime?: string;
-      /**
-       * @example Producer
-       * @enum {string}
-       */
-      aclType?: "Producer" | "Consumer";
       /**
        * @example PRINCIPAL
        * @enum {string}
@@ -716,6 +707,8 @@ export type components = {
       allPageNos?: string[];
       /** @example DevRel */
       approvingTeamDetails?: string;
+    } & {
+      topictype: unknown;
     };
     /** SchemaRequest */
     SchemaRequest: {
@@ -803,8 +796,8 @@ export type components = {
        * @example 28-Dec-2022 14:54:57
        */
       requesttimestring?: string;
-      topicstatus?: components["schemas"]["RequestStatus"];
-      requesttype?: components["schemas"]["RequestType"];
+      requestStatus?: components["schemas"]["RequestStatus"];
+      requestOperationType?: components["schemas"]["RequestOperationType"];
       forceRegister?: boolean;
       /**
        * Remarks
@@ -854,7 +847,7 @@ export type components = {
        * @description Kafka Topic name
        * @example topicName
        */
-      topicname?: string;
+      topicname: string;
       /**
        * Environment
        * @description ID of environment
@@ -871,7 +864,7 @@ export type components = {
        * @description Topic owner team name
        * @example application-X-developers
        */
-      teamname?: string;
+      teamname: string;
       /**
        * Remarks
        * @description Message for the approval
@@ -892,14 +885,14 @@ export type components = {
        * Environment name
        * @example DEV
        */
-      environmentName?: string;
+      environmentName: string;
       /**
        * Topic identifier
        * Format: int32
        * @description This identifier is used in Klaw metadata store to ensure uniquenes.
        * @example 1010
        */
-      topicid?: number;
+      topicid: number;
       /** Advanced topic configuration entries */
       advancedTopicConfigEntries?: {
         configKey?: string;
@@ -907,9 +900,9 @@ export type components = {
       }[];
       /** App name */
       appname?: string;
-      topictype?: components["schemas"]["RequestType"];
+      requestOperationType: components["schemas"]["RequestOperationType"];
       /** Requestor */
-      requestor?: string;
+      requestor: string;
       /**
        * Request time
        * Format: date-time
@@ -917,8 +910,8 @@ export type components = {
        */
       requesttime?: string;
       /** Request time string */
-      requesttimestring?: string;
-      topicstatus?: components["schemas"]["RequestStatus"];
+      requesttimestring: string;
+      requestStatus?: components["schemas"]["RequestStatus"];
       /**
        * Approver
        * @example jon.snow@klaw-project.io
@@ -1179,7 +1172,7 @@ export type operations = {
       query: {
         pageNo: string;
         currentPage?: string;
-        requestsType?: components["schemas"]["RequestStatus"];
+        requestStatus?: components["schemas"]["RequestStatus"];
         topic?: string;
         env?: string;
         aclType?: "CONSUMER" | "PRODUCER";
@@ -1272,8 +1265,7 @@ export type operations = {
       query: {
         pageNo: string;
         currentPage?: string;
-        /** Naming is a mistake (will change), this relates to the status of a request */
-        requestsType?: components["schemas"]["RequestStatus"];
+        requestStatus?: components["schemas"]["RequestStatus"];
         teamId?: number;
         env?: string;
         search?: string;
@@ -1283,7 +1275,7 @@ export type operations = {
       /** successful operation */
       200: {
         content: {
-          "application/json": components["schemas"]["TopicRequestModel"][];
+          "application/json": components["schemas"]["TopicRequest"][];
         };
       };
     };
@@ -1332,8 +1324,7 @@ export type operations = {
       query: {
         pageNo: string;
         currentPage?: string;
-        /** Naming is a mistake (will change), this relates to the status of a request */
-        requestsType?: components["schemas"]["RequestStatus"];
+        requestStatus?: components["schemas"]["RequestStatus"];
         /** Name of a topic */
         topic?: string;
         /** Environment identifier */
@@ -1345,7 +1336,7 @@ export type operations = {
       /** successful operation */
       200: {
         content: {
-          "application/json": components["schemas"]["SchemaRequestModel"][];
+          "application/json": components["schemas"]["SchemaRequest"][];
         };
       };
     };

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1253,6 +1253,10 @@ components:
         approvingTeamDetails:
           type: string
           example: "DevRel"
+        editable:
+          type: boolean
+        deletable:
+          type: boolean
     SchemaRequest:
       title: SchemaRequest
       required:

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -288,12 +288,12 @@ paths:
           required: false
           schema:
             type: string
-        - name: requestsType
+        - name: requestStatus
           in: query
           required: false
           schema:
             $ref: "#/components/schemas/RequestStatus"
-          example: "created"
+          example: "CREATED"
         - name: topic
           in: query
           required: false
@@ -438,10 +438,9 @@ paths:
           example: "2"
           schema:
             type: string
-        - name: requestsType
+        - name: requestStatus
           in: query
-          description: Naming is a mistake (will change), this relates to the status of a request
-          example: created
+          example: "CREATED"
           schema:
             $ref: "#/components/schemas/RequestStatus"
         - name: teamId
@@ -467,7 +466,7 @@ paths:
               schema:
                 type: array
                 items:
-                  $ref: "#/components/schemas/TopicRequestModel"
+                  $ref: "#/components/schemas/TopicRequest"
   /getAuth:
     get:
       operationId: getAuth
@@ -530,11 +529,11 @@ paths:
           example: "1"
           schema:
             type: string
-        - name: requestsType
+        - name: requestStatus
           in: query
-          description: Naming is a mistake (will change), this relates to the status of a request
           schema:
             $ref: "#/components/schemas/RequestStatus"
+          example: "CREATED"
         - name: topic
           description: Name of a topic
           example: "testtopic1"
@@ -559,7 +558,7 @@ paths:
               schema:
                 type: array
                 items:
-                  $ref: "#/components/schemas/SchemaRequestModel"
+                  $ref: "#/components/schemas/SchemaRequest"
 components:
   schemas:
     CommonError:
@@ -657,26 +656,26 @@ components:
           type: string
         data:
           type: object
-    RequestType:
-      title: Type of request related to topic
+    RequestOperationType:
+      title: Type of request operation
       type: string
       enum:
-        - Create
-        - Update
-        - Delete
-        - Claim
-        - Promote
-      example: Update
+        - CREATE
+        - UPDATE
+        - DELETE
+        - CLAIM
+        - PROMOTE
+      example: UPDATE
     RequestStatus:
       type: string
       title: Status of a request
       enum:
-        - created
-        - deleted
-        - declined
-        - approved
-        - all
-      example: created
+        - CREATED
+        - DELETED
+        - DECLINED
+        - APPROVED
+        - ALL
+      example: CREATED
     UserAuthenticationRequest:
       type: object
       required:
@@ -1070,14 +1069,8 @@ components:
         appname:
           title: App name
           type: string
-        topictype:
-          title: Topic type
-          type: string
-          enum:
-            - Create
-            - Update
-            - Delete
-            - Claim
+        requestOperationType:
+          $ref: "#/components/schemas/RequestOperationType"
         requestor:
           title: Requestor
           type: string
@@ -1089,7 +1082,7 @@ components:
         requesttimestring:
           title: Request time string
           type: string
-        topicstatus:
+        requestStatus:
           $ref: "#/components/schemas/RequestStatus"
         approver:
           title: Approver
@@ -1157,7 +1150,7 @@ components:
           pattern: ^$|^[a-zA-Z0-9_.-]{3,}$
           type: string
           example: "Group-one"
-          description: "This is mandatory if topictype is consumer"
+          description: "This is mandatory if acl type is consumer"
         acl_ip:
           type: array
           items:
@@ -1212,10 +1205,10 @@ components:
         appname:
           type: string
           example: "App"
-        topictype:
+        aclType:
           type: string
-          enum: ["Producer", "Consumer"]
-          example: "Producer"
+          enum: ["PRODUCER", "CONSUMER"]
+          example: "PRODUCER"
         username:
           type: string
           example: "User"
@@ -1227,7 +1220,7 @@ components:
           type: string
           pattern: dd-MMM-yyyy HH:mm:ss
           example: "10-11-2020 10:45:30"
-        aclstatus:
+        requestStatus:
           $ref: "#/components/schemas/RequestStatus"
           example: "created"
         approver:
@@ -1236,10 +1229,6 @@ components:
           type: string
           format: date-time
           example: "2018-03-20T09:12:28Z"
-        aclType:
-          type: string
-          enum: ["Producer", "Consumer"]
-          example: "Producer"
         aclIpPrincipleType:
           type: string
           enum: ["IP_ADDRESS", "PRINCIPAL", "USERNAME"]
@@ -1330,10 +1319,10 @@ components:
           title: Request time string representation
           type: string
           example: "28-Dec-2022 14:54:57"
-        topicstatus:
+        requestStatus:
           $ref: "#/components/schemas/RequestStatus"
-        requesttype:
-          $ref: "#/components/schemas/RequestType"
+        requestOperationType:
+          $ref: "#/components/schemas/RequestOperationType"
         forceRegister:
           type: boolean
         remarks:
@@ -1375,6 +1364,14 @@ components:
           type: boolean
     TopicRequest:
       type: object
+      required:
+        - "topicid"
+        - "topicname"
+        - "environmentName"
+        - "requestOperationType"
+        - "teamname"
+        - "requestor"
+        - "requesttimestring"
       properties:
         topicname:
           title: Topic name
@@ -1433,8 +1430,8 @@ components:
         appname:
           title: App name
           type: string
-        topictype:
-          $ref: "#/components/schemas/RequestType"
+        requestOperationType:
+          $ref: "#/components/schemas/RequestOperationType"
         requestor:
           title: Requestor
           type: string
@@ -1446,7 +1443,7 @@ components:
         requesttimestring:
           title: Request time string
           type: string
-        topicstatus:
+        requestStatus:
           $ref: "#/components/schemas/RequestStatus"
         approver:
           title: Approver

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -313,7 +313,6 @@ paths:
             type: string
             enum: ["CONSUMER", "PRODUCER"]
           example: "CONSUMER"
-          default: "CONSUMER"
       responses:
         "200":
           description: OK
@@ -1137,7 +1136,7 @@ components:
         - topicname
         - environment
         - teamname
-        - topictype
+        - aclType
         - aclIpPrincipleType
       type: object
       properties:
@@ -1165,7 +1164,9 @@ components:
           type: string
           enum: ["LITERAL", "PREFIXED"]
           example: "LITERAL"
-          description: "If topictype is consumer, this field can only be LITERAL. If topictype is producer, this field can be LITERAL or PREFIXED"
+          description:
+            "If aclType is consumer, this field can only be LITERAL. If aclType is producer, this field
+            can be LITERAL or PREFIXED"
         transactionalId:
           pattern: ^$|^[a-zA-Z0-9_.-]{3,}$
           type: string
@@ -1222,7 +1223,6 @@ components:
           example: "10-11-2020 10:45:30"
         requestStatus:
           $ref: "#/components/schemas/RequestStatus"
-          example: "created"
         approver:
           type: string
         approvingtime:
@@ -1256,7 +1256,23 @@ components:
     SchemaRequest:
       title: SchemaRequest
       required:
+        - environment
+        - environmentName
         - schemafull
+        - schemaversion
+        - topicname
+        - appname
+        - teamId
+        - teamname
+        - username
+        - req_no
+        - requesttime
+        - requesttimestring
+        - requestStatus
+        - requestOperationType
+        - approvingTeamDetails
+        - editable
+        - deletable
       type: object
       properties:
         req_no:
@@ -1365,13 +1381,22 @@ components:
     TopicRequest:
       type: object
       required:
-        - "topicid"
-        - "topicname"
-        - "environmentName"
-        - "requestOperationType"
-        - "teamname"
-        - "requestor"
-        - "requesttimestring"
+        - topicname
+        - environment
+        - topicpartitions
+        - teamname
+        - teamId
+        - approvingTeamDetails
+        - replicationfactor
+        - environmentName
+        - topicid
+        - requestOperationType
+        - requestor
+        - requesttime
+        - requesttimestring
+        - requestStatus
+        - editable
+        - deletable
       properties:
         topicname:
           title: Topic name
@@ -1498,6 +1523,12 @@ components:
           title: Current page number
           type: string
           example: "1"
+        editable:
+          title: Topic can be edited
+          type: boolean
+        deletable:
+          title: Topic can be deleted
+          type: boolean
     GetAuthResponse:
       title: GetAuthResponse
       type: object


### PR DESCRIPTION
# About this change - What it does

Updates openapi definition as well as our types and usage after changes from #649 

## Details: 
- we now use `requestStatus` and `requestOperationType` everywhere in api def
- I've updated `RequestType` to `RequestOperationType` to match backend naming
- `topictype` in `aclRequest` changes to `aclType`
- in sync with Backend, I updated the required properties for `TopicSchema` and `SchemaRequest` 
    - ! `SchemaRequest` is used for `uploadSchema` _and_ `getSchemaRequestsForApprover`, even so the properties needed and available are different. `CreatedSchemaRequests` type in frontend is kind of faking things a bit here 🙈 



Resolves: #650 

