### PR TITLE
feat(coral): add filter functionality to schema requests approver table

### DIFF
--- a/coral/src/app/features/approvals/schemas/SchemaApprovals.test.tsx
+++ b/coral/src/app/features/approvals/schemas/SchemaApprovals.test.tsx
@@ -1,4 +1,4 @@
-import { cleanup, screen, within } from "@testing-library/react";
+import { cleanup, screen, waitFor, within } from "@testing-library/react";
 import {
   getSchemaRequestsForApprover,
   SchemaRequest,
@@ -100,6 +100,7 @@ describe("SchemaApprovals", () => {
     pageNo: "1",
     requestStatus: "CREATED",
     env: "ALL",
+    topic: "",
   };
   beforeAll(() => {
     mockIntersectionObserver();
@@ -469,6 +470,24 @@ describe("SchemaApprovals", () => {
       expect(mockGetSchemaRequestsForApprover).toHaveBeenNthCalledWith(2, {
         ...defaultApiParams,
         env: mockedEnvironments[0].id,
+      });
+    });
+
+    it("enables user to search for topic", async () => {
+      expect(mockGetSchemaRequestsForApprover).toHaveBeenNthCalledWith(
+        1,
+        defaultApiParams
+      );
+
+      const search = screen.getByRole("search");
+
+      await userEvent.type(search, "myTopic");
+
+      await waitFor(() => {
+        expect(mockGetSchemaRequestsForApprover).toHaveBeenNthCalledWith(2, {
+          ...defaultApiParams,
+          topic: "myTopic",
+        });
       });
     });
   });

--- a/coral/src/app/features/approvals/schemas/SchemaApprovals.test.tsx
+++ b/coral/src/app/features/approvals/schemas/SchemaApprovals.test.tsx
@@ -401,4 +401,46 @@ describe("SchemaApprovals", () => {
       expect(modal).toHaveTextContent(lastRequest.topicname);
     });
   });
+
+  describe("handles filtering entries in the table", () => {
+    const initial = { pageNumber: 1, requestStatus: "CREATED" };
+    beforeEach(async () => {
+      mockGetEnvironment.mockResolvedValue([]);
+      mockGetSchemaRequestsForApprover.mockResolvedValue({
+        totalPages: 1,
+        currentPage: 1,
+        entries: mockedResponseSchemaRequests,
+      });
+
+      customRender(<SchemaApprovals />, {
+        queryClient: true,
+        memoryRouter: true,
+      });
+
+      await waitForElementToBeRemoved(screen.getByTestId("skeleton-table"));
+    });
+
+    afterEach(() => {
+      jest.clearAllMocks();
+      cleanup();
+    });
+
+    it("enables user to filter by 'status'", async () => {
+      expect(mockGetSchemaRequestsForApprover).toHaveBeenNthCalledWith(
+        1,
+        initial
+      );
+
+      const statusFilter = screen.getByRole("combobox", {
+        name: "Filter by status",
+      });
+      const statusOption = screen.getByRole("option", { name: "All statuses" });
+      await userEvent.selectOptions(statusFilter, statusOption);
+
+      expect(mockGetSchemaRequestsForApprover).toHaveBeenNthCalledWith(2, {
+        pageNumber: 1,
+        requestStatus: "ALL",
+      });
+    });
+  });
 });

