### PR TITLE
Data migration utility

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -43,7 +43,6 @@
             <artifactId>jakarta.mail</artifactId>
             <version>2.0.1</version>
         </dependency>
-
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-thymeleaf</artifactId>
@@ -155,6 +154,11 @@
         <dependency>
             <groupId>org.postgresql</groupId>
             <artifactId>postgresql</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.reflections</groupId>
+            <artifactId>reflections</artifactId>
+            <version>0.9.9</version>
         </dependency>
     </dependencies>
 

--- a/core/src/main/java/io/aiven/klaw/config/MigrationUtility.java
+++ b/core/src/main/java/io/aiven/klaw/config/MigrationUtility.java
@@ -1,0 +1,155 @@
+package io.aiven.klaw.config;
+
+import io.aiven.klaw.dao.DataVersion;
+import io.aiven.klaw.dao.migration.DataMigration;
+import io.aiven.klaw.dao.migration.MigrationRunner;
+import io.aiven.klaw.error.KlawDataMigrationException;
+import io.aiven.klaw.repository.DataVersionRepo;
+import jakarta.annotation.PostConstruct;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.sql.Timestamp;
+import java.time.Instant;
+import java.util.Set;
+import java.util.SortedMap;
+import java.util.TreeMap;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.tuple.Pair;
+import org.reflections.Reflections;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@Slf4j
+public class MigrationUtility {
+
+  public static final int SUPPORTED_KLAW_VERSION_NUMBER_SYSTEM = 3;
+
+  @Value("${klaw.data.migration.packageToScan:io.aiven.klaw.dao.migration}")
+  private String packageToScan;
+
+  @Value("${klaw.version}")
+  private String currentKlawVersion;
+
+  @Autowired private DataVersionRepo versionRepo;
+
+  @PostConstruct
+  public void migrate()
+      throws InvocationTargetException, IllegalAccessException, KlawDataMigrationException {
+
+    // Find the latest version in DB
+    DataVersion currentDataVersion = versionRepo.findTopByOrderByIdDesc();
+    if (isVersionGreaterThenOrEqualToCurrentVersion(
+        currentDataVersion.getVersion(), currentKlawVersion)) {
+      log.info(
+          "Current Data Version {} is greater then or equal to the Klaw version {}, no action needed.",
+          currentDataVersion.getVersion(),
+          currentKlawVersion);
+      return;
+    }
+
+    // Find all DataMigration annotated classes.// Migrate each one
+    Reflections reflections = new Reflections(packageToScan);
+    Set<Class<?>> classes = reflections.getTypesAnnotatedWith(DataMigration.class);
+
+    SortedMap<Integer, Pair<String, Class<?>>> orderedMapOfMigrationInstructions =
+        orderApplicableMigrationInstructions(currentDataVersion, classes);
+
+    // execute the migration
+    executeMigrationInstructions(orderedMapOfMigrationInstructions);
+
+    // Update the database with the version
+    // need to see if already created.
+    updateDataVersionInDB(currentKlawVersion);
+  }
+
+  private void updateDataVersionInDB(String version) {
+    DataVersion latestDataVersion = new DataVersion();
+    latestDataVersion.setVersion(currentKlawVersion);
+    latestDataVersion.setExecutedAt(Timestamp.from(Instant.now()));
+    latestDataVersion.setComplete(true);
+    versionRepo.save(latestDataVersion);
+  }
+
+  /**
+   * Removes any migration instructions not applicable to this upgrade. Orders the data migration
+   * instructions in the order intended to maintain data integrity.
+   *
+   * @param currentDataVersion The version of data that is currently deployed
+   * @param classes A set of Migration Instructions for migrating data.
+   * @return A sorted map that has removed any unnecessary instructions and ordered the rest.
+   */
+  private SortedMap<Integer, Pair<String, Class<?>>> orderApplicableMigrationInstructions(
+      DataVersion currentDataVersion, Set<Class<?>> classes) {
+    SortedMap<Integer, Pair<String, Class<?>>> orderedMapOfMigrationInstructions = new TreeMap<>();
+    log.info("Classes discovered {}, number of classes {}", classes, classes.size());
+    // order the Migration classes and remove any instructions from previous releases that have
+    // already been executed.
+    classes.forEach(
+        migrate -> {
+          DataMigration migration = migrate.getAnnotation(DataMigration.class);
+          if (isVersionGreaterThenOrEqualToCurrentVersion(
+              currentDataVersion.getVersion(), migration.version())) {
+            // TODO add the version and class as a tuple that way we can set the DB for each
+            // successfully run data migration.
+            Pair<String, Class<?>> pair = Pair.of(migration.version(), migrate);
+
+            orderedMapOfMigrationInstructions.put(migration.order(), pair);
+          }
+        });
+    return orderedMapOfMigrationInstructions;
+  }
+
+  /**
+   * @param orderedMapOfMigrationInstructions The ordered list of data migration instructions
+   * @throws IllegalAccessException
+   * @throws InvocationTargetException
+   * @throws KlawDataMigrationException If any of the instructions fail to complete their migration
+   *     task an exception is thrown with information on the failed instruction set.
+   */
+  private void executeMigrationInstructions(
+      SortedMap<Integer, Pair<String, Class<?>>> orderedMapOfMigrationInstructions)
+      throws IllegalAccessException, InvocationTargetException, KlawDataMigrationException {
+    for (Integer value : orderedMapOfMigrationInstructions.keySet()) {
+      Class<?> runner = orderedMapOfMigrationInstructions.get(value).getRight();
+      for (Method method : runner.getDeclaredMethods()) {
+        // Find the correct method to invoke to execute the migration instructions.
+        if (method.isAnnotationPresent(MigrationRunner.class)) {
+          boolean status = (boolean) method.invoke(runner);
+
+          // If not completed successfully do not continue
+          if (!status) {
+            throw new KlawDataMigrationException(
+                "Unable to complete Migration instructions successfully from "
+                    + runner.getCanonicalName());
+          } else {
+            // update table that this version completed.
+            updateDataVersionInDB(orderedMapOfMigrationInstructions.get(value).getLeft());
+          }
+        }
+      }
+    }
+  }
+
+  /**
+   * @param currentVersion The Current Data Version that Klaw has in the database.
+   * @param comparedVersion The version of the migration instructions which have been found.
+   * @return true if the compared version is greater then or equal to the current version. false if
+   *     it is less then the current version.
+   */
+  private boolean isVersionGreaterThenOrEqualToCurrentVersion(
+      String currentVersion, String comparedVersion) {
+
+    String[] currentVersionParts = currentVersion.split("\\.");
+    String[] compareVersionParts = comparedVersion.split("\\.");
+    // currently klaw supports a 3 part version number.
+    for (int i = 0; i < SUPPORTED_KLAW_VERSION_NUMBER_SYSTEM; i++) {
+      if (Integer.parseInt(currentVersionParts[i]) < Integer.parseInt(compareVersionParts[i])) {
+        return false;
+      }
+    }
+
+    return true;
+  }
+}

