### PR TITLE
fix(coral): Approvals: replace all instances of "reject" by "decline"

### DIFF
--- a/coral/src/app/features/approvals/acls/AclApprovals.test.tsx
+++ b/coral/src/app/features/approvals/acls/AclApprovals.test.tsx
@@ -205,7 +205,7 @@ describe("AclApprovals", () => {
         screen.getByRole("button", { name: "Approve request" })
       );
       expect(createdRow).toContainElement(
-        screen.getByRole("button", { name: "Reject request" })
+        screen.getByRole("button", { name: "Decline request" })
       );
     });
 
@@ -216,7 +216,7 @@ describe("AclApprovals", () => {
         screen.getByRole("button", { name: "Approve request" })
       );
       expect(approvedRow).not.toContainElement(
-        screen.getByRole("button", { name: "Reject request" })
+        screen.getByRole("button", { name: "Decline request" })
       );
     });
   });
@@ -259,12 +259,12 @@ describe("AclApprovals", () => {
       const approveButton = within(modal).getByRole("button", {
         name: "Approve",
       });
-      const rejectButton = within(modal).getByRole("button", {
-        name: "Reject",
+      const declineButton = within(modal).getByRole("button", {
+        name: "Decline",
       });
 
       expect(approveButton).toBeDisabled();
-      expect(rejectButton).toBeDisabled();
+      expect(declineButton).toBeDisabled();
     });
 
     it("should render enabled actions in Details modal", async () => {
@@ -278,12 +278,12 @@ describe("AclApprovals", () => {
       const approveButton = within(modal).getByRole("button", {
         name: "Approve",
       });
-      const rejectButton = within(modal).getByRole("button", {
-        name: "Reject",
+      const declineButton = within(modal).getByRole("button", {
+        name: "Decline",
       });
 
       expect(approveButton).toBeEnabled();
-      expect(rejectButton).toBeEnabled();
+      expect(declineButton).toBeEnabled();
     });
   });
 

--- a/coral/src/app/features/approvals/acls/AclApprovals.tsx
+++ b/coral/src/app/features/approvals/acls/AclApprovals.tsx
@@ -20,7 +20,7 @@ import DetailsModalContent from "src/app/features/approvals/acls/components/Deta
 import useTableFilters from "src/app/features/approvals/acls/hooks/useTableFilters";
 import { ApprovalsLayout } from "src/app/features/approvals/components/ApprovalsLayout";
 import RequestDetailsModal from "src/app/features/approvals/components/RequestDetailsModal";
-import RequestRejectModal from "src/app/features/approvals/components/RequestRejectModal";
+import RequestDeclineModal from "src/app/features/approvals/components/RequestDeclineModal";
 import {
   approveAclRequest,
   declineAclRequest,
@@ -86,7 +86,10 @@ function AclApprovals() {
     isOpen: false,
     reqNo: "",
   });
-  const [rejectModal, setRejectModal] = useState({ isOpen: false, reqNo: "" });
+  const [declineModal, setDeclineModal] = useState({
+    isOpen: false,
+    reqNo: "",
+  });
 
   const [errorMessage, setErrorMessage] = useState("");
 
@@ -154,7 +157,7 @@ function AclApprovals() {
     },
   });
 
-  const { isLoading: rejectIsLoading, mutate: rejectRequest } = useMutation({
+  const { isLoading: declineIsLoading, mutate: declineRequest } = useMutation({
     mutationFn: declineAclRequest,
     onSuccess: (responses) => {
       const response = responses[0];
@@ -164,7 +167,7 @@ function AclApprovals() {
         );
       }
       setErrorMessage("");
-      setRejectModal({ isOpen: false, reqNo: "" });
+      setDeclineModal({ isOpen: false, reqNo: "" });
 
       // If approved request is last in the page, go back to previous page
       // This avoids staying on a non-existent page of entries, which makes the table bug hard
@@ -355,9 +358,9 @@ function AclApprovals() {
           return (
             <GhostButton
               onClick={() =>
-                setRejectModal({ isOpen: true, reqNo: String(id) })
+                setDeclineModal({ isOpen: true, reqNo: String(id) })
               }
-              title={"Reject request"}
+              title={"Decline request"}
             >
               <Icon color="grey-70" icon={deleteIcon} />
             </GhostButton>
@@ -391,9 +394,9 @@ function AclApprovals() {
               reqIds: [detailsModal.reqNo],
             });
           }}
-          onReject={() => {
+          onDecline={() => {
             setDetailsModal({ isOpen: false, reqNo: "" });
-            setRejectModal({ isOpen: true, reqNo: detailsModal.reqNo });
+            setDeclineModal({ isOpen: true, reqNo: detailsModal.reqNo });
           }}
           isLoading={approveIsLoading}
           disabledActions={selectedRequest?.requestStatus !== "CREATED"}
@@ -401,18 +404,18 @@ function AclApprovals() {
           <DetailsModalContent aclRequest={selectedRequest} />
         </RequestDetailsModal>
       )}
-      {rejectModal.isOpen && (
-        <RequestRejectModal
-          onClose={() => setRejectModal({ isOpen: false, reqNo: "" })}
-          onCancel={() => setRejectModal({ isOpen: false, reqNo: "" })}
+      {declineModal.isOpen && (
+        <RequestDeclineModal
+          onClose={() => setDeclineModal({ isOpen: false, reqNo: "" })}
+          onCancel={() => setDeclineModal({ isOpen: false, reqNo: "" })}
           onSubmit={(message: string) => {
-            rejectRequest({
+            declineRequest({
               requestEntityType: "ACL",
-              reqIds: [rejectModal.reqNo],
+              reqIds: [declineModal.reqNo],
               reason: message,
             });
           }}
-          isLoading={rejectIsLoading}
+          isLoading={declineIsLoading}
         />
       )}
       {errorMessage !== "" && (

--- a/coral/src/app/features/approvals/components/RequestDeclineModal.test.tsx
+++ b/coral/src/app/features/approvals/components/RequestDeclineModal.test.tsx
@@ -1,6 +1,6 @@
 import { cleanup, render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import RequestRejectModal from "src/app/features/approvals/components/RequestRejectModal";
+import RequestDeclineModal from "src/app/features/approvals/components/RequestDeclineModal";
 
 const baseProps = {
   onClose: jest.fn(),
@@ -8,10 +8,10 @@ const baseProps = {
   onCancel: jest.fn(),
 };
 
-describe("RequestRejectModal.test", () => {
+describe("RequestDeclineModal.test", () => {
   describe("renders a Modal with correct elements when isLoading is false (before interaction)", () => {
     beforeAll(() => {
-      render(<RequestRejectModal {...baseProps} isLoading={false} />);
+      render(<RequestDeclineModal {...baseProps} isLoading={false} />);
     });
     afterAll(cleanup);
 
@@ -21,7 +21,7 @@ describe("RequestRejectModal.test", () => {
 
     it("renders correct heading", () => {
       expect(
-        screen.getByRole("heading", { name: "Reject request" })
+        screen.getByRole("heading", { name: "Decline request" })
       ).toBeVisible();
     });
 
@@ -41,22 +41,22 @@ describe("RequestRejectModal.test", () => {
       expect(screen.getByRole("button", { name: "Cancel" })).toBeEnabled();
     });
 
-    it("renders disabled Reject request button", () => {
+    it("renders disabled Decline request button", () => {
       expect(
-        screen.getByRole("button", { name: "Reject request" })
+        screen.getByRole("button", { name: "Decline request" })
       ).toBeDisabled();
     });
   });
 
   describe("renders a Modal with correct elements when isLoading is true", () => {
     beforeAll(() => {
-      render(<RequestRejectModal {...baseProps} isLoading={true} />);
+      render(<RequestDeclineModal {...baseProps} isLoading={true} />);
     });
     afterAll(cleanup);
 
     it("renders correct heading", () => {
       expect(
-        screen.getByRole("heading", { name: "Reject request" })
+        screen.getByRole("heading", { name: "Decline request" })
       ).toBeVisible();
     });
 
@@ -78,16 +78,16 @@ describe("RequestRejectModal.test", () => {
       expect(screen.getByRole("button", { name: "Cancel" })).toBeDisabled();
     });
 
-    it("renders disabled Reject request button", () => {
+    it("renders disabled Decline request button", () => {
       expect(
-        screen.getByRole("button", { name: "Reject request" })
+        screen.getByRole("button", { name: "Decline request" })
       ).toBeDisabled();
     });
   });
 
   describe("handles user interaction", () => {
     beforeAll(() => {
-      render(<RequestRejectModal {...baseProps} isLoading={false} />);
+      render(<RequestDeclineModal {...baseProps} isLoading={false} />);
     });
     afterAll(cleanup);
 
@@ -108,18 +108,18 @@ describe("RequestRejectModal.test", () => {
       expect(onCancel).toHaveBeenCalledTimes(1);
     });
 
-    it("user can reject", async () => {
+    it("user can decline", async () => {
       const { onSubmit } = baseProps;
 
-      const rejectButton = screen.getByRole("button", {
-        name: "Reject request",
+      const declineButton = screen.getByRole("button", {
+        name: "Decline request",
       });
       const textArea = screen.getByRole("textbox", {
         name: "Submit a reason to decline the request *",
       });
 
       await userEvent.type(textArea, "reason");
-      await userEvent.click(rejectButton);
+      await userEvent.click(declineButton);
       expect(onSubmit).toHaveBeenCalledWith("reason");
     });
 
@@ -127,15 +127,15 @@ describe("RequestRejectModal.test", () => {
       const tooLong =
         "Quisque commodo aliquam tristique. Class aptent taciti sociosqu ad litora torquent per conubia nostra, per inceptos himenaeos. Sed ornare turpis ac cursus vulputate. Morbi auctor sodales porttitor. Mauris placerat ante id facilisis vehicula. Pellentesque ornare quis massa elementum auctor. Suspendisse potenti. Phasellus dignissim sit amet risus vitae aliquet. Vivamus at dolor vehicula, placerat odio sit amet, imperdiet enim. Donec scelerisque pretium metus ut dignissim. Morbi posuere tortor in cursus porttitor. Maecenas a diam ut urna mattis convallis a vel ligula.";
 
-      const rejectButton = screen.getByRole("button", {
-        name: "Reject request",
+      const declineButton = screen.getByRole("button", {
+        name: "Decline request",
       });
       const textArea = screen.getByRole("textbox", {
         name: "Submit a reason to decline the request *",
       });
 
       await userEvent.type(textArea, tooLong);
-      expect(rejectButton).toBeDisabled();
+      expect(declineButton).toBeDisabled();
       expect(textArea).toBeInvalid();
     });
   });

--- a/coral/src/app/features/approvals/components/RequestDeclineModal.tsx
+++ b/coral/src/app/features/approvals/components/RequestDeclineModal.tsx
@@ -2,30 +2,30 @@ import { Textarea } from "@aivenio/aquarium";
 import { useState } from "react";
 import { Modal } from "src/app/components/Modal";
 
-interface RequestRejectModalProps {
+interface RequestDeclineModalProps {
   onClose: () => void;
   onCancel: () => void;
   onSubmit: (message: string) => void;
   isLoading: boolean;
 }
 
-const RequestRejectModal = ({
+const RequestDeclineModal = ({
   onClose,
   onSubmit,
   onCancel,
   isLoading,
-}: RequestRejectModalProps) => {
-  const [rejectionMessage, setRejectionMessage] = useState("");
-  const isValid = rejectionMessage.length < 300;
+}: RequestDeclineModalProps) => {
+  const [declineReason, setDeclineReason] = useState("");
+  const isValid = declineReason.length < 300;
 
   return (
     <Modal
-      title={"Reject request"}
+      title={"Decline request"}
       close={onClose}
       primaryAction={{
-        text: "Reject request",
-        onClick: () => onSubmit(rejectionMessage),
-        disabled: !isValid || rejectionMessage.length === 0,
+        text: "Decline request",
+        onClick: () => onSubmit(declineReason),
+        disabled: !isValid || declineReason.length === 0,
         loading: isLoading,
       }}
       secondaryAction={{
@@ -36,10 +36,10 @@ const RequestRejectModal = ({
     >
       <Textarea
         labelText="Submit a reason to decline the request"
-        name="rejection-reason"
+        name="decline-reason"
         placeholder="Write a message ..."
-        onChange={(e) => setRejectionMessage(e.target.value)}
-        helperText={!isValid ? "Rejection message is too long." : undefined}
+        onChange={(e) => setDeclineReason(e.target.value)}
+        helperText={!isValid ? "Reason to decline is too long." : undefined}
         valid={isValid}
         disabled={isLoading}
         required
@@ -48,4 +48,4 @@ const RequestRejectModal = ({
   );
 };
 
-export default RequestRejectModal;
+export default RequestDeclineModal;

--- a/coral/src/app/features/approvals/components/RequestDetailsModal.test.tsx
+++ b/coral/src/app/features/approvals/components/RequestDetailsModal.test.tsx
@@ -5,7 +5,7 @@ import RequestDetailsModal from "src/app/features/approvals/components/RequestDe
 const baseProps = {
   onClose: jest.fn(),
   onApprove: jest.fn(),
-  onReject: jest.fn(),
+  onDecline: jest.fn(),
 };
 
 describe("RequestDetailsModal.test", () => {
@@ -37,8 +37,8 @@ describe("RequestDetailsModal.test", () => {
       expect(screen.getByRole("button", { name: "Approve" })).toBeEnabled();
     });
 
-    it("renders enabled Reject request button", () => {
-      expect(screen.getByRole("button", { name: "Reject" })).toBeEnabled();
+    it("renders enabled Decline request button", () => {
+      expect(screen.getByRole("button", { name: "Decline" })).toBeEnabled();
     });
   });
 
@@ -68,8 +68,8 @@ describe("RequestDetailsModal.test", () => {
       expect(screen.getByRole("button", { name: "Approve" })).toBeDisabled();
     });
 
-    it("renders disabled Reject request button", () => {
-      expect(screen.getByRole("button", { name: "Reject" })).toBeDisabled();
+    it("renders disabled Decline request button", () => {
+      expect(screen.getByRole("button", { name: "Decline" })).toBeDisabled();
     });
   });
 
@@ -101,8 +101,8 @@ describe("RequestDetailsModal.test", () => {
       expect(screen.getByRole("button", { name: "Approve" })).toBeDisabled();
     });
 
-    it("renders disabled Reject request button", () => {
-      expect(screen.getByRole("button", { name: "Reject" })).toBeDisabled();
+    it("renders disabled Decline request button", () => {
+      expect(screen.getByRole("button", { name: "Decline" })).toBeDisabled();
     });
   });
 
@@ -132,15 +132,15 @@ describe("RequestDetailsModal.test", () => {
       expect(onApprove).toHaveBeenCalledTimes(1);
     });
 
-    it("user can reject", async () => {
-      const { onReject } = baseProps;
+    it("user can decline", async () => {
+      const { onDecline } = baseProps;
 
-      const rejectButton = screen.getByRole("button", {
-        name: "Reject",
+      const declineButton = screen.getByRole("button", {
+        name: "Decline",
       });
 
-      await userEvent.click(rejectButton);
-      expect(onReject).toHaveBeenCalledTimes(1);
+      await userEvent.click(declineButton);
+      expect(onDecline).toHaveBeenCalledTimes(1);
     });
   });
 });

--- a/coral/src/app/features/approvals/components/RequestDetailsModal.tsx
+++ b/coral/src/app/features/approvals/components/RequestDetailsModal.tsx
@@ -4,7 +4,7 @@ import { Modal } from "src/app/components/Modal";
 interface RequestDetailsModalProps {
   onClose: () => void;
   onApprove: () => void;
-  onReject: () => void;
+  onDecline: () => void;
   children: ReactElement;
   isLoading: boolean;
   disabledActions?: boolean;
@@ -14,7 +14,7 @@ const RequestDetailsModal = ({
   children,
   onClose,
   onApprove,
-  onReject,
+  onDecline,
   isLoading,
   disabledActions,
 }: RequestDetailsModalProps) => {
@@ -29,8 +29,8 @@ const RequestDetailsModal = ({
         disabled: disabledActions,
       }}
       secondaryAction={{
-        text: "Reject",
-        onClick: onReject,
+        text: "Decline",
+        onClick: onDecline,
         disabled: isLoading || disabledActions,
       }}
     >

--- a/coral/src/app/features/approvals/schemas/SchemaApprovals.tsx
+++ b/coral/src/app/features/approvals/schemas/SchemaApprovals.tsx
@@ -69,7 +69,7 @@ function SchemaApprovals() {
     console.log("approve", req_no);
   }
 
-  function rejectRequest(req_no: number | null) {
+  function declineRequest(req_no: number | null) {
     console.log("approve", req_no);
   }
 
@@ -81,9 +81,9 @@ function SchemaApprovals() {
           onApprove={() => {
             approveRequest(detailsModal.req_no);
           }}
-          onReject={() => {
+          onDecline={() => {
             setDetailsModal({ isOpen: false, req_no: null });
-            rejectRequest(detailsModal.req_no);
+            declineRequest(detailsModal.req_no);
           }}
           isLoading={false}
         >

--- a/coral/src/app/features/approvals/topics/TopicApprovals.test.tsx
+++ b/coral/src/app/features/approvals/topics/TopicApprovals.test.tsx
@@ -447,12 +447,12 @@ describe("TopicApprovals", () => {
       const approveButton = within(modal).getByRole("button", {
         name: "Approve",
       });
-      const rejectButton = within(modal).getByRole("button", {
-        name: "Reject",
+      const declineButton = within(modal).getByRole("button", {
+        name: "Decline",
       });
 
       expect(approveButton).toBeDisabled();
-      expect(rejectButton).toBeDisabled();
+      expect(declineButton).toBeDisabled();
     });
 
     it("should render enabled actions in Details modal", async () => {
@@ -469,12 +469,12 @@ describe("TopicApprovals", () => {
       const approveButton = within(modal).getByRole("button", {
         name: "Approve",
       });
-      const rejectButton = within(modal).getByRole("button", {
-        name: "Reject",
+      const declineButton = within(modal).getByRole("button", {
+        name: "Decline",
       });
 
       expect(approveButton).toBeEnabled();
-      expect(rejectButton).toBeEnabled();
+      expect(declineButton).toBeEnabled();
     });
   });
 

--- a/coral/src/app/features/approvals/topics/TopicApprovals.tsx
+++ b/coral/src/app/features/approvals/topics/TopicApprovals.tsx
@@ -5,14 +5,14 @@ import { useSearchParams } from "react-router-dom";
 import { Pagination } from "src/app/components/Pagination";
 import { ApprovalsLayout } from "src/app/features/approvals/components/ApprovalsLayout";
 import RequestDetailsModal from "src/app/features/approvals/components/RequestDetailsModal";
-import RequestRejectModal from "src/app/features/approvals/components/RequestRejectModal";
+import RequestDeclineModal from "src/app/features/approvals/components/RequestDeclineModal";
 import DetailsModalContent from "src/app/features/approvals/topics/components/DetailsModalContent";
 import { TopicApprovalsTable } from "src/app/features/approvals/topics/components/TopicApprovalsTable";
 import useTableFilters from "src/app/features/approvals/topics/hooks/useTableFilters";
 import {
   approveTopicRequest,
   getTopicRequestsForApprover,
-  rejectTopicRequest,
+  declineTopicRequest,
 } from "src/domain/topic/topic-api";
 import { HTTPError } from "src/services/api";
 
@@ -32,7 +32,7 @@ function TopicApprovals() {
     isOpen: false,
     topicId: null,
   });
-  const [rejectModal, setRejectModal] = useState<{
+  const [declineModal, setDeclineModal] = useState<{
     isOpen: boolean;
     topicId: number | null;
   }>({
@@ -112,8 +112,8 @@ function TopicApprovals() {
     },
   });
 
-  const { isLoading: rejectIsLoading, mutate: rejectRequest } = useMutation({
-    mutationFn: rejectTopicRequest,
+  const { isLoading: declineIsLoading, mutate: declineRequest } = useMutation({
+    mutationFn: declineTopicRequest,
     onSuccess: (responses) => {
       // This mutation is used on a single request, so we always want the first response in the array
       const response = responses[0];
@@ -124,7 +124,7 @@ function TopicApprovals() {
         );
       }
       setErrorMessage("");
-      setRejectModal({ isOpen: false, topicId: null });
+      setDeclineModal({ isOpen: false, topicId: null });
 
       // If approved request is last in the page, go back to previous page
       // This avoids staying on a non-existent page of entries, which makes the table bug hard
@@ -159,7 +159,7 @@ function TopicApprovals() {
     <TopicApprovalsTable
       requests={topicRequests?.entries || []}
       setDetailsModal={setDetailsModal}
-      setRejectModal={setRejectModal}
+      setDeclineModal={setDeclineModal}
       approveRequest={approveRequest}
       approveIsLoading={approveIsLoading}
     />
@@ -191,9 +191,9 @@ function TopicApprovals() {
               reqIds: [String(detailsModal.topicId)],
             });
           }}
-          onReject={() => {
+          onDecline={() => {
             setDetailsModal({ isOpen: false, topicId: null });
-            setRejectModal({ isOpen: true, topicId: detailsModal.topicId });
+            setDeclineModal({ isOpen: true, topicId: detailsModal.topicId });
           }}
           isLoading={approveIsLoading}
           disabledActions={selectedTopicRequest?.requestStatus !== "CREATED"}
@@ -201,22 +201,22 @@ function TopicApprovals() {
           <DetailsModalContent topicRequest={selectedTopicRequest} />
         </RequestDetailsModal>
       )}
-      {rejectModal.isOpen && (
-        <RequestRejectModal
-          onClose={() => setRejectModal({ isOpen: false, topicId: null })}
-          onCancel={() => setRejectModal({ isOpen: false, topicId: null })}
+      {declineModal.isOpen && (
+        <RequestDeclineModal
+          onClose={() => setDeclineModal({ isOpen: false, topicId: null })}
+          onCancel={() => setDeclineModal({ isOpen: false, topicId: null })}
           onSubmit={(message: string) => {
-            if (rejectModal.topicId === null) {
+            if (declineModal.topicId === null) {
               setErrorMessage("topicId is null, it should be a number");
               return;
             }
-            rejectRequest({
+            declineRequest({
               requestEntityType: "TOPIC",
-              reqIds: [String(rejectModal.topicId)],
+              reqIds: [String(declineModal.topicId)],
               reason: message,
             });
           }}
-          isLoading={rejectIsLoading}
+          isLoading={declineIsLoading}
         />
       )}
       {errorMessage !== "" && (

--- a/coral/src/app/features/approvals/topics/components/TopicApprovalsTable.test.tsx
+++ b/coral/src/app/features/approvals/topics/components/TopicApprovalsTable.test.tsx
@@ -5,7 +5,7 @@ import { TopicRequest } from "src/domain/topic";
 import userEvent from "@testing-library/user-event";
 
 const mockedSetDetailsModal = jest.fn();
-const mockedSetRejectModal = jest.fn();
+const mockedSetDeclineModal = jest.fn();
 const mockedApproveRequest = jest.fn();
 
 const mockedRequests: TopicRequest[] = [
@@ -93,7 +93,7 @@ describe("TopicApprovalsTable", () => {
           setDetailsModal={mockedSetDetailsModal}
           requests={mockedRequests}
           approveIsLoading={false}
-          setRejectModal={mockedSetRejectModal}
+          setDeclineModal={mockedSetDeclineModal}
           approveRequest={mockedApproveRequest}
         />
       );
@@ -162,7 +162,7 @@ describe("TopicApprovalsTable", () => {
           setDetailsModal={mockedSetDetailsModal}
           requests={mockedRequests}
           approveIsLoading={false}
-          setRejectModal={mockedSetRejectModal}
+          setDeclineModal={mockedSetDeclineModal}
           approveRequest={mockedApproveRequest}
         />
       );
@@ -226,7 +226,7 @@ describe("TopicApprovalsTable", () => {
           setDetailsModal={mockedSetDetailsModal}
           requests={mockedRequests}
           approveIsLoading={false}
-          setRejectModal={mockedSetRejectModal}
+          setDeclineModal={mockedSetDeclineModal}
           approveRequest={mockedApproveRequest}
         />
       );
@@ -246,14 +246,14 @@ describe("TopicApprovalsTable", () => {
       });
     });
 
-    it("shows a Modal when clicking Reject button", async () => {
+    it("shows a Modal when clicking Decline button", async () => {
       const showDetails = screen.getByRole("button", {
         name: "Decline topic request for test-topic-1",
       });
 
       await userEvent.click(showDetails);
 
-      expect(mockedSetRejectModal).toHaveBeenCalledWith({
+      expect(mockedSetDeclineModal).toHaveBeenCalledWith({
         isOpen: true,
         topicId: 1000,
       });

--- a/coral/src/app/features/approvals/topics/components/TopicApprovalsTable.tsx
+++ b/coral/src/app/features/approvals/topics/components/TopicApprovalsTable.tsx
@@ -31,7 +31,7 @@ type TopicApprovalsTableProp = {
       topicId: number | null;
     }>
   >;
-  setRejectModal: Dispatch<
+  setDeclineModal: Dispatch<
     SetStateAction<{
       isOpen: boolean;
       topicId: number | null;
@@ -48,7 +48,7 @@ function TopicApprovalsTable(props: TopicApprovalsTableProp) {
   const {
     requests,
     setDetailsModal,
-    setRejectModal,
+    setDeclineModal,
     approveRequest,
     approveIsLoading,
   } = props;
@@ -154,8 +154,8 @@ function TopicApprovalsTable(props: TopicApprovalsTableProp) {
         if (requestStatus === "CREATED") {
           return (
             <GhostButton
-              onClick={() => setRejectModal({ isOpen: true, topicId: id })}
-              title={"Reject request"}
+              onClick={() => setDeclineModal({ isOpen: true, topicId: id })}
+              title={"Decline request"}
               aria-label={`Decline topic request for ${topicname}`}
             >
               <Icon color="grey-70" icon={deleteIcon} />

--- a/coral/src/domain/acl/acl-api.ts
+++ b/coral/src/domain/acl/acl-api.ts
@@ -47,9 +47,9 @@ const approveAclRequest = (payload: ApproveAclRequestPayload) => {
   );
 };
 
-type RejectAclRequestPayload = RequestVerdictDecline<"ACL">;
-const declineAclRequest = (payload: RejectAclRequestPayload) => {
-  return api.post<KlawApiResponse<"declineRequest">, RejectAclRequestPayload>(
+type DeclineAclRequestPayload = RequestVerdictDecline<"ACL">;
+const declineAclRequest = (payload: DeclineAclRequestPayload) => {
+  return api.post<KlawApiResponse<"declineRequest">, DeclineAclRequestPayload>(
     `/request/decline`,
     payload
   );

--- a/coral/src/domain/topic/topic-api.ts
+++ b/coral/src/domain/topic/topic-api.ts
@@ -136,12 +136,12 @@ const approveTopicRequest = (payload: ApproveTopicRequestPayload) => {
   >(`/request/approve`, payload);
 };
 
-type RejectTopicRequestPayload = RequestVerdictDecline<"TOPIC">;
-const rejectTopicRequest = (payload: RejectTopicRequestPayload) => {
-  return api.post<KlawApiResponse<"declineRequest">, RejectTopicRequestPayload>(
-    `/request/decline`,
-    payload
-  );
+type DeclineTopicRequestPayload = RequestVerdictDecline<"TOPIC">;
+const declineTopicRequest = (payload: DeclineTopicRequestPayload) => {
+  return api.post<
+    KlawApiResponse<"declineRequest">,
+    DeclineTopicRequestPayload
+  >(`/request/decline`, payload);
 };
 
 export {
@@ -152,5 +152,5 @@ export {
   requestTopic,
   getTopicRequestsForApprover,
   approveTopicRequest,
-  rejectTopicRequest,
+  declineTopicRequest,
 };


### PR DESCRIPTION
## About this change - What it does

For consistency, unify all terminology is UI and in code to use "decline" and variations  everywhere.

Resolves: #693

