### PR TITLE
Add jakarta mail dependency to enable email

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -37,6 +37,13 @@
     </properties>
 
     <dependencies>
+
+        <dependency>
+            <groupId>com.sun.mail</groupId>
+            <artifactId>jakarta.mail</artifactId>
+            <version>2.0.1</version>
+        </dependency>
+
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-thymeleaf</artifactId>


### PR DESCRIPTION
About this change - What it does
The jakara stream provider is missing without this dependency preventing emails from sending.
Resolves: #xxxxx
Why this way
