### PR TITLE
feat(coral): add detail view modal to schema request approvals

### DIFF
--- a/coral/src/app/features/approvals/schemas/SchemaApprovals.test.tsx
+++ b/coral/src/app/features/approvals/schemas/SchemaApprovals.test.tsx
@@ -324,4 +324,53 @@ describe("SchemaApprovals", () => {
       });
     });
   });
+
+  describe("shows a detail modal for schema request", () => {
+    beforeEach(async () => {
+      mockGetSchemaRequestsForApprover.mockResolvedValue(mockedApiResponse);
+
+      customRender(<SchemaApprovals />, {
+        queryClient: true,
+        memoryRouter: true,
+      });
+
+      await waitForElementToBeRemoved(screen.getByTestId("skeleton-table"));
+    });
+
+    afterEach(() => {
+      jest.clearAllMocks();
+      cleanup();
+    });
+
+    it("shows detail modal for first request returned from the api", async () => {
+      expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+
+      const firstRequest = mockedApiResponse.entries[0];
+      const viewDetailsButton = screen.getByRole("button", {
+        name: `View schema request for ${firstRequest.topicname}`,
+      });
+
+      await userEvent.click(viewDetailsButton);
+      const modal = screen.getByRole("dialog");
+
+      expect(modal).toBeVisible();
+      expect(modal).toHaveTextContent(firstRequest.topicname);
+    });
+
+    it("shows detail modal for last request returned from the api", async () => {
+      expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+
+      const lastRequest =
+        mockedApiResponse.entries[mockedApiResponse.entries.length - 1];
+      const viewDetailsButton = screen.getByRole("button", {
+        name: `View schema request for ${lastRequest.topicname}`,
+      });
+
+      await userEvent.click(viewDetailsButton);
+      const modal = screen.getByRole("dialog");
+
+      expect(modal).toBeVisible();
+      expect(modal).toHaveTextContent(lastRequest.topicname);
+    });
+  });
 });

--- a/coral/src/app/features/approvals/schemas/SchemaApprovals.tsx
+++ b/coral/src/app/features/approvals/schemas/SchemaApprovals.tsx
@@ -5,12 +5,20 @@ import { ApprovalsLayout } from "src/app/features/approvals/components/Approvals
 import { getSchemaRequestsForApprover } from "src/domain/schema-request";
 import { useSearchParams } from "react-router-dom";
 import { useQuery } from "@tanstack/react-query";
