### PR TITLE
feat(coral): Topic Requests: add search Topic functionality #774

### DIFF
--- a/coral/src/app/features/requests/components/topics/TopicRequests.test.tsx
+++ b/coral/src/app/features/requests/components/topics/TopicRequests.test.tsx
@@ -1,9 +1,10 @@
-import { cleanup } from "@testing-library/react";
+import { cleanup, screen, waitFor } from "@testing-library/react";
 import { getTopicRequests } from "src/domain/topic/topic-api";
 import { transformGetTopicRequestsResponse } from "src/domain/topic/topic-transformer";
 import { mockIntersectionObserver } from "src/services/test-utils/mock-intersection-observer";
 import { TopicRequests } from "src/app/features/requests/components/topics/TopicRequests";
 import { customRender } from "src/services/test-utils/render-with-wrappers";
+import userEvent from "@testing-library/user-event";
 
 jest.mock("src/domain/topic/topic-api.ts");
 
@@ -58,7 +59,46 @@ describe("TopicRequests", () => {
   it("makes a request to the api to get the teams topic requests", () => {
     customRender(<TopicRequests />, {
       queryClient: true,
+      memoryRouter: true,
     });
     expect(getTopicRequests).toBeCalledTimes(1);
+  });
+
+  describe("user can filter topics based on the topic name", () => {
+    afterEach(() => {
+      cleanup();
+      jest.resetAllMocks();
+    });
+
+    it("populates the filter from the url search parameters", () => {
+      customRender(<TopicRequests />, {
+        queryClient: true,
+        memoryRouter: true,
+        customRoutePath: "/?topic=abc",
+      });
+      expect(getTopicRequests).toHaveBeenNthCalledWith(1, {
+        pageNo: "1",
+        search: "abc",
+      });
+    });
+
+    it("applies the topic filter by typing into to the search input", async () => {
+      customRender(<TopicRequests />, {
+        queryClient: true,
+        memoryRouter: true,
+      });
+      const search = screen.getByRole("search");
+      expect(search).toBeVisible();
+      expect(search).toHaveAccessibleDescription(
+        'Search for an exact match for topic name. Searching starts automatically with a little delay while typing. Press "Escape" to delete all your input.'
+      );
+      await userEvent.type(search, "abc");
+      await waitFor(() => {
+        expect(getTopicRequests).toHaveBeenLastCalledWith({
+          pageNo: "1",
+          search: "abc",
+        });
+      });
+    });
   });
 });

--- a/coral/src/app/features/requests/components/topics/TopicRequests.tsx
+++ b/coral/src/app/features/requests/components/topics/TopicRequests.tsx
@@ -2,19 +2,25 @@ import { useQuery } from "@tanstack/react-query";
 import { TableLayout } from "src/app/features/components/layouts/TableLayout";
 import { getTopicRequests } from "src/domain/topic/topic-api";
 import { TopicRequestsTable } from "src/app/features/requests/components/topics/components/TopicRequestsTable";
+import { useSearchParams } from "react-router-dom";
+import TopicFilter from "src/app/features/components/table-filters/TopicFilter";
 
 function TopicRequests() {
+  const [searchParams] = useSearchParams();
+  const currentTopic = searchParams.get("topic") ?? "";
+
   const { data, isLoading, isError, error } = useQuery({
-    queryKey: ["topicRequests"],
+    queryKey: ["topicRequests", currentTopic],
     queryFn: () =>
       getTopicRequests({
         pageNo: "1",
+        search: currentTopic,
       }),
   });
 
   return (
     <TableLayout
-      filters={[]}
+      filters={[<TopicFilter key={"topic"} />]}
       table={
         <TopicRequestsTable
           requests={data?.entries ?? []}


### PR DESCRIPTION
User is able to filter My teams topic requests by topic name. Adds topic filter input and syncs the search params to the api poll.

Resolves: #774
