### PR TITLE
feat(coral): Add approving/rejecting schema request 

### DIFF
--- a/coral/src/app/features/approvals/schemas/SchemaApprovals.test.tsx
+++ b/coral/src/app/features/approvals/schemas/SchemaApprovals.test.tsx
@@ -495,4 +495,37 @@ describe("SchemaApprovals", () => {
       });
     });
   });
+
+  describe("shows a reject modal for schema request", () => {
+    beforeEach(async () => {
+      mockGetSchemaRequestsForApprover.mockResolvedValue(mockedApiResponse);
+
+      customRender(<SchemaApprovals />, {
+        queryClient: true,
+        memoryRouter: true,
+      });
+
+      await waitForElementToBeRemoved(screen.getByTestId("skeleton-table"));
+    });
+
+    afterEach(() => {
+      jest.clearAllMocks();
+      cleanup();
+    });
+
+    it("shows decline modal for requests", async () => {
+      expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+
+      const firstRequest = mockedApiResponse.entries[0];
+      const declineButton = screen.getByRole("button", {
+        name: `Decline schema request for ${firstRequest.topicname}`,
+      });
+
+      await userEvent.click(declineButton);
+      const modal = screen.getByRole("dialog");
+
+      expect(modal).toBeVisible();
+      expect(modal).toHaveTextContent("Reject request");
+    });
+  });
 });

--- a/coral/src/app/features/approvals/schemas/SchemaApprovals.test.tsx
+++ b/coral/src/app/features/approvals/schemas/SchemaApprovals.test.tsx
@@ -471,7 +471,7 @@ describe("SchemaApprovals", () => {
 
       expect(
         within(screen.getByRole("dialog")).queryByRole("heading", {
-          name: "Reject request",
+          name: "Decline request",
         })
       ).not.toBeInTheDocument();
 
@@ -570,7 +570,7 @@ describe("SchemaApprovals", () => {
     });
   });
 
