### PR TITLE
feat(coral): Add routes for the requests views #768, #771, #766

### DIFF
--- a/coral/src/app/features/requests/components/RequestResourcesTabs.test.tsx
+++ b/coral/src/app/features/requests/components/RequestResourcesTabs.test.tsx
@@ -1,0 +1,59 @@
+import { cleanup, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import RequestsResourceTabs from "src/app/features/requests/components/RequestsResourceTabs";
+import { RequestsTabEnum } from "src/app/router_utils";
+import { customRender } from "src/services/test-utils/render-with-wrappers";
+
+const mockedNavigate = jest.fn();
+jest.mock("react-router-dom", () => ({
+  ...jest.requireActual("react-router-dom"),
+  useNavigate: () => mockedNavigate,
+}));
+
+describe("RequestResourcesTabs", () => {
+  let user: ReturnType<typeof userEvent.setup>;
+
+  describe("Tab navigation", () => {
+    beforeEach(() => {
+      user = userEvent.setup();
+      customRender(
+        <RequestsResourceTabs currentTab={RequestsTabEnum.TOPICS} />,
+        { memoryRouter: true }
+      );
+    });
+
+    afterEach(() => {
+      cleanup();
+      mockedNavigate.mockReset();
+    });
+
+    it('navigates to correct URL when "ACLs" tab is clicked', async () => {
+      await user.click(screen.getByRole("tab", { name: "ACL requests" }));
+      expect(mockedNavigate).toHaveBeenCalledWith("/requests/acls", {
+        replace: true,
+      });
+    });
+
+    it('navigates to correct URL when "Topics" tab is clicked', async () => {
+      await user.click(screen.getByRole("tab", { name: "Topic requests" }));
+      expect(mockedNavigate).toHaveBeenCalledWith("/requests/topics", {
+        replace: true,
+      });
+    });
+
+    it('navigates to correct URL when "Schemas" tab is clicked', async () => {
+      await user.click(screen.getByRole("tab", { name: "Schema requests" }));
+      expect(mockedNavigate).toHaveBeenCalledWith("/requests/schemas", {
+        replace: true,
+      });
+    });
+    // Tab is disabled because Connectors are not yet implemented in coral
+    // @TODO uncomment test when Connectors are implemented
+    // it('navigates to correct URL when "Connectors" tab is clicked', async () => {
+    //   await user.click(screen.getByRole("tab", { name: "Connectors" }));
+    //   expect(mockedNavigate).toHaveBeenCalledWith("/requests/connectors", {
+    //     replace: true,
+    //   });
+    // });
+  });
+});

--- a/coral/src/app/features/requests/components/RequestsResourceTabs.tsx
+++ b/coral/src/app/features/requests/components/RequestsResourceTabs.tsx
@@ -1,0 +1,65 @@
+import { Tabs } from "@aivenio/aquarium";
+import { NavigateFunction, Outlet, useNavigate } from "react-router-dom";
+import {
+  RequestsTabEnum,
+  isRequestsTabEnum,
+  REQUESTS_TAB_ID_INTO_PATH,
+} from "src/app/router_utils";
+
+type Props = {
+  currentTab: RequestsTabEnum;
+};
+
+function RequestsResourceTabs({ currentTab }: Props) {
+  const navigate = useNavigate();
+
+  return (
+    <Tabs
+      value={currentTab}
+      onChange={(resourceTypeId) => navigateToTab(navigate, resourceTypeId)}
+    >
+      <Tabs.Tab
+        title="Topics"
+        value={RequestsTabEnum.TOPICS}
+        aria-label={"Topic requests"}
+      >
+        {currentTab === RequestsTabEnum.TOPICS && <Outlet />}
+      </Tabs.Tab>
+      <Tabs.Tab
+        title="ACLs"
+        value={RequestsTabEnum.ACLS}
+        aria-label={"ACL requests"}
+      >
+        {currentTab === RequestsTabEnum.ACLS && <Outlet />}
+      </Tabs.Tab>
+      <Tabs.Tab
+        title="Schemas"
+        value={RequestsTabEnum.SCHEMAS}
+        aria-label={"Schema requests"}
+      >
+        {currentTab === RequestsTabEnum.SCHEMAS && <Outlet />}
+      </Tabs.Tab>
+      <Tabs.Tab
+        title="Connectors (coming soon)"
+        value={RequestsTabEnum.CONNECTORS}
+        aria-label={"Connector requests"}
+        disabled
+      >
+        {currentTab === RequestsTabEnum.CONNECTORS && <Outlet />}
+      </Tabs.Tab>
+    </Tabs>
+  );
+
+  function navigateToTab(
+    navigate: NavigateFunction,
+    resourceTypeId: unknown
+  ): void {
+    if (isRequestsTabEnum(resourceTypeId)) {
+      navigate(`/requests/${REQUESTS_TAB_ID_INTO_PATH[resourceTypeId]}`, {
+        replace: true,
+      });
+    }
+  }
+}
+
+export default RequestsResourceTabs;

--- a/coral/src/app/layout/main-navigation/MainNavigation.tsx
+++ b/coral/src/app/layout/main-navigation/MainNavigation.tsx
@@ -46,8 +46,9 @@ function MainNavigation() {
               }
             />
             <MainNavigationLink
-              to={`/myTopicRequests`}
               linkText={"My team's requests"}
+              to={Routes.REQUESTS}
+              active={pathname.startsWith(Routes.REQUESTS)}
             />
           </MainNavigationSubmenuList>
         </li>

--- a/coral/src/app/pages/requests/acls/index.tsx
+++ b/coral/src/app/pages/requests/acls/index.tsx
@@ -1,0 +1,5 @@
+const AclRequestsPage = () => {
+  return <></>;
+};
+
+export default AclRequestsPage;

--- a/coral/src/app/pages/requests/connectors/index.tsx
+++ b/coral/src/app/pages/requests/connectors/index.tsx
@@ -1,0 +1,5 @@
+const ConnectorRequestsPage = () => {
+  return <></>;
+};
+
+export default ConnectorRequestsPage;

--- a/coral/src/app/pages/requests/index.tsx
+++ b/coral/src/app/pages/requests/index.tsx
@@ -1,0 +1,43 @@
+import { PageHeader } from "@aivenio/aquarium";
+import { Navigate, useMatches } from "react-router-dom";
+import AuthenticationRequiredBoundary from "src/app/components/AuthenticationRequiredBoundary";
+import RequestsResourceTabs from "src/app/features/requests/components/RequestsResourceTabs";
+import Layout from "src/app/layout/Layout";
+import {
+  RequestsTabEnum,
+  REQUESTS_TAB_ID_INTO_PATH,
+  isRequestsTabEnum,
+} from "src/app/router_utils";
+
+const RequestsPage = () => {
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  const matches = useMatches();
+  const currentTab = findMatchingTab(matches);
+  if (currentTab === undefined) {
+    return <Navigate to={`/requests/topics`} replace={true} />;
+  }
+  return (
+    <AuthenticationRequiredBoundary>
+      <Layout>
+        <PageHeader title={"My team's requests"} />
+        <RequestsResourceTabs currentTab={currentTab} />
+      </Layout>
+    </AuthenticationRequiredBoundary>
+  );
+
+  function findMatchingTab(
+    matches: ReturnType<typeof useMatches>
+  ): RequestsTabEnum | undefined {
+    const match = matches
+      .map((match) => match.id)
+      .find((id) =>
+        Object.prototype.hasOwnProperty.call(REQUESTS_TAB_ID_INTO_PATH, id)
+      );
+    if (isRequestsTabEnum(match)) {
+      return match;
+    }
+    return undefined;
+  }
+};
+
+export default RequestsPage;

--- a/coral/src/app/pages/requests/schemas/index.tsx
+++ b/coral/src/app/pages/requests/schemas/index.tsx
@@ -1,0 +1,5 @@
+const SchemaRequestsPage = () => {
+  return <></>;
+};
+
+export default SchemaRequestsPage;

--- a/coral/src/app/pages/requests/topics/index.tsx
+++ b/coral/src/app/pages/requests/topics/index.tsx
@@ -1,0 +1,5 @@
+const TopicRequestsPage = () => {
+  return <></>;
+};
+
+export default TopicRequestsPage;

--- a/coral/src/app/router.tsx
+++ b/coral/src/app/router.tsx
@@ -2,6 +2,11 @@ import { createBrowserRouter, RouteObject } from "react-router-dom";
 import NotFound from "src/app/pages/not-found";
 import Topics from "src/app/pages/topics";
 import AclRequest from "src/app/pages/topics/acl-request";
+import RequestsPage from "src/app/pages/requests";
+import TopicRequestsPage from "src/app/pages/requests/topics";
+import AclRequestsPage from "src/app/pages/requests/acls";
+import SchemaRequestsPage from "src/app/pages/requests/schemas";
+import ConnectorRequestsPage from "src/app/pages/requests/connectors";
 import ApprovalsPage from "src/app/pages/approvals";
 import TopicApprovalsPage from "src/app/pages/approvals/topics";
 import AclApprovalsPage from "src/app/pages/approvals/acls";
@@ -13,7 +18,9 @@ import SchemaRequest from "src/app/pages/topics/schema-request";
 import {
   APPROVALS_TAB_ID_INTO_PATH,
   ApprovalsTabEnum,
+  RequestsTabEnum,
   Routes,
+  REQUESTS_TAB_ID_INTO_PATH,
 } from "src/app/router_utils";
 
 const routes: Array<RouteObject> = [
@@ -37,6 +44,32 @@ const routes: Array<RouteObject> = [
   {
     path: Routes.TOPIC_SCHEMA_REQUEST,
     element: <SchemaRequest />,
+  },
+  {
+    path: Routes.REQUESTS,
+    element: <RequestsPage />,
+    children: [
+      {
+        path: REQUESTS_TAB_ID_INTO_PATH[RequestsTabEnum.TOPICS],
+        element: <TopicRequestsPage />,
+        id: RequestsTabEnum.TOPICS,
+      },
+      {
+        path: REQUESTS_TAB_ID_INTO_PATH[RequestsTabEnum.ACLS],
+        element: <AclRequestsPage />,
+        id: RequestsTabEnum.ACLS,
+      },
+      {
+        path: REQUESTS_TAB_ID_INTO_PATH[RequestsTabEnum.SCHEMAS],
+        element: <SchemaRequestsPage />,
+        id: RequestsTabEnum.SCHEMAS,
+      },
+      {
+        path: REQUESTS_TAB_ID_INTO_PATH[RequestsTabEnum.CONNECTORS],
+        element: <ConnectorRequestsPage />,
+        id: RequestsTabEnum.CONNECTORS,
+      },
+    ],
   },
   {
     path: Routes.APPROVALS,

--- a/coral/src/app/router_utils.ts
+++ b/coral/src/app/router_utils.ts
@@ -5,7 +5,15 @@ enum Routes {
   TOPIC_REQUEST = "/topics/request",
   TOPIC_ACL_REQUEST = "/topic/:topicName/subscribe",
   TOPIC_SCHEMA_REQUEST = "/topic/:topicName/request-schema",
+  REQUESTS = "/requests",
   APPROVALS = "/approvals",
+}
+
+enum RequestsTabEnum {
+  TOPICS = "REQUESTS_TAB_ENUM_topics",
+  ACLS = "REQUESTS_TAB_ENUM_acls",
+  SCHEMAS = "REQUESTS_TAB_ENUM_schemas",
+  CONNECTORS = "REQUESTS_TAB_ENUM_connectors",
 }
 
 enum ApprovalsTabEnum {
@@ -15,12 +23,29 @@ enum ApprovalsTabEnum {
   CONNECTORS = "APPROVALS_TAB_ENUM_connectors",
 }
 
+const REQUESTS_TAB_ID_INTO_PATH = {
+  [RequestsTabEnum.TOPICS]: "topics",
+  [RequestsTabEnum.ACLS]: "acls",
+  [RequestsTabEnum.SCHEMAS]: "schemas",
+  [RequestsTabEnum.CONNECTORS]: "connectors",
+} as const;
+
 const APPROVALS_TAB_ID_INTO_PATH = {
   [ApprovalsTabEnum.TOPICS]: "topics",
   [ApprovalsTabEnum.ACLS]: "acls",
   [ApprovalsTabEnum.SCHEMAS]: "schemas",
   [ApprovalsTabEnum.CONNECTORS]: "connectors",
 } as const;
+
+function isRequestsTabEnum(value: unknown): value is RequestsTabEnum {
+  if (isString(value)) {
+    return Object.prototype.hasOwnProperty.call(
+      REQUESTS_TAB_ID_INTO_PATH,
+      value
+    );
+  }
+  return false;
+}
 
 function isApprovalsTabEnum(value: unknown): value is ApprovalsTabEnum {
   if (isString(value)) {
@@ -33,8 +58,11 @@ function isApprovalsTabEnum(value: unknown): value is ApprovalsTabEnum {
 }
 
 export {
+  RequestsTabEnum,
   ApprovalsTabEnum,
   Routes,
+  REQUESTS_TAB_ID_INTO_PATH,
   APPROVALS_TAB_ID_INTO_PATH,
+  isRequestsTabEnum,
   isApprovalsTabEnum,
 };


### PR DESCRIPTION
Implement routing and empty views to initialize
my requests view in order to enable work on
the subviews.

~~Note*: Did not add test file for `RequestResourcesTab.tsx` yet since there is not really much to test. If requested though i guess we can add similar tab checks like in `ApprovalResourcesTab.test.tsx` for now.~~

Resolves #768
Resolves #771
Resolves #766

![Screenshot from 2023-03-07 11-54-27](https://user-images.githubusercontent.com/15416578/223387294-90cf9771-d0d9-4f55-89c3-735a28641bec.png)

