### PR TITLE
fix(coral): Min-width in approvals table fits content

### DIFF
--- a/coral/src/app/features/approvals/acls/AclApprovals.tsx
+++ b/coral/src/app/features/approvals/acls/AclApprovals.tsx
@@ -303,7 +303,7 @@ function AclApprovals() {
       field: "requesttimestring",
       headerName: "Requested on",
       formatter: (value) => {
-        return `${value} UTC`;
+        return `${value}${"\u00A0"}UTC`;
       },
     },
     {

--- a/coral/src/app/features/approvals/components/ApprovalsLayout.tsx
+++ b/coral/src/app/features/approvals/components/ApprovalsLayout.tsx
@@ -47,12 +47,7 @@ function ApprovalsLayout(props: ApprovalsLayoutProps) {
             }}
             marginBottom={"l4"}
           >
-            <Box
-              style={{ minWidth: "1280px" }}
-              className={"a11y-enhancement-data-table"}
-            >
-              {table}
-            </Box>
+            <Box className={"a11y-enhancement-data-table"}>{table}</Box>
           </Box>
           <Flexbox justifyContent={"center"}>{pagination}</Flexbox>
         </>

--- a/coral/src/app/features/approvals/schemas/components/SchemaApprovalsTable.test.tsx
+++ b/coral/src/app/features/approvals/schemas/components/SchemaApprovalsTable.test.tsx
@@ -224,7 +224,7 @@ describe("SchemaApprovalsTable", () => {
 
             let text = field;
             if (column.columnHeader === "Date requested") {
-              text = `${field} UTC`;
+              text = `${field}${"\u00A0"}UTC`;
             }
             if (column.columnHeader === "Status") {
               text = requestStatusNameMap[field as RequestStatus];

--- a/coral/src/app/features/approvals/schemas/components/SchemaApprovalsTable.tsx
+++ b/coral/src/app/features/approvals/schemas/components/SchemaApprovalsTable.tsx
@@ -68,7 +68,7 @@ function SchemaApprovalsTable(props: SchemaApprovalsTableProps) {
       field: "requesttimestring",
       headerName: "Date requested",
       formatter: (value) => {
-        return `${value} UTC`;
+        return `${value}${"\u00A0"}UTC`;
       },
     },
     {

--- a/coral/src/app/features/approvals/topics/components/TopicApprovalsTable.test.tsx
+++ b/coral/src/app/features/approvals/topics/components/TopicApprovalsTable.test.tsx
@@ -211,8 +211,9 @@ describe("TopicApprovalsTable", () => {
 
             let text = field;
             if (column.columnHeader === "Requested on") {
-              text = `${field} UTC`;
+              text = `${field}${"\u00A0"}UTC`;
             }
+
             if (column.columnHeader === "Status") {
               text = requestStatusNameMap[field as RequestStatus];
             }

--- a/coral/src/app/features/approvals/topics/components/TopicApprovalsTable.tsx
+++ b/coral/src/app/features/approvals/topics/components/TopicApprovalsTable.tsx
@@ -86,7 +86,7 @@ function TopicApprovalsTable(props: TopicApprovalsTableProp) {
       field: "requesttimestring",
       headerName: "Requested on",
       formatter: (value) => {
-        return `${value} UTC`;
+        return `${value}${"\u00A0"}UTC`;
       },
     },
     {


### PR DESCRIPTION
# About this change - What it does
- removes the min width from the data tables
- adds a non-breaking space to the date to prevent linebreak that makes layout look weird ^^ (will also add a note to DS later that having a min-width for table cols could be nice!)

Resolves: #738

