### PR TITLE
coral(feat): Add pagination with functionality my-schema-requests

### DIFF
--- a/coral/src/app/features/approvals/schemas/SchemaApprovals.test.tsx
+++ b/coral/src/app/features/approvals/schemas/SchemaApprovals.test.tsx
@@ -233,6 +233,15 @@ describe("SchemaApprovals", () => {
   });
 
   describe("renders pagination dependent on response", () => {
+    beforeEach(() => {
+      mockGetSchemaRequestsForApprover.mockResolvedValue({
+        entries: [],
+        totalPages: 1,
+        currentPage: 1,
+      });
+      mockGetSchemaRegistryEnvironments.mockResolvedValue([]);
+    });
+
     afterEach(() => {
       cleanup();
       jest.clearAllMocks();
@@ -335,6 +344,8 @@ describe("SchemaApprovals", () => {
         currentPage: 1,
         entries: [],
       });
+
+      mockGetSchemaRegistryEnvironments.mockResolvedValue([]);
 
       customRender(<SchemaApprovals />, {
         queryClient: true,

--- a/coral/src/app/features/requests/components/schemas/SchemaRequests.tsx
+++ b/coral/src/app/features/requests/components/schemas/SchemaRequests.tsx
@@ -2,22 +2,45 @@ import { useQuery } from "@tanstack/react-query";
 import { getSchemaRequests } from "src/domain/schema-request";
 import { SchemaRequestTable } from "src/app/features/requests/components/schemas/components/SchemaRequestTable";
 import { TableLayout } from "src/app/features/components/layouts/TableLayout";
+import { useSearchParams } from "react-router-dom";
+import { Pagination } from "src/app/components/Pagination";
 
 function SchemaRequests() {
+  const [searchParams, setSearchParams] = useSearchParams();
+  const currentPage = searchParams.get("page")
+    ? Number(searchParams.get("page"))
+    : 1;
+
   const {
     data: schemaRequests,
     isLoading,
     isError,
     error,
   } = useQuery({
-    queryKey: ["schemaRequests"],
-    queryFn: () => getSchemaRequests({ pageNo: String(1) }),
+    queryKey: ["schemaRequests", currentPage],
+    queryFn: () => getSchemaRequests({ pageNo: String(currentPage) }),
+    keepPreviousData: true,
   });
+
+  const setCurrentPage = (page: number) => {
+    searchParams.set("page", page.toString());
+    setSearchParams(searchParams);
+  };
+
+  const pagination =
+    schemaRequests?.totalPages && schemaRequests.totalPages > 1 ? (
+      <Pagination
+        activePage={schemaRequests.currentPage}
+        totalPages={schemaRequests?.totalPages}
+        setActivePage={setCurrentPage}
+      />
+    ) : undefined;
 
   return (
     <TableLayout
       filters={[]}
       table={<SchemaRequestTable requests={schemaRequests?.entries || []} />}
+      pagination={pagination}
       isLoading={isLoading}
       isErrorLoading={isError}
       errorMessage={error}

--- a/coral/src/app/pages/requests/schemas/index.test.tsx
+++ b/coral/src/app/pages/requests/schemas/index.test.tsx
@@ -20,6 +20,7 @@ describe("SchemaRequestPage", () => {
 
     customRender(<SchemaRequestsPage />, {
       queryClient: true,
+      memoryRouter: true,
     });
   });
 


### PR DESCRIPTION
# About this change - What it does

- adds pagination to My Schema Request view
- adds missing mocks to tests in SchemaApprovals (they caused a `console.error` that only showed up when running test in separation due to async nature)

Resolves: #809


https://user-images.githubusercontent.com/943800/225607148-55a848b9-e233-4043-a3a4-674581efc0fa.mov