--- a/core/src/main/java/io/aiven/klaw/dao/DataVersion.java
+++ b/core/src/main/java/io/aiven/klaw/dao/DataVersion.java
@@ -1,17 +1,28 @@
 package io.aiven.klaw.dao;
 
 import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
 import java.io.Serializable;
 import java.sql.Timestamp;
 import lombok.Data;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.ToString;
 
+@ToString
+@Getter
+@Setter
+@Entity
 @Data
 @Table(name = "kwdatamigration")
 public class DataVersion implements Serializable {
-  @Column(name = "version")
   @Id
+  @Column(name = "id")
+  private int id;
+
+  @Column(name = "version")
   private String version;
 
   @Column(name = "executedat")

--- a/core/src/main/java/io/aiven/klaw/dao/DataVersion.java
+++ b/core/src/main/java/io/aiven/klaw/dao/DataVersion.java
@@ -1,0 +1,22 @@
+package io.aiven.klaw.dao;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import java.io.Serializable;
+import java.sql.Timestamp;
+import lombok.Data;
+
+@Data
+@Table(name = "kwdatamigration")
+public class DataVersion implements Serializable {
+  @Column(name = "version")
+  @Id
+  private String version;
+
+  @Column(name = "executedat")
+  private Timestamp executedAt;
+
+  @Column(name = "complete")
+  private boolean complete;
+}

--- a/core/src/main/java/io/aiven/klaw/dao/migration/DataMigration.java
+++ b/core/src/main/java/io/aiven/klaw/dao/migration/DataMigration.java
@@ -1,0 +1,15 @@
+package io.aiven.klaw.dao.migration;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.TYPE})
+public @interface DataMigration {
+
+  public String version() default "";
+
+  public int order();
+}

