### PR TITLE
Adding rest proxy info in clusters, global compatibility set

### DIFF
--- a/cluster-api/src/main/java/io/aiven/klaw/clusterapi/controller/ClusterApiController.java
+++ b/cluster-api/src/main/java/io/aiven/klaw/clusterapi/controller/ClusterApiController.java
@@ -330,6 +330,12 @@ public class ClusterApiController {
         HttpStatus.INTERNAL_SERVER_ERROR);
   }
 
+  /**
+   * Register a schema on schema registry. If force register is enabled - Get subject compatibility
+   * - Set subject compatibility to NONE, if it's not NONE or NOT SET - Register schema - If subject
+   * compatibility is NOT_SET, get global compatibility - Apply global compatibility on subject
+   * level If force register is not enabled - Register schema
+   */
   @PostMapping(value = "/postSchema")
   public ResponseEntity<ApiResponse> postSchema(
       @RequestBody @Valid ClusterSchemaRequest clusterSchemaRequest) {

--- a/cluster-api/src/main/java/io/aiven/klaw/clusterapi/services/SchemaService.java
+++ b/cluster-api/src/main/java/io/aiven/klaw/clusterapi/services/SchemaService.java
@@ -50,16 +50,6 @@ public class SchemaService {
     this.clusterApiUtils = clusterApiUtils;
   }
 
-  /*
-  If force register is enabled
-    1. Get subject compatibility in a var 'x'
-    2. Set subject compatibility to NONE
-    3. Register schema
-    4. If x (subject compatibility) == NOT_SET, get global compatibility
-    5. Apply global compatibility on subject level
-  If force register is not enabled
-    1. Register schema
-   */
   public synchronized ApiResponse registerSchema(ClusterSchemaRequest clusterSchemaRequest) {
     String schemaCompatibility = null;
     boolean schemaCompatibilitySetOnSubject = false;
@@ -92,7 +82,7 @@ public class SchemaService {
               null);
         }
       }
-      // register schema
+
       String updateTopicReqStatus = registerSchemaPostCall(clusterSchemaRequest);
 
       return ApiResponse.builder().result(updateTopicReqStatus).build();
@@ -126,12 +116,12 @@ public class SchemaService {
                 clusterSchemaRequest.getProtocol(),
                 clusterSchemaRequest.getClusterIdentification());
       }
