### PR TITLE
refactor(coral): Disable Connectors approvals tab

### DIFF
--- a/coral/src/app/features/approvals/components/ApprovalResourceTabs.test.tsx
+++ b/coral/src/app/features/approvals/components/ApprovalResourceTabs.test.tsx
@@ -142,12 +142,13 @@ describe("ApprovalResourceTabs", () => {
         replace: true,
       });
     });
-
-    it('navigates to correct URL when "Connectors" tab is clicked', async () => {
-      await user.click(screen.getByRole("tab", { name: "Connectors" }));
-      expect(mockedNavigate).toHaveBeenCalledWith("/approvals/connectors", {
-        replace: true,
-      });
-    });
+    // Tab is disabled because Connectors are not yet implemented in coral
+    // @TODO uncomment test when Connectors are implemented
+    // it('navigates to correct URL when "Connectors" tab is clicked', async () => {
+    //   await user.click(screen.getByRole("tab", { name: "Connectors" }));
+    //   expect(mockedNavigate).toHaveBeenCalledWith("/approvals/connectors", {
+    //     replace: true,
+    //   });
+    // });
   });
 });

--- a/coral/src/app/features/approvals/components/ApprovalResourceTabs.tsx
+++ b/coral/src/app/features/approvals/components/ApprovalResourceTabs.tsx
@@ -55,13 +55,14 @@ function ApprovalResourceTabs({ currentTab }: Props) {
         {currentTab === ApprovalsTabEnum.SCHEMAS && <Outlet />}
       </Tabs.Tab>
       <Tabs.Tab
-        title="Connectors"
+        title="Connectors (coming soon)"
         value={ApprovalsTabEnum.CONNECTORS}
         badge={getBadgeValue(numberOfPendingSchemaApprovals)}
         aria-label={getTabAriaLabel(
           "Connectors",
           numberOfPendingConnectorApprovals
         )}
+        disabled
       >
         {currentTab === ApprovalsTabEnum.CONNECTORS && <Outlet />}
       </Tabs.Tab>


### PR DESCRIPTION
## About this change - What it does

Connectors are not yet implemented in `coral`. Therefore, the corresponding tab in the Approval page should be disabled.

<img width="1502" alt="Screenshot 2023-02-27 at 13 37 03" src="https://user-images.githubusercontent.com/20607294/221566406-3ebb6562-3a08-4fca-8785-fd1ed4d6745b.png">


Resolves: #709
