### PR TITLE
coral(feat): Add table with my schema requests

### DIFF
--- a/coral/src/app/features/approvals/schemas/SchemaApprovals.test.tsx
+++ b/coral/src/app/features/approvals/schemas/SchemaApprovals.test.tsx
@@ -221,12 +221,14 @@ describe("SchemaApprovals", () => {
       );
     });
 
-    it("shows a table with all schema requests", () => {
+    it("shows a table with all schema requests and a header row", () => {
       const table = screen.getByRole("table", { name: "Schema requests" });
-      const rows = within(table).getAllByRole("rowgroup");
+      const rows = within(table).getAllByRole("row");
 
       expect(table).toBeVisible();
-      expect(rows).toHaveLength(mockedApiResponseSchemaRequests.entries.length);
+      expect(rows).toHaveLength(
+        mockedApiResponseSchemaRequests.entries.length + 1
+      );
     });
   });
 

--- a/coral/src/app/features/approvals/topics/TopicApprovals.test.tsx
+++ b/coral/src/app/features/approvals/topics/TopicApprovals.test.tsx
@@ -242,12 +242,12 @@ describe("TopicApprovals", () => {
       );
     });
 
-    it("shows a table with all topic requests", () => {
+    it("shows a table with all topic requests and a header row", () => {
       const table = screen.getByRole("table", { name: "Topic requests" });
-      const rows = within(table).getAllByRole("rowgroup");
+      const rows = within(table).getAllByRole("row");
 
       expect(table).toBeVisible();
-      expect(rows).toHaveLength(mockedApiResponse.entries.length);
+      expect(rows).toHaveLength(mockedApiResponse.entries.length + 1);
     });
   });
 

--- a/coral/src/app/features/requests/components/schemas/SchemaRequests.test.tsx
+++ b/coral/src/app/features/requests/components/schemas/SchemaRequests.test.tsx
@@ -1,0 +1,103 @@
+import { mockIntersectionObserver } from "src/services/test-utils/mock-intersection-observer";
+import { cleanup, screen, within } from "@testing-library/react";
+import { customRender } from "src/services/test-utils/render-with-wrappers";
+import { getSchemaRequests } from "src/domain/schema-request";
+import { SchemaRequests } from "src/app/features/requests/components/schemas/SchemaRequests";
+import { waitForElementToBeRemoved } from "@testing-library/react/pure";
+import { mockedApiResponseSchemaRequests } from "src/app/features/requests/components/schemas/utils/mocked-schema-requests";
+
+jest.mock("src/domain/schema-request/schema-request-api.ts");
+
+const mockGetSchemaRequests = getSchemaRequests as jest.MockedFunction<
+  typeof getSchemaRequests
+>;
+
+describe("SchemaRequest", () => {
+  beforeAll(() => {
+    mockIntersectionObserver();
+  });
+  // This block still covers important cases, but it could be brittle
+  // due to it's dependency on the async process of the api call
+  // We'll add a helper for controlling api mocks better (get a loading state etc)
+  describe("handles loading and error state when fetching the requests", () => {
+    const originalConsoleError = console.error;
+    beforeEach(() => {
+      // used to swallow a console.error that _should_ happen
+      // while making sure to not swallow other console.errors
+      console.error = jest.fn();
+
+      mockGetSchemaRequests.mockResolvedValue({
+        entries: [],
+        totalPages: 1,
+        currentPage: 1,
+      });
+    });
+
+    afterEach(() => {
+      console.error = originalConsoleError;
+      cleanup();
+      jest.clearAllMocks();
+    });
+
+    it("shows a loading state instead of a table while schema requests are being fetched", () => {
+      customRender(<SchemaRequests />, {
+        queryClient: true,
+        memoryRouter: true,
+      });
+
+      const table = screen.queryByRole("table");
+      const loading = screen.getByTestId("skeleton-table");
+
+      expect(table).not.toBeInTheDocument();
+      expect(loading).toBeVisible();
+      expect(console.error).not.toHaveBeenCalled();
+    });
+
+    it("shows a error message in case of an error for fetching schema requests", async () => {
+      mockGetSchemaRequests.mockRejectedValue("mock-error");
+
+      customRender(<SchemaRequests />, {
+        queryClient: true,
+        memoryRouter: true,
+      });
+
+      const table = screen.queryByRole("table");
+      const errorMessage = await screen.findByText(
+        "Unexpected error. Please try again later!"
+      );
+
+      expect(table).not.toBeInTheDocument();
+      expect(errorMessage).toBeVisible();
+      expect(console.error).toHaveBeenCalledWith("mock-error");
+    });
+  });
+
+  describe("renders all necessary elements", () => {
+    beforeAll(async () => {
+      mockGetSchemaRequests.mockResolvedValue(mockedApiResponseSchemaRequests);
+
+      customRender(<SchemaRequests />, {
+        queryClient: true,
+        memoryRouter: true,
+      });
+
+      await waitForElementToBeRemoved(screen.getByTestId("skeleton-table"));
+    });
+
+    afterAll(() => {
+      cleanup();
+      jest.clearAllMocks();
+    });
+
+    it("shows a table with all schema requests", () => {
+      const table = screen.getByRole("table", { name: "Schema requests" });
+      const rows = within(table).getAllByRole("row");
+      const headerRow = 1;
+
+      expect(table).toBeVisible();
+      expect(rows).toHaveLength(
+        mockedApiResponseSchemaRequests.entries.length + headerRow
+      );
+    });
+  });
+});