-      log.info(
-          "RegisterSchema - Force Commit revert to original Schema Compatibility {} for Topic {}",
-          schemaCompatibility,
-          clusterSchemaRequest.getTopicName());
       if (schemaCompatibility != null
           && !schemaCompatibility.equals(SCHEMA_COMPATIBILITY_NOT_SET)) {
+        log.info(
+            "RegisterSchema - Force Commit revert to original Schema Compatibility(Subject/Global) {} for Topic {}",
+            schemaCompatibility,
+            clusterSchemaRequest.getTopicName());
         setSchemaCompatibility(
             clusterSchemaRequest.getEnv(),
             clusterSchemaRequest.getTopicName(),
@@ -183,9 +173,10 @@ public class SchemaService {
           getSchemaVersions(environmentVal, topicName, protocol, clusterIdentification);
       String schemaCompatibility =
           getSubjectSchemaCompatibility(environmentVal, topicName, protocol, clusterIdentification);
-      if (Objects.equals(schemaCompatibility, SCHEMA_COMPATIBILITY_NOT_SET))
+      if (Objects.equals(schemaCompatibility, SCHEMA_COMPATIBILITY_NOT_SET)) {
         schemaCompatibility =
             getGlobalSchemaCompatibility(environmentVal, protocol, clusterIdentification);
+      }
       Map<Integer, Map<String, Object>> allSchemaObjects = new TreeMap<>();
 
       if (versionsList != null) {

--- a/cluster-api/src/test/java/io/aiven/klaw/clusterapi/services/SchemaServiceRegisterSchemaTest.java
+++ b/cluster-api/src/test/java/io/aiven/klaw/clusterapi/services/SchemaServiceRegisterSchemaTest.java
@@ -273,7 +273,8 @@ class SchemaServiceRegisterSchemaTest {
 
   @Test
   @Order(7)
-  public void givenSchemaWithForceRegisterEnabled_GetSchemaCompatibilityException_doNotRevert() {
+  public void
+      givenSchemaWithForceRegisterEnabled_GetSchemaCompatibilityException_applyGlobalCompatibility() {
 
     ClusterSchemaRequest schemaReq =
         ClusterSchemaRequest.builder()
@@ -311,7 +312,8 @@ class SchemaServiceRegisterSchemaTest {
 
   @Test
   @Order(8)
-  public void givenSchemaWithForceRegisterEnabled_ExistingCompatibilityIsFailValidationAndExit() {
+  public void
+      givenSchemaWithForceRegisterEnabled_ExistingCompatibilityIsFailValidationAndGetGlobalCompatibility() {
 
     ClusterSchemaRequest schemaReq =
         ClusterSchemaRequest.builder()
@@ -339,7 +341,7 @@ class SchemaServiceRegisterSchemaTest {
     schemaService.registerSchema(schemaReq);
     // change schema compatibility called once to change to none.
     verify(restTemplate, times(1)).put(any(), schemaCompatibility.capture(), eq(String.class));
-    // 2 calls to get the SchemaCompatibility subjct, global
+    // 2 calls to get the SchemaCompatibility subject, global
     verify(restTemplate, times(2))
         .exchange(
             eq(REGISTRY_URL),
@@ -351,8 +353,7 @@ class SchemaServiceRegisterSchemaTest {
 
   @Test
   @Order(9)
-  public void
-      givenSchemaWithForceRegisterEnabled_NotFoundFallBackToGlobalSchemaSettingReturnedNoResetSchemaCompatability() {
+  public void givenSchemaWithForceRegisterEnabled_NotFoundFallBackToGlobalSchemaSettingReturned() {
 
     ClusterSchemaRequest schemaReq =
         ClusterSchemaRequest.builder()
@@ -385,7 +386,7 @@ class SchemaServiceRegisterSchemaTest {
 
   @Test
   @Order(10)
-  public void givenSchemaWithForceRegisterEnabled_NotFoundAttempttoregisteranyway() {
+  public void givenSchemaWithForceRegisterEnabled_NotFoundGetGlobalCompatibility() {
 
     ClusterSchemaRequest schemaReq =
         ClusterSchemaRequest.builder()

--- a/cluster-api/src/test/java/io/aiven/klaw/clusterapi/services/SchemaServiceRegisterSchemaTest.java
+++ b/cluster-api/src/test/java/io/aiven/klaw/clusterapi/services/SchemaServiceRegisterSchemaTest.java
@@ -297,10 +297,10 @@ class SchemaServiceRegisterSchemaTest {
             any(HashMap.class)))
         .thenReturn(createErrorCompatibilityResponseEntity(HttpStatus.UNAUTHORIZED));
     schemaService.registerSchema(schemaReq);
-    // change schema compatibility never called as exception occurs.
-    verify(restTemplate, times(0)).put(any(), schemaCompatibility.capture(), eq(String.class));
+    // change schema compatibility called by setting global compatibility.
+    verify(restTemplate, times(1)).put(any(), schemaCompatibility.capture(), eq(String.class));
     // 1 call to get the current SchemaCompatibility
-    verify(restTemplate, times(1))
+    verify(restTemplate, times(2))
         .exchange(
             eq(REGISTRY_URL),
             any(HttpMethod.class),
@@ -337,10 +337,10 @@ class SchemaServiceRegisterSchemaTest {
     when(restTemplate.postForEntity(anyString(), any(HttpEntity.class), eq(String.class)))
         .thenReturn(createSchemaRegisterResponseEntity(HttpStatus.OK));
     schemaService.registerSchema(schemaReq);
-    // change schema compatibility called twice once to change to null second to change it back.
-    verify(restTemplate, times(0)).put(any(), schemaCompatibility.capture(), eq(String.class));
-    // 1 call to get the current SchemaCompatibility
-    verify(restTemplate, times(1))
+    // change schema compatibility called once to change to none.
+    verify(restTemplate, times(1)).put(any(), schemaCompatibility.capture(), eq(String.class));
+    // 2 calls to get the SchemaCompatibility subjct, global
+    verify(restTemplate, times(2))
         .exchange(
             eq(REGISTRY_URL),
             any(HttpMethod.class),
@@ -380,7 +380,7 @@ class SchemaServiceRegisterSchemaTest {
         .thenReturn(createErrorCompatibilityResponseEntity(HttpStatus.NOT_FOUND));
 
     schemaService.registerSchema(schemaReq);
-    verify(restTemplate, times(0)).put(any(), schemaCompatibility.capture(), eq(String.class));
+    verify(restTemplate, times(1)).put(any(), schemaCompatibility.capture(), eq(String.class));
   }
 
   @Test
@@ -412,13 +412,13 @@ class SchemaServiceRegisterSchemaTest {
         .thenReturn(createErrorCompatibilityResponseEntity(HttpStatus.NOT_FOUND))
         .thenReturn(createErrorCompatibilityResponseEntity(HttpStatus.NOT_FOUND));
     schemaService.registerSchema(schemaReq);
-    // don't change schema compatibility.
-    verify(restTemplate, times(0)).put(any(), any(), eq(String.class));
+    // change schema compatibility to NONE, once
+    verify(restTemplate, times(1)).put(any(), any(), eq(String.class));
 
     verify(restTemplate, times(1))
         .postForEntity(anyString(), any(HttpEntity.class), eq(String.class));
-    // 0 calls to get the current SchemaCompatibility as isForce==false
-    verify(restTemplate, times(1))
+    // 2 calls to get the current SchemaCompatibility (subject, global) as isForce==false
+    verify(restTemplate, times(2))
         .exchange(
             eq(REGISTRY_URL),
             any(HttpMethod.class),

--- a/core/src/main/java/io/aiven/klaw/model/KwClustersModel.java
+++ b/core/src/main/java/io/aiven/klaw/model/KwClustersModel.java
@@ -24,7 +24,7 @@ public class KwClustersModel implements Serializable {
 
   @NotNull
   @Size(min = 6, message = "Invalid bootstrap servers")
-  @Pattern(message = "Invalid bootstrap servers", regexp = "^[a-zA-Z0-9._:,-]{3,}$")
+  @Pattern(message = "Invalid bootstrap servers", regexp = "^[a-zA-Z0-9._:,-/]{3,}$")
   private String bootstrapServers;
 
   @NotNull(message = "Protocol cannot be null")

--- a/core/src/main/java/io/aiven/klaw/model/enums/KafkaClustersType.java
+++ b/core/src/main/java/io/aiven/klaw/model/enums/KafkaClustersType.java
@@ -4,7 +4,8 @@ public enum KafkaClustersType {
   ALL("all"),
   KAFKA("kafka"),
   SCHEMA_REGISTRY("schemaregistry"),
-  KAFKA_CONNECT("kafkaconnect");
+  KAFKA_CONNECT("kafkaconnect"),
+  KAFKA_REST_API("kafkarestapi");
 
   public final String value;
 

--- a/core/src/main/java/io/aiven/klaw/service/CommonUtilsService.java
+++ b/core/src/main/java/io/aiven/klaw/service/CommonUtilsService.java
@@ -320,7 +320,8 @@ public class CommonUtilsService {
     } else if (entityType == EntityType.CLUSTER && operationType == MetadataOperationType.DELETE) {
       manageDatabase.deleteCluster(kwMetadataUpdates.getTenantId());
     } else if (entityType == EntityType.CLUSTER && operationType == MetadataOperationType.CREATE) {
-      manageDatabase.loadClustersForOneTenant(null, null, null, kwMetadataUpdates.getTenantId());
+      manageDatabase.loadClustersForOneTenant(
+          null, null, null, null, kwMetadataUpdates.getTenantId());
     } else if (entityType == EntityType.ENVIRONMENT
         && operationType == MetadataOperationType.CREATE) {
       manageDatabase.loadEnvsForOneTenant(kwMetadataUpdates.getTenantId());

--- a/core/src/main/java/io/aiven/klaw/service/EnvsClustersTenantsControllerService.java
+++ b/core/src/main/java/io/aiven/klaw/service/EnvsClustersTenantsControllerService.java
@@ -238,7 +238,7 @@ public class EnvsClustersTenantsControllerService {
                       env.getBootstrapServers()
                           .toLowerCase()
                           .contains(searchClusterParam.toLowerCase()))
-              .collect(Collectors.toList());
+              .toList();
       List<KwClustersModel> envListMap3 =
           kwClustersModelList.stream()
               .filter(
@@ -247,7 +247,7 @@ public class EnvsClustersTenantsControllerService {
                           .getName()
                           .toLowerCase()
                           .contains(searchClusterParam.toLowerCase()))
-              .collect(Collectors.toList());
+              .toList();
       envListMap1.addAll(envListMap2);
       envListMap1.addAll(envListMap3);
 

--- a/core/src/main/resources/openapi.yaml
+++ b/core/src/main/resources/openapi.yaml
@@ -10,7 +10,7 @@
       "name" : "Apache 2.0",
       "url" : "https://www.apache.org/licenses/LICENSE-2.0.html"
     },
-    "version" : "2.0.0"
+    "version" : "2.1.0"
   },
   "externalDocs" : {
     "description" : "Klaw documentation",
@@ -4696,7 +4696,7 @@
         "properties" : {
           "status" : {
             "type" : "string",
-            "enum" : [ "100 CONTINUE", "101 SWITCHING_PROTOCOLS", "102 PROCESSING", "103 CHECKPOINT", "200 OK", "201 CREATED", "202 ACCEPTED", "203 NON_AUTHORITATIVE_INFORMATION", "204 NO_CONTENT", "205 RESET_CONTENT", "206 PARTIAL_CONTENT", "207 MULTI_STATUS", "208 ALREADY_REPORTED", "226 IM_USED", "300 MULTIPLE_CHOICES", "301 MOVED_PERMANENTLY", "302 FOUND", "302 MOVED_TEMPORARILY", "303 SEE_OTHER", "304 NOT_MODIFIED", "305 USE_PROXY", "307 TEMPORARY_REDIRECT", "308 PERMANENT_REDIRECT", "400 BAD_REQUEST", "401 UNAUTHORIZED", "402 PAYMENT_REQUIRED", "403 FORBIDDEN", "404 NOT_FOUND", "405 METHOD_NOT_ALLOWED", "406 NOT_ACCEPTABLE", "407 PROXY_AUTHENTICATION_REQUIRED", "408 REQUEST_TIMEOUT", "409 CONFLICT", "410 GONE", "411 LENGTH_REQUIRED", "412 PRECONDITION_FAILED", "413 PAYLOAD_TOO_LARGE", "413 REQUEST_ENTITY_TOO_LARGE", "414 URI_TOO_LONG", "414 REQUEST_URI_TOO_LONG", "415 UNSUPPORTED_MEDIA_TYPE", "416 REQUESTED_RANGE_NOT_SATISFIABLE", "417 EXPECTATION_FAILED", "418 I_AM_A_TEAPOT", "419 INSUFFICIENT_SPACE_ON_RESOURCE", "420 METHOD_FAILURE", "421 DESTINATION_LOCKED", "422 UNPROCESSABLE_ENTITY", "423 LOCKED", "424 FAILED_DEPENDENCY", "425 TOO_EARLY", "426 UPGRADE_REQUIRED", "428 PRECONDITION_REQUIRED", "429 TOO_MANY_REQUESTS", "431 REQUEST_HEADER_FIELDS_TOO_LARGE", "451 UNAVAILABLE_FOR_LEGAL_REASONS", "500 INTERNAL_SERVER_ERROR", "501 NOT_IMPLEMENTED", "502 BAD_GATEWAY", "503 SERVICE_UNAVAILABLE", "504 GATEWAY_TIMEOUT", "505 HTTP_VERSION_NOT_SUPPORTED", "506 VARIANT_ALSO_NEGOTIATES", "507 INSUFFICIENT_STORAGE", "508 LOOP_DETECTED", "509 BANDWIDTH_LIMIT_EXCEEDED", "510 NOT_EXTENDED", "511 NETWORK_AUTHENTICATION_REQUIRED" ]
+            "enum" : [ "100 CONTINUE", "101 SWITCHING_PROTOCOLS", "102 PROCESSING", "103 EARLY_HINTS", "103 CHECKPOINT", "200 OK", "201 CREATED", "202 ACCEPTED", "203 NON_AUTHORITATIVE_INFORMATION", "204 NO_CONTENT", "205 RESET_CONTENT", "206 PARTIAL_CONTENT", "207 MULTI_STATUS", "208 ALREADY_REPORTED", "226 IM_USED", "300 MULTIPLE_CHOICES", "301 MOVED_PERMANENTLY", "302 FOUND", "302 MOVED_TEMPORARILY", "303 SEE_OTHER", "304 NOT_MODIFIED", "305 USE_PROXY", "307 TEMPORARY_REDIRECT", "308 PERMANENT_REDIRECT", "400 BAD_REQUEST", "401 UNAUTHORIZED", "402 PAYMENT_REQUIRED", "403 FORBIDDEN", "404 NOT_FOUND", "405 METHOD_NOT_ALLOWED", "406 NOT_ACCEPTABLE", "407 PROXY_AUTHENTICATION_REQUIRED", "408 REQUEST_TIMEOUT", "409 CONFLICT", "410 GONE", "411 LENGTH_REQUIRED", "412 PRECONDITION_FAILED", "413 PAYLOAD_TOO_LARGE", "413 REQUEST_ENTITY_TOO_LARGE", "414 URI_TOO_LONG", "414 REQUEST_URI_TOO_LONG", "415 UNSUPPORTED_MEDIA_TYPE", "416 REQUESTED_RANGE_NOT_SATISFIABLE", "417 EXPECTATION_FAILED", "418 I_AM_A_TEAPOT", "419 INSUFFICIENT_SPACE_ON_RESOURCE", "420 METHOD_FAILURE", "421 DESTINATION_LOCKED", "422 UNPROCESSABLE_ENTITY", "423 LOCKED", "424 FAILED_DEPENDENCY", "425 TOO_EARLY", "426 UPGRADE_REQUIRED", "428 PRECONDITION_REQUIRED", "429 TOO_MANY_REQUESTS", "431 REQUEST_HEADER_FIELDS_TOO_LARGE", "451 UNAVAILABLE_FOR_LEGAL_REASONS", "500 INTERNAL_SERVER_ERROR", "501 NOT_IMPLEMENTED", "502 BAD_GATEWAY", "503 SERVICE_UNAVAILABLE", "504 GATEWAY_TIMEOUT", "505 HTTP_VERSION_NOT_SUPPORTED", "506 VARIANT_ALSO_NEGOTIATES", "507 INSUFFICIENT_STORAGE", "508 LOOP_DETECTED", "509 BANDWIDTH_LIMIT_EXCEEDED", "510 NOT_EXTENDED", "511 NETWORK_AUTHENTICATION_REQUIRED" ]
           },
           "timestamp" : {
             "type" : "string",
@@ -4796,10 +4796,10 @@
           "currentPage" : {
             "type" : "string"
           },
-          "editable" : {
+          "deletable" : {
             "type" : "boolean"
           },
-          "deletable" : {
+          "editable" : {
             "type" : "boolean"
           }
         },
@@ -4917,10 +4917,10 @@
           "currentPage" : {
             "type" : "string"
           },
-          "editable" : {
+          "deletable" : {
             "type" : "boolean"
           },
-          "deletable" : {
+          "editable" : {
             "type" : "boolean"
           }
         },
@@ -5521,10 +5521,10 @@
           "currentPage" : {
             "type" : "string"
           },
-          "editable" : {
+          "deletable" : {
             "type" : "boolean"
           },
-          "deletable" : {
+          "editable" : {
             "type" : "boolean"
           }
         },
@@ -5739,10 +5739,10 @@
           "approvingTeamDetails" : {
             "type" : "string"
           },
-          "editable" : {
+          "deletable" : {
             "type" : "boolean"
           },
-          "deletable" : {
+          "editable" : {
             "type" : "boolean"
           }
         },
@@ -5867,7 +5867,7 @@
           },
           "clusterType" : {
             "type" : "string",
-            "enum" : [ "ALL", "KAFKA", "SCHEMA_REGISTRY", "KAFKA_CONNECT" ],
+            "enum" : [ "ALL", "KAFKA", "SCHEMA_REGISTRY", "KAFKA_CONNECT", "KAFKA_REST_API" ],
             "writeOnly" : true
           }
         },
@@ -5897,7 +5897,7 @@
             "type" : "string",
             "maxLength" : 2147483647,
             "minLength" : 6,
-            "pattern" : "^[a-zA-Z0-9._:,-]{3,}$"
+            "pattern" : "^[a-zA-Z0-9._:,-/]{3,}$"
           },
           "protocol" : {
             "type" : "string",
@@ -6095,10 +6095,10 @@
           "currentPage" : {
             "type" : "string"
           },
-          "editable" : {
+          "deletable" : {
             "type" : "boolean"
           },
-          "deletable" : {
+          "editable" : {
             "type" : "boolean"
           }
         },

--- a/core/src/main/resources/static/js/envs.js
+++ b/core/src/main/resources/static/js/envs.js
@@ -678,14 +678,24 @@ app.controller("envsCtrl", function($scope, $http, $location, $window) {
 
                         $scope.addNewCluster.type = $scope.addNewCluster.clusterType;
 
-                        if($scope.addNewCluster.host == undefined)
+                        if($scope.addNewCluster.type === 'kafkarestapi'){
+                            $scope.kafkaFlavor = 'Apache Kafka'; // this is independent of any kafka flavor type
+                        }
+
+                        if($scope.addNewCluster.host === undefined  && $scope.addNewCluster.type !== 'kafkarestapi')
                             {
                                 $scope.alertnote = "Please fill in bootstrap servers";
                                 $scope.showAlertToast();
                                 return;
                             }
+                        else if($scope.addNewCluster.host === undefined  && $scope.addNewCluster.type === 'kafkarestapi')
+                        {
+                            $scope.alertnote = "Please fill in Rest Api server";
+                            $scope.showAlertToast();
+                            return;
+                        }
 
-                        if($scope.addNewCluster.envname == undefined)
+                        if($scope.addNewCluster.envname === undefined)
                         {
                             $scope.alertnote = "Please fill in a name for cluster";
                             $scope.showAlertToast();
@@ -706,7 +716,7 @@ app.controller("envsCtrl", function($scope, $http, $location, $window) {
                             return;
                         }
 
-                        if($scope.addNewCluster.protocol == 'SSL' && $scope.dashboardDetails.saasEnabled == 'saas'){
+                        if($scope.addNewCluster.protocol === 'SSL' && $scope.dashboardDetails.saasEnabled === 'saas'){
                             if(!$scope.addNewCluster.pubkeyUploadedFromUI)
                             {
                                 $scope.alertnote = "Please select a valid Public key file";

--- a/core/src/main/resources/static/js/envs.js
+++ b/core/src/main/resources/static/js/envs.js
@@ -683,11 +683,11 @@ app.controller("envsCtrl", function($scope, $http, $location, $window) {
                         }
 
                         if($scope.addNewCluster.host === undefined  && $scope.addNewCluster.type !== 'kafkarestapi')
-                            {
-                                $scope.alertnote = "Please fill in bootstrap servers";
-                                $scope.showAlertToast();
-                                return;
-                            }
+                        {
+                            $scope.alertnote = "Please fill in bootstrap servers";
+                            $scope.showAlertToast();
+                            return;
+                        }
                         else if($scope.addNewCluster.host === undefined  && $scope.addNewCluster.type === 'kafkarestapi')
                         {
                             $scope.alertnote = "Please fill in Rest Api server";

--- a/core/src/main/resources/static/js/modifyEnvs.js
+++ b/core/src/main/resources/static/js/modifyEnvs.js
@@ -77,9 +77,9 @@ app.controller("modifyEnvsCtrl", function($scope, $http, $location, $window) {
                     params: {'clusterId' : clusterId },
                     data: {'clusterId' : clusterId}
                 }).success(function(output) {
-                    if(output != null && output != ""){
+                    if(output != null && output !== ""){
                         $scope.clusterDetails = output;
-                        if($scope.clusterDetails.aivenCluster==true)
+                        if($scope.clusterDetails.aivenCluster === true)
                             $scope.clusterDetails.aivenClusterType='Aiven';
                         else
                             $scope.clusterDetails.aivenClusterType='Non-Aiven';
@@ -103,11 +103,11 @@ app.controller("modifyEnvsCtrl", function($scope, $http, $location, $window) {
             for (var i = 0; i < sURLVariables.length; i++)
                 {
                     var sParameterName = sURLVariables[i].split('=');
-                    if (sParameterName[0] == "clusterId")
+                    if (sParameterName[0] === "clusterId")
                     {
                         clusterId = sParameterName[1];
                     }
-                    else if (sParameterName[0] == "clusterType")
+                    else if (sParameterName[0] === "clusterType")
                     {
                         clusterType = sParameterName[1];
                     }
@@ -135,11 +135,11 @@ app.controller("modifyEnvsCtrl", function($scope, $http, $location, $window) {
             for (var i = 0; i < sURLVariables.length; i++)
                 {
                     var sParameterName = sURLVariables[i].split('=');
-                    if (sParameterName[0] == "envId")
+                    if (sParameterName[0] === "envId")
                     {
                         envId = sParameterName[1];
                     }
-                    else if (sParameterName[0] == "envType")
+                    else if (sParameterName[0] === "envType")
                     {
                         envType = sParameterName[1];
                     }
@@ -161,7 +161,7 @@ app.controller("modifyEnvsCtrl", function($scope, $http, $location, $window) {
                     params: {'envSelected' : envId, 'envType' : envType },
                     data: {'envSelected' : envId, 'envType' : envType}
                 }).success(function(output) {
-                    if(output != null && output != ""){
+                    if(output != null && output !== ""){
                         $scope.envDetails = output;
                         $scope.onChangeCluster(output.clusterId);
                     }else
@@ -178,7 +178,7 @@ app.controller("modifyEnvsCtrl", function($scope, $http, $location, $window) {
 
         $scope.onChangeProtocol = function(protocol)
         {
-            if(protocol == 'SSL')
+            if(protocol === 'SSL')
                 $scope.sslparams = "true";
             else
                 $scope.sslparams = "false";
@@ -347,14 +347,14 @@ app.controller("modifyEnvsCtrl", function($scope, $http, $location, $window) {
 
                 $scope.clusterDetails.type = 'schemaregistry';
 
-                if($scope.clusterDetails.bootstrapServers == undefined)
+                if($scope.clusterDetails.bootstrapServers === undefined)
                     {
                         $scope.alertnote = "Please fill in bootstrapServer";
                         $scope.showAlertToast();
                         return;
                     }
 
-                if($scope.clusterDetails.clusterName == undefined)
+                if($scope.clusterDetails.clusterName === undefined)
                 {
                     $scope.alertnote = "Please fill in a name for cluster";
                     $scope.showAlertToast();
@@ -386,7 +386,7 @@ app.controller("modifyEnvsCtrl", function($scope, $http, $location, $window) {
                     data: serviceInput
                 }).success(function(output) {
                     $scope.alert = "Schema registry cluster updated: "+output.result;
-                    if(output.result == 'success'){
+                    if(output.result === 'success'){
                         swal({
                              title: "",
                              text: "Schema registry cluster updated : "+output.result,
@@ -404,6 +404,68 @@ app.controller("modifyEnvsCtrl", function($scope, $http, $location, $window) {
                 );
 
             };
+
+        $scope.editKafkaRestApiCluster = function() {
+
+            $scope.clusterDetails.type = 'kafkarestapi';
+
+            if($scope.clusterDetails.bootstrapServers === undefined)
+            {
+                $scope.alertnote = "Please fill in Rest Api server";
+                $scope.showAlertToast();
+                return;
+            }
+
+            if($scope.clusterDetails.clusterName === undefined)
+            {
+                $scope.alertnote = "Please fill in a name for cluster";
+                $scope.showAlertToast();
+                return;
+            }
+
+            if($scope.clusterDetails.clusterName.length > 15)
+            {
+                $scope.alertnote = "Cluster name cannot be more than 15 characters.";
+                $scope.showAlertToast();
+                return;
+            }
+
+            var serviceInput = {};
+            serviceInput['clusterId'] = $scope.clusterToEdit;
+            serviceInput['clusterName'] = $scope.clusterDetails.clusterName;
+            serviceInput['bootstrapServers'] = $scope.clusterDetails.bootstrapServers;
+            serviceInput['protocol'] = $scope.clusterDetails.protocol;
+            serviceInput['clusterType'] = $scope.clusterDetails.type;
+            serviceInput['kafkaFlavor'] = $scope.clusterDetails.kafkaFlavor;
+
+            serviceInput['otherParams'] = "default.partitions=na,max.partitions=na,replication.factor=na";
+
+            $http({
+                method: "POST",
+                url: "addNewCluster",
+                headers : { 'Content-Type' : 'application/json' },
+                params: {'addNewEnv' : serviceInput },
+                data: serviceInput
+            }).success(function(output) {
+                $scope.alert = "Rest Api cluster updated: "+output.result;
+                if(output.result === 'success'){
+                    swal({
+                        title: "",
+                        text: "Rest Api cluster updated : "+output.result,
+                        timer: 2000,
+                        showConfirmButton: true
+                    }).then(function(isConfirm){
+                        $window.location.href = $window.location.origin + $scope.dashboardDetails.contextPath + "/clusters";
+                    });
+                }else $scope.showSubmitFailed('','');
+            }).error(
+                function(error)
+                {
+                    $scope.handleValidationErrors(error);
+                }
+            );
+
+        };
 
        $scope.editKafkaConnectCluster = function() {
 

--- a/core/src/main/resources/templates/addCluster.html
+++ b/core/src/main/resources/templates/addCluster.html
@@ -488,6 +488,7 @@
 													<option value="kafka">Kafka</option>
 													<option value="schemaregistry">SchemaRegistry</option>
 													<option value="kafkaconnect">KafkaConnect</option>
+													<option value="kafkarestapi">KafkaRestApi</option>
 												</select>
 
 											</div>
@@ -531,6 +532,13 @@
 												<small class="form-control-feedback">Ex : server1:8083</small>
 											</div>
 										</div>
+										<div class="col-md-6" ng-show="addNewCluster.clusterType == 'kafkarestapi'">
+											<div class="form-group">
+												<label>Rest proxy server</label>
+												<input type="text" class="form-control" required ng-model="addNewCluster.host" minlength="3" placeholder="https://server:12695">
+												<small class="form-control-feedback">Ex : https://server:12695</small>
+											</div>
+										</div>
 										<!--/span-->
 									</div>
 									<!--/row-->
@@ -563,6 +571,18 @@
 											</div>
 										</div>
 										<div class="col-md-6">
+										</div>
+									</div>
+
+									<div class="row" ng-show="addNewCluster.clusterType == 'kafkarestapi'">
+										<div class="col-md-6">
+											<div class="form-group">
+												<label>Protocol</label>
+												<select required class="form-control custom-select" ng-change="onChangeProtocol(addNewCluster.protocol)" ng-model="addNewCluster.protocol">
+													<option value="PLAINTEXT">PLAINTEXT</option>
+													<option value="SSL">SSL</option>
+												</select>
+											</div>
 										</div>
 									</div>
 
@@ -624,7 +644,7 @@
 										</div>
 									</div>
 
-									<div class="row">
+									<div class="row" ng-show="addNewCluster.clusterType != 'kafkarestapi'">
 										<div class="col-md-6">
 											<div class="form-group">
 												<label>Kafka Flavor</label>

--- a/core/src/main/resources/templates/clusters.html
+++ b/core/src/main/resources/templates/clusters.html
@@ -515,6 +515,9 @@
 										<td ng-show="allenv.clusterType == 'kafkaconnect'" >
 											<span class="badge badge-warning">{{ allenv.clusterType }}</span></td>
 
+										<td ng-show="allenv.clusterType == 'kafkarestapi'" >
+											<span class="badge badge-danger">{{ allenv.clusterType }}</span></td>
+
 										<td>{{ allenv.kafkaFlavor }}</td>
 
 										<td ng-show="allenv.projectName!='' && allenv.projectName!=null">project = {{ allenv.projectName }} , serviceName = {{ allenv.serviceName }}</td>
@@ -574,6 +577,27 @@
 											<input type="text" value="{{ allenv.clusterName }}{{ allenv.clusterId }}" id="kc{{ allenv.clusterName }}{{ allenv.clusterId }}" ng-show="false">
 
 											<button type="button" ng-click="copyClusterIdToClipboard('kc', allenv.clusterName, allenv.clusterId)"
+													class="btn btn-sm btn-circle" data-bs-toggle="tooltip" data-bs-placement="bottom" title="{{ allenv.clusterName }}{{ allenv.clusterId }} Cluster id to setup connectivity">
+												<i class="fa fa-clipboard"></i>
+											</button>
+
+											<button ng-show="allenv.showDeleteCluster == true" type="button" ng-click="deleteCluster(allenv.clusterId)"
+													class="btn btn-sm btn-outline-danger btn-circle">
+												<i class="fas fa-times"></i>
+											</button>
+										</td>
+										<td ng-show="dashboardDetails.addDeleteEditClusters=='Authorized' && allenv.clusterType == 'kafkarestapi'">
+
+											<a href="modifyCluster?clusterId={{ allenv.clusterId}}&clusterType=kafkarestapi">
+												<button type="button"
+														class="btn btn-sm btn-outline-secondary btn-circle">
+													<i class="fas fa-edit"></i>
+												</button>
+											</a>
+
+											<input type="text" value="{{ allenv.clusterName }}{{ allenv.clusterId }}" id="sr{{ allenv.clusterName }}{{ allenv.clusterId }}" ng-show="false">
+
+											<button type="button" ng-click="copyClusterIdToClipboard('sr', allenv.clusterName, allenv.clusterId)"
 													class="btn btn-sm btn-circle" data-bs-toggle="tooltip" data-bs-placement="bottom" title="{{ allenv.clusterName }}{{ allenv.clusterId }} Cluster id to setup connectivity">
 												<i class="fa fa-clipboard"></i>
 											</button>

--- a/core/src/main/resources/templates/modifyCluster.html
+++ b/core/src/main/resources/templates/modifyCluster.html
@@ -716,6 +716,71 @@
 							</form>
 						</div>
 					</div>
+					<div ng-if="clusterTypeToEdit=='kafkarestapi'" class="card card-outline-success">
+						<div class="card-body">
+							<form id="form1">
+								<div class="form-body">
+
+									<table class="table color-table success-table" width="100%"><tr>
+										<td align="left"><h3 class="card-title">Update Kafka Rest Api Cluster</h3>
+										</td>
+										<td align="right">
+											<a href="clusters">
+												<i class="fas fa-arrow-alt-circle-left"></i>
+												<button type="button"
+														class="btn waves-effect waves-light btn-rounded btn-outline-info">Back to Clusters</button>
+											</a>
+										</td></tr>
+									</table>
+
+									<hr size="1" color="black">
+
+									<!--/row-->
+									<div class="row">
+										<div class="col-md-6">
+											<div class="form-group">
+												<label class="control-label">Cluster Name</label>
+												<input type="text" class="form-control" maxlength="20" minlength="3" required ng-model="clusterDetails.clusterName" placeholder="DEV_SCH"/>
+
+											</div>
+										</div>
+										<!--/span-->
+										<div class="col-md-6">
+											<div class="form-group">
+												<label>Rest Proxy Server</label>
+												<input type="text" class="form-control" minlength="3" required ng-model="clusterDetails.bootstrapServers" placeholder="devams.cmp.net"/>
+											</div>
+										</div>
+										<!--/span-->
+									</div>
+
+									<div class="row">
+										<div class="col-md-6">
+											<div class="form-group">
+												<label>Protocol</label>
+												<select required class="form-control custom-select" ng-change="onChangeProtocol(clusterDetails.protocol)" ng-model="clusterDetails.protocol">
+													<option value="PLAINTEXT">PLAINTEXT</option>
+													<option value="SSL">SSL</option>
+												</select>
+											</div>
+										</div>
+										<!--/span-->
+										<div class="col-md-6">
+										</div>
+										<!--/span-->
+									</div>
+
+								</div>
+								<div id="successbar">{{ alert }}</div>
+								<div id="alertbar">{{ alertnote }}</div>
+								<div class="form-actions">
+									<button ng-click="editKafkaRestApiCluster();" class="btn btn-outline-primary"> <i class="fa fa-check"></i>
+										Save</button>
+									<button type="button" ng-click="cancelClusterRequest();" class="btn btn-outline-inverse">Cancel</button>
+								</div>
+							</form>
+						</div>
+					</div>
 				</div>
 			</div>
 			<!-- Row -->

--- a/core/src/test/java/io/aiven/klaw/EnvsClustersTenantsControllerIT.java
+++ b/core/src/test/java/io/aiven/klaw/EnvsClustersTenantsControllerIT.java
@@ -65,7 +65,7 @@ public class EnvsClustersTenantsControllerIT {
             .getResponse()
             .getContentAsString();
 
-    List<KwTenantModel> teamModel = OBJECT_MAPPER.readValue(response, List.class);
+    List<KwTenantModel> teamModel = OBJECT_MAPPER.readValue(response, new TypeReference<>() {});
     assertThat(teamModel).hasSize(1);
   }
 
@@ -101,15 +101,15 @@ public class EnvsClustersTenantsControllerIT {
             .getResponse()
             .getContentAsString();
 
-    List<KwTenantModel> teamModel = OBJECT_MAPPER.readValue(response, List.class);
+    List<KwTenantModel> teamModel = OBJECT_MAPPER.readValue(response, new TypeReference<>() {});
     assertThat(teamModel).hasSize(2);
   }
 
   // add cluster success
   @Test
   @Order(3)
-  public void addClusterSuccess() throws Exception {
-    KwClustersModel kwClustersModel = mockMethods.getClusterModel("DEV_CLUSTER");
+  public void addKafkaClusterSuccess() throws Exception {
+    KwClustersModel kwClustersModel = mockMethods.getKafkaClusterModel("DEV_CLUSTER");
     String jsonReq = OBJECT_MAPPER.writer().writeValueAsString(kwClustersModel);
 
     String response =
@@ -138,7 +138,7 @@ public class EnvsClustersTenantsControllerIT {
             .getResponse()
             .getContentAsString();
 
-    List<KwClustersModel> teamModel = OBJECT_MAPPER.readValue(response, List.class);
+    List<KwClustersModel> teamModel = OBJECT_MAPPER.readValue(response, new TypeReference<>() {});
     assertThat(teamModel).hasSize(1);
   }
 
@@ -158,13 +158,13 @@ public class EnvsClustersTenantsControllerIT {
             .getResponse()
             .getContentAsString();
 
-    List clusterModels = OBJECT_MAPPER.readValue(response, List.class);
+    List<Map<String, Object>> clusterModels =
+        OBJECT_MAPPER.readValue(response, new TypeReference<>() {});
     assertThat(clusterModels).hasSize(1);
 
-    Map<String, Integer> hashMap = (Map<String, Integer>) clusterModels.get(0);
-
-    KwClustersModel kwClustersModel = mockMethods.getClusterModel("DEV_CLUSTER");
-    kwClustersModel.setClusterId(hashMap.get("clusterId"));
+    Map<String, Object> hashMap = clusterModels.get(0);
+    KwClustersModel kwClustersModel = mockMethods.getKafkaClusterModel("DEV_CLUSTER");
+    kwClustersModel.setClusterId((Integer) hashMap.get("clusterId"));
     kwClustersModel.setBootstrapServers("localhost:9093");
     String jsonReq = OBJECT_MAPPER.writer().writeValueAsString(kwClustersModel);
     response =
@@ -207,7 +207,7 @@ public class EnvsClustersTenantsControllerIT {
   @Test
   @Order(6)
   public void addAndDeleteClusterSuccess() throws Exception {
-    KwClustersModel kwClustersModel = mockMethods.getClusterModel("TST_CLUSTER");
+    KwClustersModel kwClustersModel = mockMethods.getKafkaClusterModel("TST_CLUSTER");
     String jsonReq = OBJECT_MAPPER.writer().writeValueAsString(kwClustersModel);
 
     String response =
@@ -236,11 +236,11 @@ public class EnvsClustersTenantsControllerIT {
             .getResponse()
             .getContentAsString();
 
-    List clusterModels = OBJECT_MAPPER.readValue(response, List.class);
+    List<Map<String, Object>> clusterModels =
+        OBJECT_MAPPER.readValue(response, new TypeReference<>() {});
     assertThat(clusterModels).hasSize(2);
 
-    Map<String, Integer> hashMap = (Map) clusterModels.get(0);
-
+    Map<String, Object> hashMap = clusterModels.get(0);
     response =
         mvc.perform(
                 MockMvcRequestBuilders.post("/deleteCluster")
@@ -268,7 +268,7 @@ public class EnvsClustersTenantsControllerIT {
             .getResponse()
             .getContentAsString();
 
-    clusterModels = OBJECT_MAPPER.readValue(response, List.class);
+    clusterModels = OBJECT_MAPPER.readValue(response, new TypeReference<>() {});
     assertThat(clusterModels).hasSize(1);
   }
 
@@ -305,7 +305,8 @@ public class EnvsClustersTenantsControllerIT {
             .getResponse()
             .getContentAsString();
 
-    List clusterModels = OBJECT_MAPPER.readValue(response, List.class);
+    List<Map<String, Object>> clusterModels =
+        OBJECT_MAPPER.readValue(response, new TypeReference<>() {});
     assertThat(clusterModels).hasSize(1);
   }
 
@@ -325,8 +326,9 @@ public class EnvsClustersTenantsControllerIT {
             .getResponse()
             .getContentAsString();
 
-    List clusterModels = OBJECT_MAPPER.readValue(response, List.class);
-    Map<String, Object> envModel1 = (Map<String, Object>) clusterModels.get(0);
+    List<Map<String, Object>> clusterModels =
+        OBJECT_MAPPER.readValue(response, new TypeReference<>() {});
+    Map<String, Object> envModel1 = clusterModels.get(0);
     String envId = (String) envModel1.get("id");
     assertThat(clusterModels).hasSize(1);
 
@@ -363,8 +365,8 @@ public class EnvsClustersTenantsControllerIT {
             .getResponse()
             .getContentAsString();
 
-    clusterModels = OBJECT_MAPPER.readValue(response, List.class);
-    Map<String, Object> envModel3 = (Map<String, Object>) clusterModels.get(0);
+    clusterModels = OBJECT_MAPPER.readValue(response, new TypeReference<>() {});
+    Map<String, Object> envModel3 = clusterModels.get(0);
     String updatedOtherParams = (String) envModel3.get("otherParams");
     assertThat(updatedOtherParams).isEqualTo(otherParams);
   }
@@ -507,7 +509,8 @@ public class EnvsClustersTenantsControllerIT {
             .getResponse()
             .getContentAsString();
 
-    List clusterModels = OBJECT_MAPPER.readValue(response, List.class);
+    List<Map<String, Object>> clusterModels =
+        OBJECT_MAPPER.readValue(response, new TypeReference<>() {});
     assertThat(clusterModels).hasSize(1);
 
     response =
@@ -544,8 +547,9 @@ public class EnvsClustersTenantsControllerIT {
             .getResponse()
             .getContentAsString();
 
-    HashMap clusterModels = OBJECT_MAPPER.readValue(response, HashMap.class);
-    ArrayList<String> defaultPartitions = (ArrayList) clusterModels.get("defaultPartitions");
+    HashMap<String, ArrayList<String>> clusterModels =
+        OBJECT_MAPPER.readValue(response, new TypeReference<>() {});
+    ArrayList<String> defaultPartitions = clusterModels.get("defaultPartitions");
     assertThat(defaultPartitions.get(0)).isEqualTo("4");
   }
 
@@ -565,7 +569,44 @@ public class EnvsClustersTenantsControllerIT {
             .getResponse()
             .getContentAsString();
 
-    List clusterModels = OBJECT_MAPPER.readValue(response, List.class);
+    List<String> clusterModels = OBJECT_MAPPER.readValue(response, new TypeReference<>() {});
     assertThat(clusterModels.get(0)).isEqualTo("ACC");
+  }
+
+  // add kafka rest cluster success
+  @Test
+  @Order(14)
+  public void addKafkaRestApiClusterSuccess() throws Exception {
+    KwClustersModel kwClustersModel = mockMethods.getKafkaRestClusterModel("DEV_CLUSTER");
+    String jsonReq = OBJECT_MAPPER.writer().writeValueAsString(kwClustersModel);
+
+    String response =
+        mvc.perform(
+                MockMvcRequestBuilders.post("/addNewCluster")
+                    .with(user(superAdmin).password(superAdminPwd))
+                    .content(jsonReq)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .accept(MediaType.APPLICATION_JSON))
+            .andExpect(status().isOk())
+            .andReturn()
+            .getResponse()
+            .getContentAsString();
+
+    assertThat(response).contains(ApiResultStatus.SUCCESS.value);
+    response =
+        mvc.perform(
+                MockMvcRequestBuilders.get("/getClusters")
+                    .with(user(superAdmin).password(superAdminPwd))
+                    .param("clusterType", KafkaClustersType.KAFKA_REST_API.value)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .accept(MediaType.APPLICATION_JSON))
+            .andExpect(status().isOk())
+            .andReturn()
+            .getResponse()
+            .getContentAsString();
+
+    List<KwClustersModel> kwClustersModels =
+        OBJECT_MAPPER.readValue(response, new TypeReference<>() {});
+    assertThat(kwClustersModels).hasSize(1);
   }
 }

--- a/core/src/test/java/io/aiven/klaw/MockMethods.java
+++ b/core/src/test/java/io/aiven/klaw/MockMethods.java
@@ -71,12 +71,23 @@ public class MockMethods {
     return kwTenantModel;
   }
 
-  public KwClustersModel getClusterModel(String dev_cluster) {
+  public KwClustersModel getKafkaClusterModel(String dev_cluster) {
     KwClustersModel kwClustersModel = new KwClustersModel();
     kwClustersModel.setClusterName(dev_cluster);
     kwClustersModel.setBootstrapServers("localhost:9092");
     kwClustersModel.setProtocol(KafkaSupportedProtocol.PLAINTEXT);
     kwClustersModel.setClusterType(KafkaClustersType.KAFKA.value);
+    kwClustersModel.setKafkaFlavor("Apache Kafka");
+
+    return kwClustersModel;
+  }
+
+  public KwClustersModel getKafkaRestClusterModel(String dev_cluster) {
+    KwClustersModel kwClustersModel = new KwClustersModel();
+    kwClustersModel.setClusterName(dev_cluster);
+    kwClustersModel.setBootstrapServers("https://localhost:12695");
+    kwClustersModel.setProtocol(KafkaSupportedProtocol.SSL);
+    kwClustersModel.setClusterType(KafkaClustersType.KAFKA_REST_API.value);
     kwClustersModel.setKafkaFlavor("Apache Kafka");
 
     return kwClustersModel;

--- a/core/src/test/java/io/aiven/klaw/TopicAclControllerIT.java
+++ b/core/src/test/java/io/aiven/klaw/TopicAclControllerIT.java
@@ -154,7 +154,7 @@ public class TopicAclControllerIT {
   @Test
   @Order(2)
   public void addNewCluster() throws Exception {
-    KwClustersModel kwClustersModel = mockMethods.getClusterModel("DEV_CLUSTER");
+    KwClustersModel kwClustersModel = mockMethods.getKafkaClusterModel("DEV_CLUSTER");
     String jsonReq = OBJECT_MAPPER.writer().writeValueAsString(kwClustersModel);
 
     String response =


### PR DESCRIPTION
About this change - What it does

- New cluster type 'kafkarestproxy' can be added under Clusters menu. to store the rest proxy url info.  This cluster type is not used anywhere in klaw.
- When retrieving/registering schema for a topic, if subject compatibility is not set, get global compatibility

Resolves: #679 
Resolves : #726 
Why this way

- This url info can be used by developers while developing kafka clients.
- Compatibility is applicable when registering new schemas, and its relevant for users to view what is the actual compatibility
