### PR TITLE
Update the version to 2.1.0 from 2.0.0 for a minor Klaw release.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-version = 2.0.0
+version = 2.1.0
 
 # Sets a custom hook path in the local git config.
 # Currently there's only a pre-commit hook related

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ For the versions available, see the [tags on this repository](https://github.com
 
 - Topics (approval): Create, Update, Delete, Promote
   - React UI - New look and feel for Browse topics, Create topic Request
+  - React UI - New look and feel for Approving topics, ACLs, Schemas
   
 - Acls (approval):  Create,Delete
   - React UI - Create Acl Request 
@@ -62,6 +63,7 @@ For the versions available, see the [tags on this repository](https://github.com
   - Configurable users, teams
   - More than 35 permissions
   - Configurable roles (Roles can be pulled from AD for authorization)
+  - Ability to switch between different teams
 
 - Topic naming conventions
   - Enforce prefix and suffixes per environment

--- a/cluster-api/pom.xml
+++ b/cluster-api/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>io.aiven</groupId>
         <artifactId>klaw-project</artifactId>
-        <version>2.0.0</version>
+        <version>2.1.0</version>
     </parent>
 
     <artifactId>cluster-api</artifactId>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>io.aiven</groupId>
         <artifactId>klaw-project</artifactId>
-        <version>2.0.0</version>
+        <version>2.1.0</version>
     </parent>
 
     <artifactId>klaw</artifactId>

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1,7 +1,7 @@
 openapi: 3.0.3
 info:
   title: Klaw - OpenAPI
-  version: 1.0.0
+  version: 2.1.0
   description: >
     This specification is still a work in progress and is not yet implemented in any API. The purpose of this
     specification is to facilitate developers discussions.

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>io.aiven</groupId>
     <artifactId>klaw-project</artifactId>
-    <version>2.0.0</version>
+    <version>2.1.0</version>
     <packaging>pom</packaging>
     <name>Klaw Project</name>
     <description>Aiven Klaw - Selfservice, Governance for Kafka</description>


### PR DESCRIPTION
About this change - What it does
Update the version to 2.1.0 from 2.0.0 for a minor Klaw release.
Resolves: #xxxxx
Why this way
This will version Klaw jar files for users.