### PR TITLE
Issue topic promotion not created

### DIFF
--- a/core/src/main/java/io/aiven/klaw/helpers/db/rdbms/UpdateDataJdbc.java
+++ b/core/src/main/java/io/aiven/klaw/helpers/db/rdbms/UpdateDataJdbc.java
@@ -165,7 +165,9 @@ public class UpdateDataJdbc {
     topicObj.setHistory(topicRequest.getHistory());
     topics.add(topicObj);
 
-    if (topicRequest.getRequestOperationType().equals(RequestOperationType.CREATE.value)) {
+    // Both create and promote operations create new topic entries in the administration DB.
+    if (topicRequest.getRequestOperationType().equals(RequestOperationType.CREATE.value)
+        || topicRequest.getRequestOperationType().equals(RequestOperationType.PROMOTE.value)) {
       insertDataJdbcHelper.insertIntoTopicSOT(topics, false);
     } else if (topicRequest.getRequestOperationType().equals(RequestOperationType.UPDATE.value)) {
       updateTopicSOT(topics, topicRequest.getOtherParams());

--- a/core/src/main/java/io/aiven/klaw/helpers/db/rdbms/UpdateDataJdbc.java
+++ b/core/src/main/java/io/aiven/klaw/helpers/db/rdbms/UpdateDataJdbc.java
@@ -165,14 +165,15 @@ public class UpdateDataJdbc {
     topicObj.setHistory(topicRequest.getHistory());
     topics.add(topicObj);
 
-    // Both create and promote operations create new topic entries in the administration DB.
-    if (topicRequest.getRequestOperationType().equals(RequestOperationType.CREATE.value)
-        || topicRequest.getRequestOperationType().equals(RequestOperationType.PROMOTE.value)) {
-      insertDataJdbcHelper.insertIntoTopicSOT(topics, false);
-    } else if (topicRequest.getRequestOperationType().equals(RequestOperationType.UPDATE.value)) {
-      updateTopicSOT(topics, topicRequest.getOtherParams());
-    } else if (topicRequest.getRequestOperationType().equals(RequestOperationType.DELETE.value)) {
-      deleteDataJdbcHelper.deleteTopics(topicObj);
+    final RequestOperationType requestOperationType =
+        RequestOperationType.of(topicRequest.getRequestOperationType());
+    if (requestOperationType == null) {
+      return ApiResultStatus.SUCCESS.value;
+    }
+    switch (requestOperationType) {
+      case CREATE, PROMOTE -> insertDataJdbcHelper.insertIntoTopicSOT(topics, false);
+      case UPDATE -> updateTopicSOT(topics, topicRequest.getOtherParams());
+      case DELETE -> deleteDataJdbcHelper.deleteTopics(topicObj);
     }
 
     return ApiResultStatus.SUCCESS.value;

--- a/core/src/test/java/io/aiven/klaw/helpers/db/rdbms/UpdateDataJdbcTest.java
+++ b/core/src/test/java/io/aiven/klaw/helpers/db/rdbms/UpdateDataJdbcTest.java
@@ -104,7 +104,7 @@ public class UpdateDataJdbcTest {
     int reqNum = 1001;
     when(insertDataJdbcHelper.insertIntoTopicSOT(any(), anyBoolean()))
         .thenReturn(ApiResultStatus.SUCCESS.value);
-    when(insertDataJdbcHelper.getNextTopicRequestId(anyString(), anyInt())).thenReturn(reqNum++);
+    when(insertDataJdbcHelper.getNextTopicRequestId(anyString(), anyInt())).thenReturn(reqNum);
     TopicRequest req = utilMethods.getTopicRequest(1001);
     req.setRequestOperationType(requestOperationType);
     String result = updateData.updateTopicRequest(req, "uiuser2");


### PR DESCRIPTION
About this change - What it does
This address an issue where on sending a promotion type of request after the promotion of the topic was completed successfully it was not being saved to the Klaw Database. It has to be synced using the sync cluster functionality.

Resolves: #729 
Why this way
A bug fix changed to using enums and the enum for promotion was changed from create to promote.
So in the code where it is being saved to the database as this is a new topic it is and should be treated the same as a create operation.