### PR TITLE
fix(coral): Approvals: always make topic, env and status first columns

### DIFF
--- a/coral/src/app/features/approvals/acls/components/AclApprovalsTable.test.tsx
+++ b/coral/src/app/features/approvals/acls/components/AclApprovalsTable.test.tsx
@@ -105,32 +105,12 @@ describe("AclApprovalsTable", () => {
     screen.getByLabelText(`Acl requests, page 1 of 10`);
   });
 
-  it("has column to describe the usernames", () => {
-    renderFromProps();
-    expect(
-      within(getNthRow(0)).getAllByRole("columnheader")[0]
-    ).toHaveTextContent("Principals/Usernames");
-    expect(within(getNthRow(1)).getAllByRole("cell")[0]).toHaveTextContent(
-      "mbasani"
-    );
-  });
-
-  it("has column to describe the ip addresses", () => {
-    renderFromProps();
-    expect(
-      within(getNthRow(0)).getAllByRole("columnheader")[1]
-    ).toHaveTextContent("IP addresses");
-    expect(within(getNthRow(2)).getAllByRole("cell")[1]).toHaveTextContent(
-      "3.3.3.32 3.3.3.33"
-    );
-  });
-
   it("has column to describe the topic", () => {
     renderFromProps();
     expect(
-      within(getNthRow(0)).getAllByRole("columnheader")[2]
+      within(getNthRow(0)).getAllByRole("columnheader")[0]
     ).toHaveTextContent("Topic");
-    expect(within(getNthRow(1)).getAllByRole("cell")[2]).toHaveTextContent(
+    expect(within(getNthRow(1)).getAllByRole("cell")[0]).toHaveTextContent(
       "aivtopic1"
     );
   });
@@ -138,19 +118,49 @@ describe("AclApprovalsTable", () => {
   it("has column to describe the environment", () => {
     renderFromProps();
     expect(
-      within(getNthRow(0)).getAllByRole("columnheader")[3]
+      within(getNthRow(0)).getAllByRole("columnheader")[1]
     ).toHaveTextContent("Environment");
-    expect(within(getNthRow(1)).getAllByRole("cell")[3]).toHaveTextContent(
+    expect(within(getNthRow(1)).getAllByRole("cell")[1]).toHaveTextContent(
       "DEV"
+    );
+  });
+
+  it("has column to decsribe the status", () => {
+    renderFromProps();
+    expect(
+      within(getNthRow(0)).getAllByRole("columnheader")[2]
+    ).toHaveTextContent("Status");
+    expect(within(getNthRow(1)).getAllByRole("cell")[2]).toHaveTextContent(
+      "Awaiting approval"
+    );
+  });
+
+  it("has column to describe the usernames", () => {
+    renderFromProps();
+    expect(
+      within(getNthRow(0)).getAllByRole("columnheader")[3]
+    ).toHaveTextContent("Principals/Usernames");
+    expect(within(getNthRow(1)).getAllByRole("cell")[3]).toHaveTextContent(
+      "mbasani"
+    );
+  });
+
+  it("has column to describe the ip addresses", () => {
+    renderFromProps();
+    expect(
+      within(getNthRow(0)).getAllByRole("columnheader")[4]
+    ).toHaveTextContent("IP addresses");
+    expect(within(getNthRow(2)).getAllByRole("cell")[4]).toHaveTextContent(
+      "3.3.3.32 3.3.3.33"
     );
   });
 
   it("has column to describe the team", () => {
     renderFromProps();
     expect(
-      within(getNthRow(0)).getAllByRole("columnheader")[4]
+      within(getNthRow(0)).getAllByRole("columnheader")[5]
     ).toHaveTextContent("Team");
-    expect(within(getNthRow(1)).getAllByRole("cell")[4]).toHaveTextContent(
+    expect(within(getNthRow(1)).getAllByRole("cell")[5]).toHaveTextContent(
       "Ospo"
     );
   });
@@ -158,20 +168,10 @@ describe("AclApprovalsTable", () => {
   it("has column to decsribe the acl type", () => {
     renderFromProps();
     expect(
-      within(getNthRow(0)).getAllByRole("columnheader")[5]
-    ).toHaveTextContent("ACL type");
-    expect(within(getNthRow(1)).getAllByRole("cell")[5]).toHaveTextContent(
-      "CONSUMER"
-    );
-  });
-
-  it("has column to decsribe the status", () => {
-    renderFromProps();
-    expect(
       within(getNthRow(0)).getAllByRole("columnheader")[6]
-    ).toHaveTextContent("Status");
+    ).toHaveTextContent("ACL type");
     expect(within(getNthRow(1)).getAllByRole("cell")[6]).toHaveTextContent(
-      "Awaiting approval"
+      "CONSUMER"
     );
   });
 

--- a/coral/src/app/features/approvals/acls/components/AclApprovalsTable.tsx
+++ b/coral/src/app/features/approvals/acls/components/AclApprovalsTable.tsx
@@ -91,6 +91,45 @@ export default function AclApprovalsTable({
   const columns: Array<DataTableColumn<AclRequestTableRow>> = [
     {
       type: "custom",
+      field: "topicname",
+      headerName: "Topic",
+      UNSAFE_render({ topicname, prefixed }: AclRequestTableRow) {
+        return (
+          <>
+            {topicname}
+            {prefixed && <code>(prefixed)</code>}
+          </>
+        );
+      },
+    },
+    {
+      type: "status",
+      field: "environmentName",
+      headerName: "Environment",
+      status: ({ environmentName }) => ({
+        status: "neutral",
+        text: environmentName,
+      }),
+    },
+    {
+      type: "status",
+      field: "requestStatus",
+      headerName: "Status",
+      status: ({ requestStatus }) => {
+        if (requestStatus === "") {
+          return {
+            status: "neutral",
+            text: "-",
+          };
+        }
+        return {
+          status: requestStatusChipStatusMap[requestStatus],
+          text: requestStatusNameMap[requestStatus],
+        };
+      },
+    },
+    {
+      type: "custom",
       field: "acl_ssl",
       headerName: "Principals/Usernames",
       UNSAFE_render: ({ acl_ssl }: AclRequestTableRow) => {
@@ -132,28 +171,6 @@ export default function AclApprovalsTable({
       },
     },
     {
-      type: "custom",
-      field: "topicname",
-      headerName: "Topic",
-      UNSAFE_render({ topicname, prefixed }: AclRequestTableRow) {
-        return (
-          <>
-            {topicname}
-            {prefixed && <code>(prefixed)</code>}
-          </>
-        );
-      },
-    },
-    {
-      type: "status",
-      field: "environmentName",
-      headerName: "Environment",
-      status: ({ environmentName }) => ({
-        status: "neutral",
-        text: environmentName,
-      }),
-    },
-    {
       type: "text",
       field: "teamname",
       headerName: "Team",
@@ -166,23 +183,6 @@ export default function AclApprovalsTable({
         status: aclType === "CONSUMER" ? "success" : "info",
         text: aclType,
       }),
-    },
-    {
-      type: "status",
-      field: "requestStatus",
-      headerName: "Status",
-      status: ({ requestStatus }) => {
-        if (requestStatus === "") {
-          return {
-            status: "neutral",
-            text: "-",
-          };
-        }
-        return {
-          status: requestStatusChipStatusMap[requestStatus],
-          text: requestStatusNameMap[requestStatus],
-        };
-      },
     },
     {
       type: "status",


### PR DESCRIPTION
## About this change - What it does

Improve consistency of Approvals tables by always having the same three first columns

https://user-images.githubusercontent.com/20607294/223453801-8ba115c0-4030-48e8-b7ca-cd8f0a8be212.mov

