### PR TITLE
feat(coral): Topic requests table: add approve / reject topic request actions

### DIFF
--- a/coral/src/app/features/approvals/topics/TopicApprovals.test.tsx
+++ b/coral/src/app/features/approvals/topics/TopicApprovals.test.tsx
@@ -385,7 +385,7 @@ describe("TopicApprovals", () => {
     });
   });
 
-  describe("shows a detail modal for schema request", () => {
+  describe("shows a detail modal for Topic request", () => {
     beforeEach(async () => {
       mockGetTopicRequestsForApprover.mockResolvedValue(mockedApiResponse);
 
@@ -431,6 +431,50 @@ describe("TopicApprovals", () => {
 
       expect(modal).toBeVisible();
       expect(modal).toHaveTextContent(lastRequest.topicname);
+    });
+
+    it("should render disabled actions in Details modal", async () => {
+      expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+
+      const approvedRequest = mockedApiResponse.entries[1];
+      const viewDetailsButton = screen.getByRole("button", {
+        name: `View topic request for ${approvedRequest.topicname}`,
+      });
+
+      await userEvent.click(viewDetailsButton);
+      const modal = screen.getByRole("dialog");
+
+      const approveButton = within(modal).getByRole("button", {
+        name: "Approve",
+      });
+      const rejectButton = within(modal).getByRole("button", {
+        name: "Reject",
+      });
+
+      expect(approveButton).toBeDisabled();
+      expect(rejectButton).toBeDisabled();
+    });
+
+    it("should render enabled actions in Details modal", async () => {
+      expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+
+      const createdRequest = mockedApiResponse.entries[0];
+      const viewDetailsButton = screen.getByRole("button", {
+        name: `View topic request for ${createdRequest.topicname}`,
+      });
+
+      await userEvent.click(viewDetailsButton);
+      const modal = screen.getByRole("dialog");
+
+      const approveButton = within(modal).getByRole("button", {
+        name: "Approve",
+      });
+      const rejectButton = within(modal).getByRole("button", {
+        name: "Reject",
+      });
+
+      expect(approveButton).toBeEnabled();
+      expect(rejectButton).toBeEnabled();
     });
   });
 

--- a/coral/src/app/features/approvals/topics/TopicApprovals.tsx
+++ b/coral/src/app/features/approvals/topics/TopicApprovals.tsx
@@ -1,15 +1,24 @@
-import { useQuery } from "@tanstack/react-query";
+import { Alert } from "@aivenio/aquarium";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { useState } from "react";
 import { useSearchParams } from "react-router-dom";
 import { Pagination } from "src/app/components/Pagination";
 import { ApprovalsLayout } from "src/app/features/approvals/components/ApprovalsLayout";
 import RequestDetailsModal from "src/app/features/approvals/components/RequestDetailsModal";
+import RequestRejectModal from "src/app/features/approvals/components/RequestRejectModal";
 import DetailsModalContent from "src/app/features/approvals/topics/components/DetailsModalContent";
 import { TopicApprovalsTable } from "src/app/features/approvals/topics/components/TopicApprovalsTable";
 import useTableFilters from "src/app/features/approvals/topics/hooks/useTableFilters";
-import { getTopicRequestsForApprover } from "src/domain/topic/topic-api";
+import {
+  approveTopicRequest,
+  getTopicRequestsForApprover,
+  rejectTopicRequest,
+} from "src/domain/topic/topic-api";
+import { HTTPError } from "src/services/api";
 
 function TopicApprovals() {
+  const queryClient = useQueryClient();
+
   const [searchParams, setSearchParams] = useSearchParams();
 
   const currentPage = searchParams.get("page")
@@ -23,6 +32,20 @@ function TopicApprovals() {
     isOpen: false,
     topicId: null,
   });
+  const [rejectModal, setRejectModal] = useState<{
+    isOpen: boolean;
+    topicId: number | null;
+  }>({
+    isOpen: false,
+    topicId: null,
+  });
+
+  const [errorMessage, setErrorMessage] = useState("");
+
+  const handleChangePage = (activePage: number) => {
+    searchParams.set("page", activePage.toString());
+    setSearchParams(searchParams);
+  };
 
   const { environment, status, team, topic, filters } = useTableFilters();
 
@@ -51,6 +74,82 @@ function TopicApprovals() {
     keepPreviousData: true,
   });
 
+  const { isLoading: approveIsLoading, mutate: approveRequest } = useMutation({
+    mutationFn: approveTopicRequest,
+    onSuccess: (responses) => {
+      // This mutation is used on a single request, so we always want the first response in the array
+      const response = responses[0];
+
+      if (response.result !== "success") {
+        return setErrorMessage(
+          response.message || response.result || "Unexpected error"
+        );
+      }
+      setErrorMessage("");
+      setDetailsModal({ isOpen: false, topicId: null });
+
+      // If approved request is last in the page, go back to previous page
+      // This avoids staying on a non-existent page of entries, which makes the table bug hard
+      // With pagination being 0 of 0, and clicking Previous button sets active page at -1
+      // We also do not need to invalidate the query, as the activePage does not exist any more
+      // And there is no need to update anything on it
+      if (
+        topicRequests?.entries.length === 1 &&
+        topicRequests?.currentPage > 1
+      ) {
+        return handleChangePage(currentPage - 1);
+      }
+
+      // We need to refetch all aclrequests queries to keep Table state in sync
+      queryClient.refetchQueries(["topicRequestsForApprover"]);
+    },
+    onError: (error: HTTPError) => {
+      const errorMessage = Array.isArray(error.data)
+        ? error.data[0].message || error.data[0].result
+        : "Unexpected error";
+
+      setErrorMessage(errorMessage);
+    },
+  });
+
+  const { isLoading: rejectIsLoading, mutate: rejectRequest } = useMutation({
+    mutationFn: rejectTopicRequest,
+    onSuccess: (responses) => {
+      // This mutation is used on a single request, so we always want the first response in the array
+      const response = responses[0];
+
+      if (response.result !== "success") {
+        return setErrorMessage(
+          response.message || response.result || "Unexpected error"
+        );
+      }
+      setErrorMessage("");
+      setRejectModal({ isOpen: false, topicId: null });
+
+      // If approved request is last in the page, go back to previous page
+      // This avoids staying on a non-existent page of entries, which makes the table bug hard
+      // With pagination being 0 of 0, and clicking Previous button sets active page at -1
+      // We also do not need to invalidate the query, as the activePage does not exist any more
+      // And there is no need to update anything on it
+      if (
+        topicRequests?.entries.length === 1 &&
+        topicRequests?.currentPage > 1
+      ) {
+        return handleChangePage(currentPage - 1);
+      }
+
+      // We need to refetch all aclrequests queries to keep Table state in sync
+      queryClient.refetchQueries(["topicRequestsForApprover"]);
+    },
+    onError: (error: HTTPError) => {
+      const errorMessage = Array.isArray(error.data)
+        ? error.data[0].message || error.data[0].result
+        : "Unexpected error";
+
+      setErrorMessage(errorMessage);
+    },
+  });
+
   const setCurrentPage = (page: number) => {
     searchParams.set("page", page.toString());
     setSearchParams(searchParams);
@@ -60,6 +159,9 @@ function TopicApprovals() {
     <TopicApprovalsTable
       requests={topicRequests?.entries || []}
       setDetailsModal={setDetailsModal}
+      setRejectModal={setRejectModal}
+      approveRequest={approveRequest}
+      approveIsLoading={approveIsLoading}
     />
   );
   const pagination =
@@ -80,15 +182,47 @@ function TopicApprovals() {
         <RequestDetailsModal
           onClose={() => setDetailsModal({ isOpen: false, topicId: null })}
           onApprove={() => {
-            alert("approve");
+            if (detailsModal.topicId === null) {
+              setErrorMessage("topicId is null, it should be a number");
+              return;
+            }
+            approveRequest({
+              requestEntityType: "TOPIC",
+              reqIds: [String(detailsModal.topicId)],
+            });
           }}
           onReject={() => {
-            alert("reject");
+            setDetailsModal({ isOpen: false, topicId: null });
+            setRejectModal({ isOpen: true, topicId: detailsModal.topicId });
           }}
-          isLoading={false}
+          isLoading={approveIsLoading}
+          disabledActions={selectedTopicRequest?.requestStatus !== "CREATED"}
         >
           <DetailsModalContent topicRequest={selectedTopicRequest} />
         </RequestDetailsModal>
+      )}
+      {rejectModal.isOpen && (
+        <RequestRejectModal
+          onClose={() => setRejectModal({ isOpen: false, topicId: null })}
+          onCancel={() => setRejectModal({ isOpen: false, topicId: null })}
+          onSubmit={(message: string) => {
+            if (rejectModal.topicId === null) {
+              setErrorMessage("topicId is null, it should be a number");
+              return;
+            }
+            rejectRequest({
+              requestEntityType: "TOPIC",
+              reqIds: [String(rejectModal.topicId)],
+              reason: message,
+            });
+          }}
+          isLoading={rejectIsLoading}
+        />
+      )}
+      {errorMessage !== "" && (
+        <div role="alert">
+          <Alert type="warning">{errorMessage}</Alert>
+        </div>
       )}
       <ApprovalsLayout
         filters={filters}

--- a/coral/src/app/features/approvals/topics/components/TopicApprovalsTable.test.tsx
+++ b/coral/src/app/features/approvals/topics/components/TopicApprovalsTable.test.tsx
@@ -5,6 +5,8 @@ import { TopicRequest } from "src/domain/topic";
 import userEvent from "@testing-library/user-event";
 
 const mockedSetDetailsModal = jest.fn();
+const mockedSetRejectModal = jest.fn();
+const mockedApproveRequest = jest.fn();
 
 const mockedRequests: TopicRequest[] = [
   {
@@ -90,6 +92,9 @@ describe("TopicApprovalsTable", () => {
         <TopicApprovalsTable
           setDetailsModal={mockedSetDetailsModal}
           requests={mockedRequests}
+          approveIsLoading={false}
+          setRejectModal={mockedSetRejectModal}
+          approveRequest={mockedApproveRequest}
         />
       );
     });
@@ -115,7 +120,7 @@ describe("TopicApprovalsTable", () => {
       expect(row).toHaveLength(mockedRequests.length + 1);
     });
 
-    it("shows an detail button for every row", () => {
+    it("shows a Show details button for every row", () => {
       const table = screen.getByRole("table", { name: "Topic requests" });
       const buttons = within(table).getAllByRole("button", {
         name: /View topic request for /,
@@ -124,51 +129,28 @@ describe("TopicApprovalsTable", () => {
       expect(buttons).toHaveLength(mockedRequests.length);
     });
 
-    it("shows an approve button for every row", () => {
+    it("shows an approve button for every row with status CREATED", () => {
       const table = screen.getByRole("table", { name: "Topic requests" });
       const buttons = within(table).getAllByRole("button", {
         name: /Approve topic request for /,
       });
+      const createdRequests = mockedRequests.filter(
+        ({ requestStatus }) => requestStatus === "CREATED"
+      );
 
-      expect(buttons).toHaveLength(mockedRequests.length);
+      expect(buttons).toHaveLength(createdRequests.length);
     });
 
-    it("shows an decline button for every row", () => {
+    it("shows an decline button for every row with status CREATED", () => {
       const table = screen.getByRole("table", { name: "Topic requests" });
       const buttons = within(table).getAllByRole("button", {
         name: /Decline topic request for /,
       });
+      const createdRequests = mockedRequests.filter(
+        ({ requestStatus }) => requestStatus === "CREATED"
+      );
 
-      expect(buttons).toHaveLength(mockedRequests.length);
-    });
-
-    mockedRequests.forEach((request) => {
-      it(`shows a button to show the detailed topic request for topic name ${request.topicname}`, () => {
-        const table = screen.getByRole("table", { name: "Topic requests" });
-        const button = within(table).getByRole("button", {
-          name: `View topic request for ${request.topicname}`,
-        });
-
-        expect(button).toBeEnabled();
-      });
-
-      it(`shows a button to approve topic request for topic name ${request.topicname}`, () => {
-        const table = screen.getByRole("table", { name: "Topic requests" });
-        const button = within(table).getByRole("button", {
-          name: `Approve topic request for ${request.topicname}`,
-        });
-
-        expect(button).toBeEnabled();
-      });
-
-      it(`shows a button to approve topic request for topic name ${request.topicname}`, () => {
-        const table = screen.getByRole("table", { name: "Topic requests" });
-        const button = within(table).getByRole("button", {
-          name: `Decline topic request for ${request.topicname}`,
-        });
-
-        expect(button).toBeEnabled();
-      });
+      expect(buttons).toHaveLength(createdRequests.length);
     });
   });
 
@@ -179,6 +161,9 @@ describe("TopicApprovalsTable", () => {
         <TopicApprovalsTable
           setDetailsModal={mockedSetDetailsModal}
           requests={mockedRequests}
+          approveIsLoading={false}
+          setRejectModal={mockedSetRejectModal}
+          approveRequest={mockedApproveRequest}
         />
       );
     });
@@ -240,6 +225,9 @@ describe("TopicApprovalsTable", () => {
         <TopicApprovalsTable
           setDetailsModal={mockedSetDetailsModal}
           requests={mockedRequests}
+          approveIsLoading={false}
+          setRejectModal={mockedSetRejectModal}
+          approveRequest={mockedApproveRequest}
         />
       );
     });
@@ -255,6 +243,32 @@ describe("TopicApprovalsTable", () => {
       expect(mockedSetDetailsModal).toHaveBeenCalledWith({
         isOpen: true,
         topicId: 1000,
+      });
+    });
+
+    it("shows a Modal when clicking Reject button", async () => {
+      const showDetails = screen.getByRole("button", {
+        name: "Decline topic request for test-topic-1",
+      });
+
+      await userEvent.click(showDetails);
+
+      expect(mockedSetRejectModal).toHaveBeenCalledWith({
+        isOpen: true,
+        topicId: 1000,
+      });
+    });
+
+    it("approves request when clicking Approve button", async () => {
+      const showDetails = screen.getByRole("button", {
+        name: "Approve topic request for test-topic-1",
+      });
+
+      await userEvent.click(showDetails);
+
+      expect(mockedApproveRequest).toHaveBeenCalledWith({
+        requestEntityType: "TOPIC",
+        reqIds: ["1000"],
       });
     });
   });

--- a/coral/src/app/features/approvals/topics/components/TopicApprovalsTable.tsx
+++ b/coral/src/app/features/approvals/topics/components/TopicApprovalsTable.tsx
@@ -55,7 +55,15 @@ function TopicApprovalsTable(props: TopicApprovalsTableProp) {
 
   const columns: Array<DataTableColumn<TopicRequestTableRow>> = [
     { type: "text", field: "topicname", headerName: "Topic" },
-    { type: "text", field: "environmentName", headerName: "Environment" },
+    {
+      type: "status",
+      field: "environmentName",
+      headerName: "Environment",
+      status: ({ environmentName }) => ({
+        status: "neutral",
+        text: environmentName,
+      }),
+    },
     { type: "text", field: "requestStatus", headerName: "Status" },
     { type: "text", field: "teamname", headerName: "Claim by team" },
     { type: "text", field: "requestor", headerName: "Requested by" },

--- a/coral/src/app/features/approvals/topics/components/TopicApprovalsTable.tsx
+++ b/coral/src/app/features/approvals/topics/components/TopicApprovalsTable.tsx
@@ -6,9 +6,12 @@ import {
 } from "@aivenio/aquarium";
 import deleteIcon from "@aivenio/aquarium/dist/src/icons/delete";
 import infoSign from "@aivenio/aquarium/dist/src/icons/infoSign";
+import loadingIcon from "@aivenio/aquarium/dist/src/icons/loading";
 import tickCircle from "@aivenio/aquarium/dist/src/icons/tickCircle";
-import { Dispatch, SetStateAction } from "react";
+import { UseMutateFunction } from "@tanstack/react-query";
+import { Dispatch, SetStateAction, useState } from "react";
 import { TopicRequest } from "src/domain/topic/topic-types";
+import { GenericApiResponse, HTTPError } from "src/services/api";
 
 interface TopicRequestTableRow {
   id: TopicRequest["topicid"];
@@ -28,21 +31,31 @@ type TopicApprovalsTableProp = {
       topicId: number | null;
     }>
   >;
+  setRejectModal: Dispatch<
+    SetStateAction<{
+      isOpen: boolean;
+      topicId: number | null;
+    }>
+  >;
+  approveRequest: UseMutateFunction<
+    GenericApiResponse[],
+    HTTPError,
+    { requestEntityType: "TOPIC"; reqIds: string[] }
+  >;
+  approveIsLoading: boolean;
 };
 function TopicApprovalsTable(props: TopicApprovalsTableProp) {
-  const { requests, setDetailsModal } = props;
+  const {
+    requests,
+    setDetailsModal,
+    setRejectModal,
+    approveRequest,
+    approveIsLoading,
+  } = props;
 
   const columns: Array<DataTableColumn<TopicRequestTableRow>> = [
     { type: "text", field: "topicname", headerName: "Topic" },
-    {
-      type: "status",
-      field: "environmentName",
-      headerName: "Environment",
-      status: ({ environmentName }) => ({
-        status: "neutral",
-        text: environmentName,
-      }),
-    },
+    { type: "text", field: "environmentName", headerName: "Environment" },
     { type: "text", field: "requestStatus", headerName: "Status" },
     { type: "text", field: "teamname", headerName: "Claim by team" },
     { type: "text", field: "requestor", headerName: "Requested by" },
@@ -87,15 +100,33 @@ function TopicApprovalsTable(props: TopicApprovalsTableProp) {
       //https://github.com/aiven/design-system/pull/950
       headerName: "",
       width: 30,
-      UNSAFE_render: (row) => {
-        return (
-          <GhostButton
-            onClick={() => alert("Approve")}
-            aria-label={`Approve topic request for ${row.topicname}`}
-          >
-            <Icon color="grey-70" icon={tickCircle} />
-          </GhostButton>
-        );
+      UNSAFE_render: ({
+        topicname,
+        id,
+        requestStatus,
+      }: TopicRequestTableRow) => {
+        const [isLoading, setIsLoading] = useState(false);
+        if (requestStatus === "CREATED") {
+          return (
+            <GhostButton
+              onClick={() => {
+                setIsLoading(true);
+                return approveRequest({
+                  requestEntityType: "TOPIC",
+                  reqIds: [String(id)],
+                });
+              }}
+              title={`Approve topic request for ${topicname}`}
+              aria-label={`Approve topic request for ${topicname}`}
+            >
+              {isLoading && approveIsLoading ? (
+                <Icon color="grey-70" icon={loadingIcon} />
+              ) : (
+                <Icon color="grey-70" icon={tickCircle} />
+              )}
+            </GhostButton>
+          );
+        }
       },
     },
     {
@@ -107,15 +138,22 @@ function TopicApprovalsTable(props: TopicApprovalsTableProp) {
       //https://github.com/aiven/design-system/pull/950
       headerName: "",
       width: 30,
-      UNSAFE_render: (row) => {
-        return (
-          <GhostButton
-            onClick={() => alert("Decline")}
-            aria-label={`Decline topic request for ${row.topicname}`}
-          >
-            <Icon color="grey-70" icon={deleteIcon} />
-          </GhostButton>
-        );
+      UNSAFE_render: ({
+        id,
+        requestStatus,
+        topicname,
+      }: TopicRequestTableRow) => {
+        if (requestStatus === "CREATED") {
+          return (
+            <GhostButton
+              onClick={() => setRejectModal({ isOpen: true, topicId: id })}
+              title={"Reject request"}
+              aria-label={`Decline topic request for ${topicname}`}
+            >
+              <Icon color="grey-70" icon={deleteIcon} />
+            </GhostButton>
+          );
+        }
       },
     },
   ];

--- a/coral/src/domain/topic/topic-api.ts
+++ b/coral/src/domain/topic/topic-api.ts
@@ -1,5 +1,9 @@
 import omitBy from "lodash/omitBy";
 import { ALL_ENVIRONMENTS_VALUE } from "src/domain/environment";
+import {
+  RequestVerdictApproval,
+  RequestVerdictDecline,
+} from "src/domain/requests";
 import { Team } from "src/domain/team";
 import { ALL_TEAMS_VALUE } from "src/domain/team/team-types";
 import {
@@ -18,10 +22,6 @@ import {
   KlawApiRequestQueryParameters,
   KlawApiResponse,
 } from "types/utils";
-import {
-  RequestVerdictApproval,
-  RequestVerdictDecline,
-} from "src/domain/requests";
 
 const getTopics = async ({
   currentPage = 1,


### PR DESCRIPTION
## About this change - What it does

Add business logic to:
- approve request on clicking approve quick action
- show Reject modal when clicking reject quick action
- approve request when clicking approve button in Show details modal
- show Reject modal when clicking reject button in Show details modal

Resolves: #688
