### PR TITLE
feat(coral): Topic request approval: add View details modal

### DIFF
--- a/coral/src/app/features/approvals/topics/TopicApprovals.test.tsx
+++ b/coral/src/app/features/approvals/topics/TopicApprovals.test.tsx
@@ -331,4 +331,52 @@ describe("TopicApprovals", () => {
       });
     });
   });
+  describe("shows a detail modal for schema request", () => {
+    beforeEach(async () => {
+      mockGetTopicRequestsForApprover.mockResolvedValue(mockedApiResponse);
+
+      customRender(<TopicApprovals />, {
+        queryClient: true,
+        memoryRouter: true,
+      });
+
+      await waitForElementToBeRemoved(screen.getByTestId("skeleton-table"));
+    });
+
+    afterEach(() => {
+      jest.clearAllMocks();
+      cleanup();
+    });
+
+    it("shows detail modal for first request returned from the api", async () => {
+      expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+
+      const firstRequest = mockedApiResponse.entries[0];
+      const viewDetailsButton = screen.getByRole("button", {
+        name: `View topic request for ${firstRequest.topicname}`,
+      });
+
+      await userEvent.click(viewDetailsButton);
+      const modal = screen.getByRole("dialog");
+
+      expect(modal).toBeVisible();
+      expect(modal).toHaveTextContent(firstRequest.topicname);
+    });
+
+    it("shows detail modal for last request returned from the api", async () => {
+      expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+
+      const lastRequest =
+        mockedApiResponse.entries[mockedApiResponse.entries.length - 1];
+      const viewDetailsButton = screen.getByRole("button", {
+        name: `View topic request for ${lastRequest.topicname}`,
+      });
+
+      await userEvent.click(viewDetailsButton);
+      const modal = screen.getByRole("dialog");
+
+      expect(modal).toBeVisible();
+      expect(modal).toHaveTextContent(lastRequest.topicname);
+    });
+  });
 });

--- a/coral/src/app/features/approvals/topics/TopicApprovals.tsx
+++ b/coral/src/app/features/approvals/topics/TopicApprovals.tsx
@@ -1,10 +1,13 @@
 import { NativeSelect, SearchInput } from "@aivenio/aquarium";
-import { ApprovalsLayout } from "src/app/features/approvals/components/ApprovalsLayout";
-import { Pagination } from "src/app/components/Pagination";
-import { TopicApprovalsTable } from "src/app/features/approvals/topics/components/TopicApprovalsTable";
 import { useQuery } from "@tanstack/react-query";
-import { getTopicRequestsForApprover } from "src/domain/topic/topic-api";
+import { useState } from "react";
 import { useSearchParams } from "react-router-dom";
