### PR TITLE
feat(coral): Topic Requests: add API definition and types for `/getTopicRequests`

### DIFF
--- a/coral/src/app/features/approvals/topics/TopicApprovals.test.tsx
+++ b/coral/src/app/features/approvals/topics/TopicApprovals.test.tsx
@@ -8,7 +8,7 @@ import { transformEnvironmentApiResponse } from "src/domain/environment/environm
 import { getTeams } from "src/domain/team/team-api";
 import { TopicRequest } from "src/domain/topic";
 import { getTopicRequestsForApprover } from "src/domain/topic/topic-api";
-import { transformGetTopicRequestsForApproverResponse } from "src/domain/topic/topic-transformer";
+import { transformGetTopicRequestsResponse } from "src/domain/topic/topic-transformer";
 import { TopicRequestApiResponse } from "src/domain/topic/topic-types";
 import { mockIntersectionObserver } from "src/services/test-utils/mock-intersection-observer";
 import { customRender } from "src/services/test-utils/render-with-wrappers";
@@ -119,7 +119,7 @@ const mockedTeamsResponse = [
 ];
 
 const mockedApiResponse: TopicRequestApiResponse =
-  transformGetTopicRequestsForApproverResponse(mockedTopicRequestsResponse);
+  transformGetTopicRequestsResponse(mockedTopicRequestsResponse);
 const mockGetEnvironmentResponse = transformEnvironmentApiResponse(
   mockedEnvironmentResponse
 );
