### PR TITLE
Fix return all schema requests including those with forceRegister set

### DIFF
--- a/core/src/main/java/io/aiven/klaw/dao/SchemaRequest.java
+++ b/core/src/main/java/io/aiven/klaw/dao/SchemaRequest.java
@@ -72,5 +72,5 @@ public class SchemaRequest implements Serializable {
   private Timestamp approvingtime;
 
   @Column(name = "forceregister")
-  private boolean forceRegister;
+  private Boolean forceRegister;
 }

--- a/core/src/main/java/io/aiven/klaw/helpers/db/rdbms/SelectDataJdbc.java
+++ b/core/src/main/java/io/aiven/klaw/helpers/db/rdbms/SelectDataJdbc.java
@@ -323,6 +323,7 @@ public class SelectDataJdbc {
     if (userName != null && !userName.isEmpty()) {
       request.setUsername(userName);
     }
+    request.setForceRegister(null);
     // check if debug is enabled so the logger doesnt waste resources converting object request to a
     // string
     if (log.isDebugEnabled()) {

--- a/core/src/main/java/io/aiven/klaw/model/SchemaRequestModel.java
+++ b/core/src/main/java/io/aiven/klaw/model/SchemaRequestModel.java
@@ -46,7 +46,7 @@ public class SchemaRequestModel implements Serializable {
 
   private RequestOperationType requestOperationType;
 
-  private boolean forceRegister;
+  private Boolean forceRegister;
 
   private String approver;
 

--- a/core/src/main/java/io/aiven/klaw/model/cluster/ClusterSchemaRequest.java
+++ b/core/src/main/java/io/aiven/klaw/model/cluster/ClusterSchemaRequest.java
@@ -4,7 +4,9 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import io.aiven.klaw.model.KafkaSupportedProtocol;
 import java.io.Serializable;
 import lombok.Builder;
+import lombok.Data;
 
+@Data
 @Builder(toBuilder = true)
 public class ClusterSchemaRequest implements Serializable {
 

--- a/core/src/main/java/io/aiven/klaw/service/ClusterApiService.java
+++ b/core/src/main/java/io/aiven/klaw/service/ClusterApiService.java
@@ -660,9 +660,12 @@ public class ClusterApiService {
     getClusterApiProperties(tenantId);
     ResponseEntity<ApiResponse> response;
     try {
+      boolean forceReg =
+          schemaRequest.getForceRegister() == null ? false : schemaRequest.getForceRegister();
       String uri = clusterConnUrl + URI_POST_SCHEMA;
 
       Env envSelected = manageDatabase.getHandleDbRequests().selectEnvDetails(env, tenantId);
+      log.info("forceRegister set to : {}", forceReg);
       KwClusters kwClusters =
           manageDatabase
               .getClusters(KafkaClustersType.SCHEMA_REGISTRY, tenantId)
@@ -674,7 +677,7 @@ public class ClusterApiService {
               .topicName(topicName)
               .fullSchema(schemaRequest.getSchemafull())
               .clusterIdentification(kwClusters.getClusterName() + kwClusters.getClusterId())
-              .forceRegister(schemaRequest.isForceRegister())
+              .forceRegister(forceReg)
               .build();
 
       HttpHeaders headers = createHeaders(clusterApiUser);

--- a/core/src/main/java/io/aiven/klaw/service/ClusterApiService.java
+++ b/core/src/main/java/io/aiven/klaw/service/ClusterApiService.java
@@ -660,8 +660,7 @@ public class ClusterApiService {
     getClusterApiProperties(tenantId);
     ResponseEntity<ApiResponse> response;
     try {
-      boolean forceReg =
-          schemaRequest.getForceRegister() == null ? false : schemaRequest.getForceRegister();
+      boolean forceReg = Objects.requireNonNullElse(schemaRequest.getForceRegister(), false);
       String uri = clusterConnUrl + URI_POST_SCHEMA;
 
       Env envSelected = manageDatabase.getHandleDbRequests().selectEnvDetails(env, tenantId);

--- a/core/src/main/java/io/aiven/klaw/service/ClusterApiService.java
+++ b/core/src/main/java/io/aiven/klaw/service/ClusterApiService.java
@@ -665,7 +665,7 @@ public class ClusterApiService {
       String uri = clusterConnUrl + URI_POST_SCHEMA;
 
       Env envSelected = manageDatabase.getHandleDbRequests().selectEnvDetails(env, tenantId);
-      log.info("forceRegister set to : {}", forceReg);
+      log.debug("forceRegister set to : {}", forceReg);
       KwClusters kwClusters =
           manageDatabase
               .getClusters(KafkaClustersType.SCHEMA_REGISTRY, tenantId)

--- a/core/src/main/resources/openapi.yaml
+++ b/core/src/main/resources/openapi.yaml
@@ -4796,10 +4796,10 @@
           "currentPage" : {
             "type" : "string"
           },
-          "deletable" : {
+          "editable" : {
             "type" : "boolean"
           },
-          "editable" : {
+          "deletable" : {
             "type" : "boolean"
           }
         },
@@ -4917,10 +4917,10 @@
           "currentPage" : {
             "type" : "string"
           },
-          "deletable" : {
+          "editable" : {
             "type" : "boolean"
           },
-          "editable" : {
+          "deletable" : {
             "type" : "boolean"
           }
         },
@@ -5521,10 +5521,10 @@
           "currentPage" : {
             "type" : "string"
           },
-          "deletable" : {
+          "editable" : {
             "type" : "boolean"
           },
-          "editable" : {
+          "deletable" : {
             "type" : "boolean"
           }
         },
@@ -5739,10 +5739,10 @@
           "approvingTeamDetails" : {
             "type" : "string"
           },
-          "deletable" : {
+          "editable" : {
             "type" : "boolean"
           },
-          "editable" : {
+          "deletable" : {
             "type" : "boolean"
           }
         },
@@ -6082,10 +6082,10 @@
           "currentPage" : {
             "type" : "string"
           },
-          "deletable" : {
+          "editable" : {
             "type" : "boolean"
           },
-          "editable" : {
+          "deletable" : {
             "type" : "boolean"
           }
         },
@@ -6144,13 +6144,13 @@
       },
       "Scales" : {
         "properties" : {
-          "xaxes" : {
+          "yaxes" : {
             "type" : "array",
             "items" : {
               "$ref" : "#/components/schemas/YAx"
             }
           },
-          "yaxes" : {
+          "xaxes" : {
             "type" : "array",
             "items" : {
               "$ref" : "#/components/schemas/YAx"

--- a/core/src/test/java/io/aiven/klaw/helpers/db/rdbms/SelectDataJdbcTest.java
+++ b/core/src/test/java/io/aiven/klaw/helpers/db/rdbms/SelectDataJdbcTest.java
@@ -18,7 +18,6 @@ import io.aiven.klaw.dao.Topic;
 import io.aiven.klaw.dao.TopicRequest;
 import io.aiven.klaw.dao.TopicRequestID;
 import io.aiven.klaw.dao.UserInfo;
-import io.aiven.klaw.model.cluster.ClusterSchemaRequest;
 import io.aiven.klaw.repository.AclRepo;
 import io.aiven.klaw.repository.AclRequestsRepo;
 import io.aiven.klaw.repository.ActivityLogRepo;
@@ -39,7 +38,6 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.Mock;
 import org.springframework.data.domain.Example;
-import org.springframework.http.HttpEntity;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.util.ReflectionTestUtils;
 
@@ -73,8 +71,7 @@ public class SelectDataJdbcTest {
 
   private UtilMethods utilMethods;
 
-  @Captor
-  private ArgumentCaptor<Example<SchemaRequest>> schemaRequestCaptor;
+  @Captor private ArgumentCaptor<Example<SchemaRequest>> schemaRequestCaptor;
 
   @BeforeEach
   public void setUp() {
@@ -118,15 +115,15 @@ public class SelectDataJdbcTest {
 
     when(schemaRequestRepo.findAllByTenantId(1)).thenReturn(schemaRequests);
     when(userInfoRepo.findByUsernameIgnoreCase(requestor))
-            .thenReturn(java.util.Optional.of(userInfo));
+        .thenReturn(java.util.Optional.of(userInfo));
 
     List<SchemaRequest> schemaRequestsActual =
-            selectData.selectFilteredSchemaRequests(false, requestor, 1, null, null, null, null, false);
-    verify(schemaRequestRepo,times(1)).findAll(schemaRequestCaptor.capture());
+        selectData.selectFilteredSchemaRequests(false, requestor, 1, null, null, null, null, false);
+    verify(schemaRequestRepo, times(1)).findAll(schemaRequestCaptor.capture());
     Example<SchemaRequest> value = schemaRequestCaptor.getValue();
     assertThat(schemaRequestsActual).isEmpty();
     assertThat(value.getProbe().getForceRegister()).isNull();
-    assertThat(value.getProbe().getUsername()).isEqualTo(null);
+    assertThat(value.getProbe().getUsername()).isNull();
   }
 
   @Test
@@ -139,11 +136,11 @@ public class SelectDataJdbcTest {
 
     when(schemaRequestRepo.findAllByTenantId(1)).thenReturn(schemaRequests);
     when(userInfoRepo.findByUsernameIgnoreCase(requestor))
-            .thenReturn(java.util.Optional.of(userInfo));
+        .thenReturn(java.util.Optional.of(userInfo));
 
     List<SchemaRequest> schemaRequestsActual =
-            selectData.selectFilteredSchemaRequests(false, requestor, 1, null, null, null, null, true);
-    verify(schemaRequestRepo,times(1)).findAll(schemaRequestCaptor.capture());
+        selectData.selectFilteredSchemaRequests(false, requestor, 1, null, null, null, null, true);
+    verify(schemaRequestRepo, times(1)).findAll(schemaRequestCaptor.capture());
     Example<SchemaRequest> value = schemaRequestCaptor.getValue();
     assertThat(schemaRequestsActual).isEmpty();
     assertThat(value.getProbe().getForceRegister()).isNull();
@@ -158,12 +155,11 @@ public class SelectDataJdbcTest {
     when(schemaRequestRepo.findById(any())).thenReturn(java.util.Optional.of(schemaRequest));
     SchemaRequest schemaRequestActual = selectData.selectSchemaRequest(1001, 1);
     assertThat(schemaRequestActual.getTopicname()).isEqualTo(TESTTOPIC);
-
   }
 
   @Test
   public void selectTopicDetailsSuccess() {
-    String topicName = TESTTOPIC, env = "DEV";
+    String topicName = TESTTOPIC;
     List<Topic> topicList = new ArrayList<>();
     topicList.add(utilMethods.getTopic(topicName));
     when(topicRepo.findAllByTopicnameAndTenantId(topicName, 1)).thenReturn(topicList);

--- a/core/src/test/java/io/aiven/klaw/service/ClusterApiServiceTest.java
+++ b/core/src/test/java/io/aiven/klaw/service/ClusterApiServiceTest.java
@@ -30,7 +30,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
-
 import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.MethodOrderer;
@@ -52,6 +51,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.web.client.RestTemplate;
+
 @Slf4j
 @ExtendWith(SpringExtension.class)
 @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
@@ -71,8 +71,7 @@ public class ClusterApiServiceTest {
 
   @Mock private KwClusters kwClusters;
 
-  @Captor
-  private ArgumentCaptor<HttpEntity<ClusterSchemaRequest>> clusterSchemaRequestCaptor;
+  @Captor private ArgumentCaptor<HttpEntity<ClusterSchemaRequest>> clusterSchemaRequestCaptor;
   ClusterApiService clusterApiService;
 
   ResponseEntity<String> response;
@@ -86,6 +85,7 @@ public class ClusterApiServiceTest {
 
     this.env = new Env();
     env.setName("DEV");
+    env.setClusterId(1);
     ReflectionTestUtils.setField(clusterApiService, "httpRestTemplate", restTemplate);
     ReflectionTestUtils.setField(clusterApiService, "clusterApiUser", "testuser");
     ReflectionTestUtils.setField(
@@ -345,26 +345,26 @@ public class ClusterApiServiceTest {
 
     when(handleDbRequests.selectEnvDetails(anyString(), anyInt())).thenReturn(this.env);
     when(manageDatabase.getClusters(any(KafkaClustersType.class), anyInt()))
-            .thenReturn(clustersHashMap);
+        .thenReturn(clustersHashMap);
     when(clustersHashMap.get(any())).thenReturn(kwClusters);
     when(kwClusters.getBootstrapServers()).thenReturn(BOOTSRAP_SERVERS);
     when(kwClusters.getProtocol()).thenReturn(KafkaSupportedProtocol.PLAINTEXT);
     when(kwClusters.getClusterName()).thenReturn("cluster");
     when(restTemplate.postForEntity(Mockito.anyString(), Mockito.any(), eq(ApiResponse.class)))
-            .thenReturn(response);
+        .thenReturn(response);
 
     ResponseEntity<ApiResponse> result =
-            clusterApiService.postSchema(schemaRequest, envSel, topicName, 1);
+        clusterApiService.postSchema(schemaRequest, envSel, topicName, 1);
     assertThat(result.getBody().getResult()).isEqualTo(ApiResultStatus.SUCCESS.value);
   }
 
   @ParameterizedTest
-  @ValueSource(strings = {"null","false"})
+  @ValueSource(strings = {"null", "false"})
   @Order(12)
   public void postSchemaSucessForceRegisterNullOrFalse(String value) throws KlawException {
     SchemaRequest schemaRequest = new SchemaRequest();
     schemaRequest.setSchemafull(SCHEMAFULL);
-    schemaRequest.setForceRegister(value.equals("false")?Boolean.valueOf(value) : null);
+    schemaRequest.setForceRegister(value.equals("false") ? Boolean.valueOf(value) : null);
     String envSel = "DEV";
     String topicName = "testtopic";
 
@@ -373,17 +373,18 @@ public class ClusterApiServiceTest {
 
     when(handleDbRequests.selectEnvDetails(anyString(), anyInt())).thenReturn(this.env);
     when(manageDatabase.getClusters(any(KafkaClustersType.class), anyInt()))
-            .thenReturn(clustersHashMap);
-    when(clustersHashMap.get(any())).thenReturn(kwClusters);
+        .thenReturn(clustersHashMap);
+    when(clustersHashMap.get(anyInt())).thenReturn(kwClusters);
     when(kwClusters.getBootstrapServers()).thenReturn(BOOTSRAP_SERVERS);
     when(kwClusters.getProtocol()).thenReturn(KafkaSupportedProtocol.PLAINTEXT);
     when(kwClusters.getClusterName()).thenReturn("cluster");
     when(restTemplate.postForEntity(Mockito.anyString(), Mockito.any(), eq(ApiResponse.class)))
-            .thenReturn(response);
+        .thenReturn(response);
 
     ResponseEntity<ApiResponse> result =
-            clusterApiService.postSchema(schemaRequest, envSel, topicName, 1);
-    verify(restTemplate,times(1)).postForEntity(anyString(), clusterSchemaRequestCaptor.capture(),eq(ApiResponse.class));
+        clusterApiService.postSchema(schemaRequest, envSel, topicName, 1);
+    verify(restTemplate, times(1))
+        .postForEntity(anyString(), clusterSchemaRequestCaptor.capture(), eq(ApiResponse.class));
     assertThat(result.getBody().getResult()).isEqualTo(ApiResultStatus.SUCCESS.value);
     ClusterSchemaRequest clusterSchemaRequest = clusterSchemaRequestCaptor.getValue().getBody();
     assertThat(clusterSchemaRequest.isForceRegister()).isFalse();
@@ -404,18 +405,19 @@ public class ClusterApiServiceTest {
 
     when(handleDbRequests.selectEnvDetails(anyString(), anyInt())).thenReturn(this.env);
     when(manageDatabase.getClusters(any(KafkaClustersType.class), anyInt()))
-            .thenReturn(clustersHashMap);
-    when(clustersHashMap.get(any())).thenReturn(kwClusters);
+        .thenReturn(clustersHashMap);
+    when(clustersHashMap.get(anyInt())).thenReturn(kwClusters);
     when(kwClusters.getBootstrapServers()).thenReturn(BOOTSRAP_SERVERS);
     when(kwClusters.getProtocol()).thenReturn(KafkaSupportedProtocol.PLAINTEXT);
     when(kwClusters.getClusterName()).thenReturn("cluster");
     when(restTemplate.postForEntity(Mockito.anyString(), Mockito.any(), eq(ApiResponse.class)))
-            .thenReturn(response);
+        .thenReturn(response);
 
     ResponseEntity<ApiResponse> result =
-            clusterApiService.postSchema(schemaRequest, envSel, topicName, 1);
+        clusterApiService.postSchema(schemaRequest, envSel, topicName, 1);
 
-    verify(restTemplate,times(1)).postForEntity(anyString(), clusterSchemaRequestCaptor.capture(),eq(ApiResponse.class));
+    verify(restTemplate, times(1))
+        .postForEntity(anyString(), clusterSchemaRequestCaptor.capture(), eq(ApiResponse.class));
     assertThat(result.getBody().getResult()).isEqualTo(ApiResultStatus.SUCCESS.value);
     ClusterSchemaRequest clusterSchemaRequest = clusterSchemaRequestCaptor.getValue().getBody();
     assertThat(clusterSchemaRequest.isForceRegister()).isTrue();


### PR DESCRIPTION
About this change - What it does
This change makes forceRegister Nullable. This means when querying by example it does not automatically set forceRegister to false. Previously it was causing an issue where it would only return schema requests where forceRegister was set to false. Meaning any forceRegister requests were not viewable in the UI.
Resolves: #xxxxx
Why this way
