### PR TITLE
feat(coral) Add api definition/types/functions for approve/decline schema request

### DIFF
--- a/coral/src/domain/requests.ts
+++ b/coral/src/domain/requests.ts
@@ -1,7 +1,30 @@
 import { components } from "types/api";
-
+import { ResolveIntersectionTypes } from "types/utils";
 type RequestOperationType = components["schemas"]["RequestOperationType"];
 type RequestStatus = components["schemas"]["RequestStatus"];
 type RequestVerdict = components["schemas"]["RequestVerdict"];
+type RequestEntityType =
+  components["schemas"]["RequestVerdict"]["requestEntityType"];
 
-export type { RequestOperationType, RequestStatus, RequestVerdict };
+type RequestVerdictApproval<T extends RequestEntityType> =
+  ResolveIntersectionTypes<
+    Omit<RequestVerdict, "reason"> & {
+      requestEntityType: T;
+    }
+  >;
+
+type RequestVerdictDecline<T extends RequestEntityType> =
+  ResolveIntersectionTypes<
+    Required<Pick<RequestVerdict, "reason">> &
+      RequestVerdict & {
+        requestEntityType: T;
+      }
+  >;
+
+export type {
+  RequestOperationType,
+  RequestStatus,
+  RequestEntityType,
+  RequestVerdictApproval,
+  RequestVerdictDecline,
+};

--- a/coral/src/domain/schema-request/schema-request-api.ts
+++ b/coral/src/domain/schema-request/schema-request-api.ts
@@ -7,6 +7,10 @@ import {
 } from "src/domain/schema-request/schema-request-types";
 import { operations } from "types/api";
 import { transformGetSchemaRequestsForApproverResponse } from "src/domain/schema-request/schema-request-transformer";
+import {
+  RequestVerdictApproval,
+  RequestVerdictDecline,
+} from "src/domain/requests";
 
 const createSchemaRequest = (
   params: CreateSchemaRequestPayload
@@ -54,4 +58,23 @@ const getSchemaRequestsForApprover = ({
     .then(transformGetSchemaRequestsForApproverResponse);
 };
 
-export { createSchemaRequest, getSchemaRequestsForApprover };
+const approveSchemaRequest = (payload: RequestVerdictApproval<"SCHEMA">) => {
+  return api.post<
+    KlawApiResponse<"approveRequest">,
+    RequestVerdictApproval<"SCHEMA">
+  >(`/request/approve`, payload);
+};
+
+const declineSchemaRequest = (payload: RequestVerdictDecline<"SCHEMA">) => {
+  return api.post<
+    KlawApiResponse<"declineRequest">,
+    RequestVerdictDecline<"SCHEMA">
+  >(`/request/approve`, payload);
+};
+
+export {
+  createSchemaRequest,
+  getSchemaRequestsForApprover,
+  approveSchemaRequest,
+  declineSchemaRequest,
+};

--- a/coral/src/domain/schema-request/schema-request-types.ts
+++ b/coral/src/domain/schema-request/schema-request-types.ts
@@ -1,5 +1,6 @@
 import { KlawApiModel, Paginated, ResolveIntersectionTypes } from "types/utils";
 import { RequestStatus, RequestOperationType } from "src/domain/requests";
+import { operations } from "types/api";
 
 type CreatedSchemaRequests = ResolveIntersectionTypes<
   Required<
@@ -33,6 +34,15 @@ type SchemaRequestApiResponse = ResolveIntersectionTypes<
   Paginated<SchemaRequest[]>
 >;
 
+type GetSchemaRequestsQueryParams = ResolveIntersectionTypes<
+  Required<
+    Pick<
+      operations["getSchemaRequestsForApprover"]["parameters"]["query"],
+      "pageNo" | "requestStatus"
+    >
+  >
+>;
+
 export type {
   CreateSchemaRequestPayload,
   CreatedSchemaRequests,
@@ -40,4 +50,5 @@ export type {
   SchemaRequestOperationType,
   SchemaRequestStatus,
   SchemaRequestApiResponse,
+  GetSchemaRequestsQueryParams,
 };

--- a/coral/src/domain/topic/topic-api.ts
+++ b/coral/src/domain/topic/topic-api.ts
@@ -17,8 +17,11 @@ import {
   KlawApiRequest,
   KlawApiRequestQueryParameters,
   KlawApiResponse,
-  ResolveIntersectionTypes,
 } from "types/utils";
+import {
+  RequestVerdictApproval,
+  RequestVerdictDecline,
+} from "src/domain/requests";
 
 const getTopics = async ({
   currentPage = 1,
@@ -125,12 +128,7 @@ const getTopicRequestsForApprover = (
     .then(transformGetTopicRequestsForApproverResponse);
 };
 
-type ApproveTopicRequestPayload = ResolveIntersectionTypes<
-  Omit<KlawApiRequest<"approveRequest">, "reason"> & {
-    requestEntityType: "TOPIC";
-  }
->;
-
+type ApproveTopicRequestPayload = RequestVerdictApproval<"TOPIC">;
 const approveTopicRequest = (payload: ApproveTopicRequestPayload) => {
   return api.post<
     KlawApiResponse<"approveRequest">,
@@ -138,13 +136,7 @@ const approveTopicRequest = (payload: ApproveTopicRequestPayload) => {
   >(`/request/approve`, payload);
 };
 
-type RejectTopicRequestPayload = ResolveIntersectionTypes<
-  KlawApiRequest<"declineRequest"> & {
-    reason: string;
-    requestEntityType: "TOPIC";
-  }
->;
-
+type RejectTopicRequestPayload = RequestVerdictDecline<"TOPIC">;
 const rejectTopicRequest = (payload: RejectTopicRequestPayload) => {
   return api.post<KlawApiResponse<"declineRequest">, RejectTopicRequestPayload>(
     `/request/decline`,


### PR DESCRIPTION
# About this change - What it does

- adds a ts helper to create the types for approve/decline for different `requestEntityType` s 
    - is it necessary? maaaaaaybe not. does it make me feel like a smol typescript-🧙‍♀️? Yes, yes it does! 
- adds api calls for approving / declining in the `schema-request-api.ts`

Resolves: #691 

