### PR TITLE
coral(feat): My Schema Requests - add API definition and types for `/getSchemaRequests`

### DIFF
--- a/coral/src/app/features/approvals/schemas/SchemaApprovals.test.tsx
+++ b/coral/src/app/features/approvals/schemas/SchemaApprovals.test.tsx
@@ -8,12 +8,10 @@ import { transformEnvironmentApiResponse } from "src/domain/environment/environm
 import {
   getSchemaRequestsForApprover,
   SchemaRequest,
-} from "src/domain/schema-request";
-import {
   approveSchemaRequest,
   declineSchemaRequest,
-} from "src/domain/schema-request/schema-request-api";
-import { transformGetSchemaRequestsForApproverResponse } from "src/domain/schema-request/schema-request-transformer";
+} from "src/domain/schema-request";
+import { transformGetSchemaRequests } from "src/domain/schema-request/schema-request-transformer";
 import { SchemaRequestApiResponse } from "src/domain/schema-request/schema-request-types";
 import { mockIntersectionObserver } from "src/services/test-utils/mock-intersection-observer";
 import { customRender } from "src/services/test-utils/render-with-wrappers";
@@ -104,7 +102,7 @@ const mockedResponseSchemaRequests: SchemaRequest[] = [
 ];
 
 const mockedApiResponseSchemaRequests: SchemaRequestApiResponse =