--- a/core/src/main/java/io/aiven/klaw/dao/migration/MigrateData2x2x0.java
+++ b/core/src/main/java/io/aiven/klaw/dao/migration/MigrateData2x2x0.java
@@ -17,7 +17,7 @@ import org.springframework.context.annotation.Configuration;
 @DataMigration(version = "2.2.0", order = 0)
 @Slf4j
 @Configuration // Spring will automatically scan and instantiate this class for retrieval.
-public class MigrationRunner2x2x0 {
+public class MigrateData2x2x0 {
 
   @Autowired private SelectDataJdbc selectDataJdbc;
 

--- a/core/src/main/java/io/aiven/klaw/dao/migration/MigrationRunner.java
+++ b/core/src/main/java/io/aiven/klaw/dao/migration/MigrationRunner.java
@@ -1,0 +1,10 @@
+package io.aiven.klaw.dao.migration;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.METHOD})
+public @interface MigrationRunner {}

--- a/core/src/main/java/io/aiven/klaw/dao/migration/MigrationRunner2x2x0.java
+++ b/core/src/main/java/io/aiven/klaw/dao/migration/MigrationRunner2x2x0.java
@@ -1,0 +1,104 @@
+package io.aiven.klaw.dao.migration;
+
+import io.aiven.klaw.dao.KafkaConnectorRequest;
+import io.aiven.klaw.dao.Team;
+import io.aiven.klaw.dao.TopicRequest;
+import io.aiven.klaw.dao.UserInfo;
+import io.aiven.klaw.helpers.db.rdbms.SelectDataJdbc;
+import io.aiven.klaw.helpers.db.rdbms.UpdateDataJdbc;
+import io.aiven.klaw.model.enums.RequestOperationType;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Configuration;
+
+@DataMigration(version = "2.2.0", order = 0)
+@Slf4j
+@Configuration // Spring will automatically scan and instantiate this class for retrieval.
+public class MigrationRunner2x2x0 {
+
+  @Autowired private SelectDataJdbc selectDataJdbc;
+
+  @Autowired private UpdateDataJdbc updateDataJdbc;
+
+  @MigrationRunner()
+  public boolean migrate() {
+    List<UserInfo> allUserInfo = selectDataJdbc.selectAllUsersAllTenants();
+    Set<Integer> tenantIds =
+        allUserInfo.stream().map(UserInfo::getTenantId).collect(Collectors.toSet());
+
+    for (int tenantId : tenantIds) {
+      List<Team> teams = selectDataJdbc.selectAllTeams(tenantId);
+      List<Integer> t = teams.stream().map(team -> team.getTeamId()).collect(Collectors.toList());
+      migrateTopics(t, tenantId);
+      migrateConnectors(t, tenantId);
+    }
+
+    return true;
+  }
+
+  private void migrateConnectors(List<Integer> teams, Integer tenantId) {
+    int numberOfRequests = 0, numberOfRequestsUpdated = 0;
+    List<KafkaConnectorRequest> kcRequests =
+        selectDataJdbc.getFilteredKafkaConnectorRequests(
+            false, "superadmin", null, true, Integer.valueOf(tenantId), null, null);
+
+    kcRequests =
+        kcRequests.stream()
+            .filter(
+                topicRequest ->
+                    RequestOperationType.CLAIM.value.equals(topicRequest.getRequestOperationType()))
+            .collect(Collectors.toList());
+    numberOfRequests = kcRequests.size();
+    for (KafkaConnectorRequest req : kcRequests) {
+
+      if (req.getApprovingTeamId() == null
+          && teams.contains(Integer.valueOf(req.getDescription()))) {
+        log.info(
+            "Connector Request : {} of Type {} migrated to latest Database Schema.",
+            req.getConnectorId(),
+            req.getRequestOperationType());
+        req.setApprovingTeamId(req.getDescription());
+        updateDataJdbc.updateTopicRequest(req);
+        numberOfRequestsUpdated++;
+      }
+    }
+    log.info(
+        "Kafka Connector Claim Request migration completed, of {} Connector Claim requests {} were migrated",
+        numberOfRequests,
+        numberOfRequestsUpdated);
+  }
+
+  private void migrateTopics(List<Integer> teams, Integer tenantId) {
+    int numberOfRequests = 0, numberOfRequestsUpdated = 0;
+    List<TopicRequest> topicRequests =
+        selectDataJdbc.getFilteredTopicRequests(
+            false, "superadmin", null, true, Integer.valueOf(tenantId), null, null, null, false);
+
+    topicRequests =
+        topicRequests.stream()
+            .filter(
+                topicRequest ->
+                    RequestOperationType.CLAIM.value.equals(topicRequest.getRequestOperationType()))
+            .collect(Collectors.toList());
+    numberOfRequests = topicRequests.size();
+    for (TopicRequest req : topicRequests) {
+      if (req.getApprovingTeamId() == null
+          && teams.contains(Integer.valueOf(req.getDescription()))) {
+        log.info(
+            "Topic Request : {} of Type {} migrated to latest Database Schema.",
+            req.getTopicid(),
+            req.getRequestOperationType());
+        req.setApprovingTeamId(req.getDescription());
+        updateDataJdbc.updateTopicRequest(req);
+        numberOfRequestsUpdated++;
+      }
+    }
+    log.info(
+        "Topic Claim Request migration completed, of {} topic Claim requests {} were migrated",
+        numberOfRequests,
+        numberOfRequestsUpdated);
+  }
+}

