### PR TITLE
refactor(coral): Make ApprovalsLayout reusable as TableLayout

### DIFF
--- a/coral/src/app/features/approvals/acls/AclApprovals.tsx
+++ b/coral/src/app/features/approvals/acls/AclApprovals.tsx
@@ -5,7 +5,7 @@ import { useSearchParams } from "react-router-dom";
 import { Pagination } from "src/app/components/Pagination";
 import AclApprovalsTable from "src/app/features/approvals/acls/components/AclApprovalsTable";
 import DetailsModalContent from "src/app/features/approvals/acls/components/DetailsModalContent";
-import { ApprovalsLayout } from "src/app/features/approvals/components/ApprovalsLayout";
+import { TableLayout } from "src/app/features/components/layouts/TableLayout";
 import RequestDeclineModal from "src/app/features/approvals/components/RequestDeclineModal";
 import RequestDetailsModal from "src/app/features/approvals/components/RequestDetailsModal";
 import AclTypeFilter from "src/app/features/components/table-filters/AclTypeFilter";
@@ -216,7 +216,7 @@ function AclApprovals() {
         </div>
       )}
 
-      <ApprovalsLayout
+      <TableLayout
         filters={[
           <EnvironmentFilter key={"environment"} />,
           <StatusFilter key={"status"} />,

--- a/coral/src/app/features/approvals/schemas/SchemaApprovals.tsx
+++ b/coral/src/app/features/approvals/schemas/SchemaApprovals.tsx
@@ -3,7 +3,7 @@ import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { useState } from "react";
 import { useSearchParams } from "react-router-dom";
 import { Pagination } from "src/app/components/Pagination";
-import { ApprovalsLayout } from "src/app/features/approvals/components/ApprovalsLayout";
+import { TableLayout } from "src/app/features/components/layouts/TableLayout";
 import RequestDeclineModal from "src/app/features/approvals/components/RequestDeclineModal";
 import RequestDetailsModal from "src/app/features/approvals/components/RequestDetailsModal";
 import SchemaApprovalsTable from "src/app/features/approvals/schemas/components/SchemaApprovalsTable";
@@ -210,7 +210,7 @@ function SchemaApprovals() {
           <Alert type="error">{errorQuickActions}</Alert>
         </div>
       )}
-      <ApprovalsLayout
+      <TableLayout
         filters={[
           <EnvironmentFilter
             key={"environment"}

--- a/coral/src/app/features/approvals/topics/TopicApprovals.tsx
+++ b/coral/src/app/features/approvals/topics/TopicApprovals.tsx
@@ -3,7 +3,7 @@ import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { useState } from "react";
 import { useSearchParams } from "react-router-dom";
 import { Pagination } from "src/app/components/Pagination";
-import { ApprovalsLayout } from "src/app/features/approvals/components/ApprovalsLayout";
+import { TableLayout } from "src/app/features/components/layouts/TableLayout";
 import RequestDeclineModal from "src/app/features/approvals/components/RequestDeclineModal";
 import RequestDetailsModal from "src/app/features/approvals/components/RequestDetailsModal";
 import DetailsModalContent from "src/app/features/approvals/topics/components/DetailsModalContent";
@@ -241,7 +241,7 @@ function TopicApprovals() {
           <Alert type="error">{errorMessage}</Alert>
         </div>
       )}
-      <ApprovalsLayout
+      <TableLayout
         filters={[
           <EnvironmentFilter key={"environment"} />,
           <StatusFilter key={"status"} />,

--- a/coral/src/app/features/components/layouts/TableLayout.test.tsx
+++ b/coral/src/app/features/components/layouts/TableLayout.test.tsx
@@ -1,4 +1,4 @@
-import { ApprovalsLayout } from "src/app/features/approvals/components/ApprovalsLayout";
+import { TableLayout } from "src/app/features/components/layouts/TableLayout";
 import { cleanup, render, screen } from "@testing-library/react";
 
 const mockFilter = [
@@ -13,10 +13,10 @@ const mockTable = <div data-testid={"table-element"}>Table content</div>;
 
 const mockPagination = <div data-testid={"pagination"} />;
 
-describe("ApprovalsLayout", () => {
+describe("TableLayout", () => {
   describe("renders all necessary elements with required props", () => {
     beforeAll(() => {
-      render(<ApprovalsLayout filters={mockFilter} table={mockTable} />);
+      render(<TableLayout filters={mockFilter} table={mockTable} />);
     });
     afterAll(cleanup);
 
@@ -48,7 +48,7 @@ describe("ApprovalsLayout", () => {
     afterEach(cleanup);
 
     it("does not render a pagination element by default", () => {
-      render(<ApprovalsLayout filters={mockFilter} table={mockTable} />);
+      render(<TableLayout filters={mockFilter} table={mockTable} />);
       const pagination = screen.queryByTestId("pagination");
 
       expect(pagination).not.toBeInTheDocument();
@@ -56,7 +56,7 @@ describe("ApprovalsLayout", () => {
 
     it("renders pagination if prop is set", () => {
       render(
-        <ApprovalsLayout
+        <TableLayout
           filters={mockFilter}
           table={mockTable}
           pagination={mockPagination}
@@ -73,11 +73,7 @@ describe("ApprovalsLayout", () => {
 
     it("shows a loading state instead of the table", () => {
       render(
-        <ApprovalsLayout
-          filters={mockFilter}
-          table={mockTable}
-          isLoading={true}
-        />
+        <TableLayout filters={mockFilter} table={mockTable} isLoading={true} />
       );
 
       const table = screen.queryByRole("table");
@@ -89,7 +85,7 @@ describe("ApprovalsLayout", () => {
 
     it("shows an error message instead of the table", () => {
       render(
-        <ApprovalsLayout
+        <TableLayout
           filters={mockFilter}
           table={mockTable}
           isErrorLoading={true}
@@ -111,14 +107,14 @@ describe("ApprovalsLayout", () => {
     afterEach(cleanup);
 
     it("renders correct DOM with required props", () => {
-      render(<ApprovalsLayout filters={mockFilter} table={mockTable} />);
+      render(<TableLayout filters={mockFilter} table={mockTable} />);
 
       expect(screen).toMatchSnapshot();
     });
 
     it("renders correct DOM with optional pagination", () => {
       render(
-        <ApprovalsLayout
+        <TableLayout
           filters={mockFilter}
           table={mockTable}
           pagination={mockPagination}

--- a/coral/src/app/features/components/layouts/TableLayout.tsx
+++ b/coral/src/app/features/components/layouts/TableLayout.tsx
@@ -3,7 +3,7 @@ import { ReactElement } from "react";
 import SkeletonTable from "src/app/features/approvals/SkeletonTable";
 import { parseErrorMsg } from "src/services/mutation-utils";
 
-type ApprovalsLayoutProps = {
+type TableLayoutProps = {
   isLoading?: boolean;
   isErrorLoading?: boolean;
   errorMessage?: unknown;
@@ -12,7 +12,7 @@ type ApprovalsLayoutProps = {
   pagination?: ReactElement;
 };
 
-function ApprovalsLayout(props: ApprovalsLayoutProps) {
+function TableLayout(props: TableLayoutProps) {
   const { filters, table, pagination, isLoading, isErrorLoading } = props;
 
   const errorMessage = parseErrorMsg(props.errorMessage);
@@ -58,4 +58,4 @@ function ApprovalsLayout(props: ApprovalsLayoutProps) {
   );
 }
 
-export { ApprovalsLayout };
+export { TableLayout };

--- a/coral/src/app/features/components/layouts/__snapshots__/TableLayout.test.tsx.snap
+++ b/coral/src/app/features/components/layouts/__snapshots__/TableLayout.test.tsx.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`ApprovalsLayout renders the necessary DOM and CSS to create layout renders correct DOM with optional pagination 1`] = `
+exports[`TableLayout renders the necessary DOM and CSS to create layout renders correct DOM with optional pagination 1`] = `
 {
   "debug": [Function],
   "findAllByAltText": [Function],
@@ -55,7 +55,7 @@ exports[`ApprovalsLayout renders the necessary DOM and CSS to create layout rend
 }
 `;
 
-exports[`ApprovalsLayout renders the necessary DOM and CSS to create layout renders correct DOM with required props 1`] = `
+exports[`TableLayout renders the necessary DOM and CSS to create layout renders correct DOM with required props 1`] = `
 {
   "debug": [Function],
   "findAllByAltText": [Function],


### PR DESCRIPTION
## About this change - What it does

The My requests features use the same layout as the Approvals features. Therefore, rather than duplicating the `ApprovalsLayout` component, we can turn it into a reusable `TableLayout` component at the `coral/src/app/features/components/layouts` level.

## Message for merge:
```
- Rename ApprovalsLayout to TableLayout
- Move Table layout in coral/src/app/features/components/layouts folder
```

Resolves: #765