+import { Pagination } from "src/app/components/Pagination";
+import { ApprovalsLayout } from "src/app/features/approvals/components/ApprovalsLayout";
+import RequestDetailsModal from "src/app/features/approvals/components/RequestDetailsModal";
+import DetailsModalContent from "src/app/features/approvals/topics/components/DetailsModalContent";
+import { TopicApprovalsTable } from "src/app/features/approvals/topics/components/TopicApprovalsTable";
+import { getTopicRequestsForApprover } from "src/domain/topic/topic-api";
 
 function TopicApprovals() {
   const [searchParams, setSearchParams] = useSearchParams();
@@ -12,6 +15,14 @@ function TopicApprovals() {
   const currentPage = searchParams.get("page")
     ? Number(searchParams.get("page"))
     : 1;
+
+  const [detailsModal, setDetailsModal] = useState<{
+    isOpen: boolean;
+    topicId: number | null;
+  }>({
+    isOpen: false,
+    topicId: null,
+  });
 
   const {
     data: topicRequests,
@@ -68,7 +79,12 @@ function TopicApprovals() {
     </div>,
   ];
 
-  const table = <TopicApprovalsTable requests={topicRequests?.entries || []} />;
+  const table = (
+    <TopicApprovalsTable
+      requests={topicRequests?.entries || []}
+      setDetailsModal={setDetailsModal}
+    />
+  );
   const pagination =
     topicRequests?.totalPages && topicRequests.totalPages > 1 ? (
       <Pagination
@@ -78,15 +94,34 @@ function TopicApprovals() {
       />
     ) : undefined;
 
+  const selectedTopicRequest = topicRequests?.entries.find(
+    (request) => request.topicid === Number(detailsModal.topicId)
+  );
   return (
-    <ApprovalsLayout
-      filters={filters}
-      table={table}
-      pagination={pagination}
-      isLoading={topicRequestsLoading}
-      isErrorLoading={topicRequestsIsError}
-      errorMessage={topicRequestsError}
-    />
+    <>
+      {detailsModal.isOpen && (
+        <RequestDetailsModal
+          onClose={() => setDetailsModal({ isOpen: false, topicId: null })}
+          onApprove={() => {
+            alert("approve");
+          }}
+          onReject={() => {
+            alert("reject");
+          }}
+          isLoading={false}
+        >
+          <DetailsModalContent topicRequest={selectedTopicRequest} />
+        </RequestDetailsModal>
+      )}
+      <ApprovalsLayout
+        filters={filters}
+        table={table}
+        pagination={pagination}
+        isLoading={topicRequestsLoading}
+        isErrorLoading={topicRequestsIsError}
+        errorMessage={topicRequestsError}
+      />
+    </>
   );
 }
 

--- a/coral/src/app/features/approvals/topics/components/DetailsModalContent.test.tsx
+++ b/coral/src/app/features/approvals/topics/components/DetailsModalContent.test.tsx
@@ -1,0 +1,185 @@
+import { cleanup, render, screen } from "@testing-library/react";
+import DetailsModalContent from "src/app/features/approvals/topics/components/DetailsModalContent";
+import { TopicRequest } from "src/domain/topic/topic-types";
+
+const noAdvancedConfigRequest: TopicRequest = {
+  requestOperationType: "CREATE",
+  description: "Hello there",
+  remarks: "hello",
+  topicid: 1015,
+  topicpartitions: 2,
+  replicationfactor: "4",
+  topicname: "newaudittopic",
+  environment: "2",
+  teamname: "Ospo",
+  environmentName: "TST",
+  teamId: 1003,
+  appname: "App",
+  requestor: "amathieu",
+  requesttime: "2023-01-10T13:19:10.757+00:00",
+  requesttimestring: "10-Jan-2023 13:19:10",
+  requestStatus: "CREATED",
+  approver: undefined,
+  approvingtime: undefined,
+  currentPage: "1",
+  otherParams: undefined,
+  totalNoPages: "2",
+  allPageNos: ["1", ">", ">>"],
+  approvingTeamDetails:
+    "Team : Ospo, Users : muralibasani,josepprat,samulisuortti,mirjamaulbach,smustafa,aindriul,",
+  editable: false,
+  deletable: false,
+};
+
+const withAdvancedConfigRequest: TopicRequest = {
+  requestOperationType: "CREATE",
+  description: undefined,
+  remarks: undefined,
+  topicid: 1015,
+  topicpartitions: 2,
+  replicationfactor: "4",
+  topicname: "newaudittopic",
+  environment: "2",
+  teamname: "Ospo",
+  environmentName: "TST",
+  teamId: 1003,
+  appname: "App",
+  requestor: "amathieu",
+  requesttime: "2023-01-10T13:19:10.757+00:00",
+  requesttimestring: "10-Jan-2023 13:19:10",
+  requestStatus: "CREATED",
+  approver: undefined,
+  approvingtime: undefined,
+  currentPage: "1",
+  otherParams: undefined,
+  totalNoPages: "2",
+  allPageNos: ["1", ">", ">>"],
+  approvingTeamDetails:
+    "Team : Ospo, Users : muralibasani,josepprat,samulisuortti,mirjamaulbach,smustafa,aindriul,",
+  editable: false,
+  deletable: false,
+  advancedTopicConfigEntries: [{ configKey: "hello", configValue: "yes" }],
+};
+
+const findDefinition = (term?: string) => {
+  return screen.getAllByRole("definition").find((value) => {
+    console.log(value.textContent);
+    return value.textContent === term;
+  });
+};
+
+const findTerm = (term: string) => {
+  return screen
+    .getAllByRole("term")
+    .find((value) => value.textContent === term);
+};
+
+describe("DetailsModalContent", () => {
+  describe("renders correct content for Topic request (description, remarks, no config)", () => {
+    beforeAll(() => {
+      render(<DetailsModalContent topicRequest={noAdvancedConfigRequest} />);
+    });
+    afterAll(cleanup);
+
+    it("renders Environment", () => {
+      expect(findTerm("Environment")).toBeVisible();
+      expect(findDefinition(noAdvancedConfigRequest.environment)).toBeVisible();
+    });
+    it("renders Request type", () => {
+      expect(findTerm("Request type")).toBeVisible();
+      expect(
+        findDefinition(noAdvancedConfigRequest.requestOperationType)
+      ).toBeVisible();
+    });
+    it("renders Topic", () => {
+      expect(findTerm("Topic")).toBeVisible();
+      expect(findDefinition(noAdvancedConfigRequest.topicname)).toBeVisible();
+    });
+    it("renders Description", () => {
+      expect(findTerm("Description")).toBeVisible();
+      expect(findDefinition(noAdvancedConfigRequest.description)).toBeVisible();
+    });
+    it("renders Topic partition", () => {
+      expect(findTerm("Topic partition")).toBeVisible();
+      expect(
+        findDefinition(String(noAdvancedConfigRequest.topicpartitions))
+      ).toBeVisible();
+    });
+    it("renders Topic replication factor", () => {
+      expect(findTerm("Topic replication factor")).toBeVisible();
+      expect(
+        findDefinition(noAdvancedConfigRequest.replicationfactor)
+      ).toBeVisible();
+    });
+    it("renders Message for the approver", () => {
+      expect(findTerm("Message for the approver")).toBeVisible();
+      expect(findDefinition(noAdvancedConfigRequest.remarks)).toBeVisible();
+    });
+    it("renders Requested by", () => {
+      expect(findTerm("Requested by")).toBeVisible();
+      expect(findDefinition(noAdvancedConfigRequest.requestor)).toBeVisible();
+    });
+    it("renders Requested on", () => {
+      expect(findTerm("Requested on")).toBeVisible();
+      expect(
+        findDefinition(`${noAdvancedConfigRequest.requesttimestring} UTC`)
+      ).toBeVisible();
+    });
+  });
+
+  describe("renders correct content for Topic request (no description,  no remarks, with config)", () => {
+    beforeAll(() => {
+      render(<DetailsModalContent topicRequest={withAdvancedConfigRequest} />);
+    });
+    afterAll(cleanup);
+
+    it("renders Environment", () => {
+      expect(findTerm("Environment")).toBeVisible();
+      expect(findDefinition(noAdvancedConfigRequest.environment)).toBeVisible();
+    });
+    it("renders Request type", () => {
+      expect(findTerm("Request type")).toBeVisible();
+      expect(
+        findDefinition(noAdvancedConfigRequest.requestOperationType)
+      ).toBeVisible();
+    });
+    it("renders Topic", () => {
+      expect(findTerm("Topic")).toBeVisible();
+      expect(findDefinition(noAdvancedConfigRequest.topicname)).toBeVisible();
+    });
+    it("renders Description", () => {
+      expect(findTerm("Description")).toBeVisible();
+      expect(findDefinition("No description")).toBeVisible();
+    });
+    it("renders Topic partition", () => {
+      expect(findTerm("Topic partition")).toBeVisible();
+      expect(
+        findDefinition(String(noAdvancedConfigRequest.topicpartitions))
+      ).toBeVisible();
+    });
+    it("renders Topic replication factor", () => {
+      expect(findTerm("Topic replication factor")).toBeVisible();
+      expect(
+        findDefinition(noAdvancedConfigRequest.replicationfactor)
+      ).toBeVisible();
+    });
+    it("renders Message for the approver", () => {
+      expect(findTerm("Message for the approver")).toBeVisible();
+      expect(findDefinition("No message")).toBeVisible();
+    });
+    it("renders Requested by", () => {
+      expect(findTerm("Requested by")).toBeVisible();
+      expect(findDefinition(noAdvancedConfigRequest.requestor)).toBeVisible();
+    });
+    it("renders Requested on", () => {
+      expect(findTerm("Requested on")).toBeVisible();
+      expect(
+        findDefinition(`${noAdvancedConfigRequest.requesttimestring} UTC`)
+      ).toBeVisible();
+    });
+    it("renders Advanced configuration", () => {
+      expect(findTerm("Advanced configuration")).toBeVisible();
+      expect(screen.getByTestId("topic-advanced-config")).toBeVisible();
+    });
+  });
+});

--- a/coral/src/app/features/approvals/topics/components/DetailsModalContent.tsx
+++ b/coral/src/app/features/approvals/topics/components/DetailsModalContent.tsx
@@ -1,0 +1,140 @@
+import {
+  BorderBox,
+  Flexbox,
+  Grid,
+  GridItem,
+  StatusChip,
+} from "@aivenio/aquarium";
+import MonacoEditor from "@monaco-editor/react";
+import fromPairs from "lodash/fromPairs";
+import isEmpty from "lodash/isEmpty";
+import { TopicRequest } from "src/domain/topic/topic-types";
+
+interface DetailsModalContentProps {
+  topicRequest?: TopicRequest;
+}
+
+const formatAdvancedConfig = (
+  entries: TopicRequest["advancedTopicConfigEntries"]
+) => {
+  if (entries === undefined) {
+    return "";
+  }
+
+  const entriesToFlatObject = fromPairs(
+    entries.map((config) => [config.configKey, config.configValue])
+  );
+
+  const flatObjectToJsonString = JSON.stringify(entriesToFlatObject, null, 2);
+
+  return flatObjectToJsonString;
+};
+
+const Label = ({ children }: { children: React.ReactNode }) => (
+  <dt className="inline-block mb-2 typography-small-strong text-grey-60">
+    {children}
+  </dt>
+);
+
+const DetailsModalContent = ({ topicRequest }: DetailsModalContentProps) => {
+  if (topicRequest === undefined) {
+    return <div>Request not found.</div>;
+  }
+
+  const {
+    environmentName,
+    requestOperationType,
+    topicname,
+    description,
+    topicpartitions,
+    replicationfactor,
+    advancedTopicConfigEntries,
+    remarks,
+    requestor,
+    requesttimestring,
+  } = topicRequest;
+
+  const hasAdvancedConfig =
+    advancedTopicConfigEntries !== undefined &&
+    advancedTopicConfigEntries !== null &&
+    !isEmpty(advancedTopicConfigEntries);
+
+  return (
+    <Grid htmlTag={"dl"} cols={"2"} rowGap={"6"}>
+      <Flexbox direction={"column"}>
+        <Label>Environment</Label>
+        <dd>
+          <StatusChip status={"neutral"} text={environmentName} />
+        </dd>
+      </Flexbox>
+      <Flexbox direction={"column"}>
+        <Label>Request type</Label>
+        <dd>
+          <StatusChip status={"neutral"} text={requestOperationType} />
+        </dd>
+      </Flexbox>
+      <GridItem colSpan={"span-2"}>
+        <Flexbox direction={"column"}>
+          <Label>Topic</Label>
+          <dd>{topicname}</dd>
+        </Flexbox>
+      </GridItem>
+      <GridItem colSpan={"span-2"}>
+        <Flexbox direction={"column"}>
+          <Label>Description</Label>
+          <dd>{description || <i>No description</i>}</dd>
+        </Flexbox>
+      </GridItem>
+      <Flexbox direction={"column"}>
+        <Label>Topic partition</Label>
+        <dd>{topicpartitions}</dd>
+      </Flexbox>
+      <Flexbox direction={"column"}>
+        <Label>Topic replication factor</Label>
+        <dd>{replicationfactor}</dd>
+      </Flexbox>
+      {hasAdvancedConfig && (
+        <GridItem colSpan={"span-2"}>
+          <Flexbox direction={"column"}>
+            <Label>Advanced configuration</Label>
+            <BorderBox borderColor={"grey-20"}>
+              <MonacoEditor
+                data-testid="topic-advanced-config"
+                language="json"
+                height={"100px"}
+                theme={"light"}
+                value={formatAdvancedConfig(advancedTopicConfigEntries)}
+                options={{
+                  ariaLabel: "Advanced configuration",
+                  readOnly: true,
+                  domReadOnly: true,
+                  renderControlCharacters: false,
+                  minimap: { enabled: false },
+                  folding: false,
+                  lineNumbers: "off",
+                  scrollBeyondLastLine: false,
+                }}
+              />
+            </BorderBox>
+          </Flexbox>
+        </GridItem>
+      )}
+      <GridItem colSpan={"span-2"}>
+        <Flexbox direction={"column"}>
+          <Label>Message for the approver</Label>
+          <dd>{remarks || <i>No message</i>}</dd>
+        </Flexbox>
+      </GridItem>
+      <Flexbox direction={"column"}>
+        <Label>Requested by</Label>
+        <dd>{requestor}</dd>
+      </Flexbox>
+      <Flexbox direction={"column"}>
+        <Label>Requested on</Label>
+        <dd>{requesttimestring} UTC</dd>
+      </Flexbox>
+    </Grid>
+  );
+};
+
+export default DetailsModalContent;

--- a/coral/src/app/features/approvals/topics/components/TopicApprovalsTable.test.tsx
+++ b/coral/src/app/features/approvals/topics/components/TopicApprovalsTable.test.tsx
@@ -74,16 +74,21 @@ describe("TopicApprovalsTable", () => {
     { columnHeader: "Status", relatedField: "requestStatus" },
     { columnHeader: "Claim by team", relatedField: "teamname" },
     { columnHeader: "Requested by", relatedField: "requestor" },
-    { columnHeader: "Date requested", relatedField: "requesttimestring" },
-    { columnHeader: "Details", relatedField: null },
-    { columnHeader: "Approve", relatedField: null },
-    { columnHeader: "Decline", relatedField: null },
+    { columnHeader: "Requested on", relatedField: "requesttimestring" },
+    { columnHeader: "", relatedField: null },
+    { columnHeader: "", relatedField: null },
+    { columnHeader: "", relatedField: null },
   ];
 
   describe("renders all necessary elements", () => {
     beforeAll(() => {
       mockIntersectionObserver();
-      render(<TopicApprovalsTable requests={mockedRequests} />);
+      render(
+        <TopicApprovalsTable
+          setDetailsModal={() => null}
+          requests={mockedRequests}
+        />
+      );
     });
     afterAll(cleanup);
 
@@ -167,7 +172,12 @@ describe("TopicApprovalsTable", () => {
   describe("renders all content based on the column definition", () => {
     beforeAll(() => {
       mockIntersectionObserver();
-      render(<TopicApprovalsTable requests={mockedRequests} />);
+      render(
+        <TopicApprovalsTable
+          setDetailsModal={() => null}
+          requests={mockedRequests}
+        />
+      );
     });
 
     afterAll(cleanup);
@@ -185,6 +195,9 @@ describe("TopicApprovalsTable", () => {
 
     columnsFieldMap.forEach((column) => {
       it(`shows a column header for ${column.columnHeader}`, () => {
+        if (column.relatedField === null) {
+          return;
+        }
         const table = screen.getByRole("table", {
           name: "Topic requests",
         });
@@ -205,7 +218,7 @@ describe("TopicApprovalsTable", () => {
             // eslint-disable-next-line @typescript-eslint/ban-ts-comment
             //@ts-ignore
             const content = `${request[column.relatedField]}`;
-            const isFormattedTime = column.columnHeader === "Date requested";
+            const isFormattedTime = column.columnHeader === "Requested on";
 
             const text = `${content}${isFormattedTime ? " UTC" : ""}`;
             const cell = within(table).getByRole("cell", { name: text });

--- a/coral/src/app/features/approvals/topics/components/TopicApprovalsTable.test.tsx
+++ b/coral/src/app/features/approvals/topics/components/TopicApprovalsTable.test.tsx
@@ -2,6 +2,9 @@ import { cleanup, render, screen, within } from "@testing-library/react";
 import { mockIntersectionObserver } from "src/services/test-utils/mock-intersection-observer";
 import { TopicApprovalsTable } from "src/app/features/approvals/topics/components/TopicApprovalsTable";
 import { TopicRequest } from "src/domain/topic";
+import userEvent from "@testing-library/user-event";
+
+const mockedSetDetailsModal = jest.fn();
 
 const mockedRequests: TopicRequest[] = [
   {
@@ -85,7 +88,7 @@ describe("TopicApprovalsTable", () => {
       mockIntersectionObserver();
       render(
         <TopicApprovalsTable
-          setDetailsModal={() => null}
+          setDetailsModal={mockedSetDetailsModal}
           requests={mockedRequests}
         />
       );
@@ -174,7 +177,7 @@ describe("TopicApprovalsTable", () => {
       mockIntersectionObserver();
       render(
         <TopicApprovalsTable
-          setDetailsModal={() => null}
+          setDetailsModal={mockedSetDetailsModal}
           requests={mockedRequests}
         />
       );
@@ -227,6 +230,32 @@ describe("TopicApprovalsTable", () => {
           });
         });
       }
+    });
+  });
+
+  describe("handles interaction with action columns", () => {
+    beforeAll(() => {
+      mockIntersectionObserver();
+      render(
+        <TopicApprovalsTable
+          setDetailsModal={mockedSetDetailsModal}
+          requests={mockedRequests}
+        />
+      );
+    });
+    afterAll(cleanup);
+
+    it("shows a Modal when clicking Show details", async () => {
+      const showDetails = screen.getByRole("button", {
+        name: "View topic request for test-topic-1",
+      });
+
+      await userEvent.click(showDetails);
+
+      expect(mockedSetDetailsModal).toHaveBeenCalledWith({
+        isOpen: true,
+        topicId: 1000,
+      });
     });
   });
 });

--- a/coral/src/app/features/approvals/topics/components/TopicApprovalsTable.tsx
+++ b/coral/src/app/features/approvals/topics/components/TopicApprovalsTable.tsx
@@ -1,112 +1,128 @@
-import { DataTable, DataTableColumn, GhostButton } from "@aivenio/aquarium";
+import {
+  DataTable,
+  DataTableColumn,
+  GhostButton,
+  Icon,
+} from "@aivenio/aquarium";
 import deleteIcon from "@aivenio/aquarium/dist/src/icons/delete";
-import tickCircle from "@aivenio/aquarium/dist/src/icons/tickCircle";
 import infoSign from "@aivenio/aquarium/dist/src/icons/infoSign";
+import tickCircle from "@aivenio/aquarium/dist/src/icons/tickCircle";
+import { Dispatch, SetStateAction } from "react";
 import { TopicRequest } from "src/domain/topic/topic-types";
 
-interface TopicRequestTableData {
-  id: number; // unclear
-  topicname: string;
-  environmentName: string;
-  requestStatus: string;
-  teamname: string; // unclear
-  requestor: string;
-  requesttimestring: string;
+interface TopicRequestTableRow {
+  id: TopicRequest["topicid"];
+  topicname: TopicRequest["topicname"];
+  environmentName: TopicRequest["environmentName"];
+  requestStatus: TopicRequest["requestStatus"];
+  teamname: TopicRequest["teamname"];
+  requestor: TopicRequest["requestor"];
+  requesttimestring: TopicRequest["requesttimestring"];
 }
-
-const columns: Array<DataTableColumn<TopicRequestTableData>> = [
-  { type: "text", field: "topicname", headerName: "Topic" },
-  { type: "text", field: "environmentName", headerName: "Environment" },
-  { type: "text", field: "requestStatus", headerName: "Status" },
-  { type: "text", field: "teamname", headerName: "Claim by team" },
-  { type: "text", field: "requestor", headerName: "Requested by" },
-  {
-    type: "text",
-    field: "requesttimestring",
-    headerName: "Date requested",
-    formatter: (value) => {
-      return `${value} UTC`;
-    },
-  },
-  {
-    type: "custom",
-    // @TODO PR open in DS to be able to
-    // add an "invisible" header name that
-    // is used as aria-label. That will also
-    // solve the duplicate key warning
-    //https://github.com/aiven/design-system/pull/950
-    headerName: "Details",
-    width: 30,
-    UNSAFE_render: (row) => {
-      return (
-        <GhostButton onClick={() => alert("Approve")} icon={infoSign} dense>
-          <span aria-hidden={"true"}>View details</span>
-          <span className={"visually-hidden"}>
-            View topic request for {row.topicname}
-          </span>
-        </GhostButton>
-      );
-    },
-  },
-  {
-    type: "custom",
-    // @TODO PR open in DS to be able to
-    // add an "invisible" header name that
-    // is used as aria-label. That will also
-    // solve the duplicate key warning
-    //https://github.com/aiven/design-system/pull/950
-    headerName: "Approve",
-    width: 30,
-    UNSAFE_render: (row) => {
-      return (
-        <GhostButton
-          onClick={() => alert("Approve")}
-          aria-label={`Approve topic request for ${row.topicname}`}
-          icon={tickCircle}
-        />
-      );
-    },
-  },
-  {
-    type: "custom",
-    // @TODO PR open in DS to be able to
-    // add an "invisible" header name that
-    // is used as aria-label. That will also
-    // solve the duplicate key warning
-    //https://github.com/aiven/design-system/pull/950
-    headerName: "Decline",
-    width: 30,
-    UNSAFE_render: (row) => {
-      return (
-        <GhostButton
-          onClick={() => alert("Decline")}
-          aria-label={`Decline topic request for ${row.topicname}`}
-          icon={deleteIcon}
-        />
-      );
-    },
-  },
-];
 
 type TopicApprovalsTableProp = {
   requests: TopicRequest[];
+  setDetailsModal: Dispatch<
+    SetStateAction<{
+      isOpen: boolean;
+      topicId: number | null;
+    }>
+  >;
 };
 function TopicApprovalsTable(props: TopicApprovalsTableProp) {
-  const { requests } = props;
+  const { requests, setDetailsModal } = props;
 
-  const rows: TopicRequestTableData[] = requests.map(
-    (request: TopicRequest) => {
-      return {
-        id: request.topicid,
-        topicname: request.topicname,
-        environmentName: request.environmentName,
-        requestStatus: request.requestStatus,
-        teamname: request.teamname,
-        requestor: request.requestor,
-        requesttimestring: request.requesttimestring,
-      };
-    }
-  );
+  const columns: Array<DataTableColumn<TopicRequestTableRow>> = [
+    { type: "text", field: "topicname", headerName: "Topic" },
+    { type: "text", field: "environmentName", headerName: "Environment" },
+    { type: "text", field: "requestStatus", headerName: "Status" },
+    { type: "text", field: "teamname", headerName: "Claim by team" },
+    { type: "text", field: "requestor", headerName: "Requested by" },
+    {
+      type: "text",
+      field: "requesttimestring",
+      headerName: "Requested on",
+      formatter: (value) => {
+        return `${value} UTC`;
+      },
+    },
+    {
+      type: "custom",
+      // @TODO PR open in DS to be able to
+      // add an "invisible" header name that
+      // is used as aria-label. That will also
+      // solve the duplicate key warning
+      //https://github.com/aiven/design-system/pull/950
+      headerName: "",
+      width: 30,
+      UNSAFE_render: ({ id, topicname }: TopicRequestTableRow) => {
+        return (
+          <GhostButton
+            onClick={() => setDetailsModal({ isOpen: true, topicId: id })}
+            icon={infoSign}
+            dense
+          >
+            <span aria-hidden={"true"}>View details</span>
+            <span className={"visually-hidden"}>
+              View topic request for {topicname}
+            </span>
+          </GhostButton>
+        );
+      },
+    },
+    {
+      type: "custom",
+      // @TODO PR open in DS to be able to
+      // add an "invisible" header name that
+      // is used as aria-label. That will also
+      // solve the duplicate key warning
+      //https://github.com/aiven/design-system/pull/950
+      headerName: "",
+      width: 30,
+      UNSAFE_render: (row) => {
+        return (
+          <GhostButton
+            onClick={() => alert("Approve")}
+            aria-label={`Approve topic request for ${row.topicname}`}
+          >
+            <Icon color="grey-70" icon={tickCircle} />
+          </GhostButton>
+        );
+      },
+    },
+    {
+      type: "custom",
+      // @TODO PR open in DS to be able to
+      // add an "invisible" header name that
+      // is used as aria-label. That will also
+      // solve the duplicate key warning
+      //https://github.com/aiven/design-system/pull/950
+      headerName: "",
+      width: 30,
+      UNSAFE_render: (row) => {
+        return (
+          <GhostButton
+            onClick={() => alert("Decline")}
+            aria-label={`Decline topic request for ${row.topicname}`}
+          >
+            <Icon color="grey-70" icon={deleteIcon} />
+          </GhostButton>
+        );
+      },
+    },
+  ];
+
+  const rows: TopicRequestTableRow[] = requests.map((request: TopicRequest) => {
+    return {
+      id: request.topicid,
+      topicname: request.topicname,
+      environmentName: request.environmentName,
+      requestStatus: request.requestStatus,
+      teamname: request.teamname,
+      requestor: request.requestor,
+      requesttimestring: request.requesttimestring,
+    };
+  });
 
   return (
     <DataTable


### PR DESCRIPTION
## About this change - What it does

- Add View details modal for Topic request approval table
- Unify some styles to keep consistent with ACL approval table


https://user-images.githubusercontent.com/20607294/220571014-a90dda15-c83a-44e1-abe3-b209ca448cd7.mov



Resolves: #667
