### PR TITLE
fix(coral): Disabled reject buttons if approval is in progress

### DIFF
--- a/coral/src/app/features/approvals/acls/AclApprovals.tsx
+++ b/coral/src/app/features/approvals/acls/AclApprovals.tsx
@@ -353,6 +353,7 @@ function AclApprovals() {
                 setRejectModal({ isOpen: true, reqNo: String(id) })
               }
               title={"Reject request"}
+              disabled={approveIsLoading}
             >
               <Icon color="grey-70" icon={deleteIcon} />
             </GhostButton>

--- a/coral/src/app/features/approvals/topics/components/TopicApprovalsTable.test.tsx
+++ b/coral/src/app/features/approvals/topics/components/TopicApprovalsTable.test.tsx
@@ -1,8 +1,8 @@
 import { cleanup, render, screen, within } from "@testing-library/react";
-import { mockIntersectionObserver } from "src/services/test-utils/mock-intersection-observer";
+import userEvent from "@testing-library/user-event";
 import { TopicApprovalsTable } from "src/app/features/approvals/topics/components/TopicApprovalsTable";
 import { TopicRequest } from "src/domain/topic";
-import userEvent from "@testing-library/user-event";
+import { mockIntersectionObserver } from "src/services/test-utils/mock-intersection-observer";
 
 const mockedSetDetailsModal = jest.fn();
 const mockedSetRejectModal = jest.fn();
@@ -270,6 +270,30 @@ describe("TopicApprovalsTable", () => {
         requestEntityType: "TOPIC",
         reqIds: ["1000"],
       });
+    });
+  });
+
+  describe("handles action columns loading state", () => {
+    beforeAll(() => {
+      mockIntersectionObserver();
+      render(
+        <TopicApprovalsTable
+          setDetailsModal={mockedSetDetailsModal}
+          requests={mockedRequests}
+          approveIsLoading={true}
+          setRejectModal={mockedSetRejectModal}
+          approveRequest={mockedApproveRequest}
+        />
+      );
+    });
+    afterAll(cleanup);
+
+    it("renders disabled Reject button", async () => {
+      const decline = screen.getByRole("button", {
+        name: "Decline topic request for test-topic-1",
+      });
+
+      expect(decline).toBeDisabled;
     });
   });
 });

--- a/coral/src/app/features/approvals/topics/components/TopicApprovalsTable.tsx
+++ b/coral/src/app/features/approvals/topics/components/TopicApprovalsTable.tsx
@@ -157,6 +157,7 @@ function TopicApprovalsTable(props: TopicApprovalsTableProp) {
               onClick={() => setRejectModal({ isOpen: true, topicId: id })}
               title={"Reject request"}
               aria-label={`Decline topic request for ${topicname}`}
+              disabled={approveIsLoading}
             >
               <Icon color="grey-70" icon={deleteIcon} />
             </GhostButton>


### PR DESCRIPTION
## About this change - What it does

Approving a request is an async process that might take a few seconds, so we want to disable the ability to reject the same request while the approve request is not done.

(disregard failure of request, the DEV Kafka env is down ^^)




https://user-images.githubusercontent.com/20607294/221542803-156723d7-822b-4b1a-a888-e25fd71807f3.mov



