### PR TITLE
feat(coral): Acl Requests: Add ACL requests page and table

### DIFF
--- a/coral/src/app/features/requests/components/acls/AclRequests.test.tsx
+++ b/coral/src/app/features/requests/components/acls/AclRequests.test.tsx
@@ -1,0 +1,104 @@
+import { cleanup } from "@testing-library/react";
+import { AclRequests } from "src/app/features/requests/components/acls/AclRequests";
+import { getAclRequests } from "src/domain/acl/acl-api";
+import transformAclRequestApiResponse from "src/domain/acl/acl-transformer";
+import { mockIntersectionObserver } from "src/services/test-utils/mock-intersection-observer";
+import { customRender } from "src/services/test-utils/render-with-wrappers";
+
+jest.mock("src/domain/acl/acl-api.ts");
+
+const mockGetAclRequests = getAclRequests as jest.MockedFunction<
+  typeof getAclRequests
+>;
+
+const mockGetAclRequestsResponse = transformAclRequestApiResponse([
+  {
+    remarks: undefined,
+    consumergroup: "-na-",
+    acl_ip: undefined,
+    acl_ssl: ["josepprat"],
+    aclPatternType: "LITERAL",
+    transactionalId: undefined,
+    req_no: 1220,
+    topicname: "uptimetopic",
+    environment: "1",
+    teamname: "Ospo",
+    aclType: "PRODUCER",
+    aclIpPrincipleType: "PRINCIPAL",
+    requestStatus: "CREATED",
+    requestOperationType: "CREATE",
+    environmentName: "DEV",
+    teamId: 1003,
+    requestingteam: 1003,
+    requestingTeamName: "Ospo",
+    appname: "App",
+    username: "josepprat",
+    requesttime: "2023-03-10T12:08:46.040+00:00",
+    requesttimestring: "10-Mar-2023 12:08:46",
+    approver: undefined,
+    approvingtime: undefined,
+    aclResourceType: undefined,
+    currentPage: "1",
+    otherParams: undefined,
+    totalNoPages: "22",
+    allPageNos: ["1", ">", ">>"],
+    approvingTeamDetails:
+      "Team : Ospo, Users : muralibasani,samulisuortti,mirjamaulbach,smustafa,amathieu,aindriul,calummuir,roopek,MikeTest,Mischa,",
+    deletable: false,
+    editable: false,
+  },
+  {
+    remarks: undefined,
+    consumergroup: "sdsdsds",
+    acl_ip: ["1.1.1.1", "2.2.2.2"],
+    acl_ssl: ["User:*"],
+    aclPatternType: "LITERAL",
+    transactionalId: undefined,
+    req_no: 1217,
+    topicname: "newaudittopic",
+    environment: "2",
+    teamname: "Ospo",
+    aclType: "CONSUMER",
+    aclIpPrincipleType: "IP_ADDRESS",
+    requestStatus: "DECLINED",
+    requestOperationType: "CREATE",
+    environmentName: "TST",
+    teamId: 1003,
+    requestingteam: 1003,
+    requestingTeamName: "Ospo",
+    appname: "App",
+    username: "josepprat",
+    requesttime: "2023-03-03T07:18:23.687+00:00",
+    requesttimestring: "03-Mar-2023 07:18:23",
+    approver: "amathieu",
+    approvingtime: "2023-03-10T09:12:21.328+00:00",
+    aclResourceType: undefined,
+    currentPage: "1",
+    otherParams: undefined,
+    totalNoPages: "22",
+    allPageNos: ["1", ">", ">>"],
+    approvingTeamDetails:
+      "Team : Ospo, Users : muralibasani,samulisuortti,mirjamaulbach,smustafa,amathieu,aindriul,calummuir,roopek,MikeTest,Mischa,",
+    deletable: true,
+    editable: true,
+  },
+]);
+
+describe("AclRequests", () => {
+  beforeEach(() => {
+    mockIntersectionObserver();
+    mockGetAclRequests.mockResolvedValue(mockGetAclRequestsResponse);
+  });
+
+  afterEach(() => {
+    cleanup();
+    jest.resetAllMocks();
+  });
+
+  it("makes a request to the api to get the team's ACL requests", () => {
+    customRender(<AclRequests />, {
+      queryClient: true,
+    });
+    expect(getAclRequests).toBeCalledTimes(1);
+  });
+});

