### PR TITLE
refactor(coral): Extract a Table component from AclApprovals.tsx #711

### DIFF
--- a/coral/src/app/features/approvals/acls/AclApprovals.test.tsx
+++ b/coral/src/app/features/approvals/acls/AclApprovals.test.tsx
@@ -105,6 +105,7 @@ const mockGetAclRequestsForApproverResponseEmpty =
 describe("AclApprovals", () => {
   beforeAll(() => {
     mockIntersectionObserver();
+    mockGetEnvironments.mockResolvedValue(mockGetEnvironmentResponse);
   });
   afterAll(() => {
     jest.resetAllMocks();
@@ -139,7 +140,6 @@ describe("AclApprovals", () => {
       mockGetAclRequestsForApprover.mockRejectedValue(
         "Unexpected error. Please try again later!"
       );
-
       customRender(<AclApprovals />, {
         queryClient: true,
         memoryRouter: true,
@@ -160,86 +160,12 @@ describe("AclApprovals", () => {
     });
   });
 
-  describe("DataTable", () => {
-    beforeAll(async () => {
-      mockGetEnvironments.mockResolvedValue([]);
-      mockGetAclRequestsForApprover.mockResolvedValue(
-        mockGetAclRequestsForApproverResponse
-      );
-
-      customRender(<AclApprovals />, {
-        queryClient: true,
-        memoryRouter: true,
-      });
-
-      await waitForElementToBeRemoved(screen.getByTestId("skeleton-table"));
-    });
-
-    afterAll(() => {
-      cleanup();
-      jest.resetAllMocks();
-    });
-
-    it("shows one header row and two data rows", async () => {
-      const rows = screen.getAllByRole("row");
-
-      expect(rows).toHaveLength(3);
-      expect(rows[0]).toHaveTextContent("Principals/Usernames");
-      expect(rows[1]).toHaveTextContent("mbasani");
-      expect(rows[2]).toHaveTextContent("User:*");
-    });
-
-    it("renders (prefixed) in Topic cell when appropriate", async () => {
-      const prefixedCells = screen.getAllByText("(prefixed)");
-      const notPrefixedCells = screen.getAllByText("aivtopic1");
-
-      expect(prefixedCells).toHaveLength(1);
-      expect(notPrefixedCells).toHaveLength(1);
-    });
-
-    it("renders all values for cells who can have multiple values", async () => {
-      const cells = screen.getAllByRole("cell");
-
-      expect(
-        cells.filter((cell) => {
-          return cell.textContent === "mbasani maulbach ";
-        })
-      ).toHaveLength(1);
-      expect(
-        cells.filter((cell) => cell.textContent === "3.3.3.32 3.3.3.33 ")
-      ).toHaveLength(1);
-    });
-
-    it("render action buttons when status is CREATED", () => {
-      const createdRow = screen.getAllByRole("row")[1];
-
-      expect(createdRow).toContainElement(
-        screen.getByRole("button", { name: /Approve/ })
-      );
-      expect(createdRow).toContainElement(
-        screen.getByRole("button", { name: /Decline/ })
-      );
-    });
-
-    it("does not render action buttons when status is not CREATED", () => {
-      const approvedRow = screen.getAllByRole("row")[2];
-
-      expect(approvedRow).not.toContainElement(
-        screen.getByRole("button", { name: /Approve/ })
-      );
-      expect(approvedRow).not.toContainElement(
-        screen.getByRole("button", { name: /Decline/ })
-      );
-    });
-  });
-
   describe("handles paginated data", () => {
     beforeAll(async () => {
       mockGetEnvironments.mockResolvedValue([]);
       mockGetAclRequestsForApprover.mockResolvedValue(
         mockGetAclRequestsForApproverResponse
       );
-
       customRender(<AclApprovals />, {
         queryClient: true,
         memoryRouter: true,
@@ -267,7 +193,7 @@ describe("AclApprovals", () => {
       const approvedRow = screen.getAllByRole("row")[2];
       await userEvent.click(
         within(approvedRow).getByRole("button", {
-          name: /View topic request for/,
+          name: /View acl request for/,
         })
       );
       const modal = screen.getByRole("dialog");
@@ -287,7 +213,7 @@ describe("AclApprovals", () => {
 
       await userEvent.click(
         within(createdRow).getByRole("button", {
-          name: /View topic request for/,
+          name: /View acl request for/,
         })
       );
 

--- a/coral/src/app/features/approvals/acls/AclApprovals.tsx
+++ b/coral/src/app/features/approvals/acls/AclApprovals.tsx
@@ -1,16 +1,4 @@
-import {
-  Alert,
-  DataTable,
-  DataTableColumn,
-  Flexbox,
-  GhostButton,
-  Icon,
-  StatusChip,
-} from "@aivenio/aquarium";
-import deleteIcon from "@aivenio/aquarium/dist/src/icons/delete";
-import infoSign from "@aivenio/aquarium/dist/src/icons/infoSign";
-import loadingIcon from "@aivenio/aquarium/dist/src/icons/loading";
-import tickCircle from "@aivenio/aquarium/dist/src/icons/tickCircle";
+import { Alert } from "@aivenio/aquarium";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { useState } from "react";
 import { useSearchParams } from "react-router-dom";
@@ -21,79 +9,13 @@ import { ApprovalsLayout } from "src/app/features/approvals/components/Approvals
 import RequestDeclineModal from "src/app/features/approvals/components/RequestDeclineModal";
 import RequestDetailsModal from "src/app/features/approvals/components/RequestDetailsModal";
 import {
-  requestStatusChipStatusMap,
-  requestStatusNameMap,
-} from "src/app/features/approvals/utils/request-status-helper";
-import {
   approveAclRequest,
   declineAclRequest,
   getAclRequestsForApprover,
 } from "src/domain/acl/acl-api";
-import { AclRequest, AclRequestsForApprover } from "src/domain/acl/acl-types";
-import {
-  RequestOperationType,
-  RequestStatus,
-} from "src/domain/requests/requests-types";
+import { AclRequestsForApprover } from "src/domain/acl/acl-types";
 import { parseErrorMsg } from "src/services/mutation-utils";
-import {
-  requestOperationTypeChipStatusMap,
-  requestOperationTypeNameMap,
-} from "src/app/features/approvals/utils/request-operation-type-helper";
-
-interface AclRequestTableRow {
-  id: number;
-  acl_ssl: string[];
-  acl_ip: string[];
-  topicname: AclRequest["topicname"];
-  prefixed: boolean;
-  environmentName: string;
-  teamname: AclRequest["teamname"];
-  aclType: AclRequest["aclType"];
-  username: string;
-  requesttimestring: string;
-  // `requestStatus` and `requestOperationType` are
-  // always defined from backend
-  // but api definition says it can be undefined
-  // the empty string is used to make ts compiler
-  // happy :D
-  requestStatus: RequestStatus | "";
-  requestOperationType: RequestOperationType | "";
-}
-
-const getRows = (entries: AclRequest[] | undefined): AclRequestTableRow[] => {
-  if (entries === undefined) {
-    return [];
-  }
-  return entries.map(
-    ({
-      req_no,
-      acl_ssl,
-      acl_ip,
-      topicname,
-      aclPatternType,
-      environmentName,
-      teamname,
-      aclType,
-      username,
-      requesttimestring,
-      requestStatus,
-      requestOperationType,
-    }) => ({
-      id: Number(req_no),
-      acl_ssl: acl_ssl ?? [],
-      acl_ip: acl_ip ?? [],
-      topicname: topicname,
-      prefixed: aclPatternType === "PREFIXED",
-      environmentName: environmentName ?? "-",
-      teamname,
-      aclType,
-      username: username ?? "-",
-      requesttimestring: requesttimestring ?? "-",
-      requestStatus: requestStatus ?? "",
-      requestOperationType: requestOperationType ?? "",
-    })
-  );
-};
+import AclApprovalsTable from "src/app/features/approvals/acls/components/AclApprovalsTable";
 
 function AclApprovals() {
   const queryClient = useQueryClient();
@@ -148,7 +70,11 @@ function AclApprovals() {
     keepPreviousData: true,
   });
 
-  const { isLoading: approveIsLoading, mutate: approveRequest } = useMutation({
+  const {
+    isLoading: approveIsLoading,
+    mutate: approveRequest,
+    variables: approveVariables,
+  } = useMutation({
     mutationFn: approveAclRequest,
     onSuccess: (responses) => {
       queryClient.refetchQueries(["getRequestsWaitingForApproval"]);
@@ -208,206 +134,6 @@ function AclApprovals() {
     },
   });
 
-  const columns: Array<DataTableColumn<AclRequestTableRow>> = [
-    {
-      type: "custom",
-      field: "acl_ssl",
-      headerName: "Principals/Usernames",
-      UNSAFE_render: ({ acl_ssl }: AclRequestTableRow) => {
-        return (
-          <Flexbox wrap={"wrap"} gap={"2"}>
-            {acl_ssl.map((ssl, index) => (
-              <StatusChip
-                status="neutral"
-                key={`${ssl}-${index}`}
-                // We need to add a space after text value
-                // Otherwise a list of values would be rendered as value1value2value3 for screen readers
-                // Instead of value1 value2 value3
-                text={`${ssl} `}
-              />
-            ))}
-          </Flexbox>
-        );
-      },
-    },
-    {
-      type: "custom",
-      field: "acl_ip",
-      headerName: "IP addresses",
-      UNSAFE_render: ({ acl_ip }: AclRequestTableRow) => {
-        return (
-          <Flexbox wrap={"wrap"} gap={"2"}>
-            {acl_ip.map((ip, index) => (
-              <StatusChip
-                status="neutral"
-                key={`${ip}-${index}`}
-                // We need to add a space after text value
-                // Otherwise a list of values would be rendered as value1value2value3 for screen readers
-                // Instead of value1 value2 value3
-                text={`${ip} `}
-              />
-            ))}
-          </Flexbox>
-        );
-      },
-    },
-    {
-      type: "custom",
-      field: "topicname",
-      headerName: "Topic",
-      UNSAFE_render({ topicname, prefixed }: AclRequestTableRow) {
-        return (
-          <>
-            {topicname}
-            {prefixed && <code>(prefixed)</code>}
-          </>
-        );
-      },
-    },
-    {
-      type: "status",
-      field: "environmentName",
-      headerName: "Environment",
-      status: ({ environmentName }) => ({
-        status: "neutral",
-        text: environmentName,
-      }),
-    },
-    {
-      type: "text",
-      field: "teamname",
-      headerName: "Team",
-    },
-    {
-      type: "status",
-      field: "aclType",
-      headerName: "ACL type",
-      status: ({ aclType }) => ({
-        status: aclType === "CONSUMER" ? "success" : "info",
-        text: aclType,
-      }),
-    },
-    {
-      type: "status",
-      field: "requestStatus",
-      headerName: "Status",
-      status: ({ requestStatus }) => {
-        if (requestStatus === "") {
-          return {
-            status: "neutral",
-            text: "-",
-          };
-        }
-        return {
-          status: requestStatusChipStatusMap[requestStatus],
-          text: requestStatusNameMap[requestStatus],
-        };
-      },
-    },
-    {
-      type: "status",
-      field: "requestOperationType",
-      headerName: "Request type",
-      status: ({ requestOperationType }) => {
-        if (requestOperationType === "") {
-          return {
-            status: "neutral",
-            text: "-",
-          };
-        }
-        return {
-          status: requestOperationTypeChipStatusMap[requestOperationType],
-          text: requestOperationTypeNameMap[requestOperationType],
-        };
-      },
-    },
-    {
-      type: "text",
-      field: "username",
-      headerName: "Requested by",
-    },
-    {
-      type: "text",
-      field: "requesttimestring",
-      headerName: "Requested on",
-      formatter: (value) => {
-        return `${value}${"\u00A0"}UTC`;
-      },
-    },
-    {
-      headerName: "Details",
-      headerInvisible: true,
-      type: "custom",
-      UNSAFE_render: ({ id, topicname }: AclRequestTableRow) => {
-        return (
-          <GhostButton
-            icon={infoSign}
-            onClick={() => setDetailsModal({ isOpen: true, reqNo: String(id) })}
-            dense
-          >
-            <span aria-hidden={"true"}>View details</span>
-            <span className={"visually-hidden"}>
-              View topic request for {topicname}
-            </span>
-          </GhostButton>
-        );
-      },
-    },
-    {
-      width: 30,
-      headerName: "Approve",
-      headerInvisible: true,
-      type: "custom",
-      UNSAFE_render: ({ id, requestStatus, topicname }: AclRequestTableRow) => {
-        const [isLoading, setIsLoading] = useState(false);
-        if (requestStatus === "CREATED") {
-          return (
-            <GhostButton
-              onClick={() => {
-                setIsLoading(true);
-                approveRequest({
-                  requestEntityType: "ACL",
-                  reqIds: [String(id)],
-                });
-              }}
-              title={"Approve acl request"}
-              aria-label={`Approve schema request for ${topicname}`}
-              disabled={approveIsLoading || declineIsLoading}
-            >
-              {isLoading && approveIsLoading ? (
-                <Icon color="grey-70" icon={loadingIcon} />
-              ) : (
-                <Icon color="grey-70" icon={tickCircle} />
-              )}
-            </GhostButton>
-          );
-        }
-      },
-    },
-    {
-      width: 30,
-      headerName: "Decline",
-      headerInvisible: true,
-      type: "custom",
-      UNSAFE_render: ({ id, requestStatus, topicname }: AclRequestTableRow) => {
-        if (requestStatus === "CREATED") {
-          return (
-            <GhostButton
-              onClick={() =>
-                setDeclineModal({ isOpen: true, reqNo: String(id) })
-              }
-              title={`Decline acl request`}
-              aria-label={`Decline topic request for ${topicname}`}
-              disabled={approveIsLoading || declineIsLoading}
-            >
-              <Icon color="grey-70" icon={deleteIcon} />
-            </GhostButton>
-          );
-        }
-      },
-    },
-  ];
-
   const pagination =
     data?.totalPages && data.totalPages > 1 ? (
       <Pagination
@@ -420,6 +146,25 @@ function AclApprovals() {
   const selectedRequest = data?.entries.find(
     (request) => request.req_no === Number(detailsModal.reqNo)
   );
+
+  function handleViewRequest(reqNo: string): void {
+    setDetailsModal({ isOpen: true, reqNo });
+  }
+
+  function handleApproveRequest(reqNo: string): void {
+    approveRequest({
+      requestEntityType: "ACL",
+      reqIds: [reqNo],
+    });
+  }
+
+  function handleDeclineRequest(reqNo: string): void {
+    setDeclineModal({ isOpen: true, reqNo });
+  }
+
+  function handleIsBeingApproved(reqNo: string): boolean {
+    return Boolean(approveVariables?.reqIds?.includes(reqNo));
+  }
 
   return (
     <>
@@ -469,11 +214,15 @@ function AclApprovals() {
       <ApprovalsLayout
         filters={filters}
         table={
-          <DataTable
-            ariaLabel={"Acl requests"}
-            columns={columns}
-            rows={getRows(data?.entries)}
-            noWrap={false}
+          <AclApprovalsTable
+            aclRequests={data?.entries ?? []}
+            activePage={data?.currentPage ?? 1}
+            totalPages={data?.totalPages ?? 1}
+            actionsDisabled={approveIsLoading || declineIsLoading}
+            isBeingApproved={handleIsBeingApproved}
+            onDetails={handleViewRequest}
+            onApprove={handleApproveRequest}
+            onDecline={handleDeclineRequest}
           />
         }
         pagination={pagination}

--- a/coral/src/app/features/approvals/acls/components/AclApprovalsTable.test.tsx
+++ b/coral/src/app/features/approvals/acls/components/AclApprovalsTable.test.tsx
@@ -1,0 +1,321 @@
+import { cleanup, screen, render, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { AclRequest } from "src/domain/acl/acl-types";
+import AclApprovalsTable from "src/app/features/approvals/acls/components/AclApprovalsTable";
+import { type Props } from "src/app/features/approvals/acls/components/AclApprovalsTable";
+import { mockIntersectionObserver } from "src/services/test-utils/mock-intersection-observer";
+
+const aclRequests: AclRequest[] = [
+  {
+    remarks: undefined,
+    consumergroup: "-na-",
+    acl_ip: undefined,
+    acl_ssl: ["mbasani", "maulbach"],
+    aclPatternType: "LITERAL",
+    transactionalId: undefined,
+    req_no: 1014,
+    topicname: "aivtopic1",
+    environment: "1",
+    teamname: "Ospo",
+    aclIpPrincipleType: "PRINCIPAL",
+    environmentName: "DEV",
+    teamId: 1003,
+    requestingteam: 1003,
+    requestingTeamName: "Ospo",
+    appname: "App",
+    username: "amathieu",
+    requesttime: "2023-01-06T14:50:37.912+00:00",
+    requesttimestring: "06-Jan-2023 14:50:37",
+    requestStatus: "CREATED",
+    approver: undefined,
+    approvingtime: undefined,
+    aclType: "CONSUMER",
+    aclResourceType: undefined,
+    currentPage: "1",
+    otherParams: undefined,
+    totalNoPages: "2",
+    allPageNos: ["1", ">", ">>"],
+    approvingTeamDetails:
+      "Team : Ospo, Users : muralibasani,josepprat,samulisuortti,mirjamaulbach,smustafa,aindriul,",
+    requestOperationType: "CREATE",
+  },
+  {
+    remarks: "hello",
+    consumergroup: undefined,
+    acl_ip: ["3.3.3.32", "3.3.3.33"],
+    acl_ssl: ["User:*"],
+    aclPatternType: "PREFIXED",
+    transactionalId: undefined,
+    req_no: 1015,
+    topicname: "newaudittopic",
+    environment: "2",
+    teamname: "Ospo",
+    aclType: "PRODUCER",
+    aclIpPrincipleType: "IP_ADDRESS",
+    environmentName: "TST",
+    teamId: 1003,
+    requestingteam: 1003,
+    appname: "App",
+    username: "amathieu",
+    requesttime: "2023-01-10T13:19:10.757+00:00",
+    requesttimestring: "10-Jan-2023 13:19:10",
+    requestStatus: "APPROVED",
+    approver: undefined,
+    approvingtime: undefined,
+    aclResourceType: undefined,
+    currentPage: "1",
+    otherParams: undefined,
+    totalNoPages: "2",
+    allPageNos: ["1", ">", ">>"],
+    approvingTeamDetails:
+      "Team : Ospo, Users : muralibasani,josepprat,samulisuortti,mirjamaulbach,smustafa,aindriul,",
+    requestOperationType: "CREATE",
+  },
+];
+
+describe("AclApprovalsTable", () => {
+  function renderFromProps(props?: Partial<Props>): void {
+    render(
+      <AclApprovalsTable
+        aclRequests={aclRequests}
+        activePage={1}
+        totalPages={10}
+        isBeingApproved={jest.fn()}
+        onApprove={jest.fn()}
+        onDecline={jest.fn()}
+        onDetails={jest.fn()}
+        {...props}
+      />
+    );
+  }
+
+  function getNthRow(nth: number): HTMLElement {
+    return screen.getAllByRole("row")[nth];
+  }
+
+  beforeEach(() => {
+    mockIntersectionObserver();
+  });
+
+  afterEach(cleanup);
+
+  it("describes the table content and pagination for screen readers", () => {
+    renderFromProps();
+    screen.getByLabelText(`Acl requests, page 1 of 10`);
+  });
+
+  it("has column to describe the usernames", () => {
+    renderFromProps();
+    expect(
+      within(getNthRow(0)).getAllByRole("columnheader")[0]
+    ).toHaveTextContent("Principals/Usernames");
+    expect(within(getNthRow(1)).getAllByRole("cell")[0]).toHaveTextContent(
+      "mbasani"
+    );
+  });
+
+  it("has column to describe the ip addresses", () => {
+    renderFromProps();
+    expect(
+      within(getNthRow(0)).getAllByRole("columnheader")[1]
+    ).toHaveTextContent("IP addresses");
+    expect(within(getNthRow(2)).getAllByRole("cell")[1]).toHaveTextContent(
+      "3.3.3.32 3.3.3.33"
+    );
+  });
+
+  it("has column to describe the topic", () => {
+    renderFromProps();
+    expect(
+      within(getNthRow(0)).getAllByRole("columnheader")[2]
+    ).toHaveTextContent("Topic");
+    expect(within(getNthRow(1)).getAllByRole("cell")[2]).toHaveTextContent(
+      "aivtopic1"
+    );
+  });
+
+  it("has column to describe the environment", () => {
+    renderFromProps();
+    expect(
+      within(getNthRow(0)).getAllByRole("columnheader")[3]
+    ).toHaveTextContent("Environment");
+    expect(within(getNthRow(1)).getAllByRole("cell")[3]).toHaveTextContent(
+      "DEV"
+    );
+  });
+
+  it("has column to describe the team", () => {
+    renderFromProps();
+    expect(
+      within(getNthRow(0)).getAllByRole("columnheader")[4]
+    ).toHaveTextContent("Team");
+    expect(within(getNthRow(1)).getAllByRole("cell")[4]).toHaveTextContent(
+      "Ospo"
+    );
+  });
+
+  it("has column to decsribe the acl type", () => {
+    renderFromProps();
+    expect(
+      within(getNthRow(0)).getAllByRole("columnheader")[5]
+    ).toHaveTextContent("ACL type");
+    expect(within(getNthRow(1)).getAllByRole("cell")[5]).toHaveTextContent(
+      "CONSUMER"
+    );
+  });
+
+  it("has column to decsribe the status", () => {
+    renderFromProps();
+    expect(
+      within(getNthRow(0)).getAllByRole("columnheader")[6]
+    ).toHaveTextContent("Status");
+    expect(within(getNthRow(1)).getAllByRole("cell")[6]).toHaveTextContent(
+      "Awaiting approval"
+    );
+  });
+
+  it("has column to decsribe the request type", () => {
+    renderFromProps();
+    expect(
+      within(getNthRow(0)).getAllByRole("columnheader")[7]
+    ).toHaveTextContent("Request type");
+    expect(within(getNthRow(1)).getAllByRole("cell")[7]).toHaveTextContent(
+      "Create"
+    );
+  });
+
+  it("has column to decsribe the author of the request", () => {
+    renderFromProps();
+    expect(
+      within(getNthRow(0)).getAllByRole("columnheader")[8]
+    ).toHaveTextContent("Requested by");
+    expect(within(getNthRow(1)).getAllByRole("cell")[8]).toHaveTextContent(
+      "amathieu"
+    );
+  });
+
+  it("has column to decsribe the timestamp when the request was made", () => {
+    renderFromProps();
+    expect(
+      within(getNthRow(0)).getAllByRole("columnheader")[9]
+    ).toHaveTextContent("Requested on");
+    expect(within(getNthRow(1)).getAllByRole("cell")[9]).toHaveTextContent(
+      "06-Jan-2023 14:50:37 UTC"
+    );
+  });
+
+  it("has column for action to view request details", async () => {
+    const onDetails = jest.fn();
+    renderFromProps({ onDetails });
+    await userEvent.click(
+      within(within(getNthRow(1)).getAllByRole("cell")[10]).getByRole(
+        "button",
+        {
+          name: "View acl request for aivtopic1",
+        }
+      )
+    );
+    expect(onDetails).toHaveBeenNthCalledWith(1, String(aclRequests[0].req_no));
+  });
+
+  it("has column for action to approve request", async () => {
+    const onApprove = jest.fn();
+    renderFromProps({ onApprove });
+    await userEvent.click(
+      within(within(getNthRow(1)).getAllByRole("cell")[11]).getByRole(
+        "button",
+        {
+          name: "Approve acl request for aivtopic1",
+        }
+      )
+    );
+    expect(onApprove).toHaveBeenNthCalledWith(1, String(aclRequests[0].req_no));
+  });
+
+  it("has column for action to decline request", async () => {
+    const onDecline = jest.fn();
+    renderFromProps({ onDecline });
+    await userEvent.click(
+      within(within(getNthRow(1)).getAllByRole("cell")[12]).getByRole(
+        "button",
+        {
+          name: "Decline acl request for aivtopic1",
+        }
+      )
+    );
+    expect(onDecline).toHaveBeenNthCalledWith(1, String(aclRequests[0].req_no));
+  });
+
+  it("shows one header row and two data rows", () => {
+    renderFromProps();
+    const rows = screen.getAllByRole("row");
+    expect(rows).toHaveLength(3);
+    expect(rows[0]).toHaveTextContent("Principals/Usernames");
+    expect(rows[1]).toHaveTextContent("mbasani");
+    expect(rows[2]).toHaveTextContent("User:*");
+  });
+
+  it("renders (prefixed) in Topic cell when appropriate", () => {
+    renderFromProps();
+    const prefixedCells = screen.getAllByText("(prefixed)");
+    const notPrefixedCells = screen.getAllByText("aivtopic1");
+
+    expect(prefixedCells).toHaveLength(1);
+    expect(notPrefixedCells).toHaveLength(1);
+  });
+
+  it("renders all values for cells who can have multiple values", () => {
+    renderFromProps();
+    const cells = screen.getAllByRole("cell");
+    expect(
+      cells.filter((cell) => {
+        return cell.textContent === "mbasani maulbach ";
+      })
+    ).toHaveLength(1);
+    expect(
+      cells.filter((cell) => cell.textContent === "3.3.3.32 3.3.3.33 ")
+    ).toHaveLength(1);
+  });
+
+  it("render action buttons when status is CREATED", () => {
+    renderFromProps();
+    const createdRow = screen.getAllByRole("row")[1];
+    expect(createdRow).toContainElement(
+      screen.getByRole("button", { name: /Approve/ })
+    );
+    expect(createdRow).toContainElement(
+      screen.getByRole("button", { name: /Decline/ })
+    );
+  });
+
+  it("does not render action buttons when status is not CREATED", () => {
+    renderFromProps();
+    const approvedRow = screen.getAllByRole("row")[2];
+    expect(approvedRow).not.toContainElement(
+      screen.getByRole("button", { name: /Approve/ })
+    );
+    expect(approvedRow).not.toContainElement(
+      screen.getByRole("button", { name: /Decline/ })
+    );
+  });
+
+  it("disables approve and decline buttons when actions are disabled", () => {
+    renderFromProps({ actionsDisabled: true });
+    expect(
+      within(within(getNthRow(1)).getAllByRole("cell")[11]).getByRole(
+        "button",
+        {
+          name: "Approve acl request for aivtopic1",
+        }
+      )
+    ).toBeDisabled();
+    expect(
+      within(within(getNthRow(1)).getAllByRole("cell")[12]).getByRole(
+        "button",
+        {
+          name: "Decline acl request for aivtopic1",
+        }
+      )
+    ).toBeDisabled();
+  });
+});

--- a/coral/src/app/features/approvals/acls/components/AclApprovalsTable.tsx
+++ b/coral/src/app/features/approvals/acls/components/AclApprovalsTable.tsx
@@ -1,0 +1,304 @@
+import {
+  GhostButton,
+  Icon,
+  StatusChip,
+  Flexbox,
+  DataTable,
+  DataTableColumn,
+} from "@aivenio/aquarium";
+import { AclRequest } from "src/domain/acl/acl-types";
+import deleteIcon from "@aivenio/aquarium/dist/src/icons/delete";
+import infoSign from "@aivenio/aquarium/dist/src/icons/infoSign";
+import loadingIcon from "@aivenio/aquarium/dist/src/icons/loading";
+import tickCircle from "@aivenio/aquarium/dist/src/icons/tickCircle";
+import {
+  requestStatusChipStatusMap,
+  requestStatusNameMap,
+} from "src/app/features/approvals/utils/request-status-helper";
+import {
+  requestOperationTypeChipStatusMap,
+  requestOperationTypeNameMap,
+} from "src/app/features/approvals/utils/request-operation-type-helper";
+import {
+  RequestOperationType,
+  RequestStatus,
+} from "src/domain/requests/requests-types";
+
+interface AclRequestTableRow {
+  id: number;
+  acl_ssl: string[];
+  acl_ip: string[];
+  topicname: AclRequest["topicname"];
+  prefixed: boolean;
+  environmentName: string;
+  teamname: AclRequest["teamname"];
+  aclType: AclRequest["aclType"];
+  username: string;
+  requesttimestring: string;
+  // `requestStatus` is always defined from backend
+  // but api definition says it can be undefined
+  // the empty string is used to make ts compiler
+  // happy :D
+  requestStatus: RequestStatus | "";
+  requestOperationType: RequestOperationType | "";
+}
+
+export default function AclApprovalsTable({
+  aclRequests,
+  activePage,
+  totalPages,
+  actionsDisabled,
+  isBeingApproved,
+  onDetails,
+  onApprove,
+  onDecline,
+}: Props) {
+  const getRows = (entries: AclRequest[]): AclRequestTableRow[] => {
+    if (entries === undefined) {
+      return [];
+    }
+    return entries.map(
+      ({
+        req_no,
+        acl_ssl,
+        acl_ip,
+        topicname,
+        aclPatternType,
+        environmentName,
+        teamname,
+        aclType,
+        username,
+        requesttimestring,
+        requestStatus,
+        requestOperationType,
+      }) => ({
+        id: Number(req_no),
+        acl_ssl: acl_ssl ?? [],
+        acl_ip: acl_ip ?? [],
+        topicname: topicname,
+        prefixed: aclPatternType === "PREFIXED",
+        environmentName: environmentName ?? "-",
+        teamname,
+        aclType,
+        username: username ?? "-",
+        requesttimestring: requesttimestring ?? "-",
+        requestStatus: requestStatus ?? "",
+        requestOperationType: requestOperationType ?? "",
+      })
+    );
+  };
+
+  const columns: Array<DataTableColumn<AclRequestTableRow>> = [
+    {
+      type: "custom",
+      field: "acl_ssl",
+      headerName: "Principals/Usernames",
+      UNSAFE_render: ({ acl_ssl }: AclRequestTableRow) => {
+        return (
+          <Flexbox wrap={"wrap"} gap={"2"}>
+            {acl_ssl.map((ssl, index) => (
+              <StatusChip
+                status="neutral"
+                key={`${ssl}-${index}`}
+                // We need to add a space after text value
+                // Otherwise a list of values would be rendered as value1value2value3 for screen readers
+                // Instead of value1 value2 value3
+                text={`${ssl} `}
+              />
+            ))}
+          </Flexbox>
+        );
+      },
+    },
+    {
+      type: "custom",
+      field: "acl_ip",
+      headerName: "IP addresses",
+      UNSAFE_render: ({ acl_ip }: AclRequestTableRow) => {
+        return (
+          <Flexbox wrap={"wrap"} gap={"2"}>
+            {acl_ip.map((ip, index) => (
+              <StatusChip
+                status="neutral"
+                key={`${ip}-${index}`}
+                // We need to add a space after text value
+                // Otherwise a list of values would be rendered as value1value2value3 for screen readers
+                // Instead of value1 value2 value3
+                text={`${ip} `}
+              />
+            ))}
+          </Flexbox>
+        );
+      },
+    },
+    {
+      type: "custom",
+      field: "topicname",
+      headerName: "Topic",
+      UNSAFE_render({ topicname, prefixed }: AclRequestTableRow) {
+        return (
+          <>
+            {topicname}
+            {prefixed && <code>(prefixed)</code>}
+          </>
+        );
+      },
+    },
+    {
+      type: "status",
+      field: "environmentName",
+      headerName: "Environment",
+      status: ({ environmentName }) => ({
+        status: "neutral",
+        text: environmentName,
+      }),
+    },
+    {
+      type: "text",
+      field: "teamname",
+      headerName: "Team",
+    },
+    {
+      type: "status",
+      field: "aclType",
+      headerName: "ACL type",
+      status: ({ aclType }) => ({
+        status: aclType === "CONSUMER" ? "success" : "info",
+        text: aclType,
+      }),
+    },
+    {
+      type: "status",
+      field: "requestStatus",
+      headerName: "Status",
+      status: ({ requestStatus }) => {
+        if (requestStatus === "") {
+          return {
+            status: "neutral",
+            text: "-",
+          };
+        }
+        return {
+          status: requestStatusChipStatusMap[requestStatus],
+          text: requestStatusNameMap[requestStatus],
+        };
+      },
+    },
+    {
+      type: "status",
+      field: "requestOperationType",
+      headerName: "Request type",
+      status: ({ requestOperationType }) => {
+        if (requestOperationType === "") {
+          return {
+            status: "neutral",
+            text: "-",
+          };
+        }
+        return {
+          status: requestOperationTypeChipStatusMap[requestOperationType],
+          text: requestOperationTypeNameMap[requestOperationType],
+        };
+      },
+    },
+    {
+      type: "text",
+      field: "username",
+      headerName: "Requested by",
+    },
+    {
+      type: "text",
+      field: "requesttimestring",
+      headerName: "Requested on",
+      formatter: (value) => {
+        return `${value}${"\u00A0"}UTC`;
+      },
+    },
+    {
+      headerName: "Details",
+      headerInvisible: true,
+      type: "custom",
+      UNSAFE_render: ({ id, topicname }: AclRequestTableRow) => {
+        return (
+          <GhostButton
+            icon={infoSign}
+            aria-label={`View acl request for ${topicname}`}
+            onClick={() => onDetails(String(id))}
+            dense
+          >
+            <span aria-hidden={"true"}>View details</span>
+            <span className={"visually-hidden"}>
+              View topic request for {topicname}
+            </span>
+          </GhostButton>
+        );
+      },
+    },
+    {
+      width: 30,
+      headerName: "Approve",
+      headerInvisible: true,
+      type: "custom",
+      UNSAFE_render: ({ id, requestStatus, topicname }: AclRequestTableRow) => {
+        if (requestStatus === "CREATED") {
+          return (
+            <GhostButton
+              onClick={() => {
+                onApprove(String(id));
+              }}
+              title={"Approve acl request"}
+              aria-label={`Approve acl request for ${topicname}`}
+              disabled={actionsDisabled}
+            >
+              {isBeingApproved(String(id)) ? (
+                <Icon color="grey-70" icon={loadingIcon} />
+              ) : (
+                <Icon color="grey-70" icon={tickCircle} />
+              )}
+            </GhostButton>
+          );
+        }
+      },
+    },
+    {
+      width: 30,
+      headerName: "Decline",
+      headerInvisible: true,
+      type: "custom",
+      UNSAFE_render: ({ id, requestStatus, topicname }: AclRequestTableRow) => {
+        if (requestStatus === "CREATED") {
+          return (
+            <GhostButton
+              onClick={() => onDecline(String(id))}
+              title={`Decline acl request`}
+              aria-label={`Decline acl request for ${topicname}`}
+              disabled={actionsDisabled}
+            >
+              <Icon color="grey-70" icon={deleteIcon} />
+            </GhostButton>
+          );
+        }
+      },
+    },
+  ];
+
+  return (
+    <DataTable
+      ariaLabel={`Acl requests, page ${activePage} of ${totalPages}`}
+      columns={columns}
+      rows={getRows(aclRequests)}
+      noWrap={false}
+    />
+  );
+}
+
+export type Props = {
+  aclRequests: AclRequest[];
+  activePage: number;
+  totalPages: number;
+  actionsDisabled?: boolean;
+  isBeingApproved: (reqNo: string) => boolean;
+  onDetails: (reqNo: string) => void;
+  onApprove: (reqNo: string) => void;
+  onDecline: (reqNo: string) => void;
+};


### PR DESCRIPTION
- moves the DataTable implementation from AclApprovals into own component.
- moves test cases that test the old DataTable away from AclApprovals into own test file.
- add test coverage

By extracting functional components we can reduce the complexity and responsibility of components while increasing the testability.