--- a/coral/src/app/features/requests/components/schemas/SchemaRequests.tsx
+++ b/coral/src/app/features/requests/components/schemas/SchemaRequests.tsx
@@ -1,0 +1,28 @@
+import { useQuery } from "@tanstack/react-query";
+import { getSchemaRequests } from "src/domain/schema-request";
+import { SchemaRequestTable } from "src/app/features/requests/components/schemas/components/SchemaRequestTable";
+import { TableLayout } from "src/app/features/components/layouts/TableLayout";
+
+function SchemaRequests() {
+  const {
+    data: schemaRequests,
+    isLoading,
+    isError,
+    error,
+  } = useQuery({
+    queryKey: ["schemaRequests"],
+    queryFn: () => getSchemaRequests({ pageNo: String(1) }),
+  });
+
+  return (
+    <TableLayout
+      filters={[]}
+      table={<SchemaRequestTable requests={schemaRequests?.entries || []} />}
+      isLoading={isLoading}
+      isErrorLoading={isError}
+      errorMessage={error}
+    />
+  );
+}
+
+export { SchemaRequests };

--- a/coral/src/app/features/requests/components/schemas/components/SchemaRequestTable.test.tsx
+++ b/coral/src/app/features/requests/components/schemas/components/SchemaRequestTable.test.tsx
@@ -70,7 +70,7 @@ describe("SchemaRequestTable", () => {
     it("shows a button to view details for every row", () => {
       const table = screen.getByRole("table", { name: "Schema requests" });
       const buttons = within(table).getAllByRole("button", {
-        name: "View",
+        name: /View schema request for/,
       });
 
       expect(buttons).toHaveLength(schemaRequests.length);
@@ -79,7 +79,7 @@ describe("SchemaRequestTable", () => {
     it("shows an enabled button for every row where request is 'deletable'", () => {
       const table = screen.getByRole("table", { name: "Schema requests" });
       const buttons = within(table).getAllByRole("button", {
-        name: "Delete",
+        name: /Delete schema request for/,
       });
 
       const disabledButtons = buttons.filter((button) => {
@@ -97,7 +97,7 @@ describe("SchemaRequestTable", () => {
     schemaRequests.forEach((request) => {
       //@TODO buttons don't have discernible names right now
       // should be fixed for accessibility
-      xit(`shows a button to show the detailed schema request for topic name ${request.topicname}`, () => {
+      it(`shows a button to show the detailed schema request for topic name ${request.topicname}`, () => {
         const table = screen.getByRole("table", { name: "Schema requests" });
         const button = within(table).getByRole("button", {
           name: `View schema request for ${request.topicname}`,
@@ -110,7 +110,7 @@ describe("SchemaRequestTable", () => {
     deletableRequests.forEach((request) => {
       //@TODO buttons don't have discernible names right now
       // should be fixed for accessibility
-      xit(`shows a button to delete schema request for topic name ${request.topicname}`, () => {
+      it(`shows a button to delete schema request for topic name ${request.topicname}`, () => {
         const table = screen.getByRole("table", { name: "Schema requests" });
         const button = within(table).getByRole("button", {
           name: `Delete schema request for ${request.topicname}`,

--- a/coral/src/app/features/requests/components/schemas/components/SchemaRequestTable.test.tsx
+++ b/coral/src/app/features/requests/components/schemas/components/SchemaRequestTable.test.tsx
@@ -1,0 +1,185 @@
+import { mockIntersectionObserver } from "src/services/test-utils/mock-intersection-observer";
+import { cleanup, render, screen, within } from "@testing-library/react";
+import { SchemaRequestTable } from "src/app/features/requests/components/schemas/components/SchemaRequestTable";
+import { requestStatusNameMap } from "src/app/features/approvals/utils/request-status-helper";
+import {
+  RequestOperationType,
+  RequestStatus,
+} from "src/domain/requests/requests-types";
+import { requestOperationTypeNameMap } from "src/app/features/approvals/utils/request-operation-type-helper";
+import { mockedSchemaRequests } from "src/app/features/requests/components/schemas/utils/mocked-schema-requests";
+
+const schemaRequests = [...mockedSchemaRequests];
+const deletableRequests = schemaRequests.filter((entry) => entry.deletable);
+
+describe("SchemaRequestTable", () => {
+  beforeAll(mockIntersectionObserver);
+
+  const columnsFieldMap = [
+    { columnHeader: "Topic", relatedField: "topicname" },
+    { columnHeader: "Environment", relatedField: "environmentName" },
+    { columnHeader: "Status", relatedField: "requestStatus" },
+    { columnHeader: "Type", relatedField: "requestOperationType" },
+    { columnHeader: "Requested by", relatedField: "username" },
+    { columnHeader: "Requested on", relatedField: "requesttimestring" },
+    { columnHeader: "Details", relatedField: null },
+    { columnHeader: "Delete", relatedField: null },
+  ];
+
+  describe("shows information that table is empty when requests are empty", () => {
+    beforeAll(() => {
+      render(<SchemaRequestTable requests={[]} />);
+    });
+
+    afterAll(cleanup);
+
+    it("informs user there are no requests matching their criteria", () => {
+      const text = screen.getByText("No Schema request matched your criteria.");
+
+      expect(text).toBeVisible();
+    });
+  });
+
+  describe("renders all necessary elements", () => {
+    beforeAll(() => {
+      render(<SchemaRequestTable requests={schemaRequests} />);
+    });
+
+    afterAll(cleanup);
+
+    it("shows a table with all schema requests", () => {
+      const table = screen.getByRole("table", { name: "Schema requests" });
+
+      expect(table).toBeVisible();
+    });
+
+    it("shows all column headers", () => {
+      const table = screen.getByRole("table", { name: "Schema requests" });
+      const header = within(table).getAllByRole("columnheader");
+
+      expect(header).toHaveLength(columnsFieldMap.length);
+    });
+
+    it("shows a row for each given requests plus header row", () => {
+      const table = screen.getByRole("table", { name: "Schema requests" });
+      const row = within(table).getAllByRole("row");
+
+      expect(row).toHaveLength(schemaRequests.length + 1);
+    });
+
+    it("shows a button to view details for every row", () => {
+      const table = screen.getByRole("table", { name: "Schema requests" });
+      const buttons = within(table).getAllByRole("button", {
+        name: "View",
+      });
+
+      expect(buttons).toHaveLength(schemaRequests.length);
+    });
+
+    it("shows an enabled button for every row where request is 'deletable'", () => {
+      const table = screen.getByRole("table", { name: "Schema requests" });
+      const buttons = within(table).getAllByRole("button", {
+        name: "Delete",
+      });
+
+      const disabledButtons = buttons.filter((button) => {
+        return (button as HTMLButtonElement).disabled;
+      });
+
+      expect(disabledButtons).toHaveLength(
+        schemaRequests.length - deletableRequests.length
+      );
+      expect(buttons.length - disabledButtons.length).toEqual(
+        deletableRequests.length
+      );
+    });
+
+    schemaRequests.forEach((request) => {
+      //@TODO buttons don't have discernible names right now
+      // should be fixed for accessibility
+      xit(`shows a button to show the detailed schema request for topic name ${request.topicname}`, () => {
+        const table = screen.getByRole("table", { name: "Schema requests" });
+        const button = within(table).getByRole("button", {
+          name: `View schema request for ${request.topicname}`,
+        });
+
+        expect(button).toBeEnabled();
+      });
+    });
+
+    deletableRequests.forEach((request) => {
+      //@TODO buttons don't have discernible names right now
+      // should be fixed for accessibility
+      xit(`shows a button to delete schema request for topic name ${request.topicname}`, () => {
+        const table = screen.getByRole("table", { name: "Schema requests" });
+        const button = within(table).getByRole("button", {
+          name: `Delete schema request for ${request.topicname}`,
+        });
+
+        expect(button).toBeEnabled();
+      });
+    });
+  });
+
+  describe("renders all content based on the column definition", () => {
+    beforeAll(() => {
+      render(<SchemaRequestTable requests={schemaRequests} />);
+    });
+
+    afterAll(cleanup);
+
+    it(`renders the right amount of cells`, () => {
+      const table = screen.getByRole("table", {
+        name: "Schema requests",
+      });
+      const cells = within(table).getAllByRole("cell");
+
+      expect(cells).toHaveLength(
+        columnsFieldMap.length * schemaRequests.length
+      );
+    });
+
+    columnsFieldMap.forEach((column) => {
+      it(`shows a column header for ${column.columnHeader}`, () => {
+        const table = screen.getByRole("table", {
+          name: "Schema requests",
+        });
+        const header = within(table).getByRole("columnheader", {
+          name: column.columnHeader,
+        });
+
+        expect(header).toBeVisible();
+      });
+
+      if (column.relatedField) {
+        schemaRequests.forEach((request) => {
+          it(`shows field ${column.relatedField} for request number ${request.req_no}`, () => {
+            const table = screen.getByRole("table", {
+              name: "Schema requests",
+            });
+
+            // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+            //@ts-ignore
+            const field = request[column.relatedField];
+
+            let text = field;
+            if (column.columnHeader === "Requested on") {
+              text = `${field}${"\u00A0"}UTC`;
+            }
+
+            if (column.columnHeader === "Status") {
+              text = requestStatusNameMap[field as RequestStatus];
+            }
+
+            if (column.columnHeader === "Type") {
+              text = requestOperationTypeNameMap[field as RequestOperationType];
+            }
+            const cell = within(table).getByRole("cell", { name: text });
+
+            expect(cell).toBeVisible();
+          });
+        });
+      }
+    });
+  });
+});

--- a/coral/src/app/features/requests/components/schemas/components/SchemaRequestTable.tsx
+++ b/coral/src/app/features/requests/components/schemas/components/SchemaRequestTable.tsx
@@ -1,0 +1,132 @@
+import { DataTable, DataTableColumn, EmptyState } from "@aivenio/aquarium";
+import infoIcon from "@aivenio/aquarium/dist/src/icons/infoSign";
+import deleteIcon from "@aivenio/aquarium/dist/src/icons/delete";
+import {
+  requestStatusChipStatusMap,
+  requestStatusNameMap,
+} from "src/app/features/approvals/utils/request-status-helper";
+import {
+  requestOperationTypeChipStatusMap,
+  requestOperationTypeNameMap,
+} from "src/app/features/approvals/utils/request-operation-type-helper";
+import { SchemaRequest } from "src/domain/schema-request";
+
+interface SchemaRequestTableRow {
+  deletable: SchemaRequest["deletable"];
+  environment: SchemaRequest["environmentName"];
+  id: SchemaRequest["req_no"];
+  requestStatus: SchemaRequest["requestStatus"];
+  requestType: SchemaRequest["requestOperationType"];
+  requestedBy: SchemaRequest["username"];
+  requestedOn: SchemaRequest["requesttimestring"];
+  schemaversion: SchemaRequest["schemaversion"];
+  topic: SchemaRequest["topicname"];
+}
+
+type SchemaRequestTableProps = {
+  requests: SchemaRequest[];
+};
+
+function SchemaRequestTable({ requests }: SchemaRequestTableProps) {
+  const columns: Array<DataTableColumn<SchemaRequestTableRow>> = [
+    { type: "text", field: "topic", headerName: "Topic" },
+    {
+      type: "status",
+      field: "environment",
+      headerName: "Environment",
+      status: ({ environment }) => ({
+        status: "neutral",
+        text: environment,
+      }),
+    },
+    {
+      type: "status",
+      field: "requestStatus",
+      headerName: "Status",
+      status: ({ requestStatus }) => {
+        return {
+          status: requestStatusChipStatusMap[requestStatus],
+          text: requestStatusNameMap[requestStatus],
+        };
+      },
+    },
+    {
+      type: "status",
+      field: "requestType",
+      headerName: "Type",
+      status: ({ requestType }) => {
+        return {
+          status: requestOperationTypeChipStatusMap[requestType],
+          text: requestOperationTypeNameMap[requestType],
+        };
+      },
+    },
+    { type: "text", field: "requestedBy", headerName: "Requested by" },
+    {
+      type: "text",
+      field: "requestedOn",
+      headerName: "Requested on",
+      formatter: (value) => {
+        return `${value}${"\u00A0"}UTC`;
+      },
+    },
+    {
+      type: "action",
+      headerName: "Details",
+      headerInvisible: true,
+      width: 30,
+      action: ({ id }) => ({
+        text: "View",
+        icon: infoIcon,
+        onClick: () => console.log("details!", id),
+      }),
+    },
+    {
+      type: "action",
+      headerName: "Delete",
+      headerInvisible: true,
+      width: 30,
+      action: ({ id, deletable }) => ({
+        text: "Delete",
+        icon: deleteIcon,
+        onClick: () => console.log("delete!", id),
+        disabled: !deletable,
+      }),
+    },
+  ];
+
+  const rows: SchemaRequestTableRow[] = requests.map(
+    (request: SchemaRequest): SchemaRequestTableRow => {
+      return {
+        deletable: request.deletable,
+        environment: request.environmentName,
+        id: request.req_no,
+        requestStatus: request.requestStatus,
+        requestType: request.requestOperationType,
+        requestedBy: request.username,
+        requestedOn: request.requesttimestring,
+        schemaversion: request.schemaversion,
+        topic: request.topicname,
+      };
+    }
+  );
+
+  if (!rows.length) {
+    return (
+      <EmptyState title="No Schema requests">
+        No Schema request matched your criteria.
+      </EmptyState>
+    );
+  }
+
+  return (
+    <DataTable
+      ariaLabel={"Schema requests"}
+      columns={columns}
+      rows={rows}
+      noWrap={false}
+    />
+  );
+}
+
+export { SchemaRequestTable, type SchemaRequestTableProps };

--- a/coral/src/app/features/requests/components/schemas/components/SchemaRequestTable.tsx
+++ b/coral/src/app/features/requests/components/schemas/components/SchemaRequestTable.tsx
@@ -75,10 +75,11 @@ function SchemaRequestTable({ requests }: SchemaRequestTableProps) {
       headerName: "Details",
       headerInvisible: true,
       width: 30,
-      action: ({ id }) => ({
+      action: ({ id, topic }) => ({
         text: "View",
         icon: infoIcon,
         onClick: () => console.log("details!", id),
+        "aria-label": `View schema request for ${topic}`,
       }),
     },
     {
@@ -86,11 +87,12 @@ function SchemaRequestTable({ requests }: SchemaRequestTableProps) {
       headerName: "Delete",
       headerInvisible: true,
       width: 30,
-      action: ({ id, deletable }) => ({
+      action: ({ id, deletable, topic }) => ({
         text: "Delete",
         icon: deleteIcon,
         onClick: () => console.log("delete!", id),
         disabled: !deletable,
+        "aria-label": `Delete schema request for ${topic}`,
       }),
     },
   ];

--- a/coral/src/app/features/requests/components/schemas/utils/mocked-schema-requests.ts
+++ b/coral/src/app/features/requests/components/schemas/utils/mocked-schema-requests.ts
@@ -1,0 +1,89 @@
+import { SchemaRequest } from "src/domain/schema-request";
+import { transformGetSchemaRequests } from "src/domain/schema-request/schema-request-transformer";
+import { SchemaRequestApiResponse } from "src/domain/schema-request/schema-request-types";
+
+const mockedSchemaRequests: SchemaRequest[] = [
+  {
+    req_no: 1014,
+    topicname: "testtopic-first",
+    environment: "1",
+    environmentName: "BRG",
+    schemaversion: "1.0",
+    teamname: "NCC1701D",
+    teamId: 1701,
+    appname: "App",
+    schemafull: "",
+    username: "jlpicard",
+    requesttime: "1987-09-28T13:37:00.001+00:00",
+    requesttimestring: "28-Sep-1987 13:37:00",
+    requestStatus: "CREATED",
+    requestOperationType: "CREATE",
+    remarks: "asap",
+    approvingTeamDetails:
+      "Team : NCC1701D, Users : jlpicard, worf, bcrusher, geordilf",
+    approvingtime: "2022-11-04T14:54:13.414+00:00",
+    totalNoPages: "4",
+    allPageNos: ["1"],
+    currentPage: "1",
+    deletable: true,
+    editable: false,
+    forceRegister: false,
+  },
+  {
+    req_no: 1013,
+    topicname: "testtopic-second",
+    environment: "2",
+    environmentName: "SIC",
+    schemaversion: "1.0",
+    teamname: "NCC1701D",
+    teamId: 1701,
+    appname: "App",
+    schemafull: "",
+    username: "bcrusher",
+    requesttime: "1994-23-05T13:37:00.001+00:00",
+    requesttimestring: "23-May-1994 13:37:00",
+    requestStatus: "APPROVED",
+    requestOperationType: "PROMOTE",
+    remarks: "asap",
+    approvingTeamDetails:
+      "Team : NCC1701D, Users : jlpicard, worf, bcrusher, geordilf",
+    approvingtime: "2022-11-04T14:54:13.414+00:00",
+    totalNoPages: "4",
+    allPageNos: ["1"],
+    currentPage: "1",
+    deletable: true,
+    editable: false,
+    forceRegister: false,
+  },
+  {
+    req_no: 1042,
+    topicname: "testtopic-third",
+    environment: "2",
+    environmentName: "SEC",
+    schemaversion: "1.0",
+    teamname: "NCC1701D",
+    teamId: 1701,
+    appname: "App",
+    schemafull: "",
+    username: "worf",
+    requesttime: "1994-23-05T13:37:00.001+00:11",
+    requesttimestring: "23-May-1994 13:37:11",
+    requestStatus: "DECLINED",
+    requestOperationType: "UPDATE",
+    remarks: "asap",
+    approvingTeamDetails:
+      "Team : NCC1701D, Users : jlpicard, worf, bcrusher, geordilf",
+    approvingtime: "2022-11-04T14:54:13.414+00:00",
+    totalNoPages: "4",
+    allPageNos: ["1"],
+    currentPage: "1",
+    deletable: false,
+    editable: false,
+    forceRegister: false,
+  },
+];
+
+const mockedApiResponseSchemaRequests: SchemaRequestApiResponse =
+  transformGetSchemaRequests(mockedSchemaRequests);
+
+export { mockedSchemaRequests, mockedApiResponseSchemaRequests };

--- a/coral/src/app/pages/requests/schemas/index.test.tsx
+++ b/coral/src/app/pages/requests/schemas/index.test.tsx
@@ -1,0 +1,36 @@
+import { getSchemaRequests } from "src/domain/schema-request";
+import { customRender } from "src/services/test-utils/render-with-wrappers";
+import SchemaRequestsPage from "src/app/pages/requests/schemas/index";
+import { cleanup, screen } from "@testing-library/react";
+import { waitForElementToBeRemoved } from "@testing-library/react/pure";
+
+jest.mock("src/domain/schema-request/schema-request-api.ts");
+
+const mockGetSchemaRequests = getSchemaRequests as jest.MockedFunction<
+  typeof getSchemaRequests
+>;
+
+describe("SchemaRequestPage", () => {
+  beforeAll(() => {
+    mockGetSchemaRequests.mockResolvedValue({
+      entries: [],
+      totalPages: 1,
+      currentPage: 1,
+    });
+
+    customRender(<SchemaRequestsPage />, {
+      queryClient: true,
+    });
+  });
+
+  afterAll(cleanup);
+
+  it("renders the schema request view", async () => {
+    await waitForElementToBeRemoved(screen.getByTestId("skeleton-table"));
+    const emptyRequests = screen.getByText(
+      "No Schema request matched your criteria."
+    );
+
+    expect(emptyRequests).toBeVisible();
+  });
+});

--- a/coral/src/app/pages/requests/schemas/index.tsx
+++ b/coral/src/app/pages/requests/schemas/index.tsx
@@ -1,5 +1,7 @@
+import { SchemaRequests } from "src/app/features/requests/components/schemas/SchemaRequests";
+
 const SchemaRequestsPage = () => {
-  return <></>;
+  return <SchemaRequests />;
 };
 
 export default SchemaRequestsPage;


### PR DESCRIPTION
# About this change - What it does

- adds new directory for `/schema` in feature
- adds component with schema table
- adds component responsible for doing the api call and passing data to the schema table
- adds a utils folder with the mocked data since they are used in all tests anyway, it's easier to keep that up to date and aligned that way. 

#### Little refactor in the way: 
Changes `const rows = within(table).getAllByRole("rowgroup");` to a query checking for `rows` in approvals table for topics and schema: 
-> `rowgroup` looks for row groups (well! :D ) like `header`, `body`, `footer`. The test was green by chance. Checking for `row` will return all rows that are rendered and match the lengths of entries plus the row with the columnheaders.  Now it rests what it's supposed to -> "there is one row of content rendered for each entry".

Resolves: #808 


## Screen
- details and delete buttons are without functionality for now
- delete is only enabled if the schema request is `deleteable`  (there's none of that schema requests in that screen right now 🙈 )

<img width="1155" alt="screenshot" src="https://user-images.githubusercontent.com/943800/225324720-c4340adc-3599-4c72-a181-2c74dde31088.png">



