### PR TITLE
Extend the Request API to process delete requests.

### DIFF
--- a/core/src/main/java/io/aiven/klaw/controller/RequestController.java
+++ b/core/src/main/java/io/aiven/klaw/controller/RequestController.java
@@ -48,6 +48,16 @@ public class RequestController {
     return wrapInResponseEntity(service.processDeclineRequests(verdict));
   }
 
+  @RequestMapping(
+      value = "/delete",
+      method = RequestMethod.POST,
+      produces = {MediaType.APPLICATION_JSON_VALUE})
+  public ResponseEntity<List<ApiResponse>> deleteRequest(@Valid @RequestBody RequestVerdict verdict)
+      throws KlawException, KlawRestException {
+    log.info("Delete Requests : {}", verdict);
+    return wrapInResponseEntity(service.processDeleteRequests(verdict));
+  }
+
   private ResponseEntity<List<ApiResponse>> wrapInResponseEntity(List<ApiResponse> obj) {
     int failure = 0, success = 0;
     HttpStatus status;

--- a/core/src/main/java/io/aiven/klaw/controller/RequestController.java
+++ b/core/src/main/java/io/aiven/klaw/controller/RequestController.java
@@ -7,6 +7,10 @@ import io.aiven.klaw.model.ApiResponse;
 import io.aiven.klaw.model.RequestVerdict;
 import io.aiven.klaw.model.enums.ApiResultStatus;
 import io.aiven.klaw.service.RequestService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.ArraySchema;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.Valid;
 import java.util.List;
 import lombok.extern.slf4j.Slf4j;
@@ -30,6 +34,39 @@ public class RequestController {
       value = "/approve",
       method = RequestMethod.POST,
       produces = {MediaType.APPLICATION_JSON_VALUE})
+  @Operation(
+      summary = "Approve a Request",
+      description = "Updates the Status of a request to Approved and provisions the request",
+      responses = {
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(
+            description = "OK",
+            responseCode = "200",
+            content =
+                @Content(
+                    mediaType = "application/json",
+                    array = @ArraySchema(schema = @Schema(implementation = ApiResponse.class)))),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(
+            description = "Internal Server Error",
+            responseCode = "500",
+            content =
+                @Content(
+                    mediaType = "application/json",
+                    array = @ArraySchema(schema = @Schema(implementation = ApiResponse.class)))),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(
+            description = "Multi Status",
+            responseCode = "207",
+            content =
+                @Content(
+                    mediaType = "application/json",
+                    array = @ArraySchema(schema = @Schema(implementation = ApiResponse.class)))),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(
+            description = "Bad Request",
+            responseCode = "405",
+            content =
+                @Content(
+                    mediaType = "application/json",
+                    array = @ArraySchema(schema = @Schema(implementation = ApiResponse.class))))
+      })
   public ResponseEntity<List<ApiResponse>> approveRequest(
       @Valid @RequestBody RequestVerdict verdict) throws KlawException {
 
@@ -40,6 +77,39 @@ public class RequestController {
       value = "/decline",
       method = RequestMethod.POST,
       produces = {MediaType.APPLICATION_JSON_VALUE})
+  @Operation(
+      summary = "Decline a Request",
+      description = "Updates the Status of a request to Declined",
+      responses = {
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(
+            description = "OK",
+            responseCode = "200",
+            content =
+                @Content(
+                    mediaType = "application/json",
+                    array = @ArraySchema(schema = @Schema(implementation = ApiResponse.class)))),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(
+            description = "Internal Server Error",
+            responseCode = "500",
+            content =
+                @Content(
+                    mediaType = "application/json",
+                    array = @ArraySchema(schema = @Schema(implementation = ApiResponse.class)))),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(
+            description = "Multi Status",
+            responseCode = "207",
+            content =
+                @Content(
+                    mediaType = "application/json",
+                    array = @ArraySchema(schema = @Schema(implementation = ApiResponse.class)))),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(
+            description = "Bad Request",
+            responseCode = "405",
+            content =
+                @Content(
+                    mediaType = "application/json",
+                    array = @ArraySchema(schema = @Schema(implementation = ApiResponse.class))))
+      })
   public ResponseEntity<List<ApiResponse>> declineRequest(
       @Valid @RequestBody RequestVerdict verdict) throws KlawException, KlawRestException {
     log.info("My bad Verdict{}", verdict);
@@ -52,6 +122,39 @@ public class RequestController {
       value = "/delete",
       method = RequestMethod.POST,
       produces = {MediaType.APPLICATION_JSON_VALUE})
+  @Operation(
+      summary = "Delete a Request",
+      description = "Updates the Status of a request to Deleted",
+      responses = {
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(
+            description = "OK",
+            responseCode = "200",
+            content =
+                @Content(
+                    mediaType = "application/json",
+                    array = @ArraySchema(schema = @Schema(implementation = ApiResponse.class)))),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(
+            description = "Internal Server Error",
+            responseCode = "500",
+            content =
+                @Content(
+                    mediaType = "application/json",
+                    array = @ArraySchema(schema = @Schema(implementation = ApiResponse.class)))),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(
+            description = "Multi Status",
+            responseCode = "207",
+            content =
+                @Content(
+                    mediaType = "application/json",
+                    array = @ArraySchema(schema = @Schema(implementation = ApiResponse.class)))),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(
+            description = "Bad Request",
+            responseCode = "405",
+            content =
+                @Content(
+                    mediaType = "application/json",
+                    array = @ArraySchema(schema = @Schema(implementation = ApiResponse.class))))
+      })
   public ResponseEntity<List<ApiResponse>> deleteRequest(@Valid @RequestBody RequestVerdict verdict)
       throws KlawException, KlawRestException {
     log.info("Delete Requests : {}", verdict);

--- a/core/src/main/java/io/aiven/klaw/service/RequestService.java
+++ b/core/src/main/java/io/aiven/klaw/service/RequestService.java
@@ -39,9 +39,7 @@ public class RequestService {
         case CONNECTOR:
           return kafkaConnectControllerService.approveConnectorRequests(reqId);
         default:
-          return ApiResponse.builder()
-              .result("Failure Unable to determine target resource.")
-              .build();
+          return undeterinableResource();
       }
     } catch (Exception ex) {
 
@@ -58,6 +56,36 @@ public class RequestService {
         .collect(Collectors.toList());
   }
 
+  public List<ApiResponse> processDeleteRequests(RequestVerdict requestVerdict) {
+    return requestVerdict.getReqIds().stream()
+        .map(req -> processDeleteRequest(req, requestVerdict.getRequestEntityType()))
+        .collect(Collectors.toList());
+  }
+
+  private ApiResponse processDeleteRequest(String reqId, RequestEntityType requestEntityType) {
+    try {
+      switch (requestEntityType) {
+        case TOPIC:
+          return topicControllerService.deleteTopicRequests(reqId);
+        case ACL:
+          return aclControllerService.deleteAclRequests(reqId);
+        case SCHEMA:
+          return schemaRegstryControllerService.deleteSchemaRequests(reqId);
+        case CONNECTOR:
+          return kafkaConnectControllerService.deleteConnectorRequests(reqId);
+        default:
+          return undeterinableResource();
+      }
+
+    } catch (Exception ex) {
+      return ApiResponse.builder().result("Failure unable to delete requestId " + reqId).build();
+    }
+  }
+
+  private static ApiResponse undeterinableResource() {
+    return ApiResponse.builder().result("Failure Unable to determine target resource.").build();
+  }
+
   private ApiResponse processDeclineRequests(
       String reqId, String reason, RequestEntityType requestEntityType) {
     try {
@@ -71,14 +99,12 @@ public class RequestService {
         case CONNECTOR:
           return kafkaConnectControllerService.declineConnectorRequests(reqId, reason);
         default:
-          return ApiResponse.builder()
-              .result("Failure Unable to determine target resource.")
-              .build();
+          return undeterinableResource();
       }
 
     } catch (Exception ex) {
 
-      return ApiResponse.builder().result("Failure unable to approve requestId " + reqId).build();
+      return ApiResponse.builder().result("Failure unable to decline requestId " + reqId).build();
     }
   }
 }

--- a/core/src/main/resources/openapi.yaml
+++ b/core/src/main/resources/openapi.yaml
@@ -599,6 +599,8 @@
     "/request/delete" : {
       "post" : {
         "tags" : [ "request-controller" ],
+        "summary" : "Delete a Request",
+        "description" : "Updates the Status of a request to Deleted",
         "operationId" : "deleteRequest",
         "requestBody" : {
           "content" : {
@@ -623,6 +625,45 @@
                 }
               }
             }
+          },
+          "500" : {
+            "description" : "Internal Server Error",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "type" : "array",
+                  "items" : {
+                    "$ref" : "#/components/schemas/ApiResponse"
+                  }
+                }
+              }
+            }
+          },
+          "207" : {
+            "description" : "Multi Status",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "type" : "array",
+                  "items" : {
+                    "$ref" : "#/components/schemas/ApiResponse"
+                  }
+                }
+              }
+            }
+          },
+          "405" : {
+            "description" : "Bad Request",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "type" : "array",
+                  "items" : {
+                    "$ref" : "#/components/schemas/ApiResponse"
+                  }
+                }
+              }
+            }
           }
         }
       }