-  describe("enables user to reject a request", () => {
+  describe("enables user to decline a request", () => {
     const testRequest = mockedApiResponseSchemaRequests.entries[0];
 
     beforeEach(async () => {
@@ -602,12 +602,12 @@ describe("SchemaApprovals", () => {
       await userEvent.click(declineButton);
       const modal = screen.getByRole("dialog");
 
-      const rejectButton = within(modal).getByRole("button", {
+      const confirmDeclineButton = within(modal).getByRole("button", {
         name: "Reject request",
       });
-      expect(rejectButton).toBeDisabled();
+      expect(confirmDeclineButton).toBeDisabled();
 
-      await userEvent.click(rejectButton);
+      await userEvent.click(confirmDeclineButton);
       expect(mockDeclineSchemaRequest).not.toHaveBeenCalled();
 
       const message = within(modal).getByRole("textbox", {
@@ -618,7 +618,7 @@ describe("SchemaApprovals", () => {
       await userEvent.type(message, "This is my message");
       await userEvent.tab();
 
-      expect(rejectButton).toBeEnabled();
+      expect(confirmDeclineButton).toBeEnabled();
     });
 
     it("send a decline request api call if user declines a schema request", async () => {
@@ -631,7 +631,7 @@ describe("SchemaApprovals", () => {
       await userEvent.click(declineButton);
       const modal = screen.getByRole("dialog");
 
-      const rejectButton = within(modal).getByRole("button", {
+      const confirmDeclineButton = within(modal).getByRole("button", {
         name: "Reject request",
       });
 
@@ -641,7 +641,7 @@ describe("SchemaApprovals", () => {
 
       await userEvent.type(message, "This is my message");
       await userEvent.tab();
-      await userEvent.click(rejectButton);
+      await userEvent.click(confirmDeclineButton);
 
       expect(mockDeclineSchemaRequest).toHaveBeenCalledWith({
         reqIds: [testRequest.req_no.toString()],
@@ -663,7 +663,7 @@ describe("SchemaApprovals", () => {
       await userEvent.click(declineButton);
       const modal = screen.getByRole("dialog");
 
-      const rejectButton = within(modal).getByRole("button", {
+      const confirmDeclineButton = within(modal).getByRole("button", {
         name: "Reject request",
       });
 
@@ -673,7 +673,7 @@ describe("SchemaApprovals", () => {
 
       await userEvent.type(message, "This is my message");
       await userEvent.tab();
-      await userEvent.click(rejectButton);
+      await userEvent.click(confirmDeclineButton);
 
       expect(mockDeclineSchemaRequest).toHaveBeenCalledWith({
         reqIds: [testRequest.req_no.toString()],
@@ -701,7 +701,7 @@ describe("SchemaApprovals", () => {
       await userEvent.click(declineButton);
       const modal = screen.getByRole("dialog");
 
-      const rejectButton = within(modal).getByRole("button", {
+      const confirmDeclineButton = within(modal).getByRole("button", {
         name: "Reject request",
       });
 
@@ -711,7 +711,7 @@ describe("SchemaApprovals", () => {
 
       await userEvent.type(message, "This is my message");
       await userEvent.tab();
-      await userEvent.click(rejectButton);
+      await userEvent.click(confirmDeclineButton);
 
       expect(mockDeclineSchemaRequest).toHaveBeenCalledWith({
         reqIds: [testRequest.req_no.toString()],

--- a/coral/src/app/features/approvals/schemas/SchemaApprovals.test.tsx
+++ b/coral/src/app/features/approvals/schemas/SchemaApprovals.test.tsx
@@ -476,14 +476,14 @@ describe("SchemaApprovals", () => {
       ).not.toBeInTheDocument();
 
       const declineButton = screen.getByRole("button", {
-        name: "Reject",
+        name: "Decline",
       });
       await userEvent.click(declineButton);
 
       expect(detailsModal).not.toBeInTheDocument();
       expect(
         within(screen.getByRole("dialog")).queryByRole("heading", {
-          name: "Reject request",
+          name: "Decline request",
         })
       ).toBeVisible();
     });
@@ -603,7 +603,7 @@ describe("SchemaApprovals", () => {
       const modal = screen.getByRole("dialog");
 
       const confirmDeclineButton = within(modal).getByRole("button", {
-        name: "Reject request",
+        name: "Decline request",
       });
       expect(confirmDeclineButton).toBeDisabled();
 
@@ -632,7 +632,7 @@ describe("SchemaApprovals", () => {
       const modal = screen.getByRole("dialog");
 
       const confirmDeclineButton = within(modal).getByRole("button", {
-        name: "Reject request",
+        name: "Decline request",
       });
 
       const message = within(modal).getByRole("textbox", {
@@ -664,7 +664,7 @@ describe("SchemaApprovals", () => {
       const modal = screen.getByRole("dialog");
 
       const confirmDeclineButton = within(modal).getByRole("button", {
-        name: "Reject request",
+        name: "Decline request",
       });
 
       const message = within(modal).getByRole("textbox", {
@@ -702,7 +702,7 @@ describe("SchemaApprovals", () => {
       const modal = screen.getByRole("dialog");
 
       const confirmDeclineButton = within(modal).getByRole("button", {
-        name: "Reject request",
+        name: "Decline request",
       });
 
       const message = within(modal).getByRole("textbox", {

--- a/coral/src/app/features/approvals/schemas/SchemaApprovals.tsx
+++ b/coral/src/app/features/approvals/schemas/SchemaApprovals.tsx
@@ -25,7 +25,7 @@ function SchemaApprovals() {
     : 1;
 
   const [modals, setModals] = useState<{
-    open: "DETAILS" | "REJECT" | "NONE";
+    open: "DETAILS" | "DECLINE" | "NONE";
     req_no: number | null;
   }>({ open: "NONE", req_no: null });
 
@@ -82,7 +82,7 @@ function SchemaApprovals() {
           );
         } else {
           setErrorQuickActions("");
-          // If rejected request is last in the page, go back to previous page
+          // If declined request is last in the page, go back to previous page
           // This avoids staying on a non-existent page of entries, which makes the table bug hard
           // With pagination being 0 of 0, and clicking Previous button sets active page at -1
           // We also do not need to invalidate the query, as the activePage does not exist any more
@@ -118,7 +118,7 @@ function SchemaApprovals() {
           );
         } else {
           setErrorQuickActions("");
-          // If rejected request is last in the page, go back to previous page
+          // If declined request is last in the page, go back to previous page
           // This avoids staying on a non-existent page of entries, which makes the table bug hard
           // With pagination being 0 of 0, and clicking Previous button sets active page at -1
           // We also do not need to invalidate the query, as the activePage does not exist any more
@@ -190,8 +190,7 @@ function SchemaApprovals() {
             approveRequest({ reqIds: [modals.req_no.toString()] });
           }}
           onDecline={() => {
-            setModals({ open: "NONE", req_no: null });
-            declineRequest(modals.req_no);
+            setModals({ ...modals, open: "DECLINE" });
           }}
           isLoading={declineRequestIsLoading || approveRequestIsLoading}
         >
@@ -202,7 +201,7 @@ function SchemaApprovals() {
           />
         </RequestDetailsModal>
       )}
-      {modals.open === "REJECT" && (
+      {modals.open === "DECLINE" && (
         <RequestRejectModal
           onClose={() => closeModal()}
           onCancel={() => closeModal()}

--- a/coral/src/app/features/approvals/schemas/SchemaApprovals.tsx
+++ b/coral/src/app/features/approvals/schemas/SchemaApprovals.tsx
@@ -8,13 +8,13 @@ import useTableFilters from "src/app/features/approvals/schemas/hooks/useTableFi
 import { useState } from "react";
 import RequestDetailsModal from "src/app/features/approvals/components/RequestDetailsModal";
 import { SchemaRequestDetails } from "src/app/features/approvals/schemas/components/SchemaRequestDetails";
-import RequestRejectModal from "src/app/features/approvals/components/RequestRejectModal";
 import {
   approveSchemaRequest,
   declineSchemaRequest,
 } from "src/domain/schema-request/schema-request-api";
 import { parseErrorMsg } from "src/services/mutation-utils";
 import { Alert } from "@aivenio/aquarium";
+import RequestDeclineModal from "src/app/features/approvals/components/RequestDeclineModal";
 
 function SchemaApprovals() {
   const queryClient = useQueryClient();
@@ -170,14 +170,6 @@ function SchemaApprovals() {
       />
     ) : undefined;
 
-  function approveRequest(req_no: number | null) {
-    console.log("approve", req_no);
-  }
-
-  function declineRequest(req_no: number | null) {
-    console.log("approve", req_no);
-  }
-
   return (
     <>
       {modals.open === "DETAILS" && (
@@ -202,7 +194,7 @@ function SchemaApprovals() {
         </RequestDetailsModal>
       )}
       {modals.open === "DECLINE" && (
-        <RequestRejectModal
+        <RequestDeclineModal
           onClose={() => closeModal()}
           onCancel={() => closeModal()}
           onSubmit={(message: string) => {

--- a/coral/src/app/features/approvals/schemas/SchemaApprovals.tsx
+++ b/coral/src/app/features/approvals/schemas/SchemaApprovals.tsx
@@ -17,10 +17,10 @@ function SchemaApprovals() {
 
   const { environment, status, topic, filters } = useTableFilters();
 
-  const [detailsModal, setDetailsModal] = useState<{
-    isOpen: boolean;
+  const [modals, setModals] = useState<{
+    open: "DETAILS" | "REJECT" | "NONE";
     req_no: number | null;
-  }>({ isOpen: false, req_no: null });
+  }>({ open: "NONE", req_no: null });
 
   const {
     data: schemaRequests,
@@ -53,7 +53,7 @@ function SchemaApprovals() {
   const table = (
     <SchemaApprovalsTable
       requests={schemaRequests?.entries || []}
-      setDetailsModal={setDetailsModal}
+      setModals={setModals}
     />
   );
   const pagination =
@@ -75,25 +75,26 @@ function SchemaApprovals() {
 
   return (
     <>
-      {detailsModal.isOpen && (
+      {modals.open === "DETAILS" && (
         <RequestDetailsModal
-          onClose={() => setDetailsModal({ isOpen: false, req_no: null })}
+          onClose={() => setModals({ open: "NONE", req_no: null })}
           onApprove={() => {
-            approveRequest(detailsModal.req_no);
+            approveRequest(modals.req_no);
           }}
           onDecline={() => {
-            setDetailsModal({ isOpen: false, req_no: null });
-            declineRequest(detailsModal.req_no);
+            setModals({ open: "NONE", req_no: null });
+            declineRequest(modals.req_no);
           }}
           isLoading={false}
         >
           <SchemaRequestDetails
             request={schemaRequests?.entries.find(
-              (request) => request.req_no === detailsModal.req_no
+              (request) => request.req_no === modals.req_no
             )}
           />
         </RequestDetailsModal>
       )}
+
       <ApprovalsLayout
         filters={filters}
         table={table}

--- a/coral/src/app/features/approvals/schemas/SchemaApprovals.tsx
+++ b/coral/src/app/features/approvals/schemas/SchemaApprovals.tsx
@@ -3,25 +3,32 @@ import SchemaApprovalsTable from "src/app/features/approvals/schemas/components/
 import { ApprovalsLayout } from "src/app/features/approvals/components/ApprovalsLayout";
 import { getSchemaRequestsForApprover } from "src/domain/schema-request";
 import { useSearchParams } from "react-router-dom";
-import { useQuery } from "@tanstack/react-query";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import useTableFilters from "src/app/features/approvals/schemas/hooks/useTableFilters";
 import { useState } from "react";
 import RequestDetailsModal from "src/app/features/approvals/components/RequestDetailsModal";
 import { SchemaRequestDetails } from "src/app/features/approvals/schemas/components/SchemaRequestDetails";
 import RequestRejectModal from "src/app/features/approvals/components/RequestRejectModal";
+import { declineSchemaRequest } from "src/domain/schema-request/schema-request-api";
+import { parseErrorMsg } from "src/services/mutation-utils";
+import { Alert } from "@aivenio/aquarium";
 
 function SchemaApprovals() {
+  const queryClient = useQueryClient();
+
   const [searchParams, setSearchParams] = useSearchParams();
   const currentPage = searchParams.get("page")
     ? Number(searchParams.get("page"))
     : 1;
 
-  const { environment, status, topic, filters } = useTableFilters();
-
   const [modals, setModals] = useState<{
     open: "DETAILS" | "REJECT" | "NONE";
     req_no: number | null;
   }>({ open: "NONE", req_no: null });
+
+  const [errorQuickActions, setErrorQuickActions] = useState("");
+
+  const { environment, status, topic, filters } = useTableFilters();
 
   const {
     data: schemaRequests,
@@ -43,8 +50,58 @@ function SchemaApprovals() {
         env: environment,
         topic,
       }),
+    onSuccess: (newSchemaRequests) => {
+      // If through filtering a user finds themselves on a non existent page, reset page to 1
+      // For example:
+      // - one request returns 4 pages of results
+      // - navigate to page 4
+      // - change filters, to a request that returns 1 page of results
+      // - if not redirected to page 1, table won't be able to handle pagination (clicking "Back" will set page at -1)
+      if (
+        newSchemaRequests.entries.length === 0 &&
+        schemaRequests?.currentPage !== 1
+      ) {
+        setCurrentPage(1);
+      }
+    },
     keepPreviousData: true,
   });
+
+  const { mutate: declineRequest, isLoading: rejectRequestIsLoading } =
+    useMutation(declineSchemaRequest, {
+      onSuccess: (responses) => {
+        // @TODO follow up ticket #707
+        // (for all approval tables)
+        const response = responses[0];
+        if (response.result !== "success") {
+          setErrorQuickActions(
+            response.message || response.result || "Unexpected error"
+          );
+        } else {
+          setErrorQuickActions("");
+          // If rejected request is last in the page, go back to previous page
+          // This avoids staying on a non-existent page of entries, which makes the table bug hard
+          // With pagination being 0 of 0, and clicking Previous button sets active page at -1
+          // We also do not need to invalidate the query, as the activePage does not exist any more
+          // And there is no need to update anything on it
+          if (
+            schemaRequests?.entries.length === 1 &&
+            schemaRequests?.currentPage > 1
+          ) {
+            return setCurrentPage(schemaRequests?.currentPage - 1);
+          }
+
+          // We need to refetch all aclrequests queries to keep Table state in sync
+          queryClient.refetchQueries(["schemaRequestsForApprover"]);
+        }
+      },
+      onError(error: Error) {
+        setErrorQuickActions(parseErrorMsg(error));
+      },
+      onSettled() {
+        closeModal();
+      },
+    });
 
   const setCurrentPage = (page: number) => {
     searchParams.set("page", page.toString());
@@ -109,12 +166,18 @@ function SchemaApprovals() {
             if (modals.req_no === null) {
               throw Error("req_no can't be null");
             }
-            //do api call
-            alert(`rejected nr ${modals.req_no} for reason: ${message}`);
-            closeModal();
+            declineRequest({
+              reason: message,
+              reqIds: [modals.req_no.toString()],
+            });
           }}
-          isLoading={false}
+          isLoading={rejectRequestIsLoading}
         />
+      )}
+      {errorQuickActions && (
+        <div role="alert">
+          <Alert type="warning">{errorQuickActions}</Alert>
+        </div>
       )}
       <ApprovalsLayout
         filters={filters}

--- a/coral/src/app/features/approvals/schemas/SchemaApprovals.tsx
+++ b/coral/src/app/features/approvals/schemas/SchemaApprovals.tsx
@@ -8,6 +8,7 @@ import useTableFilters from "src/app/features/approvals/schemas/hooks/useTableFi
 import { useState } from "react";
 import RequestDetailsModal from "src/app/features/approvals/components/RequestDetailsModal";
 import { SchemaRequestDetails } from "src/app/features/approvals/schemas/components/SchemaRequestDetails";
+import RequestRejectModal from "src/app/features/approvals/components/RequestRejectModal";
 
 function SchemaApprovals() {
   const [searchParams, setSearchParams] = useSearchParams();
@@ -50,6 +51,10 @@ function SchemaApprovals() {
     setSearchParams(searchParams);
   };
 
+  function closeModal() {
+    setModals({ open: "NONE", req_no: null });
+  }
+
   const table = (
     <SchemaApprovalsTable
       requests={schemaRequests?.entries || []}
@@ -77,9 +82,11 @@ function SchemaApprovals() {
     <>
       {modals.open === "DETAILS" && (
         <RequestDetailsModal
-          onClose={() => setModals({ open: "NONE", req_no: null })}
+          onClose={closeModal}
           onApprove={() => {
-            approveRequest(modals.req_no);
+            //api call
+            console.log("APPROVE", modals.req_no);
+            closeModal();
           }}
           onDecline={() => {
             setModals({ open: "NONE", req_no: null });
@@ -94,7 +101,21 @@ function SchemaApprovals() {
           />
         </RequestDetailsModal>
       )}
-
+      {modals.open === "REJECT" && (
+        <RequestRejectModal
+          onClose={() => closeModal()}
+          onCancel={() => closeModal()}
+          onSubmit={(message: string) => {
+            if (modals.req_no === null) {
+              throw Error("req_no can't be null");
+            }
+            //do api call
+            alert(`rejected nr ${modals.req_no} for reason: ${message}`);
+            closeModal();
+          }}
+          isLoading={false}
+        />
+      )}
       <ApprovalsLayout
         filters={filters}
         table={table}

--- a/coral/src/app/features/approvals/schemas/components/SchemaApprovalsTable.test.tsx
+++ b/coral/src/app/features/approvals/schemas/components/SchemaApprovalsTable.test.tsx
@@ -277,7 +277,7 @@ describe("SchemaApprovalsTable", () => {
     });
   });
 
-  describe("disables the approve and reject buttons dependent on props", () => {
+  describe("disables the approve and decline buttons dependent on props", () => {
     beforeAll(() => {
       render(
         <SchemaApprovalsTable

--- a/coral/src/app/features/approvals/schemas/components/SchemaApprovalsTable.test.tsx
+++ b/coral/src/app/features/approvals/schemas/components/SchemaApprovalsTable.test.tsx
@@ -61,7 +61,7 @@ const mockedRequests: SchemaRequest[] = [
   },
 ];
 
-const mockSetDetailsModal = jest.fn();
+const mockSetModals = jest.fn();
 
 describe("SchemaApprovalsTable", () => {
   beforeAll(mockIntersectionObserver);
@@ -82,7 +82,7 @@ describe("SchemaApprovalsTable", () => {
       render(
         <SchemaApprovalsTable
           requests={mockedRequests}
-          setDetailsModal={mockSetDetailsModal}
+          setModals={mockSetModals}
         />
       );
     });
@@ -170,7 +170,7 @@ describe("SchemaApprovalsTable", () => {
       render(
         <SchemaApprovalsTable
           requests={mockedRequests}
-          setDetailsModal={mockSetDetailsModal}
+          setModals={mockSetModals}
         />
       );
     });
@@ -232,7 +232,7 @@ describe("SchemaApprovalsTable", () => {
       render(
         <SchemaApprovalsTable
           requests={mockedRequests}
-          setDetailsModal={mockSetDetailsModal}
+          setModals={mockSetModals}
         />
       );
     });
@@ -248,8 +248,8 @@ describe("SchemaApprovalsTable", () => {
 
       await userEvent.click(button);
 
-      expect(mockSetDetailsModal).toHaveBeenCalledWith({
-        isOpen: true,
+      expect(mockSetModals).toHaveBeenCalledWith({
+        open: "DETAILS",
         req_no: mockedRequests[0].req_no,
       });
     });
@@ -263,8 +263,8 @@ describe("SchemaApprovalsTable", () => {
 
       await userEvent.click(button);
 
-      expect(mockSetDetailsModal).toHaveBeenCalledWith({
-        isOpen: true,
+      expect(mockSetModals).toHaveBeenCalledWith({
+        open: "DETAILS",
         req_no: mockedRequests[mockedRequests.length - 1].req_no,
       });
     });

--- a/coral/src/app/features/approvals/schemas/components/SchemaApprovalsTable.test.tsx
+++ b/coral/src/app/features/approvals/schemas/components/SchemaApprovalsTable.test.tsx
@@ -62,6 +62,7 @@ const mockedRequests: SchemaRequest[] = [
 ];
 
 const mockSetModals = jest.fn();
+const mockApproveRequest = jest.fn();
 
 describe("SchemaApprovalsTable", () => {
   beforeAll(mockIntersectionObserver);
@@ -83,6 +84,8 @@ describe("SchemaApprovalsTable", () => {
         <SchemaApprovalsTable
           requests={mockedRequests}
           setModals={mockSetModals}
+          onApprove={mockApproveRequest}
+          quickActionLoading={false}
         />
       );
     });
@@ -171,6 +174,8 @@ describe("SchemaApprovalsTable", () => {
         <SchemaApprovalsTable
           requests={mockedRequests}
           setModals={mockSetModals}
+          onApprove={mockApproveRequest}
+          quickActionLoading={false}
         />
       );
     });
@@ -233,6 +238,8 @@ describe("SchemaApprovalsTable", () => {
         <SchemaApprovalsTable
           requests={mockedRequests}
           setModals={mockSetModals}
+          onApprove={mockApproveRequest}
+          quickActionLoading={false}
         />
       );
     });
@@ -267,6 +274,70 @@ describe("SchemaApprovalsTable", () => {
         open: "DETAILS",
         req_no: mockedRequests[mockedRequests.length - 1].req_no,
       });
+    });
+  });
+
+  describe("disables the approve and reject buttons dependent on props", () => {
+    beforeAll(() => {
+      render(
+        <SchemaApprovalsTable
+          requests={mockedRequests}
+          setModals={mockSetModals}
+          onApprove={mockApproveRequest}
+          quickActionLoading={true}
+        />
+      );
+    });
+
+    afterAll(cleanup);
+
+    mockedRequests.forEach((request) => {
+      it(`shows a button to approve schema request for topic name ${request.topicname}`, () => {
+        const table = screen.getByRole("table", { name: "Schema requests" });
+        const button = within(table).getByRole("button", {
+          name: `Approve schema request for ${request.topicname}`,
+        });
+
+        expect(button).toBeDisabled();
+      });
+
+      it(`shows a button to approve schema request for topic name ${request.topicname}`, () => {
+        const table = screen.getByRole("table", { name: "Schema requests" });
+        const button = within(table).getByRole("button", {
+          name: `Decline schema request for ${request.topicname}`,
+        });
+
+        expect(button).toBeDisabled();
+      });
+    });
+  });
+
+  describe("triggers approval of a request when user clicks button", () => {
+    const testRequest = mockedRequests[0];
+    beforeEach(() => {
+      render(
+        <SchemaApprovalsTable
+          requests={mockedRequests}
+          setModals={mockSetModals}
+          onApprove={mockApproveRequest}
+          quickActionLoading={false}
+        />
+      );
+    });
+
+    afterEach(() => {
+      cleanup();
+      jest.clearAllMocks();
+    });
+
+    it("triggers the approval of a request when user clicks button", async () => {
+      const button = screen.getByRole("button", {
+        name: `Approve schema request for ${testRequest.topicname}`,
+      });
+
+      await userEvent.click(button);
+
+      expect(mockApproveRequest).toHaveBeenCalledWith(testRequest.req_no);
     });
   });
 });

--- a/coral/src/app/features/approvals/schemas/components/SchemaApprovalsTable.test.tsx
+++ b/coral/src/app/features/approvals/schemas/components/SchemaApprovalsTable.test.tsx
@@ -61,6 +61,10 @@ const mockedRequests: SchemaRequest[] = [
   },
 ];
 
+const createdRequests = mockedRequests.filter(
+  (request) => request.requestStatus === "CREATED"
+);
+
 const mockSetModals = jest.fn();
 const mockApproveRequest = jest.fn();
 
@@ -120,22 +124,22 @@ describe("SchemaApprovalsTable", () => {
       expect(buttons).toHaveLength(mockedRequests.length);
     });
 
-    it("shows an approve button for every row", () => {
+    it("shows an approve button for every row where request status is CREATED", () => {
       const table = screen.getByRole("table", { name: "Schema requests" });
       const buttons = within(table).getAllByRole("button", {
         name: /Approve schema request for /,
       });
 
-      expect(buttons).toHaveLength(mockedRequests.length);
+      expect(buttons).toHaveLength(createdRequests.length);
     });
 
-    it("shows an decline button for every row", () => {
+    it("shows an decline button for every row where request status is CREATED", () => {
       const table = screen.getByRole("table", { name: "Schema requests" });
       const buttons = within(table).getAllByRole("button", {
         name: /Decline schema request for /,
       });
 
-      expect(buttons).toHaveLength(mockedRequests.length);
+      expect(buttons).toHaveLength(createdRequests.length);
     });
 
     mockedRequests.forEach((request) => {
@@ -147,7 +151,9 @@ describe("SchemaApprovalsTable", () => {
 
         expect(button).toBeEnabled();
       });
+    });
 
+    createdRequests.forEach((request) => {
       it(`shows a button to approve schema request for topic name ${request.topicname}`, () => {
         const table = screen.getByRole("table", { name: "Schema requests" });
         const button = within(table).getByRole("button", {
@@ -278,10 +284,15 @@ describe("SchemaApprovalsTable", () => {
   });
 
   describe("disables the approve and decline buttons dependent on props", () => {
+    const requestsWithStatusCreated = [
+      mockedRequests[0],
+      { ...mockedRequests[0], topicname: "Additional-topic" },
+    ];
+
     beforeAll(() => {
       render(
         <SchemaApprovalsTable
-          requests={mockedRequests}
+          requests={requestsWithStatusCreated}
           setModals={mockSetModals}
           onApprove={mockApproveRequest}
           quickActionLoading={true}
@@ -291,7 +302,7 @@ describe("SchemaApprovalsTable", () => {
 
     afterAll(cleanup);
 
-    mockedRequests.forEach((request) => {
+    requestsWithStatusCreated.forEach((request) => {
       it(`shows a button to approve schema request for topic name ${request.topicname}`, () => {
         const table = screen.getByRole("table", { name: "Schema requests" });
         const button = within(table).getByRole("button", {
@@ -301,7 +312,7 @@ describe("SchemaApprovalsTable", () => {
         expect(button).toBeDisabled();
       });
 
-      it(`shows a button to approve schema request for topic name ${request.topicname}`, () => {
+      it(`shows a button to decline schema request for topic name ${request.topicname}`, () => {
         const table = screen.getByRole("table", { name: "Schema requests" });
         const button = within(table).getByRole("button", {
           name: `Decline schema request for ${request.topicname}`,

--- a/coral/src/app/features/approvals/schemas/components/SchemaApprovalsTable.tsx
+++ b/coral/src/app/features/approvals/schemas/components/SchemaApprovalsTable.tsx
@@ -28,7 +28,7 @@ type SchemaApprovalsTableProps = {
   requests: SchemaRequest[];
   setModals: Dispatch<
     SetStateAction<{
-      open: "DETAILS" | "REJECT" | "NONE";
+      open: "DETAILS" | "DECLINE" | "NONE";
       req_no: number | null;
     }>
   >;
@@ -126,7 +126,7 @@ function SchemaApprovalsTable(props: SchemaApprovalsTableProps) {
       UNSAFE_render: (request) => {
         return (
           <GhostButton
-            onClick={() => setModals({ open: "REJECT", req_no: request.id })}
+            onClick={() => setModals({ open: "DECLINE", req_no: request.id })}
             aria-label={`Decline schema request for ${request.topicname}`}
             title={"Decline request"}
             disabled={quickActionLoading}

--- a/coral/src/app/features/approvals/schemas/components/SchemaApprovalsTable.tsx
+++ b/coral/src/app/features/approvals/schemas/components/SchemaApprovalsTable.tsx
@@ -98,24 +98,26 @@ function SchemaApprovalsTable(props: SchemaApprovalsTableProps) {
       headerInvisible: true,
       width: 30,
       UNSAFE_render: (request) => {
-        const [isLoading, setIsLoading] = useState(false);
-        return (
-          <GhostButton
-            onClick={() => {
-              setIsLoading(true);
-              onApprove(request.id);
-            }}
-            title={"Approve request"}
-            aria-label={`Approve schema request for ${request.topicname}`}
-            disabled={quickActionLoading}
-          >
-            {isLoading && quickActionLoading ? (
-              <Icon color="grey-70" icon={loadingIcon} />
-            ) : (
-              <Icon color="grey-70" icon={tickCircle} />
-            )}
-          </GhostButton>
-        );
+        if (request.requestStatus === "CREATED") {
+          const [isLoading, setIsLoading] = useState(false);
+          return (
+            <GhostButton
+              onClick={() => {
+                setIsLoading(true);
+                onApprove(request.id);
+              }}
+              title={"Approve request"}
+              aria-label={`Approve schema request for ${request.topicname}`}
+              disabled={quickActionLoading}
+            >
+              {isLoading && quickActionLoading ? (
+                <Icon color="grey-70" icon={loadingIcon} />
+              ) : (
+                <Icon color="grey-70" icon={tickCircle} />
+              )}
+            </GhostButton>
+          );
+        }
       },
     },
     {
@@ -124,16 +126,18 @@ function SchemaApprovalsTable(props: SchemaApprovalsTableProps) {
       headerInvisible: true,
       width: 30,
       UNSAFE_render: (request) => {
-        return (
-          <GhostButton
-            onClick={() => setModals({ open: "DECLINE", req_no: request.id })}
-            aria-label={`Decline schema request for ${request.topicname}`}
-            title={"Decline request"}
-            disabled={quickActionLoading}
-          >
-            <Icon color="grey-70" icon={deleteIcon} />
-          </GhostButton>
-        );
+        if (request.requestStatus === "CREATED") {
+          return (
+            <GhostButton
+              onClick={() => setModals({ open: "DECLINE", req_no: request.id })}
+              aria-label={`Decline schema request for ${request.topicname}`}
+              title={"Decline request"}
+              disabled={quickActionLoading}
+            >
+              <Icon color="grey-70" icon={deleteIcon} />
+            </GhostButton>
+          );
+        }
       },
     },
   ];

--- a/coral/src/app/features/approvals/schemas/components/SchemaApprovalsTable.tsx
+++ b/coral/src/app/features/approvals/schemas/components/SchemaApprovalsTable.tsx
@@ -13,7 +13,6 @@ import {
   requestStatusNameMap,
 } from "src/app/features/approvals/utils/request-status-helper";
 import { Dispatch, SetStateAction } from "react";
-import loadingIcon from "@aivenio/aquarium/icons/loading";
 
 interface SchemaRequestTableData {
   id: SchemaRequest["req_no"];
@@ -26,15 +25,16 @@ interface SchemaRequestTableData {
 
 type SchemaApprovalsTableProps = {
   requests: SchemaRequest[];
-  setDetailsModal: Dispatch<
+  setModals: Dispatch<
     SetStateAction<{
-      isOpen: boolean;
+      open: "DETAILS" | "REJECT" | "NONE";
       req_no: number | null;
     }>
   >;
 };
+
 function SchemaApprovalsTable(props: SchemaApprovalsTableProps) {
-  const { requests, setDetailsModal } = props;
+  const { requests, setModals } = props;
   const columns: Array<DataTableColumn<SchemaRequestTableData>> = [
     { type: "text", field: "topicname", headerName: "Topic" },
     {
@@ -76,9 +76,7 @@ function SchemaApprovalsTable(props: SchemaApprovalsTableProps) {
       UNSAFE_render: (request) => {
         return (
           <GhostButton
-            onClick={() =>
-              setDetailsModal({ isOpen: true, req_no: request.id })
-            }
+            onClick={() => setModals({ open: "DETAILS", req_no: request.id })}
             icon={infoSign}
             dense
           >
@@ -115,7 +113,7 @@ function SchemaApprovalsTable(props: SchemaApprovalsTableProps) {
       UNSAFE_render: (request) => {
         return (
           <GhostButton
-            onClick={() => alert("Decline")}
+            onClick={() => setModals({ open: "REJECT", req_no: request.id })}
             aria-label={`Decline schema request for ${request.topicname}`}
             title={"Decline request"}
           >

--- a/coral/src/app/features/approvals/schemas/components/SchemaApprovalsTable.tsx
+++ b/coral/src/app/features/approvals/schemas/components/SchemaApprovalsTable.tsx
@@ -1,4 +1,9 @@
-import { DataTable, DataTableColumn, GhostButton } from "@aivenio/aquarium";
+import {
+  DataTable,
+  DataTableColumn,
+  GhostButton,
+  Icon,
+} from "@aivenio/aquarium";
 import { SchemaRequest } from "src/domain/schema-request";
 import infoSign from "@aivenio/aquarium/icons/infoSign";
 import tickCircle from "@aivenio/aquarium/icons/tickCircle";
@@ -8,6 +13,7 @@ import {
   requestStatusNameMap,
 } from "src/app/features/approvals/utils/request-status-helper";
 import { Dispatch, SetStateAction } from "react";
+import loadingIcon from "@aivenio/aquarium/icons/loading";
 
 interface SchemaRequestTableData {
   id: SchemaRequest["req_no"];
@@ -67,16 +73,18 @@ function SchemaApprovalsTable(props: SchemaApprovalsTableProps) {
       headerName: "Details",
       headerInvisible: true,
       width: 30,
-      UNSAFE_render: (row) => {
+      UNSAFE_render: (request) => {
         return (
           <GhostButton
-            onClick={() => setDetailsModal({ isOpen: true, req_no: row.id })}
+            onClick={() =>
+              setDetailsModal({ isOpen: true, req_no: request.id })
+            }
             icon={infoSign}
             dense
           >
             <span aria-hidden={"true"}>View details</span>
             <span className={"visually-hidden"}>
-              View schema request for {row.topicname}
+              View schema request for {request.topicname}
             </span>
           </GhostButton>
         );
@@ -87,14 +95,15 @@ function SchemaApprovalsTable(props: SchemaApprovalsTableProps) {
       headerName: "Approve",
       headerInvisible: true,
       width: 30,
-      UNSAFE_render: (row) => {
+      UNSAFE_render: (request) => {
         return (
           <GhostButton
             onClick={() => alert("Approve")}
-            aria-label={`Approve schema request for ${row.topicname}`}
-            title={`Approve schema request`}
-            icon={tickCircle}
-          />
+            title={"Approve request"}
+            aria-label={`Approve schema request for ${request.topicname}`}
+          >
+            <Icon color="grey-70" icon={tickCircle} />
+          </GhostButton>
         );
       },
     },
@@ -103,14 +112,15 @@ function SchemaApprovalsTable(props: SchemaApprovalsTableProps) {
       headerName: "Decline",
       headerInvisible: true,
       width: 30,
-      UNSAFE_render: (row) => {
+      UNSAFE_render: (request) => {
         return (
           <GhostButton
             onClick={() => alert("Decline")}
-            aria-label={`Decline schema request for ${row.topicname}`}
-            title={`Decline schema request`}
-            icon={deleteIcon}
-          />
+            aria-label={`Decline schema request for ${request.topicname}`}
+            title={"Decline request"}
+          >
+            <Icon color="grey-70" icon={deleteIcon} />
+          </GhostButton>
         );
       },
     },

--- a/coral/src/app/features/approvals/schemas/components/SchemaApprovalsTable.tsx
+++ b/coral/src/app/features/approvals/schemas/components/SchemaApprovalsTable.tsx
@@ -12,7 +12,8 @@ import {
   requestStatusChipStatusMap,
   requestStatusNameMap,
 } from "src/app/features/approvals/utils/request-status-helper";
-import { Dispatch, SetStateAction } from "react";
+import { Dispatch, SetStateAction, useState } from "react";
+import loadingIcon from "@aivenio/aquarium/icons/loading";
 
 interface SchemaRequestTableData {
   id: SchemaRequest["req_no"];
@@ -31,10 +32,12 @@ type SchemaApprovalsTableProps = {
       req_no: number | null;
     }>
   >;
+  quickActionLoading: boolean;
+  onApprove: (req_no: number) => void;
 };
 
 function SchemaApprovalsTable(props: SchemaApprovalsTableProps) {
-  const { requests, setModals } = props;
+  const { requests, setModals, quickActionLoading, onApprove } = props;
   const columns: Array<DataTableColumn<SchemaRequestTableData>> = [
     { type: "text", field: "topicname", headerName: "Topic" },
     {
@@ -79,6 +82,7 @@ function SchemaApprovalsTable(props: SchemaApprovalsTableProps) {
             onClick={() => setModals({ open: "DETAILS", req_no: request.id })}
             icon={infoSign}
             dense
+            disabled={quickActionLoading}
           >
             <span aria-hidden={"true"}>View details</span>
             <span className={"visually-hidden"}>
@@ -94,13 +98,22 @@ function SchemaApprovalsTable(props: SchemaApprovalsTableProps) {
       headerInvisible: true,
       width: 30,
       UNSAFE_render: (request) => {
+        const [isLoading, setIsLoading] = useState(false);
         return (
           <GhostButton
-            onClick={() => alert("Approve")}
+            onClick={() => {
+              setIsLoading(true);
+              onApprove(request.id);
+            }}
             title={"Approve request"}
             aria-label={`Approve schema request for ${request.topicname}`}
+            disabled={quickActionLoading}
           >
-            <Icon color="grey-70" icon={tickCircle} />
+            {isLoading && quickActionLoading ? (
+              <Icon color="grey-70" icon={loadingIcon} />
+            ) : (
+              <Icon color="grey-70" icon={tickCircle} />
+            )}
           </GhostButton>
         );
       },
@@ -116,6 +129,7 @@ function SchemaApprovalsTable(props: SchemaApprovalsTableProps) {
             onClick={() => setModals({ open: "REJECT", req_no: request.id })}
             aria-label={`Decline schema request for ${request.topicname}`}
             title={"Decline request"}
+            disabled={quickActionLoading}
           >
             <Icon color="grey-70" icon={deleteIcon} />
           </GhostButton>

--- a/coral/src/domain/schema-request/schema-request-api.ts
+++ b/coral/src/domain/schema-request/schema-request-api.ts
@@ -58,11 +58,19 @@ const getSchemaRequestsForApprover = (
     .then(transformGetSchemaRequestsForApproverResponse);
 };
 
-const approveSchemaRequest = (payload: RequestVerdictApproval<"SCHEMA">) => {
+type ApproveSchemaRequestPayload = ResolveIntersectionTypes<
+  Omit<RequestVerdictApproval<"SCHEMA">, "requestEntityType">
+>;
+const approveSchemaRequest = (payload: ApproveSchemaRequestPayload) => {
+  const payloadPassed: RequestVerdictApproval<"SCHEMA"> = {
+    ...payload,
+    requestEntityType: "SCHEMA",
+  };
+
   return api.post<
     KlawApiResponse<"approveRequest">,
     RequestVerdictApproval<"SCHEMA">
-  >(`/request/approve`, payload);
+  >(`/request/approve`, payloadPassed);
 };
 
 type DeclineSchemaRequestPayload = ResolveIntersectionTypes<

--- a/coral/src/domain/schema-request/schema-request-api.ts
+++ b/coral/src/domain/schema-request/schema-request-api.ts
@@ -58,26 +58,30 @@ const getSchemaRequestsForApprover = (
     .then(transformGetSchemaRequestsForApproverResponse);
 };
 
-const approveSchemaRequest = (
-  payload: Omit<RequestVerdictApproval<"SCHEMA">, "requestEntityType">
-) => {
+const approveSchemaRequest = ({
+  reqIds,
+}: {
+  reqIds: RequestVerdictApproval<"SCHEMA">["reqIds"];
+}) => {
   return api.post<
     KlawApiResponse<"approveRequest">,
     RequestVerdictApproval<"SCHEMA">
   >(`/request/approve`, {
-    ...payload,
+    reqIds,
     requestEntityType: "SCHEMA",
   });
 };
 
-const declineSchemaRequest = (
-  payload: Omit<RequestVerdictDecline<"SCHEMA">, "requestEntityType">
-) => {
+const declineSchemaRequest = ({
+  reqIds,
+  reason,
+}: Omit<RequestVerdictDecline<"SCHEMA">, "requestEntityType">) => {
   return api.post<
     KlawApiResponse<"declineRequest">,
     RequestVerdictDecline<"SCHEMA">
   >(`/request/approve`, {
-    ...payload,
+    reqIds,
+    reason,
     requestEntityType: "SCHEMA",
   });
 };

--- a/coral/src/domain/schema-request/schema-request-api.ts
+++ b/coral/src/domain/schema-request/schema-request-api.ts
@@ -65,11 +65,19 @@ const approveSchemaRequest = (payload: RequestVerdictApproval<"SCHEMA">) => {
   >(`/request/approve`, payload);
 };
 
-const declineSchemaRequest = (payload: RequestVerdictDecline<"SCHEMA">) => {
+type DeclineSchemaRequestPayload = ResolveIntersectionTypes<
+  Omit<RequestVerdictDecline<"SCHEMA">, "requestEntityType">
+>;
+const declineSchemaRequest = (payload: DeclineSchemaRequestPayload) => {
+  const payloadPassed: RequestVerdictDecline<"SCHEMA"> = {
+    ...payload,
+    reqIds: ["4325252524"],
+    requestEntityType: "SCHEMA",
+  };
   return api.post<
     KlawApiResponse<"declineRequest">,
     RequestVerdictDecline<"SCHEMA">
-  >(`/request/approve`, payload);
+  >(`/request/approve`, payloadPassed);
 };
 
 export {

--- a/coral/src/domain/schema-request/schema-request-api.ts
+++ b/coral/src/domain/schema-request/schema-request-api.ts
@@ -58,34 +58,28 @@ const getSchemaRequestsForApprover = (
     .then(transformGetSchemaRequestsForApproverResponse);
 };
 
-type ApproveSchemaRequestPayload = ResolveIntersectionTypes<
-  Omit<RequestVerdictApproval<"SCHEMA">, "requestEntityType">
->;
-const approveSchemaRequest = (payload: ApproveSchemaRequestPayload) => {
-  const payloadPassed: RequestVerdictApproval<"SCHEMA"> = {
-    ...payload,
-    requestEntityType: "SCHEMA",
-  };
-
+const approveSchemaRequest = (
+  payload: Omit<RequestVerdictApproval<"SCHEMA">, "requestEntityType">
+) => {
   return api.post<
     KlawApiResponse<"approveRequest">,
     RequestVerdictApproval<"SCHEMA">
-  >(`/request/approve`, payloadPassed);
+  >(`/request/approve`, {
+    ...payload,
+    requestEntityType: "SCHEMA",
+  });
 };
 
-type DeclineSchemaRequestPayload = ResolveIntersectionTypes<
-  Omit<RequestVerdictDecline<"SCHEMA">, "requestEntityType">
->;
-const declineSchemaRequest = (payload: DeclineSchemaRequestPayload) => {
-  const payloadPassed: RequestVerdictDecline<"SCHEMA"> = {
-    ...payload,
-    reqIds: ["4325252524"],
-    requestEntityType: "SCHEMA",
-  };
+const declineSchemaRequest = (
+  payload: Omit<RequestVerdictDecline<"SCHEMA">, "requestEntityType">
+) => {
   return api.post<
     KlawApiResponse<"declineRequest">,
     RequestVerdictDecline<"SCHEMA">
-  >(`/request/approve`, payloadPassed);
+  >(`/request/approve`, {
+    ...payload,
+    requestEntityType: "SCHEMA",
+  });
 };
 
 export {


### PR DESCRIPTION
# About this change - What it does

- adds rejecting workflow from quick action button
- adds rejecting workflow from details modal
- adds approving workflow from quick action button
- adds rejecting workflow from details modal
- renames "reject" to "decline" (see #721) 
    - I left the RejectModal alone to not conflict with the mentioned PR!
- approving / declining buttons are disabled while another approve/decline call is in progress



Resolves: #698

