### PR TITLE
Filter requestors requests from the approval count

### DIFF
--- a/core/src/main/java/io/aiven/klaw/helpers/HandleDbRequests.java
+++ b/core/src/main/java/io/aiven/klaw/helpers/HandleDbRequests.java
@@ -71,16 +71,16 @@ public interface HandleDbRequests {
       String requestor, String status, String env, boolean isMyRequest, int tenantId);
 
   Map<String, Map<String, Long>> getTopicRequestsCounts(
-      int teamId, RequestMode requestMode, int tenantId);
+      int teamId, RequestMode requestMode, int tenantId, String requestor);
 
   Map<String, Map<String, Long>> getAclRequestsCounts(
-      int teamId, RequestMode requestMode, int tenantId);
+      int teamId, RequestMode requestMode, int tenantId, String requestor);
 
   Map<String, Map<String, Long>> getSchemaRequestsCounts(
-      int teamId, RequestMode requestMode, int tenantId);
+      int teamId, RequestMode requestMode, int tenantId, String requestor);
 
   Map<String, Map<String, Long>> getConnectorRequestsCounts(
-      int teamId, RequestMode requestMode, int tenantId);
+      int teamId, RequestMode requestMode, int tenantId, String requestor);
 
   List<TopicRequest> getCreatedTopicRequests(
       String requestor, String status, boolean showRequestsOfAllTeams, int tenantId);

