### PR TITLE
fix(coral): fix endpoint for declining schema requests

### DIFF
--- a/coral/src/domain/schema-request/schema-request-api.ts
+++ b/coral/src/domain/schema-request/schema-request-api.ts
@@ -79,7 +79,7 @@ const declineSchemaRequest = ({
   return api.post<
     KlawApiResponse<"declineRequest">,
     RequestVerdictDecline<"SCHEMA">
-  >(`/request/approve`, {
+  >(`/request/decline`, {
     reqIds,
     reason,
     requestEntityType: "SCHEMA",


### PR DESCRIPTION
# About this change - What it does

`declineSchemaRequest` used the endpoint `requests/approve` ( 🤦‍♀️ @ myself) it's updated now. 