--- a/coral/src/app/features/approvals/schemas/SchemaApprovals.test.tsx
+++ b/coral/src/app/features/approvals/schemas/SchemaApprovals.test.tsx
@@ -364,7 +364,9 @@ describe("SchemaApprovals", () => {
 
   describe("shows a detail modal for schema request", () => {
     beforeEach(async () => {
-      mockGetSchemaRequestsForApprover.mockResolvedValue(mockedApiResponse);
+      mockGetSchemaRequestsForApprover.mockResolvedValue(
+        mockedApiResponseSchemaRequests
+      );
 
       customRender(<SchemaApprovals />, {
         queryClient: true,
@@ -382,7 +384,7 @@ describe("SchemaApprovals", () => {
     it("shows detail modal for first request returned from the api", async () => {
       expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
 
-      const firstRequest = mockedApiResponse.entries[0];
+      const firstRequest = mockedApiResponseSchemaRequests.entries[0];
       const viewDetailsButton = screen.getByRole("button", {
         name: `View schema request for ${firstRequest.topicname}`,
       });
@@ -398,7 +400,9 @@ describe("SchemaApprovals", () => {
       expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
 
       const lastRequest =
-        mockedApiResponse.entries[mockedApiResponse.entries.length - 1];
+        mockedApiResponseSchemaRequests.entries[
+          mockedApiResponseSchemaRequests.entries.length - 1
+        ];
       const viewDetailsButton = screen.getByRole("button", {
         name: `View schema request for ${lastRequest.topicname}`,
       });

--- a/coral/src/app/features/approvals/schemas/SchemaApprovals.tsx
+++ b/coral/src/app/features/approvals/schemas/SchemaApprovals.tsx
@@ -1,10 +1,10 @@
-import { SearchInput, NativeSelect } from "@aivenio/aquarium";
 import { Pagination } from "src/app/components/Pagination";
 import SchemaApprovalsTable from "src/app/features/approvals/schemas/components/SchemaApprovalsTable";
 import { ApprovalsLayout } from "src/app/features/approvals/components/ApprovalsLayout";
 import { getSchemaRequestsForApprover } from "src/domain/schema-request";
 import { useSearchParams } from "react-router-dom";
 import { useQuery } from "@tanstack/react-query";
+import useTableFilters from "src/app/features/approvals/schemas/hooks/useTableFilters";
 import { useState } from "react";
 import RequestDetailsModal from "src/app/features/approvals/components/RequestDetailsModal";
 import { SchemaRequestDetails } from "src/app/features/approvals/schemas/components/SchemaRequestDetails";
@@ -14,6 +14,8 @@ function SchemaApprovals() {
   const currentPage = searchParams.get("page")
     ? Number(searchParams.get("page"))
     : 1;
+
+  const { filters } = useTableFilters();
 
   const [detailsModal, setDetailsModal] = useState<{
     isOpen: boolean;
@@ -39,41 +41,6 @@ function SchemaApprovals() {
     searchParams.set("page", page.toString());
     setSearchParams(searchParams);
   };
-
-  const filters = [
-    <NativeSelect labelText={"Filter by team"} key={"filter-team"}>
-      <option> one </option>
-      <option> two </option>
-      <option> three </option>
-    </NativeSelect>,
-
-    <NativeSelect
-      labelText={"Filter by Environment"}
-      key={"filter-environment"}
-    >
-      <option> one </option>
-      <option> two </option>
-      <option> three </option>
-    </NativeSelect>,
-
-    <NativeSelect labelText={"Filter by status"} key={"filter-status"}>
-      <option> one </option>
-      <option> two </option>
-      <option> three </option>
-    </NativeSelect>,
-    <div key={"search"}>
-      <SearchInput
-        type={"search"}
-        aria-describedby={"search-field-description"}
-        role="search"
-        placeholder={"Search Topic (exact match)"}
-      />
-      <div id={"search-field-description"} className={"visually-hidden"}>
-        Press &quot;Enter&quot; to start your search. Press &quot;Escape&quot;
-        to delete all your input.
-      </div>
-    </div>,
-  ];
 
   const table = (
     <SchemaApprovalsTable

--- a/coral/src/app/features/approvals/schemas/SchemaApprovals.tsx
+++ b/coral/src/app/features/approvals/schemas/SchemaApprovals.tsx
@@ -15,7 +15,7 @@ function SchemaApprovals() {
     ? Number(searchParams.get("page"))
     : 1;
 
-  const { status, filters } = useTableFilters();
+  const { environment, status, filters } = useTableFilters();
 
   const [detailsModal, setDetailsModal] = useState<{
     isOpen: boolean;
@@ -28,11 +28,12 @@ function SchemaApprovals() {
     isError: schemaRequestsIsError,
     error: schemaRequestsError,
   } = useQuery({
-    queryKey: ["schemaRequestsForApprover", currentPage, status],
+    queryKey: ["schemaRequestsForApprover", currentPage, status, environment],
     queryFn: () =>
       getSchemaRequestsForApprover({
         requestStatus: status,
-        pageNumber: currentPage,
+        pageNo: currentPage.toString(),
+        env: environment,
       }),
     keepPreviousData: true,
   });

--- a/coral/src/app/features/approvals/schemas/SchemaApprovals.tsx
+++ b/coral/src/app/features/approvals/schemas/SchemaApprovals.tsx
@@ -15,7 +15,7 @@ function SchemaApprovals() {
     ? Number(searchParams.get("page"))
     : 1;
 
-  const { filters } = useTableFilters();
+  const { status, filters } = useTableFilters();
 
   const [detailsModal, setDetailsModal] = useState<{
     isOpen: boolean;
@@ -28,10 +28,10 @@ function SchemaApprovals() {
     isError: schemaRequestsIsError,
     error: schemaRequestsError,
   } = useQuery({
-    queryKey: ["schemaRequestsForApprover", currentPage],
+    queryKey: ["schemaRequestsForApprover", currentPage, status],
     queryFn: () =>
       getSchemaRequestsForApprover({
-        requestStatus: "ALL",
+        requestStatus: status,
         pageNumber: currentPage,
       }),
     keepPreviousData: true,

--- a/coral/src/app/features/approvals/schemas/SchemaApprovals.tsx
+++ b/coral/src/app/features/approvals/schemas/SchemaApprovals.tsx
@@ -15,7 +15,7 @@ function SchemaApprovals() {
     ? Number(searchParams.get("page"))
     : 1;
 
-  const { environment, status, filters } = useTableFilters();
+  const { environment, status, topic, filters } = useTableFilters();
 
   const [detailsModal, setDetailsModal] = useState<{
     isOpen: boolean;
@@ -28,12 +28,19 @@ function SchemaApprovals() {
     isError: schemaRequestsIsError,
     error: schemaRequestsError,
   } = useQuery({
-    queryKey: ["schemaRequestsForApprover", currentPage, status, environment],
+    queryKey: [
+      "schemaRequestsForApprover",
+      currentPage,
+      status,
+      environment,
+      topic,
+    ],
     queryFn: () =>
       getSchemaRequestsForApprover({
         requestStatus: status,
         pageNo: currentPage.toString(),
         env: environment,
+        topic,
       }),
     keepPreviousData: true,
   });

--- a/coral/src/app/features/approvals/schemas/components/SchemaApprovalsTable.test.tsx
+++ b/coral/src/app/features/approvals/schemas/components/SchemaApprovalsTable.test.tsx
@@ -2,8 +2,9 @@ import SchemaApprovalsTable from "src/app/features/approvals/schemas/components/
 import { cleanup, render, screen, within } from "@testing-library/react";
 import { mockIntersectionObserver } from "src/services/test-utils/mock-intersection-observer";
 import { SchemaRequest } from "src/domain/schema-request";
-import { getRequestStatusName } from "src/app/features/approvals/utils/request-status-helper";
+import { requestStatusNameMap } from "src/app/features/approvals/utils/request-status-helper";
 import userEvent from "@testing-library/user-event";
+import { RequestStatus } from "src/domain/requests";
 
 const mockedRequests: SchemaRequest[] = [
   {
@@ -215,7 +216,7 @@ describe("SchemaApprovalsTable", () => {
               text = `${field} UTC`;
             }
             if (column.columnHeader === "Status") {
-              text = getRequestStatusName(field);
+              text = requestStatusNameMap[field as RequestStatus];
             }
             const cell = within(table).getByRole("cell", { name: text });
 

--- a/coral/src/app/features/approvals/schemas/components/SchemaApprovalsTable.test.tsx
+++ b/coral/src/app/features/approvals/schemas/components/SchemaApprovalsTable.test.tsx
@@ -2,6 +2,7 @@ import SchemaApprovalsTable from "src/app/features/approvals/schemas/components/
 import { cleanup, render, screen, within } from "@testing-library/react";
 import { mockIntersectionObserver } from "src/services/test-utils/mock-intersection-observer";
 import { SchemaRequest } from "src/domain/schema-request";
+import { getRequestStatusName } from "src/app/features/approvals/utils/request-status-helper";
 import userEvent from "@testing-library/user-event";
 
 const mockedRequests: SchemaRequest[] = [
@@ -44,7 +45,7 @@ const mockedRequests: SchemaRequest[] = [
     username: "bcrusher",
     requesttime: "1994-23-05T13:37:00.001+00:00",
     requesttimestring: "23-May-1994 13:37:00",
-    requestStatus: "CREATED",
+    requestStatus: "APPROVED",
     requestOperationType: "DELETE",
     remarks: "asap",
     approvingTeamDetails:
@@ -207,10 +208,15 @@ describe("SchemaApprovalsTable", () => {
 
             // eslint-disable-next-line @typescript-eslint/ban-ts-comment
             //@ts-ignore
-            const content = `${request[column.relatedField]}`;
-            const isFormattedTime = column.columnHeader === "Date requested";
+            const field = request[column.relatedField];
 
-            const text = `${content}${isFormattedTime ? " UTC" : ""}`;
+            let text = field;
+            if (column.columnHeader === "Date requested") {
+              text = `${field} UTC`;
+            }
+            if (column.columnHeader === "Status") {
+              text = getRequestStatusName(field);
+            }
             const cell = within(table).getByRole("cell", { name: text });
 
             expect(cell).toBeVisible();

--- a/coral/src/app/features/approvals/schemas/components/SchemaApprovalsTable.test.tsx
+++ b/coral/src/app/features/approvals/schemas/components/SchemaApprovalsTable.test.tsx
@@ -67,6 +67,7 @@ describe("SchemaApprovalsTable", () => {
   const columnsFieldMap = [
     { columnHeader: "Topic", relatedField: "topicname" },
     { columnHeader: "Environment", relatedField: "environmentName" },
+    { columnHeader: "Status", relatedField: "requestStatus" },
     { columnHeader: "Requested by", relatedField: "username" },
     { columnHeader: "Date requested", relatedField: "requesttimestring" },
     { columnHeader: "Details", relatedField: null },

--- a/coral/src/app/features/approvals/schemas/components/SchemaApprovalsTable.tsx
+++ b/coral/src/app/features/approvals/schemas/components/SchemaApprovalsTable.tsx
@@ -3,14 +3,19 @@ import { SchemaRequest } from "src/domain/schema-request";
 import infoSign from "@aivenio/aquarium/icons/infoSign";
 import tickCircle from "@aivenio/aquarium/icons/tickCircle";
 import deleteIcon from "@aivenio/aquarium/icons/delete";
+import {
+  getRequestStatusColor,
+  getRequestStatusName,
+} from "src/app/features/approvals/utils/request-status-helper";
 import { Dispatch, SetStateAction } from "react";
 
 interface SchemaRequestTableData {
-  id: number;
-  topicname: string;
-  environmentName: string;
-  username: string;
-  requesttimestring: string;
+  id: SchemaRequest["req_no"];
+  topicname: SchemaRequest["topicname"];
+  environmentName: SchemaRequest["environmentName"];
+  username: SchemaRequest["username"];
+  requesttimestring: SchemaRequest["requesttimestring"];
+  requestStatus: SchemaRequest["requestStatus"];
 }
 
 type SchemaApprovalsTableProps = {
@@ -27,7 +32,18 @@ function SchemaApprovalsTable(props: SchemaApprovalsTableProps) {
   const columns: Array<DataTableColumn<SchemaRequestTableData>> = [
     { type: "text", field: "topicname", headerName: "Topic" },
     { type: "text", field: "environmentName", headerName: "Environment" },
-    { type: "text", field: "username", headerName: "Requested by" },
+    {
+    type: "status",
+    field: "requestStatus",
+    headerName: "Status",
+    status: ({ requestStatus }) => {
+      return {
+        status: getRequestStatusColor(requestStatus),
+        text: getRequestStatusName(requestStatus),
+      };
+    },
+  },
+  { type: "text", field: "username", headerName: "Requested by" },
     {
       type: "text",
       field: "requesttimestring",
@@ -107,6 +123,7 @@ function SchemaApprovalsTable(props: SchemaApprovalsTableProps) {
         environmentName: request.environmentName,
         username: request.username,
         requesttimestring: request.requesttimestring,
+        requestStatus: request.requestStatus,
       };
     }
   );

--- a/coral/src/app/features/approvals/schemas/components/SchemaApprovalsTable.tsx
+++ b/coral/src/app/features/approvals/schemas/components/SchemaApprovalsTable.tsx
@@ -28,31 +28,32 @@ type SchemaApprovalsTableProps = {
   >;
 };
 function SchemaApprovalsTable(props: SchemaApprovalsTableProps) {
-  const { requests, setDetailsModal } = props;const columns: Array<DataTableColumn<SchemaRequestTableData>> = [
-  { type: "text", field: "topicname", headerName: "Topic" },
-  {
-    type: "status",
-    field: "environmentName",
-    headerName: "Environment",
-    status: ({ environmentName }) => {
-      return {
-        status: "neutral",
-        text: environmentName,
-      };
+  const { requests, setDetailsModal } = props;
+  const columns: Array<DataTableColumn<SchemaRequestTableData>> = [
+    { type: "text", field: "topicname", headerName: "Topic" },
+    {
+      type: "status",
+      field: "environmentName",
+      headerName: "Environment",
+      status: ({ environmentName }) => {
+        return {
+          status: "neutral",
+          text: environmentName,
+        };
+      },
     },
-  },
-  {
-    type: "status",
-    field: "requestStatus",
-    headerName: "Status",
-    status: ({ requestStatus }) => {
-      return {
-        status: getRequestStatusColor(requestStatus),
-        text: getRequestStatusName(requestStatus),
-      };
+    {
+      type: "status",
+      field: "requestStatus",
+      headerName: "Status",
+      status: ({ requestStatus }) => {
+        return {
+          status: getRequestStatusColor(requestStatus),
+          text: getRequestStatusName(requestStatus),
+        };
+      },
     },
-  },
-  { type: "text", field: "username", headerName: "Requested by" },
+    { type: "text", field: "username", headerName: "Requested by" },
     {
       type: "text",
       field: "requesttimestring",

--- a/coral/src/app/features/approvals/schemas/components/SchemaApprovalsTable.tsx
+++ b/coral/src/app/features/approvals/schemas/components/SchemaApprovalsTable.tsx
@@ -28,11 +28,20 @@ type SchemaApprovalsTableProps = {
   >;
 };
 function SchemaApprovalsTable(props: SchemaApprovalsTableProps) {
-  const { requests, setDetailsModal } = props;
-  const columns: Array<DataTableColumn<SchemaRequestTableData>> = [
-    { type: "text", field: "topicname", headerName: "Topic" },
-    { type: "text", field: "environmentName", headerName: "Environment" },
-    {
+  const { requests, setDetailsModal } = props;const columns: Array<DataTableColumn<SchemaRequestTableData>> = [
+  { type: "text", field: "topicname", headerName: "Topic" },
+  {
+    type: "status",
+    field: "environmentName",
+    headerName: "Environment",
+    status: ({ environmentName }) => {
+      return {
+        status: "neutral",
+        text: environmentName,
+      };
+    },
+  },
+  {
     type: "status",
     field: "requestStatus",
     headerName: "Status",

--- a/coral/src/app/features/approvals/schemas/components/SchemaApprovalsTable.tsx
+++ b/coral/src/app/features/approvals/schemas/components/SchemaApprovalsTable.tsx
@@ -4,8 +4,8 @@ import infoSign from "@aivenio/aquarium/icons/infoSign";
 import tickCircle from "@aivenio/aquarium/icons/tickCircle";
 import deleteIcon from "@aivenio/aquarium/icons/delete";
 import {
-  getRequestStatusColor,
-  getRequestStatusName,
+  requestStatusChipStatusMap,
+  requestStatusNameMap,
 } from "src/app/features/approvals/utils/request-status-helper";
 import { Dispatch, SetStateAction } from "react";
 
@@ -48,8 +48,8 @@ function SchemaApprovalsTable(props: SchemaApprovalsTableProps) {
       headerName: "Status",
       status: ({ requestStatus }) => {
         return {
-          status: getRequestStatusColor(requestStatus),
-          text: getRequestStatusName(requestStatus),
+          status: requestStatusChipStatusMap[requestStatus],
+          text: requestStatusNameMap[requestStatus],
         };
       },
     },

--- a/coral/src/app/features/approvals/schemas/components/SelectSchemaRegEnvironment.test.tsx
+++ b/coral/src/app/features/approvals/schemas/components/SelectSchemaRegEnvironment.test.tsx
@@ -1,0 +1,130 @@
+import { cleanup, screen } from "@testing-library/react";
+import {
+  ALL_ENVIRONMENTS_VALUE,
+  getSchemaRegistryEnvironments,
+} from "src/domain/environment";
+import { mockedEnvironmentResponse } from "src/domain/environment/environment-api.msw";
+import { customRender } from "src/services/test-utils/render-with-wrappers";
+import { waitForElementToBeRemoved } from "@testing-library/react/pure";
+import userEvent from "@testing-library/user-event";
+import { createEnvironment } from "src/domain/environment/environment-test-helper";
+import { SelectSchemaRegEnvironment } from "src/app/features/approvals/schemas/components/SelectSchemaRegEnvironment";
+
+jest.mock("src/domain/environment/environment-api.ts");
+
+const mockGetSchemaRegistryEnvironments =
+  getSchemaRegistryEnvironments as jest.MockedFunction<
+    typeof getSchemaRegistryEnvironments
+  >;
+
+const filterLabel = "Filter by Environment";
+
+describe("SelectSchemaRegEnvironment.tsx", () => {
+  const mockedEnvironmentDev = createEnvironment({
+    name: "DEV",
+    id: "1",
+  });
+  const mockedEnvironmentTst = createEnvironment({
+    name: "TST",
+    id: "2",
+  });
+
+  describe("renders all necessary elements", () => {
+    const mockedOnChange = jest.fn();
+
+    beforeAll(async () => {
+      mockGetSchemaRegistryEnvironments.mockResolvedValue([
+        mockedEnvironmentDev,
+        mockedEnvironmentTst,
+      ]);
+
+      customRender(
+        <SelectSchemaRegEnvironment
+          value={ALL_ENVIRONMENTS_VALUE}
+          onChange={mockedOnChange}
+        />,
+        { queryClient: true }
+      );
+      await waitForElementToBeRemoved(
+        screen.getByTestId("select-environment-loading")
+      );
+    });
+
+    afterAll(cleanup);
+
+    it("shows a select element for environments", () => {
+      const select = screen.getByRole("combobox", {
+        name: filterLabel,
+      });
+
+      expect(select).toBeEnabled();
+    });
+
+    it("renders a list of options for environments plus a option for `All environments`", () => {
+      mockedEnvironmentResponse.forEach((environment) => {
+        const option = screen.getByRole("option", {
+          name: environment.name,
+        });
+
+        expect(option).toBeEnabled();
+      });
+      expect(screen.getAllByRole("option")).toHaveLength(
+        mockedEnvironmentResponse.length + 1
+      );
+    });
+
+    it("shows `All environments` as the active option based on given value", () => {
+      const option = screen.getByRole("option", {
+        selected: true,
+      });
+      expect(option).toHaveAccessibleName("All environments");
+    });
+
+    it("has `All environments` as the active value for option", () => {
+      const select = screen.getByRole("combobox", {
+        name: filterLabel,
+      });
+      expect(select).toHaveValue(ALL_ENVIRONMENTS_VALUE);
+    });
+  });
+
+  describe("handles user selecting a environment", () => {
+    const mockedOnChange = jest.fn();
+
+    beforeEach(async () => {
+      mockGetSchemaRegistryEnvironments.mockResolvedValue([
+        mockedEnvironmentDev,
+        mockedEnvironmentTst,
+      ]);
+
+      customRender(
+        <SelectSchemaRegEnvironment
+          value={ALL_ENVIRONMENTS_VALUE}
+          onChange={mockedOnChange}
+        />,
+        { queryClient: true }
+      );
+      await waitForElementToBeRemoved(
+        screen.getByTestId("select-environment-loading")
+      );
+    });
+
+    afterEach(() => {
+      jest.resetAllMocks();
+      cleanup();
+    });
+
+    it("updates state for api call when user selects a new environment", async () => {
+      const select = screen.getByRole("combobox", {
+        name: filterLabel,
+      });
+      const option = screen.getByRole("option", {
+        name: mockedEnvironmentDev.name,
+      });
+
+      await userEvent.selectOptions(select, option);
+
+      expect(mockedOnChange).toHaveBeenCalledWith(mockedEnvironmentDev.id);
+    });
+  });
+});

--- a/coral/src/app/features/approvals/schemas/components/SelectSchemaRegEnvironment.tsx
+++ b/coral/src/app/features/approvals/schemas/components/SelectSchemaRegEnvironment.tsx
@@ -1,0 +1,52 @@
+import { NativeSelect, Option } from "@aivenio/aquarium";
+import {
+  ALL_ENVIRONMENTS_VALUE,
+  Environment,
+  getSchemaRegistryEnvironments,
+} from "src/domain/environment";
+import { useQuery } from "@tanstack/react-query";
+
+type SelectSchemaRegEnvironmentProps = {
+  value: Environment["id"];
+  onChange: (value: Environment["id"]) => void;
+};
+
+function SelectSchemaRegEnvironment(props: SelectSchemaRegEnvironmentProps) {
+  const { value, onChange } = props;
+
+  const { data: environments, isLoading } = useQuery<Environment[], Error>({
+    queryKey: ["schemaRegistryEnvironments"],
+    queryFn: () => getSchemaRegistryEnvironments(),
+  });
+
+  if (isLoading || !environments) {
+    return (
+      <div data-testid={"select-environment-loading"}>
+        <NativeSelect.Skeleton />
+      </div>
+    );
+  } else {
+    return (
+      <NativeSelect
+        labelText="Filter by Environment"
+        value={value}
+        onChange={(event) => {
+          const env = event.target.value as Environment["id"];
+          onChange(env);
+        }}
+      >
+        <Option key={ALL_ENVIRONMENTS_VALUE} value={ALL_ENVIRONMENTS_VALUE}>
+          All environments
+        </Option>
+
+        {environments.map((env: Environment) => (
+          <Option key={env.id} value={env.id}>
+            {env.name}
+          </Option>
+        ))}
+      </NativeSelect>
+    );
+  }
+}
+
+export { SelectSchemaRegEnvironment };

--- a/coral/src/app/features/approvals/schemas/hooks/useTableFilters.test.tsx
+++ b/coral/src/app/features/approvals/schemas/hooks/useTableFilters.test.tsx
@@ -62,7 +62,8 @@ describe("useTableFilters.tsx", () => {
   describe("return correct values when there are searchParams", () => {
     it("returns '1' if 'env' search param is set to 1", () => {
       const { result } = renderHook(() => useTableFilters(), {
-        wrapper: ({ children }) => wrapper({ children, searchParam: "?env=1" }),
+        wrapper: ({ children }) =>
+          wrapper({ children, searchParam: "?environment=1" }),
       });
 
       expect(result.current.environment).toBe("1");
@@ -91,7 +92,7 @@ describe("useTableFilters.tsx", () => {
         wrapper: ({ children }) =>
           wrapper({
             children,
-            searchParam: "?status=APPROVED&env=2&topic=myothertopic",
+            searchParam: "?status=APPROVED&environment=2&topic=myothertopic",
           }),
       });
       expect(result.current.status).toBe("APPROVED");

--- a/coral/src/app/features/approvals/schemas/hooks/useTableFilters.test.tsx
+++ b/coral/src/app/features/approvals/schemas/hooks/useTableFilters.test.tsx
@@ -1,0 +1,102 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { renderHook } from "@testing-library/react";
+import { ReactElement } from "react";
+import { MemoryRouter } from "react-router-dom";
+import useTableFilters from "src/app/features/approvals/schemas/hooks/useTableFilters";
+
+const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: {
+      retry: false,
+      cacheTime: Infinity,
+    },
+  },
+});
+
+const wrapper = ({
+  children,
+  searchParam,
+}: {
+  children: ReactElement;
+  searchParam?: string;
+}) => (
+  <QueryClientProvider client={queryClient}>
+    <MemoryRouter initialEntries={[searchParam || ""]}>{children}</MemoryRouter>
+  </QueryClientProvider>
+);
+
+describe("useTableFilters.tsx", () => {
+  describe("return correct default values", () => {
+    it("returns correct list of fields", () => {
+      const { result } = renderHook(() => useTableFilters(), {
+        wrapper,
+      });
+
+      expect(result.current.filters).toHaveLength(3);
+    });
+
+    it("returns 'created' value by default for environment state", () => {
+      const { result } = renderHook(() => useTableFilters(), {
+        wrapper,
+      });
+
+      expect(result.current.environment).toBe("ALL");
+    });
+
+    it("returns 'ALL' value by default for status state", () => {
+      const { result } = renderHook(() => useTableFilters(), {
+        wrapper,
+      });
+      expect(result.current.status).toBe("CREATED");
+    });
+
+    it("returns '' value by default for topic state", () => {
+      const { result } = renderHook(() => useTableFilters(), {
+        wrapper,
+      });
+
+      expect(result.current.topic).toBe("");
+    });
+  });
+
+  describe("return correct values when there are searchParams", () => {
+    it("returns '1' if 'env' search param is set to 1", () => {
+      const { result } = renderHook(() => useTableFilters(), {
+        wrapper: ({ children }) => wrapper({ children, searchParam: "?env=1" }),
+      });
+
+      expect(result.current.environment).toBe("1");
+    });
+
+    it("returns value DECLINED if 'status' search param is set to DECLINED", () => {
+      const { result } = renderHook(() => useTableFilters(), {
+        wrapper: ({ children }) =>
+          wrapper({ children, searchParam: "?status=DECLINED" }),
+      });
+
+      expect(result.current.status).toBe("DECLINED");
+    });
+
+    it("returns value my-topic if 'topic' search param is set to my-topic", () => {
+      const { result } = renderHook(() => useTableFilters(), {
+        wrapper: ({ children }) =>
+          wrapper({ children, searchParam: "?topic=my-topic" }),
+      });
+
+      expect(result.current.topic).toBe("my-topic");
+    });
+
+    it("handles all search params at the same time", () => {
+      const { result } = renderHook(() => useTableFilters(), {
+        wrapper: ({ children }) =>
+          wrapper({
+            children,
+            searchParam: "?status=APPROVED&env=2&topic=myothertopic",
+          }),
+      });
+      expect(result.current.status).toBe("APPROVED");
+      expect(result.current.environment).toBe("2");
+      expect(result.current.topic).toBe("myothertopic");
+    });
+  });
+});

--- a/coral/src/app/features/approvals/schemas/hooks/useTableFilters.tsx
+++ b/coral/src/app/features/approvals/schemas/hooks/useTableFilters.tsx
@@ -2,10 +2,11 @@ import { SearchInput } from "@aivenio/aquarium";
 import debounce from "lodash/debounce";
 import { useState } from "react";
 import { useSearchParams } from "react-router-dom";
-import SelectEnvironment from "src/app/features/topics/browse/components/select-environment/SelectEnvironment";
 import { RequestStatus } from "src/domain/requests";
 import { getRequestStatusName } from "src/app/features/approvals/utils/request-status-helper";
 import { ComplexNativeSelect } from "src/app/components/ComplexNativeSelect";
+import { SelectSchemaRegEnvironment } from "src/app/features/approvals/schemas/components/SelectSchemaRegEnvironment";
+import { ALL_ENVIRONMENTS_VALUE } from "src/domain/environment";
 
 const statusList: RequestStatus[] = [
   "ALL",
@@ -18,11 +19,13 @@ const statusList: RequestStatus[] = [
 const useTableFilters = () => {
   const [searchParams, setSearchParams] = useSearchParams();
 
-  const envParam = searchParams.get("env");
+  const envParam = searchParams.get("environment");
   const statusParam = searchParams.get("status") as RequestStatus | null;
   const topicParam = searchParams.get("topic") as string | null;
 
-  const [environment, setEnvironment] = useState(envParam ?? "ALL");
+  const [environment, setEnvironment] = useState(
+    envParam ?? ALL_ENVIRONMENTS_VALUE
+  );
   const [status, setStatus] = useState<RequestStatus>(statusParam ?? "CREATED");
   const [topic, setTopic] = useState(topicParam ?? "");
 
@@ -32,7 +35,15 @@ const useTableFilters = () => {
     });
 
   const filters = [
-    <SelectEnvironment key={"filter-environment"} onChange={setEnvironment} />,
+    <SelectSchemaRegEnvironment
+      key={"filter-environment"}
+      value={environment}
+      onChange={(envId: string) => {
+        searchParams.set("environment", envId);
+        setSearchParams(searchParams);
+        setEnvironment(envId);
+      }}
+    />,
     <ComplexNativeSelect<{ value: RequestStatus; name: string }>
       labelText={"Filter by status"}
       key={"filter-status"}

--- a/coral/src/app/features/approvals/schemas/hooks/useTableFilters.tsx
+++ b/coral/src/app/features/approvals/schemas/hooks/useTableFilters.tsx
@@ -1,10 +1,11 @@
-import { NativeSelect, SearchInput } from "@aivenio/aquarium";
+import { SearchInput } from "@aivenio/aquarium";
 import debounce from "lodash/debounce";
 import { useState } from "react";
 import { useSearchParams } from "react-router-dom";
 import SelectEnvironment from "src/app/features/topics/browse/components/select-environment/SelectEnvironment";
 import { RequestStatus } from "src/domain/requests";
 import { getRequestStatusName } from "src/app/features/approvals/utils/request-status-helper";
+import { ComplexNativeSelect } from "src/app/components/ComplexNativeSelect";
 
 const statusList: RequestStatus[] = [
   "ALL",
@@ -25,23 +26,27 @@ const useTableFilters = () => {
   const [status, setStatus] = useState<RequestStatus>(statusParam ?? "CREATED");
   const [topic, setTopic] = useState(topicParam ?? "");
 
+  const statusOptions: Array<{ value: RequestStatus; name: string }> =
+    statusList.map((status) => {
+      return { value: status, name: getRequestStatusName(status) };
+    });
+
   const filters = [
     <SelectEnvironment key={"filter-environment"} onChange={setEnvironment} />,
-    <NativeSelect
+    <ComplexNativeSelect<{ value: RequestStatus; name: string }>
       labelText={"Filter by status"}
       key={"filter-status"}
       defaultValue={status}
-      onChange={(e) => {
-        const status = e.target.value as RequestStatus;
-        searchParams.set("status", status);
+      options={statusOptions}
+      identifierValue={"value"}
+      identifierName={"name"}
+      onBlur={(option) => {
+        const { value } = option as { value: RequestStatus; name: string };
+        searchParams.set("status", value);
         setSearchParams(searchParams);
-        setStatus(status);
+        setStatus(value);
       }}
-    >
-      {statusList.map((status) => {
-        return <option key={status}>{getRequestStatusName(status)}</option>;
-      })}
-    </NativeSelect>,
+    />,
     <div key={"search"}>
       <SearchInput
         type={"search"}

--- a/coral/src/app/features/approvals/schemas/hooks/useTableFilters.tsx
+++ b/coral/src/app/features/approvals/schemas/hooks/useTableFilters.tsx
@@ -21,7 +21,7 @@ const useTableFilters = () => {
 
   const envParam = searchParams.get("environment");
   const statusParam = searchParams.get("status") as RequestStatus | null;
-  const topicParam = searchParams.get("topic") as string | null;
+  const topicParam = searchParams.get("topic");
 
   const [environment, setEnvironment] = useState(
     envParam ?? ALL_ENVIRONMENTS_VALUE

--- a/coral/src/app/features/approvals/schemas/hooks/useTableFilters.tsx
+++ b/coral/src/app/features/approvals/schemas/hooks/useTableFilters.tsx
@@ -4,6 +4,7 @@ import { useState } from "react";
 import { useSearchParams } from "react-router-dom";
 import SelectEnvironment from "src/app/features/topics/browse/components/select-environment/SelectEnvironment";
 import { RequestStatus } from "src/domain/requests";
+import { getRequestStatusName } from "src/app/features/approvals/utils/request-status-helper";
 
 const statusList: RequestStatus[] = [
   "ALL",
@@ -38,14 +39,7 @@ const useTableFilters = () => {
       }}
     >
       {statusList.map((status) => {
-        if (status === "ALL") {
-          return (
-            <option key={status} value={"ALL"}>
-              All statuses
-            </option>
-          );
-        }
-        return <option key={status}>{status}</option>;
+        return <option key={status}>{getRequestStatusName(status)}</option>;
       })}
     </NativeSelect>,
     <div key={"search"}>

--- a/coral/src/app/features/approvals/schemas/hooks/useTableFilters.tsx
+++ b/coral/src/app/features/approvals/schemas/hooks/useTableFilters.tsx
@@ -3,7 +3,7 @@ import debounce from "lodash/debounce";
 import { useState } from "react";
 import { useSearchParams } from "react-router-dom";
 import { RequestStatus } from "src/domain/requests";
-import { getRequestStatusName } from "src/app/features/approvals/utils/request-status-helper";
+import { requestStatusNameMap } from "src/app/features/approvals/utils/request-status-helper";
 import { ComplexNativeSelect } from "src/app/components/ComplexNativeSelect";
 import { SelectSchemaRegEnvironment } from "src/app/features/approvals/schemas/components/SelectSchemaRegEnvironment";
 import { ALL_ENVIRONMENTS_VALUE } from "src/domain/environment";
@@ -31,7 +31,7 @@ const useTableFilters = () => {
 
   const statusOptions: Array<{ value: RequestStatus; name: string }> =
     statusList.map((status) => {
-      return { value: status, name: getRequestStatusName(status) };
+      return { value: status, name: requestStatusNameMap[status] };
     });
 
   const filters = [

--- a/coral/src/app/features/approvals/schemas/hooks/useTableFilters.tsx
+++ b/coral/src/app/features/approvals/schemas/hooks/useTableFilters.tsx
@@ -1,0 +1,81 @@
+import { NativeSelect, SearchInput } from "@aivenio/aquarium";
+import debounce from "lodash/debounce";
+import { useState } from "react";
+import { useSearchParams } from "react-router-dom";
+import SelectEnvironment from "src/app/features/topics/browse/components/select-environment/SelectEnvironment";
+import { RequestStatus } from "src/domain/requests";
+
+const statusList: RequestStatus[] = [
+  "ALL",
+  "CREATED",
+  "APPROVED",
+  "DECLINED",
+  "DELETED",
+];
+
+const useTableFilters = () => {
+  const [searchParams, setSearchParams] = useSearchParams();
+
+  const envParam = searchParams.get("env");
+  const statusParam = searchParams.get("status") as RequestStatus | null;
+  const topicParam = searchParams.get("topic") as string | null;
+
+  const [environment, setEnvironment] = useState(envParam ?? "ALL");
+  const [status, setStatus] = useState<RequestStatus>(statusParam ?? "CREATED");
+  const [topic, setTopic] = useState(topicParam ?? "");
+
+  const filters = [
+    <SelectEnvironment key={"filter-environment"} onChange={setEnvironment} />,
+    <NativeSelect
+      labelText={"Filter by status"}
+      key={"filter-status"}
+      defaultValue={status}
+      onChange={(e) => {
+        const status = e.target.value as RequestStatus;
+        searchParams.set("status", status);
+        setSearchParams(searchParams);
+        setStatus(status);
+      }}
+    >
+      {statusList.map((status) => {
+        if (status === "ALL") {
+          return (
+            <option key={status} value={"ALL"}>
+              All statuses
+            </option>
+          );
+        }
+        return <option key={status}>{status}</option>;
+      })}
+    </NativeSelect>,
+    <div key={"search"}>
+      <SearchInput
+        type={"search"}
+        aria-describedby={"search-field-description"}
+        role="search"
+        placeholder={"Search Topic (exact match)"}
+        defaultValue={topic}
+        onChange={debounce((e) => {
+          const parsedName = String(e.target.value).trim();
+          if (parsedName === "") {
+            searchParams.delete("topic");
+            setTopic(parsedName);
+            setSearchParams(searchParams);
+          } else {
+            searchParams.set("topic", parsedName);
+            setSearchParams(searchParams);
+            setTopic(parsedName);
+          }
+        }, 500)}
+      />
+      <div id={"search-field-description"} className={"visually-hidden"}>
+        Press &quot;Enter&quot; to start your search. Press &quot;Escape&quot;
+        to delete all your input.
+      </div>
+    </div>,
+  ];
+
+  return { environment, topic, status, filters };
+};
+
+export default useTableFilters;

--- a/coral/src/app/features/approvals/topics/components/DetailsModalContent.test.tsx
+++ b/coral/src/app/features/approvals/topics/components/DetailsModalContent.test.tsx
@@ -63,7 +63,6 @@ const withAdvancedConfigRequest: TopicRequest = {
 
 const findDefinition = (term?: string) => {
   return screen.getAllByRole("definition").find((value) => {
-    console.log(value.textContent);
     return value.textContent === term;
   });
 };

--- a/coral/src/app/features/approvals/utils/request-status-helper.ts
+++ b/coral/src/app/features/approvals/utils/request-status-helper.ts
@@ -1,37 +1,24 @@
-import { checkExhaustive } from "src/services/check-exhaustive";
 import { RequestStatus } from "src/domain/requests";
 import { ChipStatus } from "@aivenio/aquarium";
 
-function getRequestStatusName(status: RequestStatus): string {
-  switch (status) {
-    case "ALL":
-      return "All statuses";
-    case "APPROVED":
-      return "Approved";
-    case "CREATED":
-      return "Created";
-    case "DECLINED":
-      return "Declined";
-    case "DELETED":
-      return "Deleted";
-  }
-  checkExhaustive(status);
-}
+const requestStatusChipStatusMap: {
+  [key in RequestStatus]: ChipStatus;
+} = {
+  ALL: "neutral",
+  APPROVED: "success",
+  CREATED: "info",
+  DECLINED: "warning",
+  DELETED: "danger",
+};
 
-function getRequestStatusColor(status: RequestStatus): ChipStatus {
-  switch (status) {
-    case "ALL":
-      return "neutral";
-    case "APPROVED":
-      return "success";
-    case "CREATED":
-      return "info";
-    case "DECLINED":
-      return "warning";
-    case "DELETED":
-      return "danger";
-  }
-  checkExhaustive(status);
-}
+const requestStatusNameMap: {
+  [key in RequestStatus]: string;
+} = {
+  ALL: "All statuses",
+  APPROVED: "Approved",
+  CREATED: "Created",
+  DECLINED: "Declined",
+  DELETED: "Deleted",
+};
 
-export { getRequestStatusColor, getRequestStatusName };
+export { requestStatusNameMap, requestStatusChipStatusMap };

--- a/coral/src/app/features/approvals/utils/request-status-helper.ts
+++ b/coral/src/app/features/approvals/utils/request-status-helper.ts
@@ -1,0 +1,37 @@
+import { checkExhaustive } from "src/services/check-exhaustive";
+import { RequestStatus } from "src/domain/requests";
+import { ChipStatus } from "@aivenio/aquarium";
+
+function getRequestStatusName(status: RequestStatus): string {
+  switch (status) {
+    case "ALL":
+      return "All statuses";
+    case "APPROVED":
+      return "Approved";
+    case "CREATED":
+      return "Created";
+    case "DECLINED":
+      return "Declined";
+    case "DELETED":
+      return "Deleted";
+  }
+  checkExhaustive(status);
+}
+
+function getRequestStatusColor(status: RequestStatus): ChipStatus {
+  switch (status) {
+    case "ALL":
+      return "neutral";
+    case "APPROVED":
+      return "success";
+    case "CREATED":
+      return "info";
+    case "DECLINED":
+      return "warning";
+    case "DELETED":
+      return "danger";
+  }
+  checkExhaustive(status);
+}
+
+export { getRequestStatusColor, getRequestStatusName };

--- a/coral/src/domain/environment/environment-types.ts
+++ b/coral/src/domain/environment/environment-types.ts
@@ -1,5 +1,8 @@
 import { KlawApiModel } from "types/utils";
 
+//@TODO this seems to be specifically modified to fit
+// for creating a TopicRequest, we should check this
+// with backend and align API and our types/needs
 type Environment = {
   name: KlawApiModel<"Environment">["name"];
   id: KlawApiModel<"Environment">["id"];

--- a/coral/src/domain/schema-request/schema-request-api.ts
+++ b/coral/src/domain/schema-request/schema-request-api.ts
@@ -38,7 +38,6 @@ type GetSchemaRequestsQueryParams = ResolveIntersectionTypes<
 const getSchemaRequestsForApprover = (
   args: GetSchemaRequestsQueryParams
 ): Promise<SchemaRequestApiResponse> => {
-  console.log("api call", args);
   const queryObject: GetSchemaRequestsQueryParams = {
     pageNo: args.pageNo,
     requestStatus: args.requestStatus,

--- a/coral/src/domain/schema-request/schema-request-api.ts
+++ b/coral/src/domain/schema-request/schema-request-api.ts
@@ -3,9 +3,8 @@ import api from "src/services/api";
 import {
   SchemaRequestApiResponse,
   CreateSchemaRequestPayload,
-  SchemaRequestStatus,
 } from "src/domain/schema-request/schema-request-types";
-import { components, operations } from "types/api";
+import { operations } from "types/api";
 import { transformGetSchemaRequestsForApproverResponse } from "src/domain/schema-request/schema-request-transformer";
 
 const createSchemaRequest = (
@@ -23,38 +22,30 @@ const createSchemaRequest = (
   );
 };
 
-type GetSchemaRequestsArgs = {
-  pageNumber?: number;
-  requestStatus: SchemaRequestStatus;
-};
-
 type GetSchemaRequestsQueryParams = ResolveIntersectionTypes<
   Required<
     Pick<
       operations["getSchemaRequestsForApprover"]["parameters"]["query"],
       "pageNo" | "requestStatus"
     >
-  >
+  > &
+    Pick<
+      operations["getSchemaRequestsForApprover"]["parameters"]["query"],
+      "env" | "topic"
+    >
 >;
 
-// query: {
-//   pageNo: string;
-//   currentPage?: string;
-//   requestStatus?: components["schemas"]["RequestStatus"];
-//   /** Name of a topic */
-//   topic?: string;
-//   /** Environment identifier */
-//   env?: string;
-//   search?: string;
-// };
-const getSchemaRequestsForApprover = ({
-  requestStatus = "CREATED",
-  pageNumber = 1,
-}: GetSchemaRequestsArgs): Promise<SchemaRequestApiResponse> => {
+const getSchemaRequestsForApprover = (
+  args: GetSchemaRequestsQueryParams
+): Promise<SchemaRequestApiResponse> => {
+  console.log("api call", args);
   const queryObject: GetSchemaRequestsQueryParams = {
-    pageNo: pageNumber.toString(),
-    requestStatus: requestStatus,
+    pageNo: args.pageNo,
+    requestStatus: args.requestStatus,
+    ...(args.topic && { topic: args.topic }),
+    ...(args.env && args.env !== "ALL" && { env: args.env }),
   };
+
   return api
     .get<KlawApiResponse<"getSchemaRequestsForApprover">>(
       `/getSchemaRequestsForApprover?${new URLSearchParams(

--- a/coral/src/domain/schema-request/schema-request-api.ts
+++ b/coral/src/domain/schema-request/schema-request-api.ts
@@ -5,7 +5,7 @@ import {
   CreateSchemaRequestPayload,
   SchemaRequestStatus,
 } from "src/domain/schema-request/schema-request-types";
-import { operations } from "types/api";
+import { components, operations } from "types/api";
 import { transformGetSchemaRequestsForApproverResponse } from "src/domain/schema-request/schema-request-transformer";
 
 const createSchemaRequest = (
@@ -37,8 +37,18 @@ type GetSchemaRequestsQueryParams = ResolveIntersectionTypes<
   >
 >;
 
+// query: {
+//   pageNo: string;
+//   currentPage?: string;
+//   requestStatus?: components["schemas"]["RequestStatus"];
+//   /** Name of a topic */
+//   topic?: string;
+//   /** Environment identifier */
+//   env?: string;
+//   search?: string;
+// };
 const getSchemaRequestsForApprover = ({
-  requestStatus,
+  requestStatus = "CREATED",
   pageNumber = 1,
 }: GetSchemaRequestsArgs): Promise<SchemaRequestApiResponse> => {
   const queryObject: GetSchemaRequestsQueryParams = {

--- a/coral/src/services/check-exhaustive.ts
+++ b/coral/src/services/check-exhaustive.ts
@@ -1,0 +1,5 @@
+const checkExhaustive = (param: never): never => {
+  throw new Error("Missing or unexpected param", param);
+};
+
+export { checkExhaustive };

--- a/coral/src/services/check-exhaustive.ts
+++ b/coral/src/services/check-exhaustive.ts
@@ -1,5 +1,0 @@
-const checkExhaustive = (param: never): never => {
-  throw new Error("Missing or unexpected param", param);
-};
-
-export { checkExhaustive };


### PR DESCRIPTION
# About this change - What it does

- adds utils maps for getting readable names for `RequestStatus` values and the correct type of status chip values matched to colours (will add that to topic/acl in a later PR to have a consistent look)
    - Replace `NativeSelect` with `ComplexNativeSelect` to sync right value for status
- adds `tableFilters` hook for schema request approvals
- adds `SelectSchemaRegEnvironment` component that takes care of fetching the right environments for schemas from `/schemaRegEnvsGet`
    - I added this component in a way that is optimised for the usage in my `tableFilters` hook, it's one of the things we can revisit after this release!
- add filter functionality for environment, status and topic


Resolves: #677 
Why this way
