### PR TITLE
fix(coral): Do not allow approve/reject when requestStatus is not CREATED

### DIFF
--- a/coral/src/app/features/approvals/acls/AclApprovals.test.tsx
+++ b/coral/src/app/features/approvals/acls/AclApprovals.test.tsx
@@ -81,7 +81,7 @@ const mockedAclRequestsForApproverApiResponse: AclRequest[] = [
     username: "amathieu",
     requesttime: "2023-01-10T13:19:10.757+00:00",
     requesttimestring: "10-Jan-2023 13:19:10",
-    requestStatus: "CREATED",
+    requestStatus: "APPROVED",
     approver: undefined,
     approvingtime: undefined,
     aclResourceType: undefined,
@@ -196,6 +196,28 @@ describe("AclApprovals", () => {
       expect(
         cells.filter((cell) => cell.textContent === "3.3.3.32 3.3.3.33 ")
       ).toHaveLength(1);
+    });
+
+    it("render action buttons when status is CREATED", () => {
+      const createdRow = screen.getAllByRole("row")[1];
+
+      expect(createdRow).toContainElement(
+        screen.getByRole("button", { name: "Approve request" })
+      );
+      expect(createdRow).toContainElement(
+        screen.getByRole("button", { name: "Reject request" })
+      );
+    });
+
+    it("does not render action buttons when status is not CREATED", () => {
+      const approvedRow = screen.getAllByRole("row")[2];
+
+      expect(approvedRow).not.toContainElement(
+        screen.getByRole("button", { name: "Approve request" })
+      );
+      expect(approvedRow).not.toContainElement(
+        screen.getByRole("button", { name: "Reject request" })
+      );
     });
   });
 

--- a/coral/src/app/features/approvals/acls/AclApprovals.test.tsx
+++ b/coral/src/app/features/approvals/acls/AclApprovals.test.tsx
@@ -249,6 +249,42 @@ describe("AclApprovals", () => {
       const pagination = screen.getByRole("navigation");
       expect(pagination).toHaveTextContent("Page 1 of 2");
     });