--- a/coral/src/app/features/requests/components/acls/AclRequests.tsx
+++ b/coral/src/app/features/requests/components/acls/AclRequests.tsx
@@ -1,0 +1,32 @@
+import { useQuery } from "@tanstack/react-query";
+import { TableLayout } from "src/app/features/components/layouts/TableLayout";
+import { getAclRequests } from "src/domain/acl/acl-api";
+import { AclRequestsTable } from "src/app/features/requests/components/acls/components/AclRequestsTable";
+
+function AclRequests() {
+  const { data, isLoading, isError, error } = useQuery({
+    queryKey: ["aclRequests"],
+    queryFn: () =>
+      getAclRequests({
+        pageNo: "1",
+      }),
+  });
+
+  return (
+    <TableLayout
+      filters={[]}
+      table={
+        <AclRequestsTable
+          requests={data?.entries ?? []}
+          onDetails={() => null}
+          onDelete={() => null}
+        />
+      }
+      isLoading={isLoading}
+      isErrorLoading={isError}
+      errorMessage={error}
+    />
+  );
+}
+
+export { AclRequests };

--- a/coral/src/app/features/requests/components/acls/components/AclRequestsTable.test.tsx
+++ b/coral/src/app/features/requests/components/acls/components/AclRequestsTable.test.tsx
@@ -1,0 +1,230 @@
+import { cleanup, render, screen, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import {
+  AclRequestsTable,
+  AclRequestsTableProps,
+} from "src/app/features/requests/components/acls/components/AclRequestsTable";
+import { AclRequest } from "src/domain/acl/acl-types";
+import { mockIntersectionObserver } from "src/services/test-utils/mock-intersection-observer";
+
+const mockedRequests: AclRequest[] = [
+  {
+    remarks: undefined,
+    consumergroup: "-na-",
+    acl_ip: undefined,
+    acl_ssl: ["josepprat"],
+    aclPatternType: "LITERAL",
+    transactionalId: undefined,
+    req_no: 1220,
+    topicname: "uptimetopic",
+    environment: "1",
+    teamname: "Ospo",
+    aclType: "PRODUCER",
+    aclIpPrincipleType: "PRINCIPAL",
+    requestStatus: "CREATED",
+    requestOperationType: "CREATE",
+    environmentName: "DEV",
+    teamId: 1003,
+    requestingteam: 1003,
+    requestingTeamName: "Ospo",
+    appname: "App",
+    username: "josepprat",
+    requesttime: "2023-03-10T12:08:46.040+00:00",
+    requesttimestring: "10-Mar-2023 12:08:46",
+    approver: undefined,
+    approvingtime: undefined,
+    aclResourceType: undefined,
+    currentPage: "1",
+    otherParams: undefined,
+    totalNoPages: "22",
+    allPageNos: ["1", ">", ">>"],
+    approvingTeamDetails:
+      "Team : Ospo, Users : muralibasani,samulisuortti,mirjamaulbach,smustafa,amathieu,aindriul,calummuir,roopek,MikeTest,Mischa,",
+    deletable: false,
+    editable: false,
+  },
+
+  {
+    remarks: undefined,
+    consumergroup: "sdsdsds",
+    acl_ip: ["1.1.1.1", "2.2.2.2"],
+    acl_ssl: ["User:*"],
+    aclPatternType: "LITERAL",
+    transactionalId: undefined,
+    req_no: 1217,
+    topicname: "newaudittopic",
+    environment: "2",
+    teamname: "Ospo",
+    aclType: "CONSUMER",
+    aclIpPrincipleType: "IP_ADDRESS",
+    requestStatus: "DECLINED",
+    requestOperationType: "CREATE",
+    environmentName: "TST",
+    teamId: 1003,
+    requestingteam: 1003,
+    requestingTeamName: "Ospo",
+    appname: "App",
+    username: "josepprat",
+    requesttime: "2023-03-03T07:18:23.687+00:00",
+    requesttimestring: "03-Mar-2023 07:18:23",
+    approver: "amathieu",
+    approvingtime: "2023-03-10T09:12:21.328+00:00",
+    aclResourceType: undefined,
+    currentPage: "1",
+    otherParams: undefined,
+    totalNoPages: "22",
+    allPageNos: ["1", ">", ">>"],
+    approvingTeamDetails:
+      "Team : Ospo, Users : muralibasani,samulisuortti,mirjamaulbach,smustafa,amathieu,aindriul,calummuir,roopek,MikeTest,Mischa,",
+    deletable: true,
+    editable: true,
+  },
+];
+
+describe("AclRequestsTable", () => {
+  function renderFromProps(props?: Partial<AclRequestsTableProps>): void {
+    render(
+      <AclRequestsTable
+        requests={mockedRequests}
+        onDetails={jest.fn()}
+        onDelete={jest.fn()}
+        {...props}
+      />
+    );
+  }
+
+  function getNthRow(nth: number): HTMLElement {
+    return screen.getAllByRole("row")[nth];
+  }
+
+  beforeEach(() => {
+    mockIntersectionObserver();
+  });
+
+  afterEach(cleanup);
+
+  it("shows a message to user in case there are no requests that match the search criteria", () => {
+    renderFromProps({ requests: [] });
+    screen.getByText("No ACL requests");
+    screen.getByText("No ACL request matched your criteria.");
+  });
+
+  it("has column to describe the topic", () => {
+    renderFromProps();
+    expect(
+      within(getNthRow(0)).getAllByRole("columnheader")[0]
+    ).toHaveTextContent("Topic");
+    expect(within(getNthRow(1)).getAllByRole("cell")[0]).toHaveTextContent(
+      "uptimetopic"
+    );
+  });
+
+  it("has column to describe the environment", () => {
+    renderFromProps();
+    expect(
+      within(getNthRow(0)).getAllByRole("columnheader")[1]
+    ).toHaveTextContent("Environment");
+    expect(within(getNthRow(1)).getAllByRole("cell")[1]).toHaveTextContent(
+      "DEV"
+    );
+  });
+
+  it("has column to decsribe the status", () => {
+    renderFromProps();
+    expect(
+      within(getNthRow(0)).getAllByRole("columnheader")[2]
+    ).toHaveTextContent("Status");
+    expect(within(getNthRow(1)).getAllByRole("cell")[2]).toHaveTextContent(
+      "Awaiting approval"
+    );
+  });
+
+  it("has column to decsribe the request type", () => {
+    renderFromProps();
+    expect(
+      within(getNthRow(0)).getAllByRole("columnheader")[3]
+    ).toHaveTextContent("Type");
+    expect(within(getNthRow(1)).getAllByRole("cell")[3]).toHaveTextContent(
+      "Create"
+    );
+  });
+
+  it("has column to describe the Principals/Usernames", () => {
+    renderFromProps();
+    expect(
+      within(getNthRow(0)).getAllByRole("columnheader")[4]
+    ).toHaveTextContent("Principals/Usernames");
+    expect(within(getNthRow(1)).getAllByRole("cell")[4]).toHaveTextContent(
+      "josepprat"
+    );
+  });
+
+  it("has column to describe the IP addresses", () => {
+    renderFromProps();
+    expect(
+      within(getNthRow(0)).getAllByRole("columnheader")[5]
+    ).toHaveTextContent("IP addresses");
+    expect(within(getNthRow(2)).getAllByRole("cell")[5]).toHaveTextContent(
+      "1.1.1.1 2.2.2.2"
+    );
+  });
+
+  it("has column to describe the ACL type", () => {
+    renderFromProps();
+    expect(
+      within(getNthRow(0)).getAllByRole("columnheader")[6]
+    ).toHaveTextContent("ACL type");
+    expect(within(getNthRow(1)).getAllByRole("cell")[6]).toHaveTextContent(
+      "PRODUCER"
+    );
+  });
+
+  it("has column to describe the ACL Type", () => {
+    renderFromProps();
+    expect(
+      within(getNthRow(0)).getAllByRole("columnheader")[7]
+    ).toHaveTextContent("Requested on");
+    expect(within(getNthRow(1)).getAllByRole("cell")[7]).toHaveTextContent(
+      "10-Mar-2023 12:08:46 UTC"
+    );
+  });
+
+  it("has column for action to view request details", async () => {
+    const onDetails = jest.fn();
+    renderFromProps({ onDetails });
+    await userEvent.click(
+      within(within(getNthRow(1)).getAllByRole("cell")[8]).getByRole("button", {
+        name: "View",
+      })
+    );
+    expect(onDetails).toHaveBeenNthCalledWith(
+      1,
+      String(mockedRequests[0].req_no)
+    );
+  });
+
+  it("has column for action to delete request", async () => {
+    const onDelete = jest.fn();
+    renderFromProps({ onDelete });
+    await userEvent.click(
+      within(within(getNthRow(2)).getAllByRole("cell")[9]).getByRole("button", {
+        name: "Delete",
+      })
+    );
+    expect(onDelete).toHaveBeenNthCalledWith(
+      1,
+      String(mockedRequests[1].req_no)
+    );
+  });
+
+  it("disables the delete button for a request if the request is not deletable", () => {
+    const onDelete = jest.fn();
+    const nonDeletableRequest = { ...mockedRequests[0], deletable: false };
+    renderFromProps({ requests: [nonDeletableRequest], onDelete });
+    expect(
+      within(within(getNthRow(1)).getAllByRole("cell")[9]).getByRole("button", {
+        name: "Delete",
+      })
+    ).toBeDisabled();
+  });
+});

--- a/coral/src/app/features/requests/components/acls/components/AclRequestsTable.tsx
+++ b/coral/src/app/features/requests/components/acls/components/AclRequestsTable.tsx
@@ -1,0 +1,200 @@
+import {
+  DataTable,
+  DataTableColumn,
+  EmptyState,
+  Flexbox,
+  StatusChip,
+} from "@aivenio/aquarium";
+import infoIcon from "@aivenio/aquarium/dist/src/icons/infoSign";
+import deleteIcon from "@aivenio/aquarium/dist/src/icons/delete";
+import { AclRequest } from "src/domain/acl/acl-types";
+import {
+  requestStatusChipStatusMap,
+  requestStatusNameMap,
+} from "src/app/features/approvals/utils/request-status-helper";
+import {
+  requestOperationTypeChipStatusMap,
+  requestOperationTypeNameMap,
+} from "src/app/features/approvals/utils/request-operation-type-helper";
+import {
+  RequestStatus,
+  RequestOperationType,
+} from "src/domain/requests/requests-types";
+
+interface AclRequestTableRow {
+  id: number;
+  topicname: AclRequest["topicname"];
+  environmentName: string;
+  acl_ssl: string[];
+  acl_ip: string[];
+  aclType: AclRequest["aclType"];
+  requesttimestring: string;
+  deletable: AclRequest["deletable"];
+  editable: AclRequest["editable"];
+  requestStatus: RequestStatus;
+  requestOperationType: RequestOperationType;
+}
+
+type AclRequestsTableProps = {
+  requests: AclRequest[];
+  onDetails: (reqNo: string) => void;
+  onDelete: (reqNo: string) => void;
+};
+
+function AclRequestsTable({
+  requests,
+  onDetails,
+  onDelete,
+}: AclRequestsTableProps) {
+  const columns: Array<DataTableColumn<AclRequestTableRow>> = [
+    { type: "text", field: "topicname", headerName: "Topic" },
+    {
+      type: "status",
+      field: "environmentName",
+      headerName: "Environment",
+      status: ({ environmentName }) => ({
+        status: "neutral",
+        text: environmentName,
+      }),
+    },
+    {
+      type: "status",
+      field: "requestStatus",
+      headerName: "Status",
+      status: ({ requestStatus }) => {
+        return {
+          status: requestStatusChipStatusMap[requestStatus],
+          text: requestStatusNameMap[requestStatus],
+        };
+      },
+    },
+    {
+      type: "status",
+      field: "requestOperationType",
+      headerName: "Type",
+      status: ({ requestOperationType }) => {
+        return {
+          status: requestOperationTypeChipStatusMap[requestOperationType],
+          text: requestOperationTypeNameMap[requestOperationType],
+        };
+      },
+    },
+    {
+      type: "custom",
+      field: "acl_ssl",
+      headerName: "Principals/Usernames",
+      UNSAFE_render: ({ acl_ssl }: AclRequestTableRow) => {
+        return (
+          <Flexbox wrap={"wrap"} gap={"2"}>
+            {acl_ssl.map((ssl, index) => (
+              <StatusChip
+                status="neutral"
+                key={`${ssl}-${index}`}
+                // We need to add a space after text value
+                // Otherwise a list of values would be rendered as value1value2value3 for screen readers
+                // Instead of value1 value2 value3
+                text={`${ssl} `}
+              />
+            ))}
+          </Flexbox>
+        );
+      },
+    },
+    {
+      type: "custom",
+      field: "acl_ip",
+      headerName: "IP addresses",
+      UNSAFE_render: ({ acl_ip }: AclRequestTableRow) => {
+        return (
+          <Flexbox wrap={"wrap"} gap={"2"}>
+            {acl_ip.map((ip, index) => (
+              <StatusChip
+                status="neutral"
+                key={`${ip}-${index}`}
+                // We need to add a space after text value
+                // Otherwise a list of values would be rendered as value1value2value3 for screen readers
+                // Instead of value1 value2 value3
+                text={`${ip} `}
+              />
+            ))}
+          </Flexbox>
+        );
+      },
+    },
+    {
+      type: "status",
+      field: "aclType",
+      headerName: "ACL type",
+      status: ({ aclType }) => ({
+        status: aclType === "CONSUMER" ? "success" : "info",
+        text: aclType,
+      }),
+    },
+    {
+      type: "text",
+      field: "requesttimestring",
+      headerName: "Requested on",
+      formatter: (value) => {
+        return `${value}${"\u00A0"}UTC`;
+      },
+    },
+    {
+      type: "action",
+      headerName: "Details",
+      headerInvisible: true,
+      width: 30,
+      action: ({ id }) => ({
+        text: "View",
+        icon: infoIcon,
+        onClick: () => onDetails(String(id)),
+      }),
+    },
+    {
+      type: "action",
+      headerName: "Delete",
+      headerInvisible: true,
+      width: 30,
+      action: ({ id, deletable }) => ({
+        text: "Delete",
+        icon: deleteIcon,
+        onClick: () => onDelete(String(id)),
+        disabled: !deletable,
+      }),
+    },
+  ];
+
+  const rows: AclRequestTableRow[] = requests.map((request: AclRequest) => {
+    return {
+      id: Number(request.req_no),
+      topicname: request.topicname,
+      environmentName: request.environmentName || "",
+      requestStatus: request.requestStatus || "ALL",
+      requestOperationType: request.requestOperationType || "CREATE",
+      acl_ssl: request.acl_ssl || [],
+      acl_ip: request.acl_ip || [],
+      aclType: request.aclType,
+      requesttimestring: request.requesttimestring || "",
+      deletable: request.deletable,
+      editable: request.editable,
+    };
+  });
+
+  if (rows.length === 0) {
+    return (
+      <EmptyState title="No ACL requests">
+        No ACL request matched your criteria.
+      </EmptyState>
+    );
+  }
+
+  return (
+    <DataTable
+      ariaLabel={"ACL requests"}
+      columns={columns}
+      rows={rows}
+      noWrap={false}
+    />
+  );
+}
+
+export { AclRequestsTable, type AclRequestsTableProps };

--- a/coral/src/app/pages/requests/acls/index.tsx
+++ b/coral/src/app/pages/requests/acls/index.tsx
@@ -1,5 +1,7 @@
+import { AclRequests } from "src/app/features/requests/components/acls/AclRequests";
+
 const AclRequestsPage = () => {
-  return <></>;
+  return <AclRequests />;
 };
 
 export default AclRequestsPage;


### PR DESCRIPTION
## About this change - What it does


In `coral/src/app/features/requests` :
- add `acls` folder
- add `AclRequests.tsx`
- add `components/AclRequestsTable.tsx` 
- add data fetching calling `getAclRequests`
- render data fetched in `AclRequestsTable`
- add tests

Resolves: #799
