### PR TITLE
refactor(coral): Make status columns in approvals consistent 

### DIFF
--- a/coral/src/app/features/approvals/acls/AclApprovals.test.tsx
+++ b/coral/src/app/features/approvals/acls/AclApprovals.test.tsx
@@ -340,14 +340,14 @@ describe("AclApprovals", () => {
       const select = screen.getByLabelText("Filter by status");
 
       const option = within(select).getByRole("option", {
-        name: "DECLINED",
+        name: "Declined",
       });
 
       expect(option).toBeEnabled();
 
       await userEvent.selectOptions(select, option);
 
-      expect(select).toHaveDisplayValue("DECLINED");
+      expect(select).toHaveDisplayValue("Declined");
 
       await waitFor(() =>
         expect(mockGetAclRequestsForApprover).toHaveBeenCalledWith({

--- a/coral/src/app/features/approvals/acls/AclApprovals.tsx
+++ b/coral/src/app/features/approvals/acls/AclApprovals.tsx
@@ -1,6 +1,5 @@
 import {
   Alert,
-  ChipStatus,
   DataTable,
   DataTableColumn,
   Flexbox,
@@ -28,6 +27,11 @@ import {
 } from "src/domain/acl/acl-api";
 import { AclRequest, AclRequestsForApprover } from "src/domain/acl/acl-types";
 import { parseErrorMsg } from "src/services/mutation-utils";
+import {
+  requestStatusChipStatusMap,
+  requestStatusNameMap,
+} from "src/app/features/approvals/utils/request-status-helper";
+import { RequestStatus } from "src/domain/requests";
 
 interface AclRequestTableRow {
   id: number;
@@ -40,7 +44,11 @@ interface AclRequestTableRow {
   aclType: AclRequest["aclType"];
   username: string;
   requesttimestring: string;
-  requestStatus: "CREATED" | "DELETED" | "DECLINED" | "APPROVED" | "ALL" | "-";
+  // `requestStatus` is always defined from backend
+  // but api definition says it can be undefined
+  // the empty string is used to make ts compiler
+  // happy :D
+  requestStatus: RequestStatus | "";
 }
 
 const getRows = (entries: AclRequest[] | undefined): AclRequestTableRow[] => {
@@ -71,7 +79,7 @@ const getRows = (entries: AclRequest[] | undefined): AclRequestTableRow[] => {
       aclType,
       username: username ?? "-",
       requesttimestring: requesttimestring ?? "-",
-      requestStatus: requestStatus ?? "-",
+      requestStatus: requestStatus ?? "",
     })
   );
 };
@@ -267,19 +275,15 @@ function AclApprovals() {
       field: "requestStatus",
       headerName: "Status",
       status: ({ requestStatus }) => {
-        const statusKind: {
-          [key in AclRequestTableRow["requestStatus"]]: ChipStatus;
-        } = {
-          CREATED: "info",
-          DELETED: "danger",
-          DECLINED: "warning",
-          APPROVED: "success",
-          ALL: "neutral",
-          "-": "neutral",
-        };
+        if (requestStatus === "") {
+          return {
+            status: "neutral",
+            text: "-",
+          };
+        }
         return {
-          status: statusKind[requestStatus],
-          text: requestStatus,
+          status: requestStatusChipStatusMap[requestStatus],
+          text: requestStatusNameMap[requestStatus],
         };
       },
     },

--- a/coral/src/app/features/approvals/acls/hooks/useTableFilters.tsx
+++ b/coral/src/app/features/approvals/acls/hooks/useTableFilters.tsx
@@ -4,6 +4,7 @@ import { useState } from "react";
 import { useSearchParams } from "react-router-dom";
 import SelectEnvironment from "src/app/features/topics/browse/components/select-environment/SelectEnvironment";
 import { RequestStatus } from "src/domain/requests";
+import { requestStatusNameMap } from "src/app/features/approvals/utils/request-status-helper";
 
 const statusList: RequestStatus[] = [
   "ALL",
@@ -40,14 +41,11 @@ const useTableFilters = () => {
       }}
     >
       {statusList.map((status) => {
-        if (status === "ALL") {
-          return (
-            <option key={status} value={"ALL"}>
-              All statuses
-            </option>
-          );
-        }
-        return <option key={status}>{status}</option>;
+        return (
+          <option key={status} value={status}>
+            {requestStatusNameMap[status]}
+          </option>
+        );
       })}
     </NativeSelect>,
     <NativeSelect

--- a/coral/src/app/features/approvals/acls/hooks/useTableFilters.tsx
+++ b/coral/src/app/features/approvals/acls/hooks/useTableFilters.tsx
@@ -4,15 +4,11 @@ import { useState } from "react";
 import { useSearchParams } from "react-router-dom";
 import SelectEnvironment from "src/app/features/topics/browse/components/select-environment/SelectEnvironment";
 import { RequestStatus } from "src/domain/requests";
-import { requestStatusNameMap } from "src/app/features/approvals/utils/request-status-helper";
+import {
+  requestStatusNameMap,
+  statusList,
+} from "src/app/features/approvals/utils/request-status-helper";
 
-const statusList: RequestStatus[] = [
-  "ALL",
-  "CREATED",
-  "APPROVED",
-  "DECLINED",
-  "DELETED",
-];
 type AclType = "ALL" | "CONSUMER" | "PRODUCER";
 const aclTypes: AclType[] = ["ALL", "CONSUMER", "PRODUCER"];
 

--- a/coral/src/app/features/approvals/schemas/hooks/useTableFilters.tsx
+++ b/coral/src/app/features/approvals/schemas/hooks/useTableFilters.tsx
@@ -3,17 +3,12 @@ import debounce from "lodash/debounce";
 import { useState } from "react";
 import { useSearchParams } from "react-router-dom";
 import { RequestStatus } from "src/domain/requests";
-import { requestStatusNameMap } from "src/app/features/approvals/utils/request-status-helper";
+import {
+  requestStatusNameMap,
+  statusList,
+} from "src/app/features/approvals/utils/request-status-helper";
 import { SelectSchemaRegEnvironment } from "src/app/features/approvals/schemas/components/SelectSchemaRegEnvironment";
 import { ALL_ENVIRONMENTS_VALUE } from "src/domain/environment";
-
-const statusList: RequestStatus[] = [
-  "ALL",
-  "CREATED",
-  "APPROVED",
-  "DECLINED",
-  "DELETED",
-];
 
 const useTableFilters = () => {
   const [searchParams, setSearchParams] = useSearchParams();

--- a/coral/src/app/features/approvals/schemas/hooks/useTableFilters.tsx
+++ b/coral/src/app/features/approvals/schemas/hooks/useTableFilters.tsx
@@ -1,10 +1,9 @@
-import { SearchInput } from "@aivenio/aquarium";
+import { NativeSelect, SearchInput } from "@aivenio/aquarium";
 import debounce from "lodash/debounce";
 import { useState } from "react";
 import { useSearchParams } from "react-router-dom";
 import { RequestStatus } from "src/domain/requests";
 import { requestStatusNameMap } from "src/app/features/approvals/utils/request-status-helper";
-import { ComplexNativeSelect } from "src/app/components/ComplexNativeSelect";
 import { SelectSchemaRegEnvironment } from "src/app/features/approvals/schemas/components/SelectSchemaRegEnvironment";
 import { ALL_ENVIRONMENTS_VALUE } from "src/domain/environment";
 
@@ -29,11 +28,6 @@ const useTableFilters = () => {
   const [status, setStatus] = useState<RequestStatus>(statusParam ?? "CREATED");
   const [topic, setTopic] = useState(topicParam ?? "");
 
-  const statusOptions: Array<{ value: RequestStatus; name: string }> =
-    statusList.map((status) => {
-      return { value: status, name: requestStatusNameMap[status] };
-    });
-
   const filters = [
     <SelectSchemaRegEnvironment
       key={"filter-environment"}
@@ -44,20 +38,26 @@ const useTableFilters = () => {
         setEnvironment(envId);
       }}
     />,
-    <ComplexNativeSelect<{ value: RequestStatus; name: string }>
+    <NativeSelect
       labelText={"Filter by status"}
       key={"filter-status"}
       defaultValue={status}
-      options={statusOptions}
-      identifierValue={"value"}
-      identifierName={"name"}
-      onBlur={(option) => {
-        const { value } = option as { value: RequestStatus; name: string };
-        searchParams.set("status", value);
+      onChange={(e) => {
+        const status = e.target.value as RequestStatus;
+        searchParams.set("status", status);
         setSearchParams(searchParams);
-        setStatus(value);
+        setStatus(status);
       }}
-    />,
+    >
+      {statusList.map((status) => {
+        return (
+          <option key={status} value={status}>
+            {requestStatusNameMap[status]}
+          </option>
+        );
+      })}
+    </NativeSelect>,
+
     <div key={"search"}>
       <SearchInput
         type={"search"}

--- a/coral/src/app/features/approvals/topics/TopicApprovals.test.tsx
+++ b/coral/src/app/features/approvals/topics/TopicApprovals.test.tsx
@@ -530,14 +530,14 @@ describe("TopicApprovals", () => {
       const select = screen.getByLabelText("Filter by status");
 
       const option = within(select).getByRole("option", {
-        name: "DECLINED",
+        name: "Declined",
       });
 
       expect(option).toBeEnabled();
 
       await userEvent.selectOptions(select, option);
 
-      expect(select).toHaveDisplayValue("DECLINED");
+      expect(select).toHaveDisplayValue("Declined");
 
       await waitFor(() =>
         expect(mockGetTopicRequestsForApprover).toHaveBeenCalledWith({

--- a/coral/src/app/features/approvals/topics/components/TopicApprovalsTable.test.tsx
+++ b/coral/src/app/features/approvals/topics/components/TopicApprovalsTable.test.tsx
@@ -3,6 +3,8 @@ import userEvent from "@testing-library/user-event";
 import { TopicApprovalsTable } from "src/app/features/approvals/topics/components/TopicApprovalsTable";
 import { TopicRequest } from "src/domain/topic";
 import { mockIntersectionObserver } from "src/services/test-utils/mock-intersection-observer";
+import { requestStatusNameMap } from "src/app/features/approvals/utils/request-status-helper";
+import { RequestStatus } from "src/domain/requests";
 
 const mockedSetDetailsModal = jest.fn();
 const mockedSetRejectModal = jest.fn();
@@ -205,10 +207,15 @@ describe("TopicApprovalsTable", () => {
 
             // eslint-disable-next-line @typescript-eslint/ban-ts-comment
             //@ts-ignore
-            const content = `${request[column.relatedField]}`;
-            const isFormattedTime = column.columnHeader === "Requested on";
+            const field = request[column.relatedField];
 
-            const text = `${content}${isFormattedTime ? " UTC" : ""}`;
+            let text = field;
+            if (column.columnHeader === "Requested on") {
+              text = `${field} UTC`;
+            }
+            if (column.columnHeader === "Status") {
+              text = requestStatusNameMap[field as RequestStatus];
+            }
             const cell = within(table).getByRole("cell", { name: text });
 
             expect(cell).toBeVisible();

--- a/coral/src/app/features/approvals/topics/components/TopicApprovalsTable.tsx
+++ b/coral/src/app/features/approvals/topics/components/TopicApprovalsTable.tsx
@@ -12,6 +12,10 @@ import { UseMutateFunction } from "@tanstack/react-query";
 import { Dispatch, SetStateAction, useState } from "react";
 import { TopicRequest } from "src/domain/topic/topic-types";
 import { GenericApiResponse, HTTPError } from "src/services/api";
+import {
+  requestStatusChipStatusMap,
+  requestStatusNameMap,
+} from "src/app/features/approvals/utils/request-status-helper";
 
 interface TopicRequestTableRow {
   id: TopicRequest["topicid"];
@@ -64,7 +68,17 @@ function TopicApprovalsTable(props: TopicApprovalsTableProp) {
         text: environmentName,
       }),
     },
-    { type: "text", field: "requestStatus", headerName: "Status" },
+    {
+      type: "status",
+      field: "requestStatus",
+      headerName: "Status",
+      status: ({ requestStatus }) => {
+        return {
+          status: requestStatusChipStatusMap[requestStatus],
+          text: requestStatusNameMap[requestStatus],
+        };
+      },
+    },
     { type: "text", field: "teamname", headerName: "Claim by team" },
     { type: "text", field: "requestor", headerName: "Requested by" },
     {

--- a/coral/src/app/features/approvals/topics/hooks/useTableFilters.tsx
+++ b/coral/src/app/features/approvals/topics/hooks/useTableFilters.tsx
@@ -6,15 +6,10 @@ import SelectTeam from "src/app/features/components/table-filters/SelectTeam";
 import SelectEnvironment from "src/app/features/topics/browse/components/select-environment/SelectEnvironment";
 import { RequestStatus } from "src/domain/requests";
 import { TopicRequest } from "src/domain/topic/topic-types";
-import { requestStatusNameMap } from "src/app/features/approvals/utils/request-status-helper";
-
-const statusList: RequestStatus[] = [
-  "ALL",
-  "CREATED",
-  "APPROVED",
-  "DECLINED",
-  "DELETED",
-];
+import {
+  requestStatusNameMap,
+  statusList,
+} from "src/app/features/approvals/utils/request-status-helper";
 
 const useTableFilters = () => {
   const [searchParams, setSearchParams] = useSearchParams();

--- a/coral/src/app/features/approvals/topics/hooks/useTableFilters.tsx
+++ b/coral/src/app/features/approvals/topics/hooks/useTableFilters.tsx
@@ -6,6 +6,7 @@ import SelectTeam from "src/app/features/components/table-filters/SelectTeam";
 import SelectEnvironment from "src/app/features/topics/browse/components/select-environment/SelectEnvironment";
 import { RequestStatus } from "src/domain/requests";
 import { TopicRequest } from "src/domain/topic/topic-types";
+import { requestStatusNameMap } from "src/app/features/approvals/utils/request-status-helper";
 
 const statusList: RequestStatus[] = [
   "ALL",
@@ -42,14 +43,11 @@ const useTableFilters = () => {
       }}
     >
       {statusList.map((status) => {
-        if (status === "ALL") {
-          return (
-            <option key={status} value={"ALL"}>
-              All statuses
-            </option>
-          );
-        }
-        return <option key={status}>{status}</option>;
+        return (
+          <option key={status} value={status}>
+            {requestStatusNameMap[status]}
+          </option>
+        );
       })}
     </NativeSelect>,
     <SelectTeam key={"team"} onChange={setTeam} />,

--- a/coral/src/app/features/approvals/utils/request-status-helper.ts
+++ b/coral/src/app/features/approvals/utils/request-status-helper.ts
@@ -1,9 +1,16 @@
 import { RequestStatus } from "src/domain/requests";
 import { ChipStatus } from "@aivenio/aquarium";
 
-const requestStatusChipStatusMap: {
-  [key in RequestStatus]: ChipStatus;
-} = {
+// @TODO add safe list
+const statusList: RequestStatus[] = [
+  "ALL",
+  "APPROVED",
+  "CREATED",
+  "DECLINED",
+  "DELETED",
+];
+
+const requestStatusChipStatusMap: { [key in RequestStatus]: ChipStatus } = {
   ALL: "neutral",
   APPROVED: "success",
   CREATED: "info",
@@ -21,4 +28,4 @@ const requestStatusNameMap: {
   DELETED: "Deleted",
 };
 
-export { requestStatusNameMap, requestStatusChipStatusMap };
+export { requestStatusNameMap, requestStatusChipStatusMap, statusList };

--- a/coral/src/app/features/approvals/utils/request-status-helper.ts
+++ b/coral/src/app/features/approvals/utils/request-status-helper.ts
@@ -1,7 +1,10 @@
 import { RequestStatus } from "src/domain/requests";
 import { ChipStatus } from "@aivenio/aquarium";
 
-// @TODO add safe list
+// @TODO a nice improvement would be to
+// have a more typesafe / exhaustive list
+// here TS won't complain if a possible
+// value is missing from the array.
 const statusList: RequestStatus[] = [
   "ALL",
   "APPROVED",


### PR DESCRIPTION
# About this change - What it does

- uses the `statusRequest[x]Map` for all approval table views
- removes the unnecessary `ComplexNativeSelect` in schemas table filters
- adds on const `statusList` to be used in all table views

Resolves: #690

