### PR TITLE
fix(coral): Errors should be shown in alerts of type error

### DIFF
--- a/coral/src/app/features/approvals/acls/AclApprovals.tsx
+++ b/coral/src/app/features/approvals/acls/AclApprovals.tsx
@@ -434,7 +434,7 @@ function AclApprovals() {
       )}
       {errorMessage !== "" && (
         <div role="alert">
-          <Alert type="warning">{errorMessage}</Alert>
+          <Alert type="error">{errorMessage}</Alert>
         </div>
       )}
 

--- a/coral/src/app/features/approvals/components/ApprovalsLayout.test.tsx
+++ b/coral/src/app/features/approvals/components/ApprovalsLayout.test.tsx
@@ -98,12 +98,12 @@ describe("ApprovalsLayout", () => {
       );
 
       const table = screen.queryByRole("table");
-      const errorMessage = screen.getByText(
-        "Oh no, this is an error. Please try again later!"
-      );
+      const alert = screen.getByRole("alert");
 
       expect(table).not.toBeInTheDocument();
-      expect(errorMessage).toBeVisible();
+      expect(alert).toHaveTextContent(
+        "Oh no, this is an error. Please try again later!"
+      );
     });
   });
 

--- a/coral/src/app/features/approvals/components/ApprovalsLayout.tsx
+++ b/coral/src/app/features/approvals/components/ApprovalsLayout.tsx
@@ -37,7 +37,9 @@ function ApprovalsLayout(props: ApprovalsLayoutProps) {
       </Box>
       {isLoading && <SkeletonTable />}
       {isErrorLoading && (
-        <Alert type={"error"}>{errorMessage}. Please try again later!</Alert>
+        <div role={"alert"}>
+          <Alert type={"error"}>{errorMessage}. Please try again later!</Alert>
+        </div>
       )}
       {!isLoading && !isErrorLoading && (
         <>

--- a/coral/src/app/features/approvals/schemas/SchemaApprovals.tsx
+++ b/coral/src/app/features/approvals/schemas/SchemaApprovals.tsx
@@ -216,7 +216,7 @@ function SchemaApprovals() {
       )}
       {errorQuickActions && (
         <div role="alert">
-          <Alert type="warning">{errorQuickActions}</Alert>
+          <Alert type="error">{errorQuickActions}</Alert>
         </div>
       )}
       <ApprovalsLayout

--- a/coral/src/app/features/approvals/topics/TopicApprovals.tsx
+++ b/coral/src/app/features/approvals/topics/TopicApprovals.tsx
@@ -229,7 +229,7 @@ function TopicApprovals() {
       )}
       {errorMessage !== "" && (
         <div role="alert">
-          <Alert type="warning">{errorMessage}</Alert>
+          <Alert type="error">{errorMessage}</Alert>
         </div>
       )}
       <ApprovalsLayout

--- a/coral/src/app/features/topics/acl-request/forms/TopicConsumerForm.tsx
+++ b/coral/src/app/features/topics/acl-request/forms/TopicConsumerForm.tsx
@@ -103,7 +103,7 @@ const TopicConsumerForm = ({
     <>
       {isError && (
         <Box marginBottom={"l1"} role="alert">
-          <Alert type="warning">{parseErrorMsg(error)}</Alert>
+          <Alert type="error">{parseErrorMsg(error)}</Alert>
         </Box>
       )}
       <Form

--- a/coral/src/app/features/topics/acl-request/forms/TopicProducerForm.tsx
+++ b/coral/src/app/features/topics/acl-request/forms/TopicProducerForm.tsx
@@ -104,7 +104,7 @@ const TopicProducerForm = ({
     <>
       {isError && (
         <Box marginBottom={"l1"} role="alert">
-          <Alert type="warning">{parseErrorMsg(error)}</Alert>
+          <Alert type="error">{parseErrorMsg(error)}</Alert>
         </Box>
       )}
       <Form

--- a/coral/src/app/features/topics/request/TopicRequest.tsx
+++ b/coral/src/app/features/topics/request/TopicRequest.tsx
@@ -83,7 +83,7 @@ function TopicRequest() {
       <Box maxWidth={"7xl"}>
         {isError && (
           <Box marginBottom={"l1"} role="alert">
-            <Alert type="warning">{parseErrorMsg(error)}</Alert>
+            <Alert type="error">{parseErrorMsg(error)}</Alert>
           </Box>
         )}
         <Form

--- a/coral/src/app/features/topics/schema-request/TopicSchemaRequest.tsx
+++ b/coral/src/app/features/topics/schema-request/TopicSchemaRequest.tsx
@@ -90,7 +90,7 @@ function TopicSchemaRequest(props: TopicSchemaRequestProps) {
       <Box maxWidth={"7xl"}>
         {schemaRequestMutation.isError && (
           <Box marginBottom={"l1"} role="alert">
-            <Alert type="warning">
+            <Alert type="error">
               {parseErrorMsg(schemaRequestMutation.error)}
             </Alert>
           </Box>


### PR DESCRIPTION
# About this change - What it does
- uses `Alert type="error"` for alerts that notify user that app was unsuccessful to do an operation 
- also adds a missing role alert to ApprovalsLayout

Resolves: #735

