### PR TITLE
feat(coral): Add EmptyState to tables #684

### DIFF
--- a/coral/src/app/features/approvals/acls/components/AclApprovalsTable.test.tsx
+++ b/coral/src/app/features/approvals/acls/components/AclApprovalsTable.test.tsx
@@ -100,6 +100,12 @@ describe("AclApprovalsTable", () => {
 
   afterEach(cleanup);
 
+  it("shows a message to user in case there are no requests that match the search criteria", () => {
+    renderFromProps({ aclRequests: [] });
+    screen.getByText("No ACL requests");
+    screen.getByText("No ACL request matched your criteria.");
+  });
+
   it("describes the table content and pagination for screen readers", () => {
     renderFromProps();
     screen.getByLabelText(`Acl requests, page 1 of 10`);

--- a/coral/src/app/features/approvals/acls/components/AclApprovalsTable.tsx
+++ b/coral/src/app/features/approvals/acls/components/AclApprovalsTable.tsx
@@ -5,6 +5,7 @@ import {
   Flexbox,
   DataTable,
   DataTableColumn,
+  EmptyState,
 } from "@aivenio/aquarium";
 import { AclRequest } from "src/domain/acl/acl-types";
 import deleteIcon from "@aivenio/aquarium/dist/src/icons/delete";
@@ -282,11 +283,21 @@ export default function AclApprovalsTable({
     },
   ];
 
+  const rows = getRows(aclRequests);
+
+  if (!rows.length) {
+    return (
+      <EmptyState title="No ACL requests">
+        No ACL request matched your criteria.
+      </EmptyState>
+    );
+  }
+
   return (
     <DataTable
       ariaLabel={`Acl requests, page ${activePage} of ${totalPages}`}
       columns={columns}
-      rows={getRows(aclRequests)}
+      rows={rows}
       noWrap={false}
     />
   );

--- a/coral/src/app/features/approvals/schemas/components/SchemaApprovalsTable.test.tsx
+++ b/coral/src/app/features/approvals/schemas/components/SchemaApprovalsTable.test.tsx
@@ -87,6 +87,19 @@ describe("SchemaApprovalsTable", () => {
     { columnHeader: "Decline", relatedField: null },
   ];
 
+  it("shows a message to user in case there are no requests that match the search criteria", () => {
+    render(
+      <SchemaApprovalsTable
+        requests={[]}
+        setModals={mockSetModals}
+        onApprove={mockApproveRequest}
+        quickActionLoading={false}
+      />
+    );
+    screen.getByText("No Schema requests");
+    screen.getByText("No Schema request matched your criteria.");
+  });
+
   describe("renders all necessary elements", () => {
     beforeAll(() => {
       render(

--- a/coral/src/app/features/approvals/schemas/components/SchemaApprovalsTable.tsx
+++ b/coral/src/app/features/approvals/schemas/components/SchemaApprovalsTable.tsx
@@ -1,6 +1,7 @@
 import {
   DataTable,
   DataTableColumn,
+  EmptyState,
   GhostButton,
   Icon,
 } from "@aivenio/aquarium";
@@ -169,6 +170,14 @@ function SchemaApprovalsTable(props: SchemaApprovalsTableProps) {
       };
     }
   );
+
+  if (!rows.length) {
+    return (
+      <EmptyState title="No Schema requests">
+        No Schema request matched your criteria.
+      </EmptyState>
+    );
+  }
 
   return (
     <DataTable

--- a/coral/src/app/features/approvals/topics/components/TopicApprovalsTable.test.tsx
+++ b/coral/src/app/features/approvals/topics/components/TopicApprovalsTable.test.tsx
@@ -92,6 +92,20 @@ describe("TopicApprovalsTable", () => {
     { columnHeader: "", relatedField: null },
   ];
 
+  it("shows a message to user in case there are no requests that match the search criteria", () => {
+    render(
+      <TopicApprovalsTable
+        setDetailsModal={mockedSetDetailsModal}
+        requests={[]}
+        quickActionLoading={false}
+        setDeclineModal={mockedSetDeclineModal}
+        approveRequest={mockedApproveRequest}
+      />
+    );
+    screen.getByText("No Topic requests");
+    screen.getByText("No Topic request matched your criteria.");
+  });
+
   describe("renders all necessary elements", () => {
     beforeAll(() => {
       mockIntersectionObserver();

--- a/coral/src/app/features/approvals/topics/components/TopicApprovalsTable.tsx
+++ b/coral/src/app/features/approvals/topics/components/TopicApprovalsTable.tsx
@@ -1,6 +1,7 @@
 import {
   DataTable,
   DataTableColumn,
+  EmptyState,
   GhostButton,
   Icon,
 } from "@aivenio/aquarium";
@@ -198,6 +199,14 @@ function TopicApprovalsTable(props: TopicApprovalsTableProp) {
       requesttimestring: request.requesttimestring,
     };
   });
+
+  if (!rows.length) {
+    return (
+      <EmptyState title="No Topic requests">
+        No Topic request matched your criteria.
+      </EmptyState>
+    );
+  }
 
   return (
     <DataTable


### PR DESCRIPTION
Make it clear for user when there are no approvable requests either at all or matching search criteria by adding empty state with a message to the approve request tables.

Note: Does not add empty state for the All topics view, since the state handling there is more "advanced" and needs some discussion.

Resolves: #684

![image](https://user-images.githubusercontent.com/15416578/223973827-7cdd569c-b67e-4fb5-aeb4-d305d8ad18cc.png)