--- a/core/src/main/java/io/aiven/klaw/dao/migration/README.md
+++ b/core/src/main/java/io/aiven/klaw/dao/migration/README.md
@@ -1,0 +1,26 @@
+# How to Migrate Data between versions.
+Occasionally when introducing new features or addressing tech debt we need to migrate data into new tables or into new columns within the same table.
+To address this, Klaw has a method for automatically migrating data to reduce the effort that is required by users to avail of the newest features.
+
+## Creating Migration Instruction class
+Create a class that will handle all data migration between the last version release and the target version release.
+This class should be in the package "io.aiven.klaw.dao.migration"
+The Class should be named with the target release version in the name with the dots replaced by 'x'.
+examples: MigrateData2x0x0 (version 2.0.0),MigrateData2x5x0 (version 2.5.0),MigrateData3x0x2(version 3.0.2)
+
+## Annotations
+
+This class should contain a class level annotation "@DataMigration" and takes two variables.
+The version in regular format e.g. "2.2.0" and the order in which the migration should be executed. The order allows for explicit control of the order of executing instructions.
+This prevents issues with executing instructions out of order and not having data migrated correctly.
+At the class level it should also be annotated with the Spring Boot "@Configuration" to ensure that all the autowired objects are correctly initialised.
+
+The third annotation is a method level annotation called "@MigrationRunner" which signifies the method to invoke to execute the migration instructions. 
+
+## How does it work ?
+The MigrationUtility invokes a PostConstruct method, this means that after Klaw is successfully initialised including all liquibase operations to make changes to the database.
+This PostConstruct then searches the package "io.aiven.klaw.dao.migration" to find all initialised classes annotated with @DataMigration.
+The returned list is stripped of any already applied Migration instructions, for example if upgrading from version 2.5.0 to 3.0.0 the migration included in 2.2.0 would be excluded as it has already been applied before this.
+The classes are then ordered by the order number and the method in each class annotated by MigrationRunner is invoked.
+After each successfully invoked action a boolean is returned and the DataVersion Table is updated with the information that the migration for that version has been successfully completed.
+If at any point a failure occurs a Klaw error is returned with the class that failed to execute and when re-running the migration it will pick up its data migration from the last successfully run migration instruction.

