### PR TITLE
Label changes for switch teams

### DIFF
--- a/core/src/main/resources/templates/addUser.html
+++ b/core/src/main/resources/templates/addUser.html
@@ -560,7 +560,7 @@
 											<div class="form-group">
 												<label class="custom-control custom-checkbox">
 													<input ng-change="onChangeSwitchTeams()" id="switchteams" type="checkbox" class="custom-control-input" ng-model="addNewUser.canswitchteams">
-													<span class="custom-control-label">Can switch Teams ?</span>
+													<span class="custom-control-label">Enable switching Teams</span>
 												</label>
 											</div>
 										</div>

--- a/core/src/main/resources/templates/modifyUser.html
+++ b/core/src/main/resources/templates/modifyUser.html
@@ -543,7 +543,7 @@
 											<div class="form-group">
 												<label class="custom-control custom-checkbox">
 													<input ng-change="onChangeSwitchTeams()" id="switchteams" type="checkbox" class="custom-control-input" ng-model="userDetails.switchTeams">
-													<span class="custom-control-label">Can switch Teams ?</span>
+													<span class="custom-control-label">Enable switching Teams</span>
 												</label>
 											</div>
 										</div>

--- a/core/src/main/resources/templates/myProfile.html
+++ b/core/src/main/resources/templates/myProfile.html
@@ -520,7 +520,7 @@
 											<div class="form-group">
 												<label class="custom-control custom-checkbox">
 													<input disabled id="switchteams" type="checkbox" class="custom-control-input" ng-model="myProfInfo.switchTeams">
-													<span class="custom-control-label">Can switch Teams ?</span>
+													<span class="custom-control-label">Enable switching Teams</span>
 												</label>
 											</div>
 										</div>

--- a/core/src/main/resources/templates/showUsers.html
+++ b/core/src/main/resources/templates/showUsers.html
@@ -479,7 +479,7 @@
 										<th width="10%">Team</th>
 										<th width="10%">Role</th>
 										<th width="10%">EmailId</th>
-										<th width="10%">Can switch Teams</th>
+										<th width="10%">Enable switching Teams</th>
 										<th width="10%">Switch between Teams</th>
 										<th width="5%" ng-show="dashboardDetails.addUser=='Authorized'">Edit</th>
 										<th width="5%" ng-show="dashboardDetails.addUser=='Authorized'">Delete</th>


### PR DESCRIPTION
About this change - What it does

Updates the label from 'Can switch Teams' to 'Enable switching Teams'  in user profile pages

Resolves: #xxxxx
Why this way
