### PR TITLE
chore(coral): Update approve and reject ACL request endpoints

### DIFF
--- a/coral/src/app/features/approvals/acls/AclApprovals.tsx
+++ b/coral/src/app/features/approvals/acls/AclApprovals.tsx
@@ -127,7 +127,8 @@ function AclApprovals() {
 
   const { isLoading: approveIsLoading, mutate: approveRequest } = useMutation({
     mutationFn: approveAclRequest,
-    onSuccess: (response) => {
+    onSuccess: (responses) => {
+      const response = responses[0];
       if (response.result !== "success") {
         return setErrorMessage(
           response.message || response.result || "Unexpected error"
@@ -155,7 +156,8 @@ function AclApprovals() {
 
   const { isLoading: rejectIsLoading, mutate: rejectRequest } = useMutation({
     mutationFn: declineAclRequest,
-    onSuccess: (response) => {
+    onSuccess: (responses) => {
+      const response = responses[0];
       if (response.result !== "success") {
         return setErrorMessage(
           response.message || response.result || "Unexpected error"
@@ -325,7 +327,10 @@ function AclApprovals() {
             <GhostButton
               onClick={() => {
                 setIsLoading(true);
-                return approveRequest({ req_no: String(id) });
+                return approveRequest({
+                  requestEntityType: "ACL",
+                  reqIds: [String(id)],
+                });
               }}
               title={"Approve request"}
             >
@@ -381,7 +386,10 @@ function AclApprovals() {
         <RequestDetailsModal
           onClose={() => setDetailsModal({ isOpen: false, reqNo: "" })}
           onApprove={() => {
-            approveRequest({ req_no: detailsModal.reqNo });
+            approveRequest({
+              requestEntityType: "ACL",
+              reqIds: [detailsModal.reqNo],
+            });
           }}
           onReject={() => {
             setDetailsModal({ isOpen: false, reqNo: "" });
@@ -399,8 +407,9 @@ function AclApprovals() {
           onCancel={() => setRejectModal({ isOpen: false, reqNo: "" })}
           onSubmit={(message: string) => {
             rejectRequest({
-              req_no: rejectModal.reqNo,
-              reasonForDecline: message,
+              requestEntityType: "ACL",
+              reqIds: [rejectModal.reqNo],
+              reason: message,
             });
           }}
           isLoading={rejectIsLoading}

--- a/coral/src/domain/acl/acl-api.ts
+++ b/coral/src/domain/acl/acl-api.ts
@@ -5,12 +5,12 @@ import {
   CreateAclRequestTopicTypeProducer,
   GetCreatedAclRequestParameters,
 } from "src/domain/acl/acl-types";
-import api from "src/services/api";
 import {
-  KlawApiRequest,
-  KlawApiRequestQueryParameters,
-  KlawApiResponse,
-} from "types/utils";
+  RequestVerdictApproval,
+  RequestVerdictDecline,
+} from "src/domain/requests";
+import api from "src/services/api";
+import { KlawApiRequest, KlawApiResponse } from "types/utils";
 
 const createAclRequest = (
   aclParams:
@@ -39,19 +39,19 @@ const getAclRequestsForApprover = (params: GetCreatedAclRequestParameters) => {
     .then(transformAclRequestApiResponse);
 };
 
-const approveAclRequest = (
-  params: KlawApiRequestQueryParameters<"approveAclRequests">
-): Promise<KlawApiResponse<"approveAclRequests">> => {
-  return api.post<KlawApiResponse<"approveAclRequests">, never>(
-    `/execAclRequest?${new URLSearchParams(params)}`
+type ApproveAclRequestPayload = RequestVerdictApproval<"ACL">;
+const approveAclRequest = (payload: ApproveAclRequestPayload) => {
+  return api.post<KlawApiResponse<"approveRequest">, ApproveAclRequestPayload>(
+    `/request/approve`,
+    payload
   );
 };
 
-const declineAclRequest = (
-  params: KlawApiRequestQueryParameters<"declineAclRequests">
-): Promise<KlawApiResponse<"declineAclRequests">> => {
-  return api.post<KlawApiResponse<"declineAclRequests">, never>(
-    `/execAclRequestDecline?${new URLSearchParams(params)}`
+type RejectAclRequestPayload = RequestVerdictDecline<"ACL">;
+const declineAclRequest = (payload: RejectAclRequestPayload) => {
+  return api.post<KlawApiResponse<"declineRequest">, RejectAclRequestPayload>(
+    `/request/decline`,
+    payload
   );
 };
 


### PR DESCRIPTION
## About this change - What it does

Replace soon deprecated `execAclRequest` and `execAclRequestDecline` endpoint with the generic `request/approve` and `request/decline` endpoints

Resolves: #633