+
+    it("should render disabled actions in Details modal", async () => {
+      const approvedRow = screen.getAllByRole("row")[2];
+      await userEvent.click(
+        within(approvedRow).getByRole("button", { name: "View details" })
+      );
+      const modal = screen.getByRole("dialog");
+      const approveButton = within(modal).getByRole("button", {
+        name: "Approve",
+      });
+      const rejectButton = within(modal).getByRole("button", {
+        name: "Reject",
+      });
+
+      expect(approveButton).toBeDisabled();
+      expect(rejectButton).toBeDisabled();
+    });
+
+    it("should render enabled actions in Details modal", async () => {
+      const createdRow = screen.getAllByRole("row")[1];
+
+      await userEvent.click(
+        within(createdRow).getByRole("button", { name: "View details" })
+      );
+
+      const modal = screen.getByRole("dialog");
+      const approveButton = within(modal).getByRole("button", {
+        name: "Approve",
+      });
+      const rejectButton = within(modal).getByRole("button", {
+        name: "Reject",
+      });
+
+      expect(approveButton).toBeEnabled();
+      expect(rejectButton).toBeEnabled();
+    });
   });
 
   describe("handles filtering", () => {

--- a/coral/src/app/features/approvals/acls/AclApprovals.tsx
+++ b/coral/src/app/features/approvals/acls/AclApprovals.tsx
@@ -318,24 +318,25 @@ function AclApprovals() {
       // Warning: Encountered two children with the same key, ``.
       headerName: "",
       type: "custom",
-      UNSAFE_render: ({ id }: AclRequestTableRow) => {
+      UNSAFE_render: ({ id, requestStatus }: AclRequestTableRow) => {
         const [isLoading, setIsLoading] = useState(false);
-
-        return (
-          <GhostButton
-            onClick={() => {
-              setIsLoading(true);
-              return approveRequest({ req_no: String(id) });
-            }}
-            title={"Approve request"}
-          >
-            {isLoading && approveIsLoading ? (
-              <Icon color="grey-70" icon={loadingIcon} />
-            ) : (
-              <Icon color="grey-70" icon={tickCircle} />
-            )}
-          </GhostButton>
-        );
+        if (requestStatus === "CREATED") {
+          return (
+            <GhostButton
+              onClick={() => {
+                setIsLoading(true);
+                return approveRequest({ req_no: String(id) });
+              }}
+              title={"Approve request"}
+            >
+              {isLoading && approveIsLoading ? (
+                <Icon color="grey-70" icon={loadingIcon} />
+              ) : (
+                <Icon color="grey-70" icon={tickCircle} />
+              )}
+            </GhostButton>
+          );
+        }
       },
     },
     {
@@ -344,15 +345,19 @@ function AclApprovals() {
       // Warning: Encountered two children with the same key, ``.
       headerName: "",
       type: "custom",
-      UNSAFE_render: ({ id }: AclRequestTableRow) => {
-        return (
-          <GhostButton
-            onClick={() => setRejectModal({ isOpen: true, reqNo: String(id) })}
-            title={"Reject request"}
-          >
-            <Icon color="grey-70" icon={deleteIcon} />
-          </GhostButton>
-        );
+      UNSAFE_render: ({ id, requestStatus }: AclRequestTableRow) => {
+        if (requestStatus === "CREATED") {
+          return (
+            <GhostButton
+              onClick={() =>
+                setRejectModal({ isOpen: true, reqNo: String(id) })
+              }
+              title={"Reject request"}
+            >
+              <Icon color="grey-70" icon={deleteIcon} />
+            </GhostButton>
+          );
+        }
       },
     },
   ];
@@ -365,6 +370,10 @@ function AclApprovals() {
         setActivePage={handleChangePage}
       />
     ) : undefined;
+
+  const selectedRequest = data?.entries.find(
+    (request) => request.req_no === Number(detailsModal.reqNo)
+  );
 
   return (
     <>
@@ -379,12 +388,9 @@ function AclApprovals() {
             setRejectModal({ isOpen: true, reqNo: detailsModal.reqNo });
           }}
           isLoading={approveIsLoading}
+          disabledActions={selectedRequest?.requestStatus !== "CREATED"}
         >
-          <DetailsModalContent
-            aclRequest={data?.entries.find(
-              (request) => request.req_no === Number(detailsModal.reqNo)
-            )}
-          />
+          <DetailsModalContent aclRequest={selectedRequest} />
         </RequestDetailsModal>
       )}
       {rejectModal.isOpen && (

--- a/coral/src/app/features/approvals/components/RequestDetailsModal.test.tsx
+++ b/coral/src/app/features/approvals/components/RequestDetailsModal.test.tsx
@@ -73,6 +73,39 @@ describe("RequestDetailsModal.test", () => {
     });
   });
 
+  describe("renders a Modal with correct elements when disabledActions is true", () => {
+    beforeAll(() => {
+      render(
+        <RequestDetailsModal
+          {...baseProps}
+          isLoading={false}
+          disabledActions={true}
+        >
+          <div>content</div>
+        </RequestDetailsModal>
+      );
+    });
+    afterAll(cleanup);
+
+    it("renders correct heading", () => {
+      expect(
+        screen.getByRole("heading", { name: "Request details" })
+      ).toBeVisible();
+    });
+
+    it("renders enabled Close button", () => {
+      expect(screen.getByRole("button", { name: "Close modal" })).toBeEnabled();
+    });
+
+    it("renders disabled Approve button", () => {
+      expect(screen.getByRole("button", { name: "Approve" })).toBeDisabled();
+    });
+
+    it("renders disabled Reject request button", () => {
+      expect(screen.getByRole("button", { name: "Reject" })).toBeDisabled();
+    });
+  });
+
   describe("handles user interaction", () => {
     beforeAll(() => {
       render(

--- a/coral/src/app/features/approvals/components/RequestDetailsModal.tsx
+++ b/coral/src/app/features/approvals/components/RequestDetailsModal.tsx
@@ -7,6 +7,7 @@ interface RequestDetailsModalProps {
   onReject: () => void;
   children: ReactElement;
   isLoading: boolean;
+  disabledActions?: boolean;
 }
 
 const RequestDetailsModal = ({
@@ -15,6 +16,7 @@ const RequestDetailsModal = ({
   onApprove,
   onReject,
   isLoading,
+  disabledActions,
 }: RequestDetailsModalProps) => {
   return (
     <Modal
@@ -24,11 +26,12 @@ const RequestDetailsModal = ({
         text: "Approve",
         onClick: onApprove,
         loading: isLoading,
+        disabled: disabledActions,
       }}
       secondaryAction={{
         text: "Reject",
         onClick: onReject,
-        disabled: isLoading,
+        disabled: isLoading || disabledActions,
       }}
     >
       {children}


### PR DESCRIPTION
## About this change - What it does

- do not render quick actions in rows for request where `requestStatus` is not `CREATED`
- add `disabledActiouns` prop to `RequestDetailsModal` to forbid accepting/rejecting a request  where `requestStatus` is not `CREATED` 

https://user-images.githubusercontent.com/20607294/220363203-3e009693-4593-4d31-8bdc-5ac48f0a25f5.mov


Resolves: #660