@@ -146,7 +146,7 @@ describe("TopicApprovals", () => {
 
     it("shows a loading state instead of a table while topic requests are being fetched", () => {
       mockGetTopicRequestsForApprover.mockResolvedValue(
-        transformGetTopicRequestsForApproverResponse([])
+        transformGetTopicRequestsResponse([])
       );
 
       customRender(<TopicApprovals />, {

--- a/coral/src/domain/topic/topic-api.ts
+++ b/coral/src/domain/topic/topic-api.ts
@@ -128,6 +128,31 @@ const getTopicRequestsForApprover = (
     .then(transformGetTopicRequestsForApproverResponse);
 };
 
+const getTopicRequests = (
+  params: KlawApiRequestQueryParameters<"getTopicRequests">
+): Promise<TopicRequestApiResponse> => {
+  const filteredParams = omitBy(
+    { ...params, isMyRequest: String(Boolean(params.isMyRequest)) },
+    (value, property) => {
+      const omitIsMyRequest = property === "isMyRequest" && value === "false";
+      const omitSearch = property === "search" && value === "";
+      const omitEnv =
+        property === "env" && (value === "ALL" || value === undefined);
+      const omitOperationType =
+        property === "operationType" &&
+        (value === "ALL" || value === undefined);
+
+      return omitIsMyRequest || omitSearch || omitEnv || omitOperationType;
+    }
+  );
+
+  return api
+    .get<KlawApiResponse<"getTopicRequests">>(
+      `/getTopicRequests?${new URLSearchParams(filteredParams)}`
+    )
+    .then(transformGetTopicRequestsForApproverResponse);
+};
+
 type ApproveTopicRequestPayload = RequestVerdictApproval<"TOPIC">;
 const approveTopicRequest = (payload: ApproveTopicRequestPayload) => {
   return api.post<
@@ -151,6 +176,7 @@ export {
   getTopicAdvancedConfigOptions,
   requestTopic,
   getTopicRequestsForApprover,
+  getTopicRequests,
   approveTopicRequest,
   declineTopicRequest,
 };

--- a/coral/src/domain/topic/topic-api.ts
+++ b/coral/src/domain/topic/topic-api.ts
@@ -138,11 +138,13 @@ const getTopicRequests = (
       const omitSearch = property === "search" && value === "";
       const omitEnv =
         property === "env" && (value === "ALL" || value === undefined);
-      const omitOperationType =
-        property === "operationType" &&
+      const omitRequestOperationType =
+        property === "requestOperationType" &&
         (value === "ALL" || value === undefined);
 
-      return omitIsMyRequest || omitSearch || omitEnv || omitOperationType;
+      return (
+        omitIsMyRequest || omitSearch || omitEnv || omitRequestOperationType
+      );
     }
   );
 

--- a/coral/src/domain/topic/topic-api.ts
+++ b/coral/src/domain/topic/topic-api.ts
@@ -8,7 +8,7 @@ import { Team } from "src/domain/team";
 import { ALL_TEAMS_VALUE } from "src/domain/team/team-types";
 import {
   transformGetTopicAdvancedConfigOptionsResponse,
-  transformGetTopicRequestsForApproverResponse,
+  transformGetTopicRequestsResponse,
   transformTopicApiResponse,
 } from "src/domain/topic/topic-transformer";
 import {
@@ -125,7 +125,7 @@ const getTopicRequestsForApprover = (
     .get<KlawApiResponse<"getTopicRequestsForApprover">>(
       `/getTopicRequestsForApprover?${new URLSearchParams(filteredParams)}`
     )
-    .then(transformGetTopicRequestsForApproverResponse);
+    .then(transformGetTopicRequestsResponse);
 };
 
 const getTopicRequests = (
@@ -150,7 +150,7 @@ const getTopicRequests = (
     .get<KlawApiResponse<"getTopicRequests">>(
       `/getTopicRequests?${new URLSearchParams(filteredParams)}`
     )
-    .then(transformGetTopicRequestsForApproverResponse);
+    .then(transformGetTopicRequestsResponse);
 };
 
 type ApproveTopicRequestPayload = RequestVerdictApproval<"TOPIC">;

--- a/coral/src/domain/topic/topic-transformer.test.ts
+++ b/coral/src/domain/topic/topic-transformer.test.ts
@@ -1,6 +1,6 @@
 import {
   transformGetTopicAdvancedConfigOptionsResponse,
-  transformGetTopicRequestsForApproverResponse,
+  transformGetTopicRequestsResponse,
   transformTopicApiResponse,
 } from "src/domain/topic/topic-transformer";
 import {
@@ -93,11 +93,9 @@ describe("topic-transformer.ts", () => {
     });
   });
 
-  describe("transformGetTopicRequestsForApproverResponse", () => {
+  describe("transformGetTopicRequestsResponse", () => {
     it("transforms empty payload into empty array", () => {
-      const transformedResponse = transformGetTopicRequestsForApproverResponse(
-        []
-      );
+      const transformedResponse = transformGetTopicRequestsResponse([]);
 
       const result: TopicRequestApiResponse = {
         totalPages: 0,
@@ -173,7 +171,7 @@ describe("topic-transformer.ts", () => {
         },
       ];
       const transformedResponse =
-        transformGetTopicRequestsForApproverResponse(mockedResponse);
+        transformGetTopicRequestsResponse(mockedResponse);
 
       const result: TopicRequestApiResponse = {
         totalPages: 3,

--- a/coral/src/domain/topic/topic-transformer.ts
+++ b/coral/src/domain/topic/topic-transformer.ts
@@ -149,7 +149,7 @@ function transformGetTopicAdvancedConfigOptionsResponse(
   });
 }
 
-function transformGetTopicRequestsForApproverResponse(
+function transformGetTopicRequestsResponse(
   apiResponse: KlawApiResponse<"getTopicRequestsForApprover">
 ): TopicRequestApiResponse {
   if (apiResponse.length === 0) {
@@ -170,5 +170,5 @@ function transformGetTopicRequestsForApproverResponse(
 export {
   transformTopicApiResponse,
   transformGetTopicAdvancedConfigOptionsResponse,
-  transformGetTopicRequestsForApproverResponse,
+  transformGetTopicRequestsResponse,
 };

--- a/coral/types/api.d.ts
+++ b/coral/types/api.d.ts
@@ -1349,7 +1349,7 @@ export type operations = {
         pageNo: string;
         currentPage?: string;
         requestStatus?: components["schemas"]["RequestStatus"];
-        operationType?: components["schemas"]["RequestOperationType"];
+        requestOperationType?: components["schemas"]["RequestOperationType"];
         env?: string;
         search?: string;
         isMyRequest?: boolean;

--- a/coral/types/api.d.ts
+++ b/coral/types/api.d.ts
@@ -60,6 +60,9 @@ export type paths = {
   "/getTopicRequestsForApprover": {
     get: operations["getTopicRequestsForApprover"];
   };
+  "/getTopicRequests": {
+    get: operations["getTopicRequests"];
+  };
   "/getAuth": {
     get: operations["getAuth"];
   };
@@ -1340,6 +1343,27 @@ export type operations = {
       };
     };
   };
+  getTopicRequests: {
+    parameters: {
+      query: {
+        pageNo: string;
+        currentPage?: string;
+        requestStatus?: components["schemas"]["RequestStatus"];
+        operationType?: components["schemas"]["RequestOperationType"];
+        env?: string;
+        search?: string;
+        isMyRequest?: boolean;
+      };
+    };
+    responses: {
+      /** successful operation */
+      200: {
+        content: {
+          "application/json": components["schemas"]["TopicRequest"][];
+        };
+      };
+    };
+  };
   getAuth: {
     responses: {
       200: {
@@ -1439,6 +1463,7 @@ export enum ApiPaths {
   schemaRegEnvsGet = "/getSchemaRegEnvs",
   schemaUpload = "/uploadSchema",
   getTopicRequestsForApprover = "/getTopicRequestsForApprover",
+  getTopicRequests = "/getTopicRequests",
   getAuth = "/getAuth",
   approveRequest = "/request/approve",
   declineRequest = "/request/decline",

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -481,6 +481,54 @@ paths:
                 type: array
                 items:
                   $ref: "#/components/schemas/TopicRequest"
+  /getTopicRequests:
+    get:
+      operationId: getTopicRequests
+      parameters:
+        - name: pageNo
+          in: query
+          required: true
+          example: "2"
+          schema:
+            type: string
+        - name: currentPage
+          in: query
+          example: "2"
+          schema:
+            type: string
+        - name: requestStatus
+          in: query
+          example: "CREATED"
+          schema:
+            $ref: "#/components/schemas/RequestStatus"
+        - name: operationType
+          in: query
+          example: "CREATE"
+          schema:
+            $ref: "#/components/schemas/RequestOperationType"
+        - name: env
+          in: query
+          schema:
+            type: string
+          example: "1"
+        - name: search
+          in: query
+          schema:
+            type: string
+        - name: isMyRequest
+          in: query
+          schema:
+            type: boolean
+      responses:
+        200:
+          description: successful operation
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/TopicRequest"
+
   /getAuth:
     get:
       operationId: getAuth

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -501,7 +501,7 @@ paths:
           example: "CREATED"
           schema:
             $ref: "#/components/schemas/RequestStatus"
-        - name: operationType
+        - name: requestOperationType
           in: query
           example: "CREATE"
           schema:


### PR DESCRIPTION
## About this change - What it does

- add `openapi` specs for `getTopicRequests`
- generate types
- add `getTopicRequests` function to `topic-api`

## To be noted

- the `operationType` param currently do not exist, but will be added shortly
- the transfomer used for `getTopicRequestsForApprover` has been renamed to `transformGetTopicRequestsResponse`, as it is also used for `getTopicRequests`


Resolves: #769
