### PR TITLE
feat(coral): Add schema version to details modal for approvals

### DIFF
--- a/coral/src/app/features/approvals/schemas/components/SchemaRequestDetails.test.tsx
+++ b/coral/src/app/features/approvals/schemas/components/SchemaRequestDetails.test.tsx
@@ -72,8 +72,16 @@ describe("SchemaRequestDetails", () => {
       expect(definition).toHaveTextContent(testRequest.topicname);
     });
 
+    it("shows the Schema version", () => {
+      const term = findTerm("Schema version");
+      const definition = findDefinition(term);
+
+      expect(term).toBeVisible();
+      expect(definition).toHaveTextContent(testRequest.schemaversion);
+    });
+
     it("shows a preview of the schema", () => {
-      const term = findTerm("Schema");
+      const term = findTerm("Schema preview");
       const definition = findDefinition(term);
 
       expect(term).toBeVisible();

--- a/coral/src/app/features/approvals/schemas/components/SchemaRequestDetails.tsx
+++ b/coral/src/app/features/approvals/schemas/components/SchemaRequestDetails.tsx
@@ -28,8 +28,12 @@ function SchemaRequestDetails(props: DetailsModalContentProps) {
       </Flexbox>
 
       <GridItem colSpan={"span-2"}>
+        <Label>Schema version</Label>
+        <dd>{request.schemaversion}</dd>
+      </GridItem>
+      <GridItem colSpan={"span-2"}>
         <Flexbox direction={"column"}>
-          <Label>Schema</Label>
+          <Label>Schema preview</Label>
           <dd>
             <MonacoEditor
               data-testid="topic-schema"


### PR DESCRIPTION
# About this change - What it does

- adds schema version to details modal
- renames label for schema preview to "Schema preview" (more consistent with label above)

## Screenshot
<img width="917" alt="version" src="https://user-images.githubusercontent.com/943800/222430282-9acd6493-b2bd-4801-920f-59f4a00d92b2.png">


Resolves: #746