--- a/core/src/main/java/io/aiven/klaw/error/KlawDataMigrationException.java
+++ b/core/src/main/java/io/aiven/klaw/error/KlawDataMigrationException.java
@@ -1,0 +1,7 @@
+package io.aiven.klaw.error;
+
+public class KlawDataMigrationException extends Exception {
+  public KlawDataMigrationException(String error) {
+    super(error);
+  }
+}

--- a/core/src/main/java/io/aiven/klaw/helpers/db/rdbms/UpdateDataJdbc.java
+++ b/core/src/main/java/io/aiven/klaw/helpers/db/rdbms/UpdateDataJdbc.java
@@ -134,6 +134,16 @@ public class UpdateDataJdbc {
     return ApiResultStatus.SUCCESS.value;
   }
 
+  public TopicRequest updateTopicRequest(TopicRequest topicRequest) {
+    log.debug("updateTopicRequestStatus {}", topicRequest.getTopicname());
+    return topicRequestsRepo.save(topicRequest);
+  }
+
+  public KafkaConnectorRequest updateTopicRequest(KafkaConnectorRequest kcRequest) {
+    log.debug("updateTopicRequestStatus {}", kcRequest.getConnectorName());
+    return kafkaConnectorRequestsRepo.save(kcRequest);
+  }
+
   public String updateConnectorRequestStatus(
       KafkaConnectorRequest connectorRequest, String approver) {
     log.debug("updateConnectorRequestStatus {} {}", connectorRequest.getConnectorName(), approver);

--- a/core/src/main/java/io/aiven/klaw/repository/DataVersionRepo.java
+++ b/core/src/main/java/io/aiven/klaw/repository/DataVersionRepo.java
@@ -1,0 +1,9 @@
+package io.aiven.klaw.repository;
+
+import io.aiven.klaw.dao.DataVersion;
+import org.springframework.data.repository.CrudRepository;
+
+public interface DataVersionRepo extends CrudRepository<DataVersion, Integer> {
+
+  DataVersion findTopByOrderByIdDesc();
+}

--- a/core/src/main/resources/db/changelog/changelog.yaml
+++ b/core/src/main/resources/db/changelog/changelog.yaml
@@ -987,3 +987,28 @@ databaseChangeLog:
                     name: deleteassociatedschema
                     type: BOOLEAN
                     defaultValue: false
+    - changeSet:
+        id: 13-03-2023 Data Migration Table for allowing automatic data migration
+        author: aindriu-aiven
+        changes:
+          - createTable:
+              columns:
+                - column:
+                    constraints:
+                      nullable: false
+                      primaryKey: true
+                      primaryKeyName: VERSION_ID
+                    name: id
+                    type: INT
+                - column:
+                    name: version
+                    type: VARCHAR(10)
+                - column:
+                    name: executedat
+                    type: TIMESTAMP
+                - column:
+                    constraints:
+                      nullable: false
+                    name: complete
+                    type: boolean
+              tableName: kwdatamigration


### PR DESCRIPTION
About this change - What it does
This change provides the capability to manage data migration within Klaw.
When a new feature or refactoring causes Klaw to need to move data to a new table or to a new column within an existing table, this PR provides a platform to do that.
It also allows a user to skip multiple versions of Klaw and on update have all of the migration instructions execute in order ensuring data integrity.
Resolves: #xxxxx
Why this way
This provides a re-useable way of managing data migration utilising the same spring boot tools that are used for other functions within Klaw, re-using existing code where possible.