+import { useState } from "react";
+import RequestDetailsModal from "src/app/features/approvals/components/RequestDetailsModal";
+import { SchemaRequestDetails } from "src/app/features/approvals/schemas/components/SchemaRequestDetails";
 
 function SchemaApprovals() {
   const [searchParams, setSearchParams] = useSearchParams();
   const currentPage = searchParams.get("page")
     ? Number(searchParams.get("page"))
     : 1;
+
+  const [detailsModal, setDetailsModal] = useState<{
+    isOpen: boolean;
+    req_no: number | null;
+  }>({ isOpen: false, req_no: null });
 
   const {
     data: schemaRequests,
@@ -68,7 +76,10 @@ function SchemaApprovals() {
   ];
 
   const table = (
-    <SchemaApprovalsTable requests={schemaRequests?.entries || []} />
+    <SchemaApprovalsTable
+      requests={schemaRequests?.entries || []}
+      setDetailsModal={setDetailsModal}
+    />
   );
   const pagination =
     schemaRequests?.totalPages && schemaRequests.totalPages > 1 ? (
@@ -79,15 +90,44 @@ function SchemaApprovals() {
       />
     ) : undefined;
 
+  function approveRequest(req_no: number | null) {
+    console.log("approve", req_no);
+  }
+
+  function rejectRequest(req_no: number | null) {
+    console.log("approve", req_no);
+  }
+
   return (
-    <ApprovalsLayout
-      filters={filters}
-      table={table}
-      pagination={pagination}
-      isLoading={schemaRequestsIsLoading}
-      isErrorLoading={schemaRequestsIsError}
-      errorMessage={schemaRequestsError}
-    />
+    <>
+      {detailsModal.isOpen && (
+        <RequestDetailsModal
+          onClose={() => setDetailsModal({ isOpen: false, req_no: null })}
+          onApprove={() => {
+            approveRequest(detailsModal.req_no);
+          }}
+          onReject={() => {
+            setDetailsModal({ isOpen: false, req_no: null });
+            rejectRequest(detailsModal.req_no);
+          }}
+          isLoading={false}
+        >
+          <SchemaRequestDetails
+            request={schemaRequests?.entries.find(
+              (request) => request.req_no === detailsModal.req_no
+            )}
+          />
+        </RequestDetailsModal>
+      )}
+      <ApprovalsLayout
+        filters={filters}
+        table={table}
+        pagination={pagination}
+        isLoading={schemaRequestsIsLoading}
+        isErrorLoading={schemaRequestsIsError}
+        errorMessage={schemaRequestsError}
+      />
+    </>
   );
 }
 

--- a/coral/src/app/features/approvals/schemas/components/SchemaApprovalsTable.test.tsx
+++ b/coral/src/app/features/approvals/schemas/components/SchemaApprovalsTable.test.tsx
@@ -2,6 +2,7 @@ import SchemaApprovalsTable from "src/app/features/approvals/schemas/components/
 import { cleanup, render, screen, within } from "@testing-library/react";
 import { mockIntersectionObserver } from "src/services/test-utils/mock-intersection-observer";
 import { SchemaRequest } from "src/domain/schema-request";
+import userEvent from "@testing-library/user-event";
 
 const mockedRequests: SchemaRequest[] = [
   {
@@ -58,7 +59,11 @@ const mockedRequests: SchemaRequest[] = [
   },
 ];
 
+const mockSetDetailsModal = jest.fn();
+
 describe("SchemaApprovalsTable", () => {
+  beforeAll(mockIntersectionObserver);
+
   const columnsFieldMap = [
     { columnHeader: "Topic", relatedField: "topicname" },
     { columnHeader: "Environment", relatedField: "environmentName" },
@@ -71,8 +76,12 @@ describe("SchemaApprovalsTable", () => {
 
   describe("renders all necessary elements", () => {
     beforeAll(() => {
-      mockIntersectionObserver();
-      render(<SchemaApprovalsTable requests={mockedRequests} />);
+      render(
+        <SchemaApprovalsTable
+          requests={mockedRequests}
+          setDetailsModal={mockSetDetailsModal}
+        />
+      );
     });
     afterAll(cleanup);
 
@@ -155,8 +164,12 @@ describe("SchemaApprovalsTable", () => {
 
   describe("renders all content based on the column definition", () => {
     beforeAll(() => {
-      mockIntersectionObserver();
-      render(<SchemaApprovalsTable requests={mockedRequests} />);
+      render(
+        <SchemaApprovalsTable
+          requests={mockedRequests}
+          setDetailsModal={mockSetDetailsModal}
+        />
+      );
     });
 
     afterAll(cleanup);
@@ -203,6 +216,49 @@ describe("SchemaApprovalsTable", () => {
           });
         });
       }
+    });
+  });
+
+  describe("triggers opening of a modal with all details if user clicks button for overview", () => {
+    beforeEach(() => {
+      render(
+        <SchemaApprovalsTable
+          requests={mockedRequests}
+          setDetailsModal={mockSetDetailsModal}
+        />
+      );
+    });
+    afterEach(() => {
+      cleanup();
+      jest.clearAllMocks();
+    });
+
+    it("triggers opening a modal with details for the first given schema request", async () => {
+      const button = screen.getByRole("button", {
+        name: `View schema request for ${mockedRequests[0].topicname}`,
+      });
+
+      await userEvent.click(button);
+
+      expect(mockSetDetailsModal).toHaveBeenCalledWith({
+        isOpen: true,
+        req_no: mockedRequests[0].req_no,
+      });
+    });
+
+    it("triggers opening a modal with details for the laft given schema request", async () => {
+      const button = screen.getByRole("button", {
+        name: `View schema request for ${
+          mockedRequests[mockedRequests.length - 1].topicname
+        }`,
+      });
+
+      await userEvent.click(button);
+
+      expect(mockSetDetailsModal).toHaveBeenCalledWith({
+        isOpen: true,
+        req_no: mockedRequests[mockedRequests.length - 1].req_no,
+      });
     });
   });
 });

--- a/coral/src/app/features/approvals/schemas/components/SchemaApprovalsTable.tsx
+++ b/coral/src/app/features/approvals/schemas/components/SchemaApprovalsTable.tsx
@@ -3,6 +3,7 @@ import { SchemaRequest } from "src/domain/schema-request";
 import infoSign from "@aivenio/aquarium/icons/infoSign";
 import tickCircle from "@aivenio/aquarium/icons/tickCircle";
 import deleteIcon from "@aivenio/aquarium/icons/delete";
+import { Dispatch, SetStateAction } from "react";
 
 interface SchemaRequestTableData {
   id: number;
@@ -12,84 +13,92 @@ interface SchemaRequestTableData {
   requesttimestring: string;
 }
 
-const columns: Array<DataTableColumn<SchemaRequestTableData>> = [
-  { type: "text", field: "topicname", headerName: "Topic" },
-  { type: "text", field: "environmentName", headerName: "Environment" },
-  { type: "text", field: "username", headerName: "Requested by" },
-  {
-    type: "text",
-    field: "requesttimestring",
-    headerName: "Date requested",
-    formatter: (value) => {
-      return `${value} UTC`;
-    },
-  },
-  {
-    type: "custom",
-    // @TODO PR open in DS to be able to
-    // add an "invisible" header name that
-    // is used as aria-label. That will also
-    // solve the duplicate key warning
-    //https://github.com/aiven/design-system/pull/950
-    headerName: "Details",
-    width: 30,
-    UNSAFE_render: (row) => {
-      return (
-        <GhostButton onClick={() => alert("Approve")} icon={infoSign} dense>
-          <span aria-hidden={"true"}>View details</span>
-          <span className={"visually-hidden"}>
-            View schema request for {row.topicname}
-          </span>
-        </GhostButton>
-      );
-    },
-  },
-  {
-    type: "custom",
-    // @TODO PR open in DS to be able to
-    // add an "invisible" header name that
-    // is used as aria-label. That will also
-    // solve the duplicate key warning
-    //https://github.com/aiven/design-system/pull/950
-    headerName: "Approve",
-    width: 30,
-    UNSAFE_render: (row) => {
-      return (
-        <GhostButton
-          onClick={() => alert("Approve")}
-          aria-label={`Approve schema request for ${row.topicname}`}
-          icon={tickCircle}
-        />
-      );
-    },
-  },
-  {
-    type: "custom",
-    // @TODO PR open in DS to be able to
-    // add an "invisible" header name that
-    // is used as aria-label. That will also
-    // solve the duplicate key warning
-    //https://github.com/aiven/design-system/pull/950
-    headerName: "Decline",
-    width: 30,
-    UNSAFE_render: (row) => {
-      return (
-        <GhostButton
-          onClick={() => alert("Decline")}
-          aria-label={`Decline schema request for ${row.topicname}`}
-          icon={deleteIcon}
-        />
-      );
-    },
-  },
-];
-
 type SchemaApprovalsTableProps = {
   requests: SchemaRequest[];
+  setDetailsModal: Dispatch<
+    SetStateAction<{
+      isOpen: boolean;
+      req_no: number | null;
+    }>
+  >;
 };
 function SchemaApprovalsTable(props: SchemaApprovalsTableProps) {
-  const { requests } = props;
-
+  const { requests, setDetailsModal } = props;
+  const columns: Array<DataTableColumn<SchemaRequestTableData>> = [
+    { type: "text", field: "topicname", headerName: "Topic" },
+    { type: "text", field: "environmentName", headerName: "Environment" },
+    { type: "text", field: "username", headerName: "Requested by" },
+    {
+      type: "text",
+      field: "requesttimestring",
+      headerName: "Date requested",
+      formatter: (value) => {
+        return `${value} UTC`;
+      },
+    },
+    {
+      type: "custom",
+      // @TODO PR open in DS to be able to
+      // add an "invisible" header name that
+      // is used as aria-label. That will also
+      // solve the duplicate key warning
+      //https://github.com/aiven/design-system/pull/950
+      headerName: "Details",
+      width: 30,
+      UNSAFE_render: (row) => {
+        return (
+          <GhostButton
+            onClick={() => setDetailsModal({ isOpen: true, req_no: row.id })}
+            icon={infoSign}
+            dense
+          >
+            <span aria-hidden={"true"}>View details</span>
+            <span className={"visually-hidden"}>
+              View schema request for {row.topicname}
+            </span>
+          </GhostButton>
+        );
+      },
+    },
+    {
+      type: "custom",
+      // @TODO PR open in DS to be able to
+      // add an "invisible" header name that
+      // is used as aria-label. That will also
+      // solve the duplicate key warning
+      //https://github.com/aiven/design-system/pull/950
+      headerName: "Approve",
+      width: 30,
+      UNSAFE_render: (row) => {
+        return (
+          <GhostButton
+            onClick={() => alert("Approve")}
+            aria-label={`Approve schema request for ${row.topicname}`}
+            icon={tickCircle}
+          />
+        );
+      },
+    },
+    {
+      type: "custom",
+      // @TODO PR open in DS to be able to
+      // add an "invisible" header name that
+      // is used as aria-label. That will also
+      // solve the duplicate key warning
+      //https://github.com/aiven/design-system/pull/950
+      headerName: "Decline",
+      width: 30,
+      UNSAFE_render: (row) => {
+        return (
+          <GhostButton
+            onClick={() => alert("Decline")}
+            aria-label={`Decline schema request for ${row.topicname}`}
+            icon={deleteIcon}
+          />
+        );
+      },
+    },
+  ];
   const rows: SchemaRequestTableData[] = requests.map(
     (request: SchemaRequest) => {
       return {

--- a/coral/src/app/features/approvals/schemas/components/SchemaRequestDetails.test.tsx
+++ b/coral/src/app/features/approvals/schemas/components/SchemaRequestDetails.test.tsx
@@ -1,0 +1,102 @@
+import { cleanup, render, screen, within } from "@testing-library/react";
+import { SchemaRequestDetails } from "src/app/features/approvals/schemas/components/SchemaRequestDetails";
+import { SchemaRequest } from "src/domain/schema-request";
+
+const testRequest: SchemaRequest = {
+  req_no: 1014,
+  topicname: "testtopic-first",
+  environment: "1",
+  environmentName: "BRG",
+  schemaversion: "1.0",
+  teamname: "NCC1701D",
+  teamId: 1701,
+  appname: "App",
+  schemafull: "",
+  username: "jlpicard",
+  requesttime: "1987-09-28T13:37:00.001+00:00",
+  requesttimestring: "28-Sep-1987 13:37:00",
+  requestStatus: "CREATED",
+  requestOperationType: "CREATE",
+  remarks: "asap",
+  approvingTeamDetails:
+    "Team : NCC1701D, Users : jlpicard, worf, bcrusher, geordilf",
+  approvingtime: "2022-11-04T14:54:13.414+00:00",
+  totalNoPages: "4",
+  allPageNos: ["1"],
+  currentPage: "1",
+  deletable: false,
+  editable: false,
+  forceRegister: false,
+};
+
+const findTerm = (term: string) => {
+  return screen
+    .getAllByRole("term")
+    .find((value) => value.textContent === term);
+};
+
+const findDefinition = (term: HTMLElement | undefined) => {
+  if (!term) throw Error("term is null");
+  const termParent = term.parentElement;
+  if (!termParent) throw Error("term has no parent element");
+
+  return within(termParent).getByRole("definition");
+};
+
+describe("SchemaRequestDetails", () => {
+  describe("renders all necessary elements", () => {
+    beforeAll(() => {
+      render(<SchemaRequestDetails request={testRequest} />);
+    });
+
+    afterAll(cleanup);
+
+    it("shows the Environment", () => {
+      const term = findTerm("Environment");
+      const definition = findDefinition(term);
+
+      expect(term).toBeVisible();
+      expect(definition).toHaveTextContent(testRequest.environmentName);
+    });
+
+    it("shows the Topic name", () => {
+      const term = findTerm("Topic name");
+      const definition = findDefinition(term);
+
+      expect(term).toBeVisible();
+      expect(definition).toHaveTextContent(testRequest.topicname);
+    });
+
+    it("shows a preview of the schema", () => {
+      const term = findTerm("Schema");
+      const definition = findDefinition(term);
+
+      expect(term).toBeVisible();
+      expect(definition).toHaveTextContent(testRequest.schemafull);
+    });
+
+    it("shows a message to approver", () => {
+      const term = findTerm("Message for the approver");
+      const definition = findDefinition(term);
+
+      expect(term).toBeVisible();
+      expect(definition).toHaveTextContent(testRequest.remarks as string);
+    });
+
+    it("shows who requested the schema", () => {
+      const term = findTerm("Requested by");
+      const definition = findDefinition(term);
+
+      expect(term).toBeVisible();
+      expect(definition).toHaveTextContent(testRequest.username);
+    });
+
+    it("shows the time the schema request was made", () => {
+      const term = findTerm("Requested on");
+      const definition = findDefinition(term);
+
+      expect(term).toBeVisible();
+      expect(definition).toHaveTextContent(testRequest.requesttimestring);
+    });
+  });
+});

--- a/coral/src/app/features/approvals/schemas/components/SchemaRequestDetails.test.tsx
+++ b/coral/src/app/features/approvals/schemas/components/SchemaRequestDetails.test.tsx
@@ -35,6 +35,11 @@ const findTerm = (term: string) => {
     .find((value) => value.textContent === term);
 };
 
+// since all our dt/dd pairs are always wrapped in a div
+// this makes sure the right pairs relate to each other.
+// this depends heavily on DOM structure, so it can be
+// brittle in case we change that. In that case, the helper
+// function has to be updated.
 const findDefinition = (term: HTMLElement | undefined) => {
   if (!term) throw Error("term is null");
   const termParent = term.parentElement;

--- a/coral/src/app/features/approvals/schemas/components/SchemaRequestDetails.tsx
+++ b/coral/src/app/features/approvals/schemas/components/SchemaRequestDetails.tsx
@@ -29,7 +29,6 @@ function SchemaRequestDetails(props: DetailsModalContentProps) {
 
       <GridItem colSpan={"span-2"}>
         <Flexbox direction={"column"}>
-          {/*//@TODO add editor preview*/}
           <Label>Schema</Label>
           <dd>
             <MonacoEditor
@@ -48,9 +47,6 @@ function SchemaRequestDetails(props: DetailsModalContentProps) {
                 folding: false,
                 lineNumbers: "off",
                 scrollBeyondLastLine: false,
-                scrollbar: {
-                  vertical: "hidden",
-                },
               }}
             />
           </dd>

--- a/coral/src/app/features/approvals/schemas/components/SchemaRequestDetails.tsx
+++ b/coral/src/app/features/approvals/schemas/components/SchemaRequestDetails.tsx
@@ -1,0 +1,79 @@
+import { SchemaRequest } from "src/domain/schema-request";
+import { Flexbox, Grid, GridItem, StatusChip } from "@aivenio/aquarium";
+import MonacoEditor from "@monaco-editor/react";
+
+type DetailsModalContentProps = {
+  request?: SchemaRequest;
+};
+
+const Label = ({ children }: { children: React.ReactNode }) => (
+  <dt className="inline-block mb-2 typography-small-strong text-grey-60">
+    {children}
+  </dt>
+);
+function SchemaRequestDetails(props: DetailsModalContentProps) {
+  const { request } = props;
+  if (!request) return null;
+  return (
+    <Grid htmlTag={"dl"} cols={"2"} rowGap={"6"}>
+      <Flexbox direction={"column"}>
+        <Label>Environment</Label>
+        <dd>
+          <StatusChip text={request.environmentName} />
+        </dd>
+      </Flexbox>
+      <Flexbox direction={"column"}>
+        <Label>Topic name</Label>
+        <dd>{request.topicname}</dd>
+      </Flexbox>
+
+      <GridItem colSpan={"span-2"}>
+        <Flexbox direction={"column"}>
+          {/*//@TODO add editor preview*/}
+          <Label>Schema</Label>
+          <dd>
+            <MonacoEditor
+              data-testid="topic-schema"
+              height="300px"
+              language="json"
+              theme={"light"}
+              value={request.schemafull}
+              loading={"Loading preview"}
+              options={{
+                ariaLabel: "Schema preview",
+                readOnly: true,
+                domReadOnly: true,
+                renderControlCharacters: false,
+                minimap: { enabled: false },
+                folding: false,
+                lineNumbers: "off",
+                scrollBeyondLastLine: false,
+                scrollbar: {
+                  vertical: "hidden",
+                },
+              }}
+            />
+          </dd>
+        </Flexbox>
+      </GridItem>
+
+      <GridItem colSpan={"span-2"}>
+        <Flexbox direction={"column"}>
+          <Label>Message for the approver</Label>
+          <dd>{request.remarks || <i>No message</i>}</dd>
+        </Flexbox>
+      </GridItem>
+
+      <Flexbox direction={"column"}>
+        <Label>Requested by</Label>
+        <dd>{request.username}</dd>
+      </Flexbox>
+      <Flexbox direction={"column"}>
+        <Label>Requested on</Label>
+        <dd>{request.requesttimestring} UTC</dd>
+      </Flexbox>
+    </Grid>
+  );
+}
+
+export { SchemaRequestDetails };

--- a/coral/src/app/features/topics/schema-request/components/TopicSchema.tsx
+++ b/coral/src/app/features/topics/schema-request/components/TopicSchema.tsx
@@ -129,9 +129,6 @@ function TopicSchema(props: TopicSchemaProps) {
                     folding: false,
                     lineNumbers: "off",
                     scrollBeyondLastLine: false,
-                    scrollbar: {
-                      vertical: "hidden",
-                    },
                   }}
                 />
               )}


### PR DESCRIPTION
# About this change - What it does

- add a modal for details overview to the schema requests list for approvers

## Note
I named the component that is used in the Modal itself `SchemaRequestDetails` because it describes better what it does. It could be used outside of a modal, so I don't think it should have the connection to `Modal` in it's name. 

I also updated the function to check for a definition of a term in test, so we can make sure the definition is related to a certain term. BUT this only works correctly in that way because our dt/dd terms all are wrapped in a div together, so it depends a bit much on DOM structure, so I'm not too sure about the approach. I think it's important to make sure the right key/values pairs are related, on the other hand it's more brittle that way because it depends on the DOM structure. 🤔  I added a comment at the helper function. I think it's ok to do it that way, because in case we change the structure and tests are failing, it's easy to see why and it only needs a change in one place to fix it. (but open to discuss!)

Resolves: #664