-  transformGetSchemaRequestsForApproverResponse(mockedResponseSchemaRequests);
+  transformGetSchemaRequests(mockedResponseSchemaRequests);
 
 describe("SchemaApprovals", () => {
   const defaultApiParams = {

--- a/coral/src/app/features/approvals/schemas/SchemaApprovals.tsx
+++ b/coral/src/app/features/approvals/schemas/SchemaApprovals.tsx
@@ -12,11 +12,11 @@ import EnvironmentFilter from "src/app/features/components/table-filters/Environ
 import StatusFilter from "src/app/features/components/table-filters/StatusFilter";
 import TopicFilter from "src/app/features/components/table-filters/TopicFilter";
 import { RequestStatus } from "src/domain/requests/requests-types";
-import { getSchemaRequestsForApprover } from "src/domain/schema-request";
 import {
+  getSchemaRequestsForApprover,
   approveSchemaRequest,
   declineSchemaRequest,
-} from "src/domain/schema-request/schema-request-api";
+} from "src/domain/schema-request";
 import { parseErrorMsg } from "src/services/mutation-utils";
 
 function SchemaApprovals() {

--- a/coral/src/domain/schema-request/index.ts
+++ b/coral/src/domain/schema-request/index.ts
@@ -1,5 +1,8 @@
 import {
+  approveSchemaRequest,
   createSchemaRequest,
+  declineSchemaRequest,
+  getSchemaRequests,
   getSchemaRequestsForApprover,
 } from "src/domain/schema-request/schema-request-api";
 import {
@@ -8,4 +11,10 @@ import {
 } from "src/domain/schema-request/schema-request-types";
 
 export type { CreatedSchemaRequests, SchemaRequest };
-export { createSchemaRequest, getSchemaRequestsForApprover };
+export {
+  createSchemaRequest,
+  getSchemaRequestsForApprover,
+  getSchemaRequests,
+  approveSchemaRequest,
+  declineSchemaRequest,
+};

--- a/coral/src/domain/schema-request/schema-request-api.ts
+++ b/coral/src/domain/schema-request/schema-request-api.ts
@@ -41,12 +41,12 @@ type GetSchemaRequestsForApproverQueryParams = ResolveIntersectionTypes<
   Required<
     Pick<
       KlawApiRequestQueryParameters<"getSchemaRequestsForApprover">,
-      "pageNo" | "requestStatus"
+      "requestStatus"
     >
   > &
     Pick<
       KlawApiRequestQueryParameters<"getSchemaRequestsForApprover">,
-      "env" | "topic"
+      "pageNo" | "env" | "topic"
     >
 >;
 
@@ -70,11 +70,10 @@ const getSchemaRequestsForApprover = (
 };
 
 type GetSchemaRequestsQueryParams = ResolveIntersectionTypes<
-  Required<Pick<KlawApiRequestQueryParameters<"getSchemaRequests">, "pageNo">> &
-    Pick<
-      KlawApiRequestQueryParameters<"getSchemaRequests">,
-      "requestStatus" | "topic" | "env" | "isMyRequest"
-    >
+  Pick<
+    KlawApiRequestQueryParameters<"getSchemaRequests">,
+    "pageNo" | "requestStatus" | "topic" | "env" | "isMyRequest"
+  >
 >;
 
 const getSchemaRequests = (

--- a/coral/src/domain/schema-request/schema-request-transformer.test.ts
+++ b/coral/src/domain/schema-request/schema-request-transformer.test.ts
@@ -1,4 +1,4 @@
-import { transformGetSchemaRequestsForApproverResponse } from "src/domain/schema-request/schema-request-transformer";
+import { transformGetSchemaRequests } from "src/domain/schema-request/schema-request-transformer";
 import {
   SchemaRequest,
   SchemaRequestApiResponse,
@@ -7,9 +7,7 @@ import {
 describe("schema-request-transformer.ts", () => {
   describe("transformGetSchemaRequestsForApproverResponse", () => {
     it("transforms empty payload into empty array", () => {
-      const transformedResponse = transformGetSchemaRequestsForApproverResponse(
-        []
-      );
+      const transformedResponse = transformGetSchemaRequests([]);
 
       const result: SchemaRequestApiResponse = {
         totalPages: 0,
@@ -75,8 +73,7 @@ describe("schema-request-transformer.ts", () => {
           forceRegister: false,
         },
       ];
-      const transformedResponse =
-        transformGetSchemaRequestsForApproverResponse(mockedResponse);
+      const transformedResponse = transformGetSchemaRequests(mockedResponse);
 
       const result: SchemaRequestApiResponse = {
         totalPages: 4,

--- a/coral/src/domain/schema-request/schema-request-transformer.ts
+++ b/coral/src/domain/schema-request/schema-request-transformer.ts
@@ -1,8 +1,10 @@
 import { KlawApiResponse } from "types/utils";
 import { SchemaRequestApiResponse } from "src/domain/schema-request/schema-request-types";
 
-function transformGetSchemaRequestsForApproverResponse(
-  apiResponse: KlawApiResponse<"getSchemaRequestsForApprover">
+function transformGetSchemaRequests(
+  apiResponse:
+    | KlawApiResponse<"getSchemaRequestsForApprover">
+    | KlawApiResponse<"getSchemaRequests">
 ): SchemaRequestApiResponse {
   if (apiResponse.length === 0) {
     return {
@@ -19,4 +21,4 @@ function transformGetSchemaRequestsForApproverResponse(
   };
 }
 
-export { transformGetSchemaRequestsForApproverResponse };
+export { transformGetSchemaRequests };

--- a/coral/src/domain/schema-request/schema-request-types.ts
+++ b/coral/src/domain/schema-request/schema-request-types.ts
@@ -1,9 +1,4 @@
 import { KlawApiModel, Paginated, ResolveIntersectionTypes } from "types/utils";
-import {
-  RequestStatus,
-  RequestOperationType,
-} from "src/domain/requests/requests-types";
-import { operations } from "types/api";
 
 type CreatedSchemaRequests = ResolveIntersectionTypes<
   Required<
@@ -18,40 +13,10 @@ type CreatedSchemaRequests = ResolveIntersectionTypes<
   >
 >;
 
-type CreateSchemaRequestPayload = ResolveIntersectionTypes<
-  Required<
-    Pick<
-      KlawApiModel<"SchemaRequest">,
-      "environment" | "schemafull" | "topicname"
-    >
-  > &
-    Partial<KlawApiModel<"SchemaRequest">>
->;
-
-type SchemaRequestOperationType = RequestOperationType;
-type SchemaRequestStatus = RequestStatus;
-
 type SchemaRequest = ResolveIntersectionTypes<KlawApiModel<"SchemaRequest">>;
 
 type SchemaRequestApiResponse = ResolveIntersectionTypes<
   Paginated<SchemaRequest[]>
 >;
 
-type GetSchemaRequestsQueryParams = ResolveIntersectionTypes<
-  Required<
-    Pick<
-      operations["getSchemaRequestsForApprover"]["parameters"]["query"],
-      "pageNo" | "requestStatus"
-    >
-  >
->;
-
-export type {
-  CreateSchemaRequestPayload,
-  CreatedSchemaRequests,
-  SchemaRequest,
-  SchemaRequestOperationType,
-  SchemaRequestStatus,
-  SchemaRequestApiResponse,
-  GetSchemaRequestsQueryParams,
-};
+export type { CreatedSchemaRequests, SchemaRequest, SchemaRequestApiResponse };

--- a/coral/types/api.d.ts
+++ b/coral/types/api.d.ts
@@ -101,6 +101,9 @@ export type paths = {
   "/getSchemaRequestsForApprover": {
     get: operations["getSchemaRequestsForApprover"];
   };
+  "/getSchemaRequests": {
+    get: operations["getSchemaRequests"];
+  };
 };
 
 export type webhooks = Record<string, never>;
@@ -1481,6 +1484,26 @@ export type operations = {
     };
     responses: {
       /** @description successful operation */
+      200: {
+        content: {
+          "application/json": (components["schemas"]["SchemaRequest"])[];
+        };
+      };
+    };
+  };
+  getSchemaRequests: {
+    parameters: {
+      query: {
+        pageNo: string;
+        currentPage?: string;
+        requestStatus?: components["schemas"]["RequestStatus"];
+        topic?: string;
+        env?: string;
+        isMyRequest?: boolean;
+      };
+    };
+    responses: {
+      /** @description OK */
       200: {
         content: {
           "application/json": (components["schemas"]["SchemaRequest"])[];

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -583,7 +583,6 @@ paths:
                 type: array
                 items:
                   $ref: "#/components/schemas/TopicRequest"
-
   /getAuth:
     get:
       operationId: getAuth
@@ -689,6 +688,50 @@ paths:
       responses:
         200:
           description: successful operation
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/SchemaRequest"
+  /getSchemaRequests:
+    get:
+      operationId: getSchemaRequests
+      parameters:
+        - name: pageNo
+          in: query
+          required: true
+          schema:
+            type: string
+        - name: currentPage
+          in: query
+          required: false
+          schema:
+            type: string
+            default: ""
+        - name: requestStatus
+          in: query
+          schema:
+            $ref: "#/components/schemas/RequestStatus"
+        - name: topic
+          in: query
+          required: false
+          schema:
+            type: string
+        - name: env
+          in: query
+          required: false
+          schema:
+            type: string
+        - name: isMyRequest
+          in: query
+          required: false
+          schema:
+            type: boolean
+            default: false
+      responses:
+        "200":
+          description: OK
           content:
             application/json:
               schema:


### PR DESCRIPTION
# About this change - What it does

- Add `getSchemaRequests` endpoint to openapi
- Add autogenerated types
- Add api call function
- rename existing functions / type to fit better (shared or separate usage)
- remove unnecessary / unused types
- update barrel file and imports from schema domain

Resolves: #806 

