### PR TITLE
feat(coral): Add request types in approval tables

### DIFF
--- a/coral/src/app/features/approvals/acls/AclApprovals.test.tsx
+++ b/coral/src/app/features/approvals/acls/AclApprovals.test.tsx
@@ -324,10 +324,31 @@ describe("AclApprovals", () => {
       cleanup();
     });
 
-    it("renders correct filters", () => {
-      expect(screen.getByLabelText("Filter by Environment")).toBeVisible();
-      expect(screen.getByLabelText("Filter by status")).toBeVisible();
-      expect(screen.getByLabelText("Filter by ACL type")).toBeVisible();
+    it("renders a select to filter by environment with default", () => {
+      const select = screen.getByRole("combobox", {
+        name: "Filter by Environment",
+      });
+
+      expect(select).toBeVisible();
+      expect(select).toHaveDisplayValue("All environments");
+    });
+
+    it("renders a select to filter by status with default", () => {
+      const select = screen.getByRole("combobox", { name: "Filter by status" });
+
+      expect(select).toBeVisible();
+      expect(select).toHaveDisplayValue("Awaiting approval");
+    });
+
+    it("renders a select to filter by ACL type with default", () => {
+      const select = screen.getByRole("combobox", {
+        name: "Filter by ACL type",
+      });
+      expect(select).toBeVisible();
+      expect(select).toHaveDisplayValue("All ACL types");
+    });
+
+    it("renders a select to filter by environment with default", () => {
       expect(screen.getByRole("search")).toBeVisible();
     });
 

--- a/coral/src/app/features/approvals/acls/AclApprovals.tsx
+++ b/coral/src/app/features/approvals/acls/AclApprovals.tsx
@@ -30,8 +30,15 @@ import {
   getAclRequestsForApprover,
 } from "src/domain/acl/acl-api";
 import { AclRequest, AclRequestsForApprover } from "src/domain/acl/acl-types";
-import { RequestStatus } from "src/domain/requests/requests-types";
+import {
+  RequestOperationType,
+  RequestStatus,
+} from "src/domain/requests/requests-types";
 import { parseErrorMsg } from "src/services/mutation-utils";
+import {
+  requestOperationTypeChipStatusMap,
+  requestOperationTypeNameMap,
+} from "src/app/features/approvals/utils/request-operation-type-helper";
 
 interface AclRequestTableRow {
   id: number;
@@ -44,11 +51,13 @@ interface AclRequestTableRow {
   aclType: AclRequest["aclType"];
   username: string;
   requesttimestring: string;
-  // `requestStatus` is always defined from backend
+  // `requestStatus` and `requestOperationType` are
+  // always defined from backend
   // but api definition says it can be undefined
   // the empty string is used to make ts compiler
   // happy :D
   requestStatus: RequestStatus | "";
+  requestOperationType: RequestOperationType | "";
 }
 
 const getRows = (entries: AclRequest[] | undefined): AclRequestTableRow[] => {
@@ -68,6 +77,7 @@ const getRows = (entries: AclRequest[] | undefined): AclRequestTableRow[] => {
       username,
       requesttimestring,
       requestStatus,
+      requestOperationType,
     }) => ({
       id: Number(req_no),
       acl_ssl: acl_ssl ?? [],
@@ -80,6 +90,7 @@ const getRows = (entries: AclRequest[] | undefined): AclRequestTableRow[] => {
       username: username ?? "-",
       requesttimestring: requesttimestring ?? "-",
       requestStatus: requestStatus ?? "",
+      requestOperationType: requestOperationType ?? "",
     })
   );
 };
@@ -290,6 +301,23 @@ function AclApprovals() {
         return {
           status: requestStatusChipStatusMap[requestStatus],
           text: requestStatusNameMap[requestStatus],
+        };
+      },
+    },
+    {
+      type: "status",
+      field: "requestOperationType",
+      headerName: "Request type",
+      status: ({ requestOperationType }) => {
+        if (requestOperationType === "") {
+          return {
+            status: "neutral",
+            text: "-",
+          };
+        }
+        return {
+          status: requestOperationTypeChipStatusMap[requestOperationType],
+          text: requestOperationTypeNameMap[requestOperationType],
         };
       },
     },

--- a/coral/src/app/features/approvals/acls/hooks/useTableFilters.test.tsx
+++ b/coral/src/app/features/approvals/acls/hooks/useTableFilters.test.tsx
@@ -34,7 +34,7 @@ describe("useTableFilters.tsx", () => {
 
       expect(result.current.filters).toHaveLength(4);
     });
-    it("returns 'created' value by default for status state", () => {
+    it("returns 'CREATED' value by default for status state", () => {
       const { result } = renderHook(() => useTableFilters(), {
         wrapper,
       });

--- a/coral/src/app/features/approvals/schemas/SchemaApprovals.test.tsx
+++ b/coral/src/app/features/approvals/schemas/SchemaApprovals.test.tsx
@@ -198,20 +198,22 @@ describe("SchemaApprovals", () => {
       jest.clearAllMocks();
     });
 
-    it("shows a select to filter by environment", () => {
+    it("shows a select to filter by environment with default", () => {
       const select = screen.getByRole("combobox", {
         name: "Filter by Environment",
       });
 
       expect(select).toBeVisible();
+      expect(select).toHaveDisplayValue("All environments");
     });
 
-    it("shows a select to filter by status", () => {
+    it("shows a select to filter by status with default value", () => {
       const select = screen.getByRole("combobox", {
         name: "Filter by status",
       });
 
       expect(select).toBeVisible();
+      expect(select).toHaveDisplayValue("Awaiting approval");
     });
 
     it("shows a search input to search for topic names", () => {

--- a/coral/src/app/features/approvals/schemas/components/SchemaApprovalsTable.test.tsx
+++ b/coral/src/app/features/approvals/schemas/components/SchemaApprovalsTable.test.tsx
@@ -4,7 +4,11 @@ import { mockIntersectionObserver } from "src/services/test-utils/mock-intersect
 import { SchemaRequest } from "src/domain/schema-request";
 import { requestStatusNameMap } from "src/app/features/approvals/utils/request-status-helper";
 import userEvent from "@testing-library/user-event";
-import { RequestStatus } from "src/domain/requests/requests-types";
+import {
+  RequestOperationType,
+  RequestStatus,
+} from "src/domain/requests/requests-types";
+import { requestOperationTypeNameMap } from "src/app/features/approvals/utils/request-operation-type-helper";
 
 const mockedRequests: SchemaRequest[] = [
   {
@@ -75,6 +79,7 @@ describe("SchemaApprovalsTable", () => {
     { columnHeader: "Topic", relatedField: "topicname" },
     { columnHeader: "Environment", relatedField: "environmentName" },
     { columnHeader: "Status", relatedField: "requestStatus" },
+    { columnHeader: "Request type", relatedField: "requestOperationType" },
     { columnHeader: "Requested by", relatedField: "username" },
     { columnHeader: "Date requested", relatedField: "requesttimestring" },
     { columnHeader: "Details", relatedField: null },
@@ -226,8 +231,13 @@ describe("SchemaApprovalsTable", () => {
             if (column.columnHeader === "Date requested") {
               text = `${field}${"\u00A0"}UTC`;
             }
+
             if (column.columnHeader === "Status") {
               text = requestStatusNameMap[field as RequestStatus];
+            }
+
+            if (column.columnHeader === "Request type") {
+              text = requestOperationTypeNameMap[field as RequestOperationType];
             }
             const cell = within(table).getByRole("cell", { name: text });
 

--- a/coral/src/app/features/approvals/schemas/components/SchemaApprovalsTable.tsx
+++ b/coral/src/app/features/approvals/schemas/components/SchemaApprovalsTable.tsx
@@ -14,6 +14,10 @@ import {
 } from "src/app/features/approvals/utils/request-status-helper";
 import { Dispatch, SetStateAction, useState } from "react";
 import loadingIcon from "@aivenio/aquarium/icons/loading";
+import {
+  requestOperationTypeChipStatusMap,
+  requestOperationTypeNameMap,
+} from "src/app/features/approvals/utils/request-operation-type-helper";
 
 interface SchemaRequestTableData {
   id: SchemaRequest["req_no"];
@@ -22,6 +26,7 @@ interface SchemaRequestTableData {
   username: SchemaRequest["username"];
   requesttimestring: SchemaRequest["requesttimestring"];
   requestStatus: SchemaRequest["requestStatus"];
+  requestOperationType: SchemaRequest["requestOperationType"];
 }
 
 type SchemaApprovalsTableProps = {
@@ -59,6 +64,17 @@ function SchemaApprovalsTable(props: SchemaApprovalsTableProps) {
         return {
           status: requestStatusChipStatusMap[requestStatus],
           text: requestStatusNameMap[requestStatus],
+        };
+      },
+    },
+    {
+      type: "status",
+      field: "requestOperationType",
+      headerName: "Request type",
+      status: ({ requestOperationType }) => {
+        return {
+          status: requestOperationTypeChipStatusMap[requestOperationType],
+          text: requestOperationTypeNameMap[requestOperationType],
         };
       },
     },
@@ -149,6 +165,7 @@ function SchemaApprovalsTable(props: SchemaApprovalsTableProps) {
         username: request.username,
         requesttimestring: request.requesttimestring,
         requestStatus: request.requestStatus,
+        requestOperationType: request.requestOperationType,
       };
     }
   );

--- a/coral/src/app/features/approvals/schemas/hooks/useTableFilters.test.tsx
+++ b/coral/src/app/features/approvals/schemas/hooks/useTableFilters.test.tsx
@@ -35,7 +35,7 @@ describe("useTableFilters.tsx", () => {
       expect(result.current.filters).toHaveLength(3);
     });
 
-    it("returns 'created' value by default for environment state", () => {
+    it("returns 'ALL' value by default for environment state", () => {
       const { result } = renderHook(() => useTableFilters(), {
         wrapper,
       });
@@ -43,7 +43,7 @@ describe("useTableFilters.tsx", () => {
       expect(result.current.environment).toBe("ALL");
     });
 
-    it("returns 'ALL' value by default for status state", () => {
+    it("returns 'CREATED' value by default for status state", () => {
       const { result } = renderHook(() => useTableFilters(), {
         wrapper,
       });

--- a/coral/src/app/features/approvals/topics/TopicApprovals.test.tsx
+++ b/coral/src/app/features/approvals/topics/TopicApprovals.test.tsx
@@ -208,26 +208,29 @@ describe("TopicApprovals", () => {
       jest.clearAllMocks();
     });
 
-    it("shows a select to filter by teams", () => {
+    it("shows a select to filter by teams with default", () => {
       const select = screen.getByRole("combobox", { name: "Filter by team" });
 
       expect(select).toBeVisible();
+      expect(select).toHaveDisplayValue("All teams");
     });
 
-    it("shows a select to filter by environment", () => {
+    it("shows a select to filter by environment with default", () => {
       const select = screen.getByRole("combobox", {
         name: "Filter by Environment",
       });
 
       expect(select).toBeVisible();
+      expect(select).toHaveDisplayValue("All environments");
     });
 
-    it("shows a select to filter by status", () => {
+    it("shows a select to filter by status with default", () => {
       const select = screen.getByRole("combobox", {
         name: "Filter by status",
       });
 
       expect(select).toBeVisible();
+      expect(select).toHaveDisplayValue("Awaiting approval");
     });
 
     it("shows a search input to search for topic names", () => {

--- a/coral/src/app/features/approvals/topics/components/TopicApprovalsTable.test.tsx
+++ b/coral/src/app/features/approvals/topics/components/TopicApprovalsTable.test.tsx
@@ -79,7 +79,7 @@ describe("TopicApprovalsTable", () => {
     { columnHeader: "Topic", relatedField: "topicname" },
     { columnHeader: "Environment", relatedField: "environmentName" },
     { columnHeader: "Status", relatedField: "requestStatus" },
-    { columnHeader: "Claim by team", relatedField: "teamname" },
+    { columnHeader: "Team", relatedField: "teamname" },
     { columnHeader: "Requested by", relatedField: "requestor" },
     { columnHeader: "Requested on", relatedField: "requesttimestring" },
     { columnHeader: "", relatedField: null },

--- a/coral/src/app/features/approvals/topics/components/TopicApprovalsTable.test.tsx
+++ b/coral/src/app/features/approvals/topics/components/TopicApprovalsTable.test.tsx
@@ -4,7 +4,11 @@ import { TopicApprovalsTable } from "src/app/features/approvals/topics/component
 import { TopicRequest } from "src/domain/topic";
 import { mockIntersectionObserver } from "src/services/test-utils/mock-intersection-observer";
 import { requestStatusNameMap } from "src/app/features/approvals/utils/request-status-helper";
-import { RequestStatus } from "src/domain/requests/requests-types";
+import {
+  RequestOperationType,
+  RequestStatus,
+} from "src/domain/requests/requests-types";
+import { requestOperationTypeNameMap } from "src/app/features/approvals/utils/request-operation-type-helper";
 
 const mockedSetDetailsModal = jest.fn();
 const mockedSetDeclineModal = jest.fn();
@@ -79,6 +83,7 @@ describe("TopicApprovalsTable", () => {
     { columnHeader: "Topic", relatedField: "topicname" },
     { columnHeader: "Environment", relatedField: "environmentName" },
     { columnHeader: "Status", relatedField: "requestStatus" },
+    { columnHeader: "Request type", relatedField: "requestOperationType" },
     { columnHeader: "Team", relatedField: "teamname" },
     { columnHeader: "Requested by", relatedField: "requestor" },
     { columnHeader: "Requested on", relatedField: "requesttimestring" },
@@ -216,6 +221,10 @@ describe("TopicApprovalsTable", () => {
 
             if (column.columnHeader === "Status") {
               text = requestStatusNameMap[field as RequestStatus];
+            }
+
+            if (column.columnHeader === "Request type") {
+              text = requestOperationTypeNameMap[field as RequestOperationType];
             }
             const cell = within(table).getByRole("cell", { name: text });
 

--- a/coral/src/app/features/approvals/topics/components/TopicApprovalsTable.tsx
+++ b/coral/src/app/features/approvals/topics/components/TopicApprovalsTable.tsx
@@ -79,7 +79,7 @@ function TopicApprovalsTable(props: TopicApprovalsTableProp) {
         };
       },
     },
-    { type: "text", field: "teamname", headerName: "Claim by team" },
+    { type: "text", field: "teamname", headerName: "Team" },
     { type: "text", field: "requestor", headerName: "Requested by" },
     {
       type: "text",

--- a/coral/src/app/features/approvals/topics/components/TopicApprovalsTable.tsx
+++ b/coral/src/app/features/approvals/topics/components/TopicApprovalsTable.tsx
@@ -16,12 +16,17 @@ import {
   requestStatusChipStatusMap,
   requestStatusNameMap,
 } from "src/app/features/approvals/utils/request-status-helper";
+import {
+  requestOperationTypeChipStatusMap,
+  requestOperationTypeNameMap,
+} from "src/app/features/approvals/utils/request-operation-type-helper";
 
 interface TopicRequestTableRow {
   id: TopicRequest["topicid"];
   topicname: TopicRequest["topicname"];
   environmentName: TopicRequest["environmentName"];
   requestStatus: TopicRequest["requestStatus"];
+  requestOperationType: TopicRequest["requestOperationType"];
   teamname: TopicRequest["teamname"];
   requestor: TopicRequest["requestor"];
   requesttimestring: TopicRequest["requesttimestring"];
@@ -76,6 +81,17 @@ function TopicApprovalsTable(props: TopicApprovalsTableProp) {
         return {
           status: requestStatusChipStatusMap[requestStatus],
           text: requestStatusNameMap[requestStatus],
+        };
+      },
+    },
+    {
+      type: "status",
+      field: "requestOperationType",
+      headerName: "Request type",
+      status: ({ requestOperationType }) => {
+        return {
+          status: requestOperationTypeChipStatusMap[requestOperationType],
+          text: requestOperationTypeNameMap[requestOperationType],
         };
       },
     },
@@ -176,6 +192,7 @@ function TopicApprovalsTable(props: TopicApprovalsTableProp) {
       topicname: request.topicname,
       environmentName: request.environmentName,
       requestStatus: request.requestStatus,
+      requestOperationType: request.requestOperationType,
       teamname: request.teamname,
       requestor: request.requestor,
       requesttimestring: request.requesttimestring,

--- a/coral/src/app/features/approvals/topics/hooks/useTableFilters.test.tsx
+++ b/coral/src/app/features/approvals/topics/hooks/useTableFilters.test.tsx
@@ -34,7 +34,7 @@ describe("useTableFilters.tsx", () => {
 
       expect(result.current.filters).toHaveLength(4);
     });
-    it("returns 'created' value by default for status state", () => {
+    it("returns 'CREATED' value by default for status state", () => {
       const { result } = renderHook(() => useTableFilters(), {
         wrapper,
       });

--- a/coral/src/app/features/approvals/utils/request-operation-type-helper.ts
+++ b/coral/src/app/features/approvals/utils/request-operation-type-helper.ts
@@ -1,0 +1,40 @@
+import { RequestOperationType } from "src/domain/requests/requests-types";
+import { ChipStatus } from "@aivenio/aquarium";
+
+// @TODO a nice improvement would be to
+// have a more typesafe / exhaustive list
+// here TS won't complain if a possible
+// value is missing from the array.
+const operationTypeList: RequestOperationType[] = [
+  "CLAIM",
+  "CREATE",
+  "DELETE",
+  "PROMOTE",
+  "UPDATE",
+];
+
+const requestOperationTypeChipStatusMap: {
+  [key in RequestOperationType]: ChipStatus;
+} = {
+  CLAIM: "neutral",
+  CREATE: "neutral",
+  DELETE: "neutral",
+  PROMOTE: "neutral",
+  UPDATE: "neutral",
+};
+
+const requestOperationTypeNameMap: {
+  [key in RequestOperationType]: string;
+} = {
+  CLAIM: "Claim",
+  CREATE: "Create",
+  DELETE: "Delete",
+  PROMOTE: "Promote",
+  UPDATE: "Update",
+};
+
+export {
+  operationTypeList,
+  requestOperationTypeChipStatusMap,
+  requestOperationTypeNameMap,
+};

--- a/coral/src/app/features/approvals/utils/request-status-helper.ts
+++ b/coral/src/app/features/approvals/utils/request-status-helper.ts
@@ -26,7 +26,7 @@ const requestStatusNameMap: {
 } = {
   ALL: "All statuses",
   APPROVED: "Approved",
-  CREATED: "Created",
+  CREATED: "Open",
   DECLINED: "Declined",
   DELETED: "Deleted",
 };

--- a/coral/src/app/features/approvals/utils/request-status-helper.ts
+++ b/coral/src/app/features/approvals/utils/request-status-helper.ts
@@ -26,7 +26,7 @@ const requestStatusNameMap: {
 } = {
   ALL: "All statuses",
   APPROVED: "Approved",
-  CREATED: "Open",
+  CREATED: "Awaiting approval",
   DECLINED: "Declined",
   DELETED: "Deleted",
 };

--- a/coral/types/api.d.ts
+++ b/coral/types/api.d.ts
@@ -696,6 +696,7 @@ export type components = {
       /** @example 10-11-2020 10:45:30 */
       requesttimestring?: string;
       requestStatus?: components["schemas"]["RequestStatus"];
+      requestOperationType?: components["schemas"]["RequestOperationType"];
       approver?: string;
       /**
        * Format: date-time

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1291,6 +1291,8 @@ components:
           example: "10-11-2020 10:45:30"
         requestStatus:
           $ref: "#/components/schemas/RequestStatus"
+        requestOperationType:
+          $ref: "#/components/schemas/RequestOperationType"
         approver:
           type: string
         approvingtime:


### PR DESCRIPTION
# About this change - What it does
- adds a request operation type helper
- chip colour is neutral (for now)
- update type for AclRequest 
- add request types to all tables 
- rename string representation for CREATED status to "Open"
- rename "Claim by team" to "Team" in topics approval table

Resolves: #753


## Screenshots
<img width="1728" alt="Screenshot 2023-03-02 at 17 22 08" src="https://user-images.githubusercontent.com/943800/222488654-d8196576-bdad-4bcc-8fd3-c2901c5ceaf4.png">

<img width="1728" alt="Screenshot 2023-03-02 at 17 22 15" src="https://user-images.githubusercontent.com/943800/222488643-181ad7d7-e486-4a87-9ebe-4aa4fddf81ae.png">

<img width="1726" alt="Screenshot 2023-03-02 at 17 22 01" src="https://user-images.githubusercontent.com/943800/222488659-7dd5d281-f837-4555-900f-4ddc6e731e49.png">
