### PR TITLE
feat(coral): Disable approve/reject buttons in approvals table while action is in progress

### DIFF
--- a/coral/src/app/features/approvals/acls/AclApprovals.test.tsx
+++ b/coral/src/app/features/approvals/acls/AclApprovals.test.tsx
@@ -111,7 +111,15 @@ describe("AclApprovals", () => {
   });
 
   describe("shows loading or error state for fetching acls requests", () => {
-    afterEach(cleanup);
+    const originalConsoleError = console.error;
+    beforeEach(() => {
+      console.error = jest.fn();
+      mockGetEnvironments.mockResolvedValue([]);
+    });
+    afterEach(() => {
+      console.error = originalConsoleError;
+      cleanup();
+    });
 
     it("shows a skeleton table while loading", () => {
       mockGetAclRequestsForApprover.mockResolvedValue(
@@ -124,6 +132,7 @@ describe("AclApprovals", () => {
       const skeleton = screen.getByTestId("skeleton-table");
 
       expect(skeleton).toBeVisible();
+      expect(console.error).not.toHaveBeenCalled();
     });
 
     it("shows an error message when an error occurs", async () => {
@@ -145,16 +154,19 @@ describe("AclApprovals", () => {
       );
 
       expect(error).toBeVisible();
+      expect(console.error).toHaveBeenCalledWith(
+        "Unexpected error. Please try again later!"
+      );
     });
   });
 
   describe("DataTable", () => {
     beforeAll(async () => {
+      mockGetEnvironments.mockResolvedValue([]);
       mockGetAclRequestsForApprover.mockResolvedValue(
         mockGetAclRequestsForApproverResponse
       );
-      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-      //@ts-ignore
+
       customRender(<AclApprovals />, {
         queryClient: true,
         memoryRouter: true,
@@ -223,6 +235,7 @@ describe("AclApprovals", () => {
 
   describe("handles paginated data", () => {
     beforeAll(async () => {
+      mockGetEnvironments.mockResolvedValue([]);
       mockGetAclRequestsForApprover.mockResolvedValue(
         mockGetAclRequestsForApproverResponse
       );

--- a/coral/src/app/features/approvals/acls/AclApprovals.tsx
+++ b/coral/src/app/features/approvals/acls/AclApprovals.tsx
@@ -313,7 +313,6 @@ function AclApprovals() {
             icon={infoSign}
             onClick={() => setDetailsModal({ isOpen: true, reqNo: String(id) })}
             dense
-            disabled={approveIsLoading || declineIsLoading}
           >
             <span aria-hidden={"true"}>View details</span>
             <span className={"visually-hidden"}>
@@ -335,7 +334,7 @@ function AclApprovals() {
             <GhostButton
               onClick={() => {
                 setIsLoading(true);
-                return approveRequest({
+                approveRequest({
                   requestEntityType: "ACL",
                   reqIds: [String(id)],
                 });
@@ -406,8 +405,12 @@ function AclApprovals() {
             setDetailsModal({ isOpen: false, reqNo: "" });
             setDeclineModal({ isOpen: true, reqNo: detailsModal.reqNo });
           }}
-          isLoading={approveIsLoading}
-          disabledActions={selectedRequest?.requestStatus !== "CREATED"}
+          isLoading={approveIsLoading || declineIsLoading}
+          disabledActions={
+            selectedRequest?.requestStatus !== "CREATED" ||
+            approveIsLoading ||
+            declineIsLoading
+          }
         >
           <DetailsModalContent aclRequest={selectedRequest} />
         </RequestDetailsModal>

--- a/coral/src/app/features/approvals/acls/AclApprovals.tsx
+++ b/coral/src/app/features/approvals/acls/AclApprovals.tsx
@@ -313,6 +313,7 @@ function AclApprovals() {
             icon={infoSign}
             onClick={() => setDetailsModal({ isOpen: true, reqNo: String(id) })}
             dense
+            disabled={approveIsLoading || declineIsLoading}
           >
             <span aria-hidden={"true"}>View details</span>
             <span className={"visually-hidden"}>
@@ -341,6 +342,7 @@ function AclApprovals() {
               }}
               title={"Approve acl request"}
               aria-label={`Approve schema request for ${topicname}`}
+              disabled={approveIsLoading || declineIsLoading}
             >
               {isLoading && approveIsLoading ? (
                 <Icon color="grey-70" icon={loadingIcon} />
@@ -366,7 +368,7 @@ function AclApprovals() {
               }
               title={`Decline acl request`}
               aria-label={`Decline topic request for ${topicname}`}
-              disabled={approveIsLoading}
+              disabled={approveIsLoading || declineIsLoading}
             >
               <Icon color="grey-70" icon={deleteIcon} />
             </GhostButton>

--- a/coral/src/app/features/approvals/schemas/SchemaApprovals.tsx
+++ b/coral/src/app/features/approvals/schemas/SchemaApprovals.tsx
@@ -185,6 +185,7 @@ function SchemaApprovals() {
             setModals({ ...modals, open: "DECLINE" });
           }}
           isLoading={declineRequestIsLoading || approveRequestIsLoading}
+          disabledActions={declineRequestIsLoading || approveRequestIsLoading}
         >
           <SchemaRequestDetails
             request={schemaRequests?.entries.find(

--- a/coral/src/app/features/approvals/schemas/components/SchemaApprovalsTable.test.tsx
+++ b/coral/src/app/features/approvals/schemas/components/SchemaApprovalsTable.test.tsx
@@ -283,10 +283,10 @@ describe("SchemaApprovalsTable", () => {
     });
   });
 
-  describe("disables the approve and decline buttons dependent on props", () => {
+  describe("disables the quick actions dependent on props", () => {
     const requestsWithStatusCreated = [
       mockedRequests[0],
-      { ...mockedRequests[0], topicname: "Additional-topic" },
+      { ...mockedRequests[0], topicname: "Additional-topic", req_no: 1234 },
     ];
 
     beforeAll(() => {
@@ -303,7 +303,7 @@ describe("SchemaApprovalsTable", () => {
     afterAll(cleanup);
 
     requestsWithStatusCreated.forEach((request) => {
-      it(`shows a button to approve schema request for topic name ${request.topicname}`, () => {
+      it(`disables button to approve schema request for topic name ${request.topicname}`, () => {
         const table = screen.getByRole("table", { name: "Schema requests" });
         const button = within(table).getByRole("button", {
           name: `Approve schema request for ${request.topicname}`,
@@ -312,13 +312,22 @@ describe("SchemaApprovalsTable", () => {
         expect(button).toBeDisabled();
       });
 
-      it(`shows a button to decline schema request for topic name ${request.topicname}`, () => {
+      it(`disables  button to decline schema request for topic name ${request.topicname}`, () => {
         const table = screen.getByRole("table", { name: "Schema requests" });
         const button = within(table).getByRole("button", {
           name: `Decline schema request for ${request.topicname}`,
         });
 
         expect(button).toBeDisabled();
+      });
+
+      it(`disables details for schema request for topic name ${request.topicname}`, () => {
+        const table = screen.getByRole("table", { name: "Schema requests" });
+        const detailsButton = within(table).getByRole("button", {
+          name: `View schema request for ${request.topicname}`,
+        });
+
+        expect(detailsButton).toBeDisabled();
       });
     });
   });

--- a/coral/src/app/features/approvals/schemas/components/SchemaApprovalsTable.test.tsx
+++ b/coral/src/app/features/approvals/schemas/components/SchemaApprovalsTable.test.tsx
@@ -312,7 +312,7 @@ describe("SchemaApprovalsTable", () => {
         expect(button).toBeDisabled();
       });
 
-      it(`disables  button to decline schema request for topic name ${request.topicname}`, () => {
+      it(`disables button to decline schema request for topic name ${request.topicname}`, () => {
         const table = screen.getByRole("table", { name: "Schema requests" });
         const button = within(table).getByRole("button", {
           name: `Decline schema request for ${request.topicname}`,
@@ -321,13 +321,13 @@ describe("SchemaApprovalsTable", () => {
         expect(button).toBeDisabled();
       });
 
-      it(`disables details for schema request for topic name ${request.topicname}`, () => {
+      it(`does not disable details for schema request for topic name ${request.topicname}`, () => {
         const table = screen.getByRole("table", { name: "Schema requests" });
         const detailsButton = within(table).getByRole("button", {
           name: `View schema request for ${request.topicname}`,
         });
 
-        expect(detailsButton).toBeDisabled();
+        expect(detailsButton).toBeEnabled();
       });
     });
   });

--- a/coral/src/app/features/approvals/schemas/components/SchemaApprovalsTable.tsx
+++ b/coral/src/app/features/approvals/schemas/components/SchemaApprovalsTable.tsx
@@ -82,7 +82,6 @@ function SchemaApprovalsTable(props: SchemaApprovalsTableProps) {
             onClick={() => setModals({ open: "DETAILS", req_no: request.id })}
             icon={infoSign}
             dense
-            disabled={quickActionLoading}
           >
             <span aria-hidden={"true"}>View details</span>
             <span className={"visually-hidden"}>

--- a/coral/src/app/features/approvals/topics/TopicApprovals.test.tsx
+++ b/coral/src/app/features/approvals/topics/TopicApprovals.test.tsx
@@ -133,7 +133,16 @@ describe("TopicApprovals", () => {
   });
 
   describe("handles loading and error state when fetching the requests", () => {
-    afterEach(cleanup);
+    const originalConsoleError = console.error;
+    beforeEach(() => {
+      console.error = jest.fn();
+      mockGetEnvironments.mockResolvedValue([]);
+      mockGetTeams.mockResolvedValue([]);
+    });
+    afterEach(() => {
+      console.error = originalConsoleError;
+      cleanup();
+    });
 
     it("shows a loading state instead of a table while topic requests are being fetched", () => {
       mockGetTopicRequestsForApprover.mockResolvedValue(
@@ -150,6 +159,7 @@ describe("TopicApprovals", () => {
 
       expect(table).not.toBeInTheDocument();
       expect(loading).toBeVisible();
+      expect(console.error).not.toHaveBeenCalled();
     });
 
     it("shows a error message in case of an error for fetching topic requests", async () => {
@@ -173,6 +183,9 @@ describe("TopicApprovals", () => {
 
       expect(table).not.toBeInTheDocument();
       expect(errorMessage).toBeVisible();
+      expect(console.error).toHaveBeenCalledWith(
+        "Unexpected error. Please try again later!"
+      );
     });
   });
 
@@ -236,6 +249,15 @@ describe("TopicApprovals", () => {
   });
 
   describe("renders pagination dependent on response", () => {
+    beforeEach(() => {
+      mockGetTopicRequestsForApprover.mockResolvedValue({
+        totalPages: 1,
+        currentPage: 1,
+        entries: [],
+      });
+      mockGetEnvironments.mockResolvedValue([]);
+      mockGetTeams.mockResolvedValue([]);
+    });
     afterEach(() => {
       cleanup();
       jest.clearAllMocks();
@@ -339,6 +361,8 @@ describe("TopicApprovals", () => {
 
   describe("handles user stepping through pagination", () => {
     beforeEach(async () => {
+      mockGetTeams.mockResolvedValue([]);
+      mockGetEnvironments.mockResolvedValue([]);
       mockGetTopicRequestsForApprover.mockResolvedValue({
         totalPages: 3,
         currentPage: 1,
@@ -387,6 +411,8 @@ describe("TopicApprovals", () => {
 
   describe("shows a detail modal for Topic request", () => {
     beforeEach(async () => {
+      mockGetTeams.mockResolvedValue([]);
+      mockGetEnvironments.mockResolvedValue([]);
       mockGetTopicRequestsForApprover.mockResolvedValue(mockedApiResponse);
 
       customRender(<TopicApprovals />, {

--- a/coral/src/app/features/approvals/topics/TopicApprovals.tsx
+++ b/coral/src/app/features/approvals/topics/TopicApprovals.tsx
@@ -161,7 +161,7 @@ function TopicApprovals() {
       setDetailsModal={setDetailsModal}
       setDeclineModal={setDeclineModal}
       approveRequest={approveRequest}
-      approveIsLoading={approveIsLoading}
+      quickActionLoading={approveIsLoading || declineIsLoading}
     />
   );
   const pagination =

--- a/coral/src/app/features/approvals/topics/TopicApprovals.tsx
+++ b/coral/src/app/features/approvals/topics/TopicApprovals.tsx
@@ -195,8 +195,12 @@ function TopicApprovals() {
             setDetailsModal({ isOpen: false, topicId: null });
             setDeclineModal({ isOpen: true, topicId: detailsModal.topicId });
           }}
-          isLoading={approveIsLoading}
-          disabledActions={selectedTopicRequest?.requestStatus !== "CREATED"}
+          isLoading={approveIsLoading || declineIsLoading}
+          disabledActions={
+            selectedTopicRequest?.requestStatus !== "CREATED" ||
+            approveIsLoading ||
+            declineIsLoading
+          }
         >
           <DetailsModalContent topicRequest={selectedTopicRequest} />
         </RequestDetailsModal>
@@ -216,7 +220,7 @@ function TopicApprovals() {
               reason: message,
             });
           }}
-          isLoading={declineIsLoading}
+          isLoading={declineIsLoading || approveIsLoading}
         />
       )}
       {errorMessage !== "" && (

--- a/coral/src/app/features/approvals/topics/components/TopicApprovalsTable.test.tsx
+++ b/coral/src/app/features/approvals/topics/components/TopicApprovalsTable.test.tsx
@@ -319,13 +319,13 @@ describe("TopicApprovalsTable", () => {
         expect(button).toBeDisabled();
       });
 
-      it(`disables details for schema request for topic name ${request.topicname}`, () => {
+      it(`does not disables details for schema request for topic name ${request.topicname}`, () => {
         const table = screen.getByRole("table", { name: "Topic requests" });
         const detailsButton = within(table).getByRole("button", {
           name: `View topic request for ${request.topicname}`,
         });
 
-        expect(detailsButton).toBeDisabled();
+        expect(detailsButton).toBeEnabled();
       });
     });
   });

--- a/coral/src/app/features/approvals/topics/components/TopicApprovalsTable.test.tsx
+++ b/coral/src/app/features/approvals/topics/components/TopicApprovalsTable.test.tsx
@@ -94,7 +94,7 @@ describe("TopicApprovalsTable", () => {
         <TopicApprovalsTable
           setDetailsModal={mockedSetDetailsModal}
           requests={mockedRequests}
-          approveIsLoading={false}
+          quickActionLoading={false}
           setDeclineModal={mockedSetDeclineModal}
           approveRequest={mockedApproveRequest}
         />
@@ -163,7 +163,7 @@ describe("TopicApprovalsTable", () => {
         <TopicApprovalsTable
           setDetailsModal={mockedSetDetailsModal}
           requests={mockedRequests}
-          approveIsLoading={false}
+          quickActionLoading={false}
           setDeclineModal={mockedSetDeclineModal}
           approveRequest={mockedApproveRequest}
         />
@@ -232,7 +232,7 @@ describe("TopicApprovalsTable", () => {
         <TopicApprovalsTable
           setDetailsModal={mockedSetDetailsModal}
           requests={mockedRequests}
-          approveIsLoading={false}
+          quickActionLoading={false}
           setDeclineModal={mockedSetDeclineModal}
           approveRequest={mockedApproveRequest}
         />
@@ -280,14 +280,19 @@ describe("TopicApprovalsTable", () => {
     });
   });
 
-  describe("handles action columns loading state", () => {
+  describe("disables the quick actions dependent on props", () => {
+    const requestsWithStatusCreated = [
+      mockedRequests[0],
+      { ...mockedRequests[0], topicname: "Additional-topic", topicid: 1234 },
+    ];
+
     beforeAll(() => {
       mockIntersectionObserver();
       render(
         <TopicApprovalsTable
           setDetailsModal={mockedSetDetailsModal}
-          requests={mockedRequests}
-          approveIsLoading={true}
+          requests={requestsWithStatusCreated}
+          quickActionLoading={true}
           setDeclineModal={mockedSetDeclineModal}
           approveRequest={mockedApproveRequest}
         />
@@ -295,12 +300,33 @@ describe("TopicApprovalsTable", () => {
     });
     afterAll(cleanup);
 
-    it("renders disabled decline button", async () => {
-      const decline = screen.getByRole("button", {
-        name: "Decline topic request for test-topic-1",
+    requestsWithStatusCreated.forEach((request) => {
+      it(`disables button to approve schema request for topic name ${request.topicname}`, () => {
+        const table = screen.getByRole("table", { name: "Topic requests" });
+        const button = within(table).getByRole("button", {
+          name: `Approve topic request for ${request.topicname}`,
+        });
+
+        expect(button).toBeDisabled();
       });
 
-      expect(decline).toBeDisabled;
+      it(`disables  button to decline schema request for topic name ${request.topicname}`, () => {
+        const table = screen.getByRole("table", { name: "Topic requests" });
+        const button = within(table).getByRole("button", {
+          name: `Decline topic request for ${request.topicname}`,
+        });
+
+        expect(button).toBeDisabled();
+      });
+
+      it(`disables details for schema request for topic name ${request.topicname}`, () => {
+        const table = screen.getByRole("table", { name: "Topic requests" });
+        const detailsButton = within(table).getByRole("button", {
+          name: `View topic request for ${request.topicname}`,
+        });
+
+        expect(detailsButton).toBeDisabled();
+      });
     });
   });
 });

--- a/coral/src/app/features/approvals/topics/components/TopicApprovalsTable.tsx
+++ b/coral/src/app/features/approvals/topics/components/TopicApprovalsTable.tsx
@@ -100,7 +100,6 @@ function TopicApprovalsTable(props: TopicApprovalsTableProp) {
             onClick={() => setDetailsModal({ isOpen: true, topicId: id })}
             icon={infoSign}
             dense
-            disabled={quickActionLoading}
           >
             <span aria-hidden={"true"}>View details</span>
             <span className={"visually-hidden"}>

--- a/coral/src/app/features/approvals/topics/components/TopicApprovalsTable.tsx
+++ b/coral/src/app/features/approvals/topics/components/TopicApprovalsTable.tsx
@@ -46,7 +46,7 @@ type TopicApprovalsTableProp = {
     HTTPError,
     { requestEntityType: "TOPIC"; reqIds: string[] }
   >;
-  approveIsLoading: boolean;
+  quickActionLoading: boolean;
 };
 function TopicApprovalsTable(props: TopicApprovalsTableProp) {
   const {
@@ -54,7 +54,7 @@ function TopicApprovalsTable(props: TopicApprovalsTableProp) {
     setDetailsModal,
     setDeclineModal,
     approveRequest,
-    approveIsLoading,
+    quickActionLoading,
   } = props;
 
   const columns: Array<DataTableColumn<TopicRequestTableRow>> = [
@@ -100,6 +100,7 @@ function TopicApprovalsTable(props: TopicApprovalsTableProp) {
             onClick={() => setDetailsModal({ isOpen: true, topicId: id })}
             icon={infoSign}
             dense
+            disabled={quickActionLoading}
           >
             <span aria-hidden={"true"}>View details</span>
             <span className={"visually-hidden"}>
@@ -132,8 +133,9 @@ function TopicApprovalsTable(props: TopicApprovalsTableProp) {
               }}
               title={`Approve topic request`}
               aria-label={`Approve topic request for ${topicname}`}
+              disabled={quickActionLoading}
             >
-              {isLoading && approveIsLoading ? (
+              {isLoading && quickActionLoading ? (
                 <Icon color="grey-70" icon={loadingIcon} />
               ) : (
                 <Icon color="grey-70" icon={tickCircle} />
@@ -159,7 +161,7 @@ function TopicApprovalsTable(props: TopicApprovalsTableProp) {
               onClick={() => setDeclineModal({ isOpen: true, topicId: id })}
               title={`Decline topic request`}
               aria-label={`Decline topic request for ${topicname}`}
-              disabled={approveIsLoading}
+              disabled={quickActionLoading}
             >
               <Icon color="grey-70" icon={deleteIcon} />
             </GhostButton>


### PR DESCRIPTION
# About this change - What it does

- ⛔️ disables quick actions for other requests while an approve or decline is in process

**Note:** While the disabling is tested in the tables (where there are separate table components), there are no test in the higher up components `SchemaRequest` and `TopicRequest` for it right now. These components are responsible for giving the correct values in the prop for table, so they should be tested. Since it's an async process, we would (at our current state) need to add a kind of timeout to get this to work reliable and stable in the tests and that's just a baaaad pattern. We will work on our way to mock api calls that also include a better way of deferring, then we can cover these cases. It's all tested manually. 


- 🧹 unrelated change, removed console.errors from test logs
We had some console.errors in tests caused by missing mocks (and also 2 that where expected). I removed those logs by adding the mocks. Where they were happening on purpose (testing error state), I mocked out console.error for this scope, but added a `expect(console.error).not.toHaveBeenCalled()` in the `it` blocks where we don't cause the error, while I checked the mock to have been called with the exact message in the `it` block where we test the error case. 

Background here is that while these kind of `console.errors` are mostly showing us a forgotten mock etc., they can also happen in cases where actually is an error in the code. Having console.errors in the test output leads to us just ignoring them ("hey, they are always there, it's not a real problem") which means we won't (and can't) notice if they are a hint for a real problem. Also, they clutter the test output A LOT, so if a test in the test suite fails it can be really hard to even find the failing test (at one point we had 274 console.errors ^^).  

So we should take care of not having them (or any kind of logs to the console) in the tests at all. 

## Why this change
We want to avoid that user fire multiple approvals(*) at once (one approve causes at least 2 api calls, can be more), because we don't handle e.g. one out of 8 api calls having an error gracefully. The api itself already is ready to do batch approvals and this will be a feature later. The behaviour right now matches the one available in the current Klaw frontend. 

(*) also declines of course, but they are harder to fire really quickly because you have to add a reason to decline 
Resolves: #722 