@@ -630,6 +671,8 @@
     "/request/decline" : {
       "post" : {
         "tags" : [ "request-controller" ],
+        "summary" : "Decline a Request",
+        "description" : "Updates the Status of a request to Declined",
         "operationId" : "declineRequest",
         "requestBody" : {
           "content" : {
@@ -654,6 +697,45 @@
                 }
               }
             }
+          },
+          "500" : {
+            "description" : "Internal Server Error",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "type" : "array",
+                  "items" : {
+                    "$ref" : "#/components/schemas/ApiResponse"
+                  }
+                }
+              }
+            }
+          },
+          "207" : {
+            "description" : "Multi Status",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "type" : "array",
+                  "items" : {
+                    "$ref" : "#/components/schemas/ApiResponse"
+                  }
+                }
+              }
+            }
+          },
+          "405" : {
+            "description" : "Bad Request",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "type" : "array",
+                  "items" : {
+                    "$ref" : "#/components/schemas/ApiResponse"
+                  }
+                }
+              }
+            }
           }
         }
       }
@@ -661,6 +743,8 @@
     "/request/approve" : {
       "post" : {
         "tags" : [ "request-controller" ],
+        "summary" : "Approve a Request",
+        "description" : "Updates the Status of a request to Approved and provisions the request",
         "operationId" : "approveRequest",
         "requestBody" : {
           "content" : {
@@ -675,6 +759,45 @@
         "responses" : {
           "200" : {
             "description" : "OK",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "type" : "array",
+                  "items" : {
+                    "$ref" : "#/components/schemas/ApiResponse"
+                  }
+                }
+              }
+            }
+          },
+          "500" : {
+            "description" : "Internal Server Error",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "type" : "array",
+                  "items" : {
+                    "$ref" : "#/components/schemas/ApiResponse"
+                  }
+                }
+              }
+            }
+          },
+          "207" : {
+            "description" : "Multi Status",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "type" : "array",
+                  "items" : {
+                    "$ref" : "#/components/schemas/ApiResponse"
+                  }
+                }
+              }
+            }
+          },
+          "405" : {
+            "description" : "Bad Request",
             "content" : {
               "application/json" : {
                 "schema" : {

--- a/core/src/main/resources/openapi.yaml
+++ b/core/src/main/resources/openapi.yaml
@@ -596,6 +596,37 @@
         }
       }
     },
+    "/request/delete" : {
+      "post" : {
+        "tags" : [ "request-controller" ],
+        "operationId" : "deleteRequest",
+        "requestBody" : {
+          "content" : {
+            "application/json" : {
+              "schema" : {
+                "$ref" : "#/components/schemas/RequestVerdict"
+              }
+            }
+          },
+          "required" : true
+        },
+        "responses" : {
+          "200" : {
+            "description" : "OK",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "type" : "array",
+                  "items" : {
+                    "$ref" : "#/components/schemas/ApiResponse"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/request/decline" : {
       "post" : {
         "tags" : [ "request-controller" ],

--- a/core/src/test/java/io/aiven/klaw/controller/RequestControllerTest.java
+++ b/core/src/test/java/io/aiven/klaw/controller/RequestControllerTest.java
@@ -343,7 +343,7 @@ class RequestControllerTest {
     verify(topicControllerService, times(2)).declineTopicRequests(anyString(), anyString());
   }
 
-  @Order(4)
+  @Order(21)
   @Test
   public void givenARequestToDeclineCCallCorrectTOPICServiceAndReturnISEResponse()
       throws KlawException, KlawRestException {
@@ -356,7 +356,7 @@ class RequestControllerTest {
     verify(topicControllerService, times(1)).declineTopicRequests(anyString(), anyString());
   }
 
-  @Order(4)
+  @Order(22)
   @Test
   public void givenMultipleRequestToDeclineCCallCorrectTOPICServiceAndReturnISEResponse()
       throws KlawException, KlawRestException {
@@ -370,7 +370,7 @@ class RequestControllerTest {
     verify(topicControllerService, times(2)).declineTopicRequests(anyString(), anyString());
   }
 
-  @Order(5)
+  @Order(23)
   @Test
   public void givenARequestToDeclineCMulitpleCallCorrectSCHEMAServiceAndReturnSuccessOK()
       throws KlawException, KlawRestException {
@@ -384,7 +384,7 @@ class RequestControllerTest {
         .execSchemaRequestsDecline(anyString(), anyString());
   }
 
-  @Order(6)
+  @Order(24)
   @Test
   public void
       givenARequestToDeclineCMulitpleCallCorrectSCHEMAServiceAndReturnSuccessMultiStatusResponse()
@@ -400,7 +400,7 @@ class RequestControllerTest {
         .execSchemaRequestsDecline(anyString(), anyString());
   }
 
-  @Order(7)
+  @Order(25)
   @Test
   public void givenARequestToDeclineCCallCorrectSCHEMAServiceAndReturnISEResponse()
       throws KlawException, KlawRestException {
@@ -414,7 +414,7 @@ class RequestControllerTest {
         .execSchemaRequestsDecline(anyString(), anyString());
   }
 
-  @Order(8)
+  @Order(26)
   @Test
   public void givenMultipleRequestToDeclineCCallCorrectSCHEMAServiceAndReturnISEResponse()
       throws KlawException, KlawRestException {
@@ -428,7 +428,7 @@ class RequestControllerTest {
         .execSchemaRequestsDecline(anyString(), anyString());
   }
 
-  @Order(9)
+  @Order(27)
   @Test
   public void givenARequestToDeclineCMulitpleCallCorrectCONNECTORServiceAndReturnSuccessOK()
       throws KlawException, KlawRestException {
@@ -442,7 +442,7 @@ class RequestControllerTest {
         .declineConnectorRequests(anyString(), anyString());
   }
 
-  @Order(10)
+  @Order(28)
   @Test
   public void
       givenARequestToDeclineCMulitpleCallCorrectCONNECTORServiceAndReturnSuccessMultiStatusResponse()
@@ -458,7 +458,7 @@ class RequestControllerTest {
         .declineConnectorRequests(anyString(), anyString());
   }
 
-  @Order(11)
+  @Order(29)
   @Test
   public void givenARequestToDeclineCCallCorrectCONNECTORServiceAndReturnISEResponse()
       throws KlawException, KlawRestException {
@@ -472,7 +472,7 @@ class RequestControllerTest {
         .declineConnectorRequests(anyString(), anyString());
   }
 
-  @Order(12)
+  @Order(30)
   @Test
   public void givenMultipleRequestToDeclineCCallCorrectCONNECTORServiceAndReturnISEResponse()
       throws KlawException, KlawRestException {
@@ -486,7 +486,7 @@ class RequestControllerTest {
         .declineConnectorRequests(anyString(), anyString());
   }
 
-  @Order(13)
+  @Order(31)
   @Test
   public void givenARequestToDeclineCMulitpleCallCorrectACLServiceAndReturnSuccessOK()
       throws KlawException, KlawRestException {
@@ -499,7 +499,7 @@ class RequestControllerTest {
     verify(aclControllerService, times(2)).declineAclRequests(anyString(), anyString());
   }
 
-  @Order(14)
+  @Order(32)
   @Test
   public void
       givenARequestToDeclineCMulitpleCallCorrectACLServiceAndReturnSuccessMultiStatusResponse()
@@ -514,7 +514,7 @@ class RequestControllerTest {
     verify(aclControllerService, times(2)).declineAclRequests(anyString(), anyString());
   }
 
-  @Order(15)
+  @Order(33)
   @Test
   public void givenARequestToDeclineCCallCorrectACLServiceAndReturnISEResponse()
       throws KlawException, KlawRestException {
@@ -527,7 +527,7 @@ class RequestControllerTest {
     verify(aclControllerService, times(1)).declineAclRequests(anyString(), anyString());
   }
 
-  @Order(16)
+  @Order(34)
   @Test
   public void givenMultipleRequestToDeclineCCallCorrectACLServiceAndReturnISEResponse()
       throws KlawException, KlawRestException {
@@ -540,7 +540,7 @@ class RequestControllerTest {
     verify(aclControllerService, times(2)).declineAclRequests(anyString(), anyString());
   }
 
-  @Order(17)
+  @Order(35)
   @Test
   public void givenMultipleRequestToDeclineCCCallCorrectUSERServiceAndReturnISEResponse()
       throws KlawException, KlawRestException {
@@ -555,6 +555,242 @@ class RequestControllerTest {
     verify(schemaRegstryControllerService, times(0))
         .execSchemaRequestsDecline(anyString(), anyString());
     verify(topicControllerService, times(0)).declineTopicRequests(anyString(), anyString());
+  }
+
+  @Order(36)
+  @Test
+  public void givenARequestToDeleteCallCorrectServiceAndReturnSuccessOK()
+      throws KlawException, KlawRestException {
+    when(topicControllerService.deleteTopicRequests(eq("1001")))
+        .thenReturn(getApiResponse(ApiResultStatus.SUCCESS));
+    ResponseEntity<List<ApiResponse>> result =
+        controller.deleteRequest(createRequestVerdict(RequestEntityType.TOPIC, null, "1001"));
+    assertThat(result.getStatusCode()).isEqualTo(HttpStatusCode.valueOf(200));
+    verify(topicControllerService, times(1)).deleteTopicRequests(eq("1001"));
+  }
+
+  @Order(37)
+  @Test
+  public void givenMultipleRequestsToDeleteCallCorrectServiceAndReturnSuccessOK()
+      throws KlawException, KlawRestException {
+    when(topicControllerService.deleteTopicRequests(anyString()))
+        .thenReturn(getApiResponse(ApiResultStatus.SUCCESS));
+    ResponseEntity<List<ApiResponse>> result =
+        controller.deleteRequest(
+            createRequestVerdict(RequestEntityType.TOPIC, null, "1001", "2002"));
+    assertThat(result.getStatusCode()).isEqualTo(HttpStatusCode.valueOf(200));
+    verify(topicControllerService, times(2)).deleteTopicRequests(anyString());
+  }
+
+  @Order(38)
+  @Test
+  public void
+      givenARequestToDeleteCMulitpleCallCorrectTOPICServiceAndReturnSuccessMultiStatusResponse()
+          throws KlawException, KlawRestException {
+    when(topicControllerService.deleteTopicRequests(anyString()))
+        .thenReturn(getApiResponse(ApiResultStatus.SUCCESS))
+        .thenReturn(getApiResponse(ApiResultStatus.FAILURE));
+    ResponseEntity<List<ApiResponse>> result =
+        controller.deleteRequest(
+            createRequestVerdict(RequestEntityType.TOPIC, null, "1001", "2001"));
+    assertThat(result.getStatusCode()).isEqualTo(HttpStatusCode.valueOf(207));
+    verify(topicControllerService, times(2)).deleteTopicRequests(anyString());
+  }
+
+  @Order(39)
+  @Test
+  public void givenARequestToDeleteCallCorrectTOPICServiceAndReturnISEResponse()
+      throws KlawException, KlawRestException {
+    when(topicControllerService.deleteTopicRequests(anyString()))
+        .thenReturn(getApiResponse(ApiResultStatus.FAILURE));
+    ResponseEntity<List<ApiResponse>> result =
+        controller.deleteRequest(createRequestVerdict(RequestEntityType.TOPIC, null, "1001"));
+    assertThat(result.getStatusCode()).isEqualTo(HttpStatusCode.valueOf(500));
+    verify(topicControllerService, times(1)).deleteTopicRequests(anyString());
+  }
+
+  @Order(40)
+  @Test
+  public void givenMultipleRequestToDeleteCallCorrectTOPICServiceAndReturnISEResponse()
+      throws KlawException, KlawRestException {
+    when(topicControllerService.deleteTopicRequests(anyString()))
+        .thenReturn(getApiResponse(ApiResultStatus.FAILURE));
+    ResponseEntity<List<ApiResponse>> result =
+        controller.deleteRequest(
+            createRequestVerdict(RequestEntityType.TOPIC, null, "1001", "2001"));
+    assertThat(result.getStatusCode()).isEqualTo(HttpStatusCode.valueOf(500));
+    verify(topicControllerService, times(2)).deleteTopicRequests(anyString());
+  }
+
+  @Order(41)
+  @Test
+  public void givenARequestToDeleteMulitpleCallCorrectSCHEMAServiceAndReturnSuccessOK()
+      throws KlawException, KlawRestException {
+    when(schemaRegstryControllerService.deleteSchemaRequests(anyString()))
+        .thenReturn(getApiResponse(ApiResultStatus.SUCCESS));
+    ResponseEntity<List<ApiResponse>> result =
+        controller.deleteRequest(
+            createRequestVerdict(RequestEntityType.SCHEMA, null, "1001", "2001"));
+    assertThat(result.getStatusCode()).isEqualTo(HttpStatusCode.valueOf(200));
+    verify(schemaRegstryControllerService, times(2)).deleteSchemaRequests(anyString());
+  }
+
+  @Order(42)
+  @Test
+  public void
+      givenARequestToDeleteMulitpleCallCorrectSCHEMAServiceAndReturnSuccessMultiStatusResponse()
+          throws KlawException, KlawRestException {
+    when(schemaRegstryControllerService.deleteSchemaRequests(anyString()))
+        .thenReturn(getApiResponse(ApiResultStatus.SUCCESS))
+        .thenReturn(getApiResponse(ApiResultStatus.FAILURE));
+    ResponseEntity<List<ApiResponse>> result =
+        controller.deleteRequest(
+            createRequestVerdict(RequestEntityType.SCHEMA, null, "1001", "2001"));
+    assertThat(result.getStatusCode()).isEqualTo(HttpStatusCode.valueOf(207));
+    verify(schemaRegstryControllerService, times(2)).deleteSchemaRequests(anyString());
+  }
+
+  @Order(43)
+  @Test
+  public void givenARequestToDeleteCallCorrectSCHEMAServiceAndReturnISEResponse()
+      throws KlawException, KlawRestException {
+    when(schemaRegstryControllerService.deleteSchemaRequests(anyString()))
+        .thenReturn(getApiResponse(ApiResultStatus.FAILURE));
+    ResponseEntity<List<ApiResponse>> result =
+        controller.deleteRequest(createRequestVerdict(RequestEntityType.SCHEMA, null, "1001"));
+    assertThat(result.getStatusCode()).isEqualTo(HttpStatusCode.valueOf(500));
+    verify(schemaRegstryControllerService, times(1)).deleteSchemaRequests(anyString());
+  }
+
+  @Order(44)
+  @Test
+  public void givenMultipleRequestToDeleteCallCorrectSCHEMAServiceAndReturnISEResponse()
+      throws KlawException, KlawRestException {
+    when(schemaRegstryControllerService.deleteSchemaRequests(anyString()))
+        .thenReturn(getApiResponse(ApiResultStatus.FAILURE));
+    ResponseEntity<List<ApiResponse>> result =
+        controller.deleteRequest(
+            createRequestVerdict(RequestEntityType.SCHEMA, null, "1001", "2001"));
+    assertThat(result.getStatusCode()).isEqualTo(HttpStatusCode.valueOf(500));
+    verify(schemaRegstryControllerService, times(2)).deleteSchemaRequests(anyString());
+  }
+
+  @Order(45)
+  @Test
+  public void givenARequestToDeleteMulitpleCallCorrectCONNECTORServiceAndReturnSuccessOK()
+      throws KlawException, KlawRestException {
+    when(kafkaConnectControllerService.deleteConnectorRequests(anyString()))
+        .thenReturn(getApiResponse(ApiResultStatus.SUCCESS));
+    ResponseEntity<List<ApiResponse>> result =
+        controller.deleteRequest(
+            createRequestVerdict(RequestEntityType.CONNECTOR, null, "1001", "2001"));
+    assertThat(result.getStatusCode()).isEqualTo(HttpStatusCode.valueOf(200));
+    verify(kafkaConnectControllerService, times(2)).deleteConnectorRequests(anyString());
+  }
+
+  @Order(46)
+  @Test
+  public void
+      givenARequestToDeleteMulitpleCallCorrectCONNECTORServiceAndReturnSuccessMultiStatusResponse()
+          throws KlawException, KlawRestException {
+    when(kafkaConnectControllerService.deleteConnectorRequests(anyString()))
+        .thenReturn(getApiResponse(ApiResultStatus.SUCCESS))
+        .thenReturn(getApiResponse(ApiResultStatus.FAILURE));
+    ResponseEntity<List<ApiResponse>> result =
+        controller.deleteRequest(
+            createRequestVerdict(RequestEntityType.CONNECTOR, null, "1001", "2001"));
+    assertThat(result.getStatusCode()).isEqualTo(HttpStatusCode.valueOf(207));
+    verify(kafkaConnectControllerService, times(2)).deleteConnectorRequests(anyString());
+  }
+
+  @Order(47)
+  @Test
+  public void givenARequestToDeleteCallCorrectCONNECTORServiceAndReturnISEResponse()
+      throws KlawException, KlawRestException {
+    when(kafkaConnectControllerService.deleteConnectorRequests(anyString()))
+        .thenReturn(getApiResponse(ApiResultStatus.FAILURE));
+    ResponseEntity<List<ApiResponse>> result =
+        controller.deleteRequest(createRequestVerdict(RequestEntityType.CONNECTOR, null, "1001"));
+    assertThat(result.getStatusCode()).isEqualTo(HttpStatusCode.valueOf(500));
+    verify(kafkaConnectControllerService, times(1)).deleteConnectorRequests(anyString());
+  }
+
+  @Order(48)
+  @Test
+  public void givenMultipleRequestToDeleteCallCorrectCONNECTORServiceAndReturnISEResponse()
+      throws KlawException, KlawRestException {
+    when(kafkaConnectControllerService.deleteConnectorRequests(anyString()))
+        .thenReturn(getApiResponse(ApiResultStatus.FAILURE));
+    ResponseEntity<List<ApiResponse>> result =
+        controller.deleteRequest(
+            createRequestVerdict(RequestEntityType.CONNECTOR, null, "1001", "2001"));
+    assertThat(result.getStatusCode()).isEqualTo(HttpStatusCode.valueOf(500));
+    verify(kafkaConnectControllerService, times(2)).deleteConnectorRequests(anyString());
+  }
+
+  @Order(49)
+  @Test
+  public void givenARequestToDeleteMulitpleCallCorrectACLServiceAndReturnSuccessOK()
+      throws KlawException, KlawRestException {
+    when(aclControllerService.deleteAclRequests(anyString()))
+        .thenReturn(getApiResponse(ApiResultStatus.SUCCESS));
+    ResponseEntity<List<ApiResponse>> result =
+        controller.deleteRequest(createRequestVerdict(RequestEntityType.ACL, null, "1001", "2001"));
+    assertThat(result.getStatusCode()).isEqualTo(HttpStatusCode.valueOf(200));
+    verify(aclControllerService, times(2)).deleteAclRequests(anyString());
+  }
+
+  @Order(50)
+  @Test
+  public void
+      givenARequestToDeleteMulitpleCallCorrectACLServiceAndReturnSuccessMultiStatusResponse()
+          throws KlawException, KlawRestException {
+    when(aclControllerService.deleteAclRequests(anyString()))
+        .thenReturn(getApiResponse(ApiResultStatus.SUCCESS))
+        .thenReturn(getApiResponse(ApiResultStatus.FAILURE));
+    ResponseEntity<List<ApiResponse>> result =
+        controller.deleteRequest(createRequestVerdict(RequestEntityType.ACL, null, "1001", "2001"));
+    assertThat(result.getStatusCode()).isEqualTo(HttpStatusCode.valueOf(207));
+    verify(aclControllerService, times(2)).deleteAclRequests(anyString());
+  }
+
+  @Order(51)
+  @Test
+  public void givenARequestToDeleteCallCorrectACLServiceAndReturnISEResponse()
+      throws KlawException, KlawRestException {
+    when(aclControllerService.deleteAclRequests(anyString()))
+        .thenReturn(getApiResponse(ApiResultStatus.FAILURE));
+    ResponseEntity<List<ApiResponse>> result =
+        controller.deleteRequest(createRequestVerdict(RequestEntityType.ACL, null, "1001"));
+    assertThat(result.getStatusCode()).isEqualTo(HttpStatusCode.valueOf(500));
+    verify(aclControllerService, times(1)).deleteAclRequests(anyString());
+  }
+
+  @Order(52)
+  @Test
+  public void givenMultipleRequestToDeleteCallCorrectACLServiceAndReturnISEResponse()
+      throws KlawException, KlawRestException {
+    when(aclControllerService.deleteAclRequests(anyString()))
+        .thenReturn(getApiResponse(ApiResultStatus.FAILURE));
+    ResponseEntity<List<ApiResponse>> result =
+        controller.deleteRequest(createRequestVerdict(RequestEntityType.ACL, null, "1001", "2001"));
+    assertThat(result.getStatusCode()).isEqualTo(HttpStatusCode.valueOf(500));
+    verify(aclControllerService, times(2)).deleteAclRequests(anyString());
+  }
+
+  @Order(53)
+  @Test
+  public void givenMultipleRequestToDeleteCallCorrectUSERServiceAndReturnISEResponse()
+      throws KlawException, KlawRestException {
+
+    ResponseEntity<List<ApiResponse>> result =
+        controller.deleteRequest(
+            createRequestVerdict(RequestEntityType.USER, null, "1001", "2001"));
+    assertThat(result.getStatusCode()).isEqualTo(HttpStatusCode.valueOf(500));
+    verify(aclControllerService, times(0)).deleteAclRequests(anyString());
+    verify(kafkaConnectControllerService, times(0)).deleteConnectorRequests(anyString());
+    verify(schemaRegstryControllerService, times(0)).deleteSchemaRequests(anyString());
+    verify(topicControllerService, times(0)).deleteTopicRequests(anyString());
   }
 
   private RequestVerdict createRequestVerdict(


### PR DESCRIPTION
About this change - What it does
This change extends the Request Controller to allow Delete Requests to be processed in the same manner as Approve and decline requests.

It provides the ability to do a multi or bulk delete in the API and it also provides an expanded number of Status Codes to help the UI best understand what worked and what didnt when using the API.

Resolves: #802 
Why this way
This follows a pattern of increasing the usage of Status Codes and reducing the number of endpoints and different objects needed to use the API.