--- a/core/src/main/java/io/aiven/klaw/helpers/db/rdbms/HandleDbRequestsJdbc.java
+++ b/core/src/main/java/io/aiven/klaw/helpers/db/rdbms/HandleDbRequestsJdbc.java
@@ -129,26 +129,26 @@ public class HandleDbRequestsJdbc implements HandleDbRequests {
 
   @Override
   public Map<String, Map<String, Long>> getTopicRequestsCounts(
-      int teamId, RequestMode requestMode, int tenantId) {
-    return jdbcSelectHelper.getTopicRequestsCounts(teamId, requestMode, tenantId);
+      int teamId, RequestMode requestMode, int tenantId, String requestor) {
+    return jdbcSelectHelper.getTopicRequestsCounts(teamId, requestMode, tenantId, requestor);
   }
 
   @Override
   public Map<String, Map<String, Long>> getAclRequestsCounts(
-      int teamId, RequestMode requestMode, int tenantId) {
-    return jdbcSelectHelper.getAclRequestsCounts(teamId, requestMode, tenantId);
+      int teamId, RequestMode requestMode, int tenantId, String requestor) {
+    return jdbcSelectHelper.getAclRequestsCounts(teamId, requestMode, tenantId, requestor);
   }
 
   @Override
   public Map<String, Map<String, Long>> getSchemaRequestsCounts(
-      int teamId, RequestMode requestMode, int tenantId) {
-    return jdbcSelectHelper.getSchemaRequestsCounts(teamId, requestMode, tenantId);
+      int teamId, RequestMode requestMode, int tenantId, String requestor) {
+    return jdbcSelectHelper.getSchemaRequestsCounts(teamId, requestMode, tenantId, requestor);
   }
 
   @Override
   public Map<String, Map<String, Long>> getConnectorRequestsCounts(
-      int teamId, RequestMode requestMode, int tenantId) {
-    return jdbcSelectHelper.getConnectorRequestsCounts(teamId, requestMode, tenantId);
+      int teamId, RequestMode requestMode, int tenantId, String requestor) {
+    return jdbcSelectHelper.getConnectorRequestsCounts(teamId, requestMode, tenantId, requestor);
   }
 
   public List<TopicRequest> getCreatedTopicRequests(

--- a/core/src/main/java/io/aiven/klaw/helpers/db/rdbms/SelectDataJdbc.java
+++ b/core/src/main/java/io/aiven/klaw/helpers/db/rdbms/SelectDataJdbc.java
@@ -1450,13 +1450,12 @@ public class SelectDataJdbc {
       operationTypeCountsMap.put(RequestOperationType.CLAIM.value, assignedToClaimReqs);
       if (RequestMode.MY_APPROVALS == requestMode) {
         // Make sure to remove any requests which the requestor can not approve
-        List<Object[]> connectorApprovalStatusObj =
-            topicRequestsRepo.findOtherRequestorsTopicRequestsGroupByStatus(
+        Long topicApprovalCount =
+            topicRequestsRepo.countRequestorsTopicRequestsGroupByStatusType(
                 teamId, tenantId, requestor, RequestStatus.CREATED.value);
-        updateMap(statusCountsMap, connectorApprovalStatusObj);
-        if (connectorApprovalStatusObj.size() == 0) {
-          statusCountsMap.put(RequestStatus.CREATED.value, 0L);
-        }
+
+        statusCountsMap.put(
+            RequestStatus.CREATED.value, topicApprovalCount == null ? 0L : topicApprovalCount);
       }
     }
 
@@ -1496,14 +1495,12 @@ public class SelectDataJdbc {
       updateMap(statusCountsMap, aclRequestsStatusObj);
       if (RequestMode.MY_APPROVALS == requestMode) {
         // Make sure to remove any requests which the requestor can not approve
-        List<Object[]> aclApprovalRequestsStatusObj =
-            aclRequestsRepo.findOtherRequestorsAclRequestsGroupByStatusAssignedToTeam(
+        Long aclApprovalCount =
+            aclRequestsRepo.countRequestorsAclRequestsGroupByStatusType(
                 teamId, tenantId, requestor, RequestStatus.CREATED.value);
-        if (aclApprovalRequestsStatusObj.size() == 0) {
-          statusCountsMap.put(RequestStatus.CREATED.value, 0L);
-        }
 
-        updateMap(statusCountsMap, aclApprovalRequestsStatusObj);
+        statusCountsMap.put(
+            RequestStatus.CREATED.value, aclApprovalCount == null ? 0L : aclApprovalCount);
       }
     }
     // update with 0L if requests don't exist
@@ -1536,13 +1533,11 @@ public class SelectDataJdbc {
     }
     if (RequestMode.MY_APPROVALS == requestMode) {
       // Make sure to remove any requests which the requestor can not approve
-      List<Object[]> schemaApprovalStatusObj =
-          schemaRequestRepo.findOtherRequestorsSchemaRequestsGroupByStatus(
+      Long schemaApprovalCount =
+          schemaRequestRepo.countRequestorsSchemaRequestsGroupForStatusType(
               teamId, tenantId, requestor, RequestStatus.CREATED.value);
-      updateMap(statusCountsMap, schemaApprovalStatusObj);
-      if (schemaApprovalStatusObj.size() == 0) {
-        statusCountsMap.put(RequestStatus.CREATED.value, 0L);
-      }
+      statusCountsMap.put(
+          RequestStatus.CREATED.value, schemaApprovalCount == null ? 0L : schemaApprovalCount);
     }
 
     // update with 0L if requests don't exist
@@ -1576,13 +1571,13 @@ public class SelectDataJdbc {
 
     if (RequestMode.MY_APPROVALS == requestMode) {
       // Make sure to remove any requests which the requestor can not approve
-      List<Object[]> connectorApprovalStatusObj =
-          kafkaConnectorRequestsRepo.findOtherRequestorsConnectorRequestsGroupByStatus(
+      Long connectorApprovalCount =
+          kafkaConnectorRequestsRepo.countRequestorsConnectorRequestsGroupByStatusType(
               teamId, tenantId, requestor, RequestStatus.CREATED.value);
-      updateMap(statusCountsMap, connectorApprovalStatusObj);
-      if (connectorApprovalStatusObj.size() == 0) {
-        statusCountsMap.put(RequestStatus.CREATED.value, 0L);
-      }
+
+      statusCountsMap.put(
+          RequestStatus.CREATED.value,
+          connectorApprovalCount == null ? 0L : connectorApprovalCount);
     }
 
     // update with 0L if requests don't exist

--- a/core/src/main/java/io/aiven/klaw/helpers/db/rdbms/SelectDataJdbc.java
+++ b/core/src/main/java/io/aiven/klaw/helpers/db/rdbms/SelectDataJdbc.java
@@ -1523,7 +1523,9 @@ public class SelectDataJdbc {
     Map<String, Long> operationTypeCountsMap = new HashMap<>();
     Map<String, Long> statusCountsMap = new HashMap<>();
 
-    if (RequestMode.MY_REQUESTS == requestMode || RequestMode.TO_APPROVE == requestMode) {
+    if (RequestMode.MY_REQUESTS == requestMode
+        || RequestMode.TO_APPROVE == requestMode
+        || RequestMode.MY_APPROVALS == requestMode) {
       List<Object[]> schemaRequestsOperationTypObj =
           schemaRequestRepo.findAllSchemaRequestsGroupByOperationType(teamId, tenantId);
       updateMap(operationTypeCountsMap, schemaRequestsOperationTypObj);

--- a/core/src/main/java/io/aiven/klaw/model/enums/RequestMode.java
+++ b/core/src/main/java/io/aiven/klaw/model/enums/RequestMode.java
@@ -2,6 +2,7 @@ package io.aiven.klaw.model.enums;
 
 public enum RequestMode {
   TO_APPROVE("to_approve"),
+  MY_APPROVALS("my_approvals"),
   MY_REQUESTS("my_requests");
 
   public final String value;

--- a/core/src/main/java/io/aiven/klaw/repository/AclRequestsRepo.java
+++ b/core/src/main/java/io/aiven/klaw/repository/AclRequestsRepo.java
@@ -69,4 +69,17 @@ public interface AclRequestsRepo
       nativeQuery = true)
   List<Object[]> findAllAclRequestsGroupByStatusAssignedToTeam(
       @Param("assignedToTeamId") Integer assignedToTeamId, @Param("tenantId") Integer tenantId);
+
+  // requests assigned to my team
+  @Query(
+      value =
+          "select topicstatus, count(*) from kwaclrequests where tenantid = :tenantId"
+              + " and teamid = :assignedToTeamId and requestor != :requestor "
+              + " and topicstatus = :topicStatus group by topicStatus",
+      nativeQuery = true)
+  List<Object[]> findOtherRequestorsAclRequestsGroupByStatusAssignedToTeam(
+      @Param("assignedToTeamId") Integer assignedToTeamId,
+      @Param("tenantId") Integer tenantId,
+      @Param("requestor") String requestor,
+      @Param("topicStatus") String topicStatus);
 }

--- a/core/src/main/java/io/aiven/klaw/repository/AclRequestsRepo.java
+++ b/core/src/main/java/io/aiven/klaw/repository/AclRequestsRepo.java
@@ -73,11 +73,11 @@ public interface AclRequestsRepo
   // requests assigned to my team
   @Query(
       value =
-          "select topicstatus, count(*) from kwaclrequests where tenantid = :tenantId"
+          "select count(*) from kwaclrequests where tenantid = :tenantId"
               + " and teamid = :assignedToTeamId and requestor != :requestor "
               + " and topicstatus = :topicStatus group by topicStatus",
       nativeQuery = true)
-  List<Object[]> findOtherRequestorsAclRequestsGroupByStatusAssignedToTeam(
+  Long countRequestorsAclRequestsGroupByStatusType(
       @Param("assignedToTeamId") Integer assignedToTeamId,
       @Param("tenantId") Integer tenantId,
       @Param("requestor") String requestor,

--- a/core/src/main/java/io/aiven/klaw/repository/KwKafkaConnectorRequestsRepo.java
+++ b/core/src/main/java/io/aiven/klaw/repository/KwKafkaConnectorRequestsRepo.java
@@ -56,10 +56,10 @@ public interface KwKafkaConnectorRequestsRepo
 
   @Query(
       value =
-          "select connectorstatus, count(*) from kwkafkaconnectorrequests where tenantid = :tenantId"
+          "select count(*) from kwkafkaconnectorrequests where tenantid = :tenantId"
               + " and teamid = :teamId and requestor != :requestor and connectorstatus = :connectorStatus group by connectorstatus",
       nativeQuery = true)
-  List<Object[]> findOtherRequestorsConnectorRequestsGroupByStatus(
+  Long countRequestorsConnectorRequestsGroupByStatusType(
       @Param("teamId") Integer teamId,
       @Param("tenantId") Integer tenantId,
       @Param("requestor") String requestor,

--- a/core/src/main/java/io/aiven/klaw/repository/KwKafkaConnectorRequestsRepo.java
+++ b/core/src/main/java/io/aiven/klaw/repository/KwKafkaConnectorRequestsRepo.java
@@ -53,4 +53,15 @@ public interface KwKafkaConnectorRequestsRepo
       nativeQuery = true)
   List<Object[]> findAllConnectorRequestsGroupByStatus(
       @Param("teamId") Integer teamId, @Param("tenantId") Integer tenantId);
+
+  @Query(
+      value =
+          "select connectorstatus, count(*) from kwkafkaconnectorrequests where tenantid = :tenantId"
+              + " and teamid = :teamId and requestor != :requestor and connectorstatus = :connectorStatus group by connectorstatus",
+      nativeQuery = true)
+  List<Object[]> findOtherRequestorsConnectorRequestsGroupByStatus(
+      @Param("teamId") Integer teamId,
+      @Param("tenantId") Integer tenantId,
+      @Param("requestor") String requestor,
+      @Param("connectorStatus") String connectorStatus);
 }

--- a/core/src/main/java/io/aiven/klaw/repository/SchemaRequestRepo.java
+++ b/core/src/main/java/io/aiven/klaw/repository/SchemaRequestRepo.java
@@ -52,11 +52,11 @@ public interface SchemaRequestRepo
 
   @Query(
       value =
-          "select topicstatus, count(*) from kwschemarequests where tenantid = :tenantId"
+          "select count(*) from kwschemarequests where tenantid = :tenantId"
               + " and teamid = :teamId and requestor != :requestor "
               + " and topicstatus = :topicStatus group by topicstatus",
       nativeQuery = true)
-  List<Object[]> findOtherRequestorsSchemaRequestsGroupByStatus(
+  Long countRequestorsSchemaRequestsGroupForStatusType(
       @Param("teamId") Integer teamId,
       @Param("tenantId") Integer tenantId,
       @Param("requestor") String requestor,

--- a/core/src/main/java/io/aiven/klaw/repository/SchemaRequestRepo.java
+++ b/core/src/main/java/io/aiven/klaw/repository/SchemaRequestRepo.java
@@ -49,4 +49,16 @@ public interface SchemaRequestRepo
       nativeQuery = true)
   List<Object[]> findAllSchemaRequestsGroupByStatus(
       @Param("teamId") Integer teamId, @Param("tenantId") Integer tenantId);
+
+  @Query(
+      value =
+          "select topicstatus, count(*) from kwschemarequests where tenantid = :tenantId"
+              + " and teamid = :teamId and requestor != :requestor "
+              + " and topicstatus = :topicStatus group by topicstatus",
+      nativeQuery = true)
+  List<Object[]> findOtherRequestorsSchemaRequestsGroupByStatus(
+      @Param("teamId") Integer teamId,
+      @Param("tenantId") Integer tenantId,
+      @Param("requestor") String requestor,
+      @Param("topicStatus") String topicStatus);
 }

--- a/core/src/main/java/io/aiven/klaw/repository/TopicRequestsRepo.java
+++ b/core/src/main/java/io/aiven/klaw/repository/TopicRequestsRepo.java
@@ -65,11 +65,11 @@ public interface TopicRequestsRepo
 
   @Query(
       value =
-          "select topicstatus, count(*) from kwtopicrequests where tenantid = :tenantId"
+          "select count(*) from kwtopicrequests where tenantid = :tenantId"
               + " and teamid = :teamId and requestor != :requestor "
               + "and topicstatus = :topicStatus  group by topicstatus",
       nativeQuery = true)
-  List<Object[]> findOtherRequestorsTopicRequestsGroupByStatus(
+  Long countRequestorsTopicRequestsGroupByStatusType(
       @Param("teamId") Integer teamId,
       @Param("tenantId") Integer tenantId,
       @Param("requestor") String requestor,

--- a/core/src/main/java/io/aiven/klaw/repository/TopicRequestsRepo.java
+++ b/core/src/main/java/io/aiven/klaw/repository/TopicRequestsRepo.java
@@ -62,4 +62,16 @@ public interface TopicRequestsRepo
       @Param("tenantId") Integer tenantId,
       @Param("description") String description,
       @Param("topictype") String requestOperationType);
+
+  @Query(
+      value =
+          "select topicstatus, count(*) from kwtopicrequests where tenantid = :tenantId"
+              + " and teamid = :teamId and requestor != :requestor "
+              + "and topicstatus = :topicStatus  group by topicstatus",
+      nativeQuery = true)
+  List<Object[]> findOtherRequestorsTopicRequestsGroupByStatus(
+      @Param("teamId") Integer teamId,
+      @Param("tenantId") Integer tenantId,
+      @Param("requestor") String requestor,
+      @Param("topicStatus") String topicStatus);
 }

--- a/core/src/main/java/io/aiven/klaw/service/RequestStatisticsService.java
+++ b/core/src/main/java/io/aiven/klaw/service/RequestStatisticsService.java
@@ -29,15 +29,16 @@ public class RequestStatisticsService {
   public RequestsCountOverview getRequestsCountOverview(RequestMode requestMode) {
     RequestsCountOverview requestsCountOverview = new RequestsCountOverview();
     Set<RequestEntityStatusCount> requestEntityStatusCountSet = new HashSet<>();
-
+    String userName = getUserName();
     // get topics count and update requestsCountOverview
     Map<String, Map<String, Long>> topicRequestCountsMap =
         manageDatabase
             .getHandleDbRequests()
             .getTopicRequestsCounts(
-                commonUtilsService.getTeamId(getUserName()),
+                commonUtilsService.getTeamId(userName),
                 requestMode,
-                commonUtilsService.getTenantId(getUserName()));
+                commonUtilsService.getTenantId(userName),
+                userName);
     updateRequestsCountOverview(
         topicRequestCountsMap, requestEntityStatusCountSet, RequestEntityType.TOPIC);
 
@@ -46,9 +47,10 @@ public class RequestStatisticsService {
         manageDatabase
             .getHandleDbRequests()
             .getAclRequestsCounts(
-                commonUtilsService.getTeamId(getUserName()),
+                commonUtilsService.getTeamId(userName),
                 requestMode,
-                commonUtilsService.getTenantId(getUserName()));
+                commonUtilsService.getTenantId(userName),
+                userName);
     updateRequestsCountOverview(
         aclsRequestCountsMap, requestEntityStatusCountSet, RequestEntityType.ACL);
 
@@ -57,9 +59,10 @@ public class RequestStatisticsService {
         manageDatabase
             .getHandleDbRequests()
             .getSchemaRequestsCounts(
-                commonUtilsService.getTeamId(getUserName()),
+                commonUtilsService.getTeamId(userName),
                 requestMode,
-                commonUtilsService.getTenantId(getUserName()));
+                commonUtilsService.getTenantId(userName),
+                userName);
     updateRequestsCountOverview(
         schemasRequestCountsMap, requestEntityStatusCountSet, RequestEntityType.SCHEMA);
 
@@ -68,9 +71,10 @@ public class RequestStatisticsService {
         manageDatabase
             .getHandleDbRequests()
             .getConnectorRequestsCounts(
-                commonUtilsService.getTeamId(getUserName()),
+                commonUtilsService.getTeamId(userName),
                 requestMode,
-                commonUtilsService.getTenantId(getUserName()));
+                commonUtilsService.getTenantId(userName),
+                userName);
     updateRequestsCountOverview(
         connectorRequestCountsMap, requestEntityStatusCountSet, RequestEntityType.CONNECTOR);
 

--- a/core/src/main/java/io/aiven/klaw/service/RequestStatisticsService.java
+++ b/core/src/main/java/io/aiven/klaw/service/RequestStatisticsService.java
@@ -29,7 +29,7 @@ public class RequestStatisticsService {
   public RequestsCountOverview getRequestsCountOverview(RequestMode requestMode) {
     RequestsCountOverview requestsCountOverview = new RequestsCountOverview();
     Set<RequestEntityStatusCount> requestEntityStatusCountSet = new HashSet<>();
-    String userName = getUserName();
+    final String userName = getUserName();
     // get topics count and update requestsCountOverview
     Map<String, Map<String, Long>> topicRequestCountsMap =
         manageDatabase

--- a/core/src/main/resources/openapi.yaml
+++ b/core/src/main/resources/openapi.yaml
@@ -1935,7 +1935,7 @@
           "required" : true,
           "schema" : {
             "type" : "string",
-            "enum" : [ "TO_APPROVE", "MY_REQUESTS" ]
+            "enum" : [ "TO_APPROVE", "MY_APPROVALS", "MY_REQUESTS" ]
           }
         } ],
         "responses" : {
@@ -6144,13 +6144,13 @@
       },
       "Scales" : {
         "properties" : {
-          "xaxes" : {
+          "yaxes" : {
             "type" : "array",
             "items" : {
               "$ref" : "#/components/schemas/YAx"
             }
           },
-          "yaxes" : {
+          "xaxes" : {
             "type" : "array",
             "items" : {
               "$ref" : "#/components/schemas/YAx"

--- a/core/src/main/resources/openapi.yaml
+++ b/core/src/main/resources/openapi.yaml
@@ -6144,13 +6144,13 @@
       },
       "Scales" : {
         "properties" : {
-          "yaxes" : {
+          "xaxes" : {
             "type" : "array",
             "items" : {
               "$ref" : "#/components/schemas/YAx"
             }
           },
-          "xaxes" : {
+          "yaxes" : {
             "type" : "array",
             "items" : {
               "$ref" : "#/components/schemas/YAx"

--- a/core/src/test/java/io/aiven/klaw/helpers/db/rdbms/AclRequestsIntegrationTest.java
+++ b/core/src/test/java/io/aiven/klaw/helpers/db/rdbms/AclRequestsIntegrationTest.java
@@ -317,7 +317,7 @@ public class AclRequestsIntegrationTest {
   @Order(11)
   public void getAclRequestsCountsForMyRequestsTeam1() {
     Map<String, Map<String, Long>> results =
-        selectDataJdbc.getAclRequestsCounts(101, RequestMode.MY_REQUESTS, 101);
+        selectDataJdbc.getAclRequestsCounts(101, RequestMode.MY_REQUESTS, 101, "James");
 
     Map<String, Long> statsCount = results.get("STATUS_COUNTS");
     Map<String, Long> operationTypeCount = results.get("OPERATION_TYPE_COUNTS");
@@ -336,7 +336,7 @@ public class AclRequestsIntegrationTest {
   @Order(12)
   public void getAclRequestsCountsForApproveForTeam1() {
     Map<String, Map<String, Long>> results =
-        selectDataJdbc.getAclRequestsCounts(101, RequestMode.TO_APPROVE, 101);
+        selectDataJdbc.getAclRequestsCounts(101, RequestMode.TO_APPROVE, 101, "James");
 
     Map<String, Long> statsCount = results.get("STATUS_COUNTS");
     Map<String, Long> operationTypeCount = results.get("OPERATION_TYPE_COUNTS");
@@ -355,7 +355,7 @@ public class AclRequestsIntegrationTest {
   @Order(13)
   public void getAclRequestsCountsForApproveForTeam2() {
     Map<String, Map<String, Long>> results =
-        selectDataJdbc.getAclRequestsCounts(103, RequestMode.TO_APPROVE, 101);
+        selectDataJdbc.getAclRequestsCounts(103, RequestMode.TO_APPROVE, 101, "James");
 
     Map<String, Long> statsCount = results.get("STATUS_COUNTS");
     Map<String, Long> operationTypeCount = results.get("OPERATION_TYPE_COUNTS");
@@ -374,7 +374,7 @@ public class AclRequestsIntegrationTest {
   @Order(14)
   public void getAclRequestsCountsForMyRequestsForTeam2Tenant1() {
     Map<String, Map<String, Long>> results =
-        selectDataJdbc.getAclRequestsCounts(103, RequestMode.MY_REQUESTS, 101);
+        selectDataJdbc.getAclRequestsCounts(103, RequestMode.MY_REQUESTS, 101, "James");
 
     Map<String, Long> statsCount = results.get("STATUS_COUNTS");
     Map<String, Long> operationTypeCount = results.get("OPERATION_TYPE_COUNTS");
@@ -393,7 +393,7 @@ public class AclRequestsIntegrationTest {
   @Order(15)
   public void getAclRequestsCountsForMyRequestsForTeam2Tenant2() {
     Map<String, Map<String, Long>> results =
-        selectDataJdbc.getAclRequestsCounts(103, RequestMode.MY_REQUESTS, 103);
+        selectDataJdbc.getAclRequestsCounts(103, RequestMode.MY_REQUESTS, 103, "James");
 
     Map<String, Long> statsCount = results.get("STATUS_COUNTS");
     Map<String, Long> operationTypeCount = results.get("OPERATION_TYPE_COUNTS");
@@ -495,6 +495,44 @@ public class AclRequestsIntegrationTest {
         selectDataJdbc.selectAclRequests(
             false, "Jackie", "USER", "ALL", true, null, null, null, false, 101);
     assertThat(jackie.size()).isEqualTo(31);
+  }
+
+  @Test
+  @Order(22)
+  public void getAclRequestsCountsForMyApprovals() {
+    Map<String, Map<String, Long>> results =
+        selectDataJdbc.getAclRequestsCounts(103, RequestMode.MY_APPROVALS, 101, "Jackie");
+
+    Map<String, Long> statsCount = results.get("STATUS_COUNTS");
+    Map<String, Long> operationTypeCount = results.get("OPERATION_TYPE_COUNTS");
+
+    assertThat(results.size()).isEqualTo(2);
+    // Jackie created all the requests so there should be none returned for Jackie.
+    assertThat(statsCount.get(RequestStatus.CREATED.value)).isEqualTo(0L);
+    assertThat(statsCount.get(RequestStatus.APPROVED.value)).isEqualTo(0L);
+    assertThat(statsCount.get(RequestStatus.DECLINED.value)).isEqualTo(10L);
+    assertThat(statsCount.get(RequestStatus.DELETED.value)).isEqualTo(0L);
+    assertThat(operationTypeCount.get(RequestOperationType.CREATE.value)).isEqualTo(20L);
+    assertThat(operationTypeCount.get(RequestOperationType.DELETE.value)).isEqualTo(0L);
+  }
+
+  @Test
+  @Order(23)
+  public void getAclRequestsCountsForMyApprovalsJohnCreatedNone() {
+    Map<String, Map<String, Long>> results =
+        selectDataJdbc.getAclRequestsCounts(103, RequestMode.MY_APPROVALS, 101, "John");
+
+    Map<String, Long> statsCount = results.get("STATUS_COUNTS");
+    Map<String, Long> operationTypeCount = results.get("OPERATION_TYPE_COUNTS");
+
+    assertThat(results.size()).isEqualTo(2);
+
+    assertThat(statsCount.get(RequestStatus.CREATED.value)).isEqualTo(10L);
+    assertThat(statsCount.get(RequestStatus.APPROVED.value)).isEqualTo(0L);
+    assertThat(statsCount.get(RequestStatus.DECLINED.value)).isEqualTo(10L);
+    assertThat(statsCount.get(RequestStatus.DELETED.value)).isEqualTo(0L);
+    assertThat(operationTypeCount.get(RequestOperationType.CREATE.value)).isEqualTo(20L);
+    assertThat(operationTypeCount.get(RequestOperationType.DELETE.value)).isEqualTo(0L);
   }
 
   private void generateData(

--- a/core/src/test/java/io/aiven/klaw/helpers/db/rdbms/AclRequestsIntegrationTest.java
+++ b/core/src/test/java/io/aiven/klaw/helpers/db/rdbms/AclRequestsIntegrationTest.java
@@ -506,7 +506,7 @@ public class AclRequestsIntegrationTest {
     Map<String, Long> statsCount = results.get("STATUS_COUNTS");
     Map<String, Long> operationTypeCount = results.get("OPERATION_TYPE_COUNTS");
 
-    assertThat(results.size()).isEqualTo(2);
+    assertThat(results).hasSize(2);
     // Jackie created all the requests so there should be none returned for Jackie.
     assertThat(statsCount.get(RequestStatus.CREATED.value)).isEqualTo(0L);
     assertThat(statsCount.get(RequestStatus.APPROVED.value)).isEqualTo(0L);
@@ -525,7 +525,7 @@ public class AclRequestsIntegrationTest {
     Map<String, Long> statsCount = results.get("STATUS_COUNTS");
     Map<String, Long> operationTypeCount = results.get("OPERATION_TYPE_COUNTS");
 
-    assertThat(results.size()).isEqualTo(2);
+    assertThat(results).hasSize(2);
 
     assertThat(statsCount.get(RequestStatus.CREATED.value)).isEqualTo(10L);
     assertThat(statsCount.get(RequestStatus.APPROVED.value)).isEqualTo(0L);

--- a/core/src/test/java/io/aiven/klaw/helpers/db/rdbms/ConnectorRequestsIntegrationTest.java
+++ b/core/src/test/java/io/aiven/klaw/helpers/db/rdbms/ConnectorRequestsIntegrationTest.java
@@ -112,7 +112,7 @@ public class ConnectorRequestsIntegrationTest {
   @Order(1)
   public void getConnectorRequestsCountsForMyRequestsTeam1() {
     Map<String, Map<String, Long>> results =
-        selectDataJdbc.getConnectorRequestsCounts(101, RequestMode.MY_REQUESTS, 101);
+        selectDataJdbc.getConnectorRequestsCounts(101, RequestMode.MY_REQUESTS, 101, "James");
 
     Map<String, Long> statsCount = results.get("STATUS_COUNTS");
     Map<String, Long> operationTypeCount = results.get("OPERATION_TYPE_COUNTS");
@@ -129,7 +129,7 @@ public class ConnectorRequestsIntegrationTest {
   @Order(2)
   public void getConnectorRequestsCountsForApproveForTeam1() {
     Map<String, Map<String, Long>> results =
-        selectDataJdbc.getConnectorRequestsCounts(101, RequestMode.TO_APPROVE, 101);
+        selectDataJdbc.getConnectorRequestsCounts(101, RequestMode.TO_APPROVE, 101, "James");
 
     Map<String, Long> statsCount = results.get("STATUS_COUNTS");
     Map<String, Long> operationTypeCount = results.get("OPERATION_TYPE_COUNTS");
@@ -146,7 +146,7 @@ public class ConnectorRequestsIntegrationTest {
   @Order(3)
   public void getConnectorRequestsCountsForApproveForTeam2() {
     Map<String, Map<String, Long>> results =
-        selectDataJdbc.getConnectorRequestsCounts(103, RequestMode.TO_APPROVE, 101);
+        selectDataJdbc.getConnectorRequestsCounts(103, RequestMode.TO_APPROVE, 101, "James");
 
     Map<String, Long> statsCount = results.get("STATUS_COUNTS");
     Map<String, Long> operationTypeCount = results.get("OPERATION_TYPE_COUNTS");
@@ -163,7 +163,7 @@ public class ConnectorRequestsIntegrationTest {
   @Order(3)
   public void getConnectorRequestsCountsForMyRequestsForTeam2() {
     Map<String, Map<String, Long>> results =
-        selectDataJdbc.getConnectorRequestsCounts(103, RequestMode.MY_REQUESTS, 101);
+        selectDataJdbc.getConnectorRequestsCounts(103, RequestMode.MY_REQUESTS, 101, "James");
 
     Map<String, Long> statsCount = results.get("STATUS_COUNTS");
     Map<String, Long> operationTypeCount = results.get("OPERATION_TYPE_COUNTS");

--- a/core/src/test/java/io/aiven/klaw/helpers/db/rdbms/KafkaConnectorsIntegrationTest.java
+++ b/core/src/test/java/io/aiven/klaw/helpers/db/rdbms/KafkaConnectorsIntegrationTest.java
@@ -584,7 +584,7 @@ public class KafkaConnectorsIntegrationTest {
     Map<String, Long> statsCount = results.get("STATUS_COUNTS");
     Map<String, Long> operationTypeCount = results.get("OPERATION_TYPE_COUNTS");
 
-    assertThat(results.size()).isEqualTo(2);
+    assertThat(results).hasSize(2);
     // Jackie created all the requests so we expect 0 for created status which is approval status
     assertThat(statsCount.get(RequestStatus.CREATED.value)).isEqualTo(0L);
     assertThat(operationTypeCount.get(RequestOperationType.CREATE.value)).isEqualTo(0L);
@@ -604,7 +604,7 @@ public class KafkaConnectorsIntegrationTest {
     Map<String, Long> statsCount = results.get("STATUS_COUNTS");
     Map<String, Long> operationTypeCount = results.get("OPERATION_TYPE_COUNTS");
 
-    assertThat(results.size()).isEqualTo(2);
+    assertThat(results).hasSize(2);
     assertThat(statsCount.get(RequestStatus.CREATED.value)).isEqualTo(21L);
     assertThat(operationTypeCount.get(RequestOperationType.CREATE.value)).isEqualTo(0L);
     assertThat(operationTypeCount.get(RequestOperationType.CLAIM.value)).isEqualTo(0L);

--- a/core/src/test/java/io/aiven/klaw/helpers/db/rdbms/KafkaConnectorsIntegrationTest.java
+++ b/core/src/test/java/io/aiven/klaw/helpers/db/rdbms/KafkaConnectorsIntegrationTest.java
@@ -7,12 +7,14 @@ import io.aiven.klaw.UtilMethods;
 import io.aiven.klaw.dao.KafkaConnectorRequest;
 import io.aiven.klaw.dao.Team;
 import io.aiven.klaw.dao.UserInfo;
+import io.aiven.klaw.model.enums.RequestMode;
 import io.aiven.klaw.model.enums.RequestOperationType;
 import io.aiven.klaw.model.enums.RequestStatus;
 import io.aiven.klaw.repository.KwKafkaConnectorRequestsRepo;
 import io.aiven.klaw.repository.TeamRepo;
 import io.aiven.klaw.repository.UserInfoRepo;
 import java.util.List;
+import java.util.Map;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Test;
@@ -571,6 +573,45 @@ public class KafkaConnectorsIntegrationTest {
         selectDataJdbc.getFilteredKafkaConnectorRequests(
             true, "James", RequestStatus.ALL.value, false, 103, null, "lots");
     assertThat(resultSet.size()).isEqualTo(0);
+  }
+
+  @Test
+  @Order(26)
+  public void getConnectorRequestsCountsForMyApprovals() {
+    Map<String, Map<String, Long>> results =
+        selectDataJdbc.getConnectorRequestsCounts(101, RequestMode.MY_APPROVALS, 101, "Jackie");
+
+    Map<String, Long> statsCount = results.get("STATUS_COUNTS");
+    Map<String, Long> operationTypeCount = results.get("OPERATION_TYPE_COUNTS");
+
+    assertThat(results.size()).isEqualTo(2);
+    // Jackie created all the requests so we expect 0 for created status which is approval status
+    assertThat(statsCount.get(RequestStatus.CREATED.value)).isEqualTo(0L);
+    assertThat(operationTypeCount.get(RequestOperationType.CREATE.value)).isEqualTo(0L);
+    assertThat(operationTypeCount.get(RequestOperationType.CLAIM.value)).isEqualTo(0L);
+    assertThat(statsCount.get(RequestStatus.APPROVED.value)).isEqualTo(0L);
+    assertThat(statsCount.get(RequestStatus.DECLINED.value)).isEqualTo(10L);
+    assertThat(statsCount.get(RequestStatus.DELETED.value)).isEqualTo(0L);
+    assertThat(operationTypeCount.get(RequestOperationType.UPDATE.value)).isEqualTo(0L);
+  }
+
+  @Test
+  @Order(27)
+  public void getConnectorRequestsCountsForMyApprovalsJohnCreatedNone() {
+    Map<String, Map<String, Long>> results =
+        selectDataJdbc.getConnectorRequestsCounts(101, RequestMode.MY_APPROVALS, 101, "John");
+
+    Map<String, Long> statsCount = results.get("STATUS_COUNTS");
+    Map<String, Long> operationTypeCount = results.get("OPERATION_TYPE_COUNTS");
+
+    assertThat(results.size()).isEqualTo(2);
+    assertThat(statsCount.get(RequestStatus.CREATED.value)).isEqualTo(21L);
+    assertThat(operationTypeCount.get(RequestOperationType.CREATE.value)).isEqualTo(0L);
+    assertThat(operationTypeCount.get(RequestOperationType.CLAIM.value)).isEqualTo(0L);
+    assertThat(statsCount.get(RequestStatus.APPROVED.value)).isEqualTo(0L);
+    assertThat(statsCount.get(RequestStatus.DECLINED.value)).isEqualTo(10L);
+    assertThat(statsCount.get(RequestStatus.DELETED.value)).isEqualTo(0L);
+    assertThat(operationTypeCount.get(RequestOperationType.UPDATE.value)).isEqualTo(0L);
   }
 
   private void generateData(

--- a/core/src/test/java/io/aiven/klaw/helpers/db/rdbms/SchemaRequestsIntegrationTest.java
+++ b/core/src/test/java/io/aiven/klaw/helpers/db/rdbms/SchemaRequestsIntegrationTest.java
@@ -144,7 +144,7 @@ public class SchemaRequestsIntegrationTest {
   @Order(1)
   public void getSchemaRequestsCountsForMyRequestsTeam1() {
     Map<String, Map<String, Long>> results =
-        selectDataJdbc.getSchemaRequestsCounts(101, RequestMode.MY_REQUESTS, 101);
+        selectDataJdbc.getSchemaRequestsCounts(101, RequestMode.MY_REQUESTS, 101, "James");
 
     Map<String, Long> statsCount = results.get("STATUS_COUNTS");
     Map<String, Long> operationTypeCount = results.get("OPERATION_TYPE_COUNTS");
@@ -161,7 +161,7 @@ public class SchemaRequestsIntegrationTest {
   @Order(2)
   public void getSchemaRequestsCountsForApproveForTeam1() {
     Map<String, Map<String, Long>> results =
-        selectDataJdbc.getSchemaRequestsCounts(101, RequestMode.TO_APPROVE, 101);
+        selectDataJdbc.getSchemaRequestsCounts(101, RequestMode.TO_APPROVE, 101, "James");
 
     Map<String, Long> statsCount = results.get("STATUS_COUNTS");
     Map<String, Long> operationTypeCount = results.get("OPERATION_TYPE_COUNTS");
@@ -178,7 +178,7 @@ public class SchemaRequestsIntegrationTest {
   @Order(3)
   public void getSchemaRequestsCountsForApproveForTeam2() {
     Map<String, Map<String, Long>> results =
-        selectDataJdbc.getSchemaRequestsCounts(103, RequestMode.TO_APPROVE, 101);
+        selectDataJdbc.getSchemaRequestsCounts(103, RequestMode.TO_APPROVE, 101, "James");
 
     Map<String, Long> statsCount = results.get("STATUS_COUNTS");
     Map<String, Long> operationTypeCount = results.get("OPERATION_TYPE_COUNTS");
@@ -195,7 +195,7 @@ public class SchemaRequestsIntegrationTest {
   @Order(3)
   public void getSchemaRequestsCountsForMyRequestsForTeam2() {
     Map<String, Map<String, Long>> results =
-        selectDataJdbc.getSchemaRequestsCounts(103, RequestMode.MY_REQUESTS, 101);
+        selectDataJdbc.getSchemaRequestsCounts(103, RequestMode.MY_REQUESTS, 101, "James");
 
     Map<String, Long> statsCount = results.get("STATUS_COUNTS");
     Map<String, Long> operationTypeCount = results.get("OPERATION_TYPE_COUNTS");
@@ -517,6 +517,42 @@ public class SchemaRequestsIntegrationTest {
         selectDataJdbc.selectFilteredSchemaRequests(
             false, "James", 101, null, null, RequestStatus.ALL.value, null, false);
     assertThat(results.size()).isEqualTo(17);
+  }
+
+  @Test
+  @Order(24)
+  public void getSchemaRequestsCountsForMyApprovals() {
+    Map<String, Map<String, Long>> results =
+        selectDataJdbc.getSchemaRequestsCounts(103, RequestMode.MY_APPROVALS, 101, "Jackie");
+
+    Map<String, Long> statsCount = results.get("STATUS_COUNTS");
+    Map<String, Long> operationTypeCount = results.get("OPERATION_TYPE_COUNTS");
+
+    assertThat(results.size()).isEqualTo(2);
+    // Jackie created all the requests so there should be none returned for Jackie.
+    assertThat(statsCount.get(RequestStatus.CREATED.value)).isEqualTo(4L);
+    assertThat(statsCount.get(RequestStatus.APPROVED.value)).isEqualTo(0L);
+    assertThat(statsCount.get(RequestStatus.DECLINED.value)).isEqualTo(0L);
+    assertThat(statsCount.get(RequestStatus.DELETED.value)).isEqualTo(0L);
+    assertThat(operationTypeCount.get(RequestOperationType.CREATE.value)).isEqualTo(0L);
+  }
+
+  @Test
+  @Order(25)
+  public void getSchemaRequestsCountsForMyApprovalsJohnCreatedNone() {
+    Map<String, Map<String, Long>> results =
+        selectDataJdbc.getSchemaRequestsCounts(103, RequestMode.MY_APPROVALS, 101, "John");
+
+    Map<String, Long> statsCount = results.get("STATUS_COUNTS");
+    Map<String, Long> operationTypeCount = results.get("OPERATION_TYPE_COUNTS");
+
+    assertThat(results.size()).isEqualTo(2);
+
+    assertThat(statsCount.get(RequestStatus.CREATED.value)).isEqualTo(4L);
+    assertThat(statsCount.get(RequestStatus.APPROVED.value)).isEqualTo(0L);
+    assertThat(statsCount.get(RequestStatus.DECLINED.value)).isEqualTo(0L);
+    assertThat(statsCount.get(RequestStatus.DELETED.value)).isEqualTo(0L);
+    assertThat(operationTypeCount.get(RequestOperationType.CREATE.value)).isEqualTo(0L);
   }
 
   private void generateData(

--- a/core/src/test/java/io/aiven/klaw/helpers/db/rdbms/SchemaRequestsIntegrationTest.java
+++ b/core/src/test/java/io/aiven/klaw/helpers/db/rdbms/SchemaRequestsIntegrationTest.java
@@ -523,36 +523,36 @@ public class SchemaRequestsIntegrationTest {
   @Order(24)
   public void getSchemaRequestsCountsForMyApprovals() {
     Map<String, Map<String, Long>> results =
-        selectDataJdbc.getSchemaRequestsCounts(103, RequestMode.MY_APPROVALS, 101, "Jackie");
+        selectDataJdbc.getSchemaRequestsCounts(101, RequestMode.MY_APPROVALS, 101, "Jackie");
 
     Map<String, Long> statsCount = results.get("STATUS_COUNTS");
     Map<String, Long> operationTypeCount = results.get("OPERATION_TYPE_COUNTS");
 
     assertThat(results.size()).isEqualTo(2);
     // Jackie created all the requests so there should be none returned for Jackie.
-    assertThat(statsCount.get(RequestStatus.CREATED.value)).isEqualTo(4L);
-    assertThat(statsCount.get(RequestStatus.APPROVED.value)).isEqualTo(0L);
-    assertThat(statsCount.get(RequestStatus.DECLINED.value)).isEqualTo(0L);
-    assertThat(statsCount.get(RequestStatus.DELETED.value)).isEqualTo(0L);
-    assertThat(operationTypeCount.get(RequestOperationType.CREATE.value)).isEqualTo(0L);
+    assertThat(statsCount.get(RequestStatus.CREATED.value)).isEqualTo(0L);
+    assertThat(statsCount.get(RequestStatus.APPROVED.value)).isEqualTo(3L);
+    assertThat(statsCount.get(RequestStatus.DECLINED.value)).isEqualTo(7L);
+    assertThat(statsCount.get(RequestStatus.DELETED.value)).isEqualTo(2L);
+    assertThat(operationTypeCount.get(RequestOperationType.CREATE.value)).isEqualTo(15L);
   }
 
   @Test
   @Order(25)
   public void getSchemaRequestsCountsForMyApprovalsJohnCreatedNone() {
     Map<String, Map<String, Long>> results =
-        selectDataJdbc.getSchemaRequestsCounts(103, RequestMode.MY_APPROVALS, 101, "John");
+        selectDataJdbc.getSchemaRequestsCounts(101, RequestMode.MY_APPROVALS, 101, "John");
 
     Map<String, Long> statsCount = results.get("STATUS_COUNTS");
     Map<String, Long> operationTypeCount = results.get("OPERATION_TYPE_COUNTS");
 
     assertThat(results.size()).isEqualTo(2);
 
-    assertThat(statsCount.get(RequestStatus.CREATED.value)).isEqualTo(4L);
-    assertThat(statsCount.get(RequestStatus.APPROVED.value)).isEqualTo(0L);
-    assertThat(statsCount.get(RequestStatus.DECLINED.value)).isEqualTo(0L);
-    assertThat(statsCount.get(RequestStatus.DELETED.value)).isEqualTo(0L);
-    assertThat(operationTypeCount.get(RequestOperationType.CREATE.value)).isEqualTo(0L);
+    assertThat(statsCount.get(RequestStatus.CREATED.value)).isEqualTo(5L);
+    assertThat(statsCount.get(RequestStatus.APPROVED.value)).isEqualTo(3L);
+    assertThat(statsCount.get(RequestStatus.DECLINED.value)).isEqualTo(7L);
+    assertThat(statsCount.get(RequestStatus.DELETED.value)).isEqualTo(2L);
+    assertThat(operationTypeCount.get(RequestOperationType.CREATE.value)).isEqualTo(15L);
   }
 
   private void generateData(

--- a/core/src/test/java/io/aiven/klaw/helpers/db/rdbms/SchemaRequestsIntegrationTest.java
+++ b/core/src/test/java/io/aiven/klaw/helpers/db/rdbms/SchemaRequestsIntegrationTest.java
@@ -528,7 +528,7 @@ public class SchemaRequestsIntegrationTest {
     Map<String, Long> statsCount = results.get("STATUS_COUNTS");
     Map<String, Long> operationTypeCount = results.get("OPERATION_TYPE_COUNTS");
 
-    assertThat(results.size()).isEqualTo(2);
+    assertThat(results).hasSize(2);
     // Jackie created all the requests so there should be none returned for Jackie.
     assertThat(statsCount.get(RequestStatus.CREATED.value)).isEqualTo(0L);
     assertThat(statsCount.get(RequestStatus.APPROVED.value)).isEqualTo(3L);
@@ -546,7 +546,7 @@ public class SchemaRequestsIntegrationTest {
     Map<String, Long> statsCount = results.get("STATUS_COUNTS");
     Map<String, Long> operationTypeCount = results.get("OPERATION_TYPE_COUNTS");
 
-    assertThat(results.size()).isEqualTo(2);
+    assertThat(results).hasSize(2);
 
     assertThat(statsCount.get(RequestStatus.CREATED.value)).isEqualTo(5L);
     assertThat(statsCount.get(RequestStatus.APPROVED.value)).isEqualTo(3L);

--- a/core/src/test/java/io/aiven/klaw/helpers/db/rdbms/TopicRequestsIntegrationTest.java
+++ b/core/src/test/java/io/aiven/klaw/helpers/db/rdbms/TopicRequestsIntegrationTest.java
@@ -238,7 +238,7 @@ public class TopicRequestsIntegrationTest {
   @Order(1)
   public void getTopicRequestsCountsForMyRequestsTeam1() {
     Map<String, Map<String, Long>> results =
-        selectDataJdbc.getTopicRequestsCounts(101, RequestMode.MY_REQUESTS, 101);
+        selectDataJdbc.getTopicRequestsCounts(101, RequestMode.MY_REQUESTS, 101, "James");
 
     Map<String, Long> statsCount = results.get("STATUS_COUNTS");
     Map<String, Long> operationTypeCount = results.get("OPERATION_TYPE_COUNTS");
@@ -258,7 +258,7 @@ public class TopicRequestsIntegrationTest {
   @Order(2)
   public void getTopicRequestsCountsForApproveForTeam1() {
     Map<String, Map<String, Long>> results =
-        selectDataJdbc.getTopicRequestsCounts(101, RequestMode.TO_APPROVE, 101);
+        selectDataJdbc.getTopicRequestsCounts(101, RequestMode.TO_APPROVE, 101, "James");
 
     Map<String, Long> statsCount = results.get("STATUS_COUNTS");
     Map<String, Long> operationTypeCount = results.get("OPERATION_TYPE_COUNTS");
@@ -277,7 +277,7 @@ public class TopicRequestsIntegrationTest {
   @Order(3)
   public void getTopicRequestsCountsForApproveForTeam2() {
     Map<String, Map<String, Long>> results =
-        selectDataJdbc.getTopicRequestsCounts(103, RequestMode.TO_APPROVE, 101);
+        selectDataJdbc.getTopicRequestsCounts(103, RequestMode.TO_APPROVE, 101, "James");
 
     Map<String, Long> statsCount = results.get("STATUS_COUNTS");
     Map<String, Long> operationTypeCount = results.get("OPERATION_TYPE_COUNTS");
@@ -296,7 +296,7 @@ public class TopicRequestsIntegrationTest {
   @Order(3)
   public void getTopicRequestsCountsForMyRequestsForTeam2() {
     Map<String, Map<String, Long>> results =
-        selectDataJdbc.getTopicRequestsCounts(103, RequestMode.MY_REQUESTS, 101);
+        selectDataJdbc.getTopicRequestsCounts(103, RequestMode.MY_REQUESTS, 101, "James");
 
     Map<String, Long> statsCount = results.get("STATUS_COUNTS");
     Map<String, Long> operationTypeCount = results.get("OPERATION_TYPE_COUNTS");
@@ -756,6 +756,45 @@ public class TopicRequestsIntegrationTest {
     for (TopicRequest req : john) {
       assertThat(req.getDescription().equals("John"));
     }
+  }
+
+  @Test
+  @Order(29)
+  public void getTopicRequestsCountsForMyApprovals() {
+    Map<String, Map<String, Long>> results =
+        selectDataJdbc.getTopicRequestsCounts(103, RequestMode.MY_APPROVALS, 101, "Jackie");
+
+    Map<String, Long> statsCount = results.get("STATUS_COUNTS");
+    Map<String, Long> operationTypeCount = results.get("OPERATION_TYPE_COUNTS");
+
+    assertThat(results.size()).isEqualTo(2);
+    // Jackie created all the requests so we expect 0 for created status which is approval status
+    assertThat(statsCount.get(RequestStatus.CREATED.value)).isEqualTo(0L);
+    assertThat(operationTypeCount.get(RequestOperationType.CREATE.value)).isEqualTo(0L);
+    assertThat(operationTypeCount.get(RequestOperationType.CLAIM.value)).isEqualTo(7L);
+    assertThat(statsCount.get(RequestStatus.APPROVED.value)).isEqualTo(0L);
+    assertThat(statsCount.get(RequestStatus.DECLINED.value)).isEqualTo(0L);
+    assertThat(statsCount.get(RequestStatus.DELETED.value)).isEqualTo(0L);
+    assertThat(operationTypeCount.get(RequestOperationType.UPDATE.value)).isEqualTo(0L);
+  }
+
+  @Test
+  @Order(30)
+  public void getTopicRequestsCountsForMyApprovalsJohnCreatedNone() {
+    Map<String, Map<String, Long>> results =
+        selectDataJdbc.getTopicRequestsCounts(103, RequestMode.MY_APPROVALS, 101, "John");
+
+    Map<String, Long> statsCount = results.get("STATUS_COUNTS");
+    Map<String, Long> operationTypeCount = results.get("OPERATION_TYPE_COUNTS");
+
+    assertThat(results.size()).isEqualTo(2);
+    assertThat(statsCount.get(RequestStatus.CREATED.value)).isEqualTo(4L);
+    assertThat(operationTypeCount.get(RequestOperationType.CREATE.value)).isEqualTo(0L);
+    assertThat(operationTypeCount.get(RequestOperationType.CLAIM.value)).isEqualTo(7L);
+    assertThat(statsCount.get(RequestStatus.APPROVED.value)).isEqualTo(0L);
+    assertThat(statsCount.get(RequestStatus.DECLINED.value)).isEqualTo(0L);
+    assertThat(statsCount.get(RequestStatus.DELETED.value)).isEqualTo(0L);
+    assertThat(operationTypeCount.get(RequestOperationType.UPDATE.value)).isEqualTo(0L);
   }
 
   private void generateData(

--- a/core/src/test/java/io/aiven/klaw/helpers/db/rdbms/TopicRequestsIntegrationTest.java
+++ b/core/src/test/java/io/aiven/klaw/helpers/db/rdbms/TopicRequestsIntegrationTest.java
@@ -767,7 +767,7 @@ public class TopicRequestsIntegrationTest {
     Map<String, Long> statsCount = results.get("STATUS_COUNTS");
     Map<String, Long> operationTypeCount = results.get("OPERATION_TYPE_COUNTS");
 
-    assertThat(results.size()).isEqualTo(2);
+    assertThat(results).hasSize(2);
     // Jackie created all the requests so we expect 0 for created status which is approval status
     assertThat(statsCount.get(RequestStatus.CREATED.value)).isEqualTo(0L);
     assertThat(operationTypeCount.get(RequestOperationType.CREATE.value)).isEqualTo(0L);
@@ -787,7 +787,7 @@ public class TopicRequestsIntegrationTest {
     Map<String, Long> statsCount = results.get("STATUS_COUNTS");
     Map<String, Long> operationTypeCount = results.get("OPERATION_TYPE_COUNTS");
 
-    assertThat(results.size()).isEqualTo(2);
+    assertThat(results).hasSize(2);
     assertThat(statsCount.get(RequestStatus.CREATED.value)).isEqualTo(4L);
     assertThat(operationTypeCount.get(RequestOperationType.CREATE.value)).isEqualTo(0L);
     assertThat(operationTypeCount.get(RequestOperationType.CLAIM.value)).isEqualTo(7L);

--- a/core/src/test/java/io/aiven/klaw/service/RequestStatisticsServiceTest.java
+++ b/core/src/test/java/io/aiven/klaw/service/RequestStatisticsServiceTest.java
@@ -63,14 +63,17 @@ public class RequestStatisticsServiceTest {
   public void getRequestsCountOverview() {
     stubUserInfo();
     when(commonUtilsService.getTenantId(userDetails.getUsername())).thenReturn(1);
-    when(handleDbRequests.getTopicRequestsCounts(anyInt(), eq(RequestMode.MY_REQUESTS), anyInt()))
+    when(handleDbRequests.getTopicRequestsCounts(
+            anyInt(), eq(RequestMode.MY_REQUESTS), anyInt(), anyString()))
         .thenReturn(utilMethods.getRequestCounts());
-    when(handleDbRequests.getAclRequestsCounts(anyInt(), eq(RequestMode.MY_REQUESTS), anyInt()))
+    when(handleDbRequests.getAclRequestsCounts(
+            anyInt(), eq(RequestMode.MY_REQUESTS), anyInt(), anyString()))
         .thenReturn(utilMethods.getRequestCounts());
-    when(handleDbRequests.getSchemaRequestsCounts(anyInt(), eq(RequestMode.MY_REQUESTS), anyInt()))
+    when(handleDbRequests.getSchemaRequestsCounts(
+            anyInt(), eq(RequestMode.MY_REQUESTS), anyInt(), anyString()))
         .thenReturn(utilMethods.getRequestCounts());
     when(handleDbRequests.getConnectorRequestsCounts(
-            anyInt(), eq(RequestMode.MY_REQUESTS), anyInt()))
+            anyInt(), eq(RequestMode.MY_REQUESTS), anyInt(), anyString()))
         .thenReturn(utilMethods.getRequestCounts());
     RequestsCountOverview requestsCountOverview =
         requestStatisticsService.getRequestsCountOverview(RequestMode.MY_REQUESTS);


### PR DESCRIPTION
About this change - What it does
The count statistics mismatch the data returned in some instances because that data is filtered.
So a new option is being provided to allow the correct filtering to also occur on the API stats count that is being returned.
Resolves: #xxxxx
Why this way
This follows a similar pattern already applied and is trying to reduce the number of queries required against the database.