### PR TITLE
feat(coral): Add approveTopicRequest and rejectTopicRequest endpoints 

### DIFF
--- a/coral/src/domain/topic/topic-api.ts
+++ b/coral/src/domain/topic/topic-api.ts
@@ -137,6 +137,33 @@ const getTopicRequestsForApprover = ({
     .then(transformGetTopicRequestsForApproverResponse);
 };
 
+type ApproveTopicRequestPayload = ResolveIntersectionTypes<
+  Omit<KlawApiRequest<"approveRequest">, "reason"> & {
+    requestEntityType: "TOPIC";
+  }
+>;
+
+const approveTopicRequest = (payload: ApproveTopicRequestPayload) => {
+  return api.post<
+    KlawApiResponse<"approveRequest">,
+    ApproveTopicRequestPayload
+  >(`/request/approve`, payload);
+};
+
+type RejectTopicRequestPayload = ResolveIntersectionTypes<
+  KlawApiRequest<"declineRequest"> & {
+    reason: string;
+    requestEntityType: "TOPIC";
+  }
+>;
+
+const rejectTopicRequest = (payload: RejectTopicRequestPayload) => {
+  return api.post<KlawApiResponse<"declineRequest">, RejectTopicRequestPayload>(
+    `/request/decline`,
+    payload
+  );
+};
+
 export {
   getTopics,
   getTopicNames,
@@ -144,4 +171,6 @@ export {
   getTopicAdvancedConfigOptions,
   requestTopic,
   getTopicRequestsForApprover,
+  approveTopicRequest,
+  rejectTopicRequest,
 };

--- a/coral/types/api.d.ts
+++ b/coral/types/api.d.ts
@@ -1324,13 +1324,13 @@ export type operations = {
       /** successful operation */
       200: {
         content: {
-          "application/json": components["schemas"]["ApiResponse"][];
+          "application/json": components["schemas"]["GenericApiResponse"][];
         };
       };
     };
     requestBody: {
       content: {
-        "*/*": components["schemas"]["RequestVerdict"];
+        "application/json": components["schemas"]["RequestVerdict"];
       };
     };
   };
@@ -1339,13 +1339,13 @@ export type operations = {
       /** successful operation */
       200: {
         content: {
-          "application/json": components["schemas"]["ApiResponse"][];
+          "application/json": components["schemas"]["GenericApiResponse"][];
         };
       };
     };
     requestBody: {
       content: {
-        "*/*": components["schemas"]["RequestVerdict"];
+        "application/json": components["schemas"]["RequestVerdict"];
       };
     };
   };

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -495,7 +495,7 @@ paths:
       operationId: approveRequest
       requestBody:
         content:
-          "*/*":
+          application/json:
             schema:
               $ref: "#/components/schemas/RequestVerdict"
         required: false
@@ -507,14 +507,14 @@ paths:
               schema:
                 type: array
                 items:
-                  $ref: "#/components/schemas/ApiResponse"
+                  $ref: "#/components/schemas/GenericApiResponse"
       x-codegen-request-body-name: body
   /request/decline:
     post:
       operationId: declineRequest
       requestBody:
         content:
-          "*/*":
+          application/json:
             schema:
               $ref: "#/components/schemas/RequestVerdict"
         required: false
@@ -526,7 +526,7 @@ paths:
               schema:
                 type: array
                 items:
-                  $ref: "#/components/schemas/ApiResponse"
+                  $ref: "#/components/schemas/GenericApiResponse"
       x-codegen-request-body-name: body
   /getSchemaRequestsForApprover:
     get:


### PR DESCRIPTION
## About this change - What it does

- Fix documentation of the `request/approve` and `request/decline` endpoint in `openapi.yaml`
- Use those endpoint to define the `domain/topic` entities `approveTopicRequest` and `rejectTopicRequest`

Resolves: #686

