### PR TITLE
Remove functionality

### DIFF
--- a/core/src/main/java/io/aiven/klaw/model/requests/AclRequestsModel.java
+++ b/core/src/main/java/io/aiven/klaw/model/requests/AclRequestsModel.java
@@ -40,7 +40,9 @@ public class AclRequestsModel extends BaseRequestModel implements Serializable {
   private String transactionalId;
 
   // topic owner team id
-  @NotNull private Integer teamId;
+  private Integer teamId; // OPENAPI add notnull
+
+  private String teamname; // OPENAPI Remove
 
   // Producer/Consumer
   @NotNull private AclType aclType;

--- a/core/src/main/java/io/aiven/klaw/model/requests/BaseRequestModel.java
+++ b/core/src/main/java/io/aiven/klaw/model/requests/BaseRequestModel.java
@@ -13,7 +13,7 @@ import lombok.ToString;
 public class BaseRequestModel implements Serializable {
 
   // CREATE / DELETE / ..
-  @NotNull private RequestOperationType requestOperationType;
+  private RequestOperationType requestOperationType;
 
   @NotNull private String environment;
 
@@ -22,4 +22,6 @@ public class BaseRequestModel implements Serializable {
   private String remarks;
 
   private String requestor;
+
+  private String username; // OPENAPI Remove
 }

--- a/core/src/main/java/io/aiven/klaw/model/response/BaseRequestsResponseModel.java
+++ b/core/src/main/java/io/aiven/klaw/model/response/BaseRequestsResponseModel.java
@@ -57,4 +57,6 @@ public class BaseRequestsResponseModel implements Serializable {
   private String appname;
 
   private String otherParams;
+
+  private String username; // OPENAPI Remove
 }

--- a/core/src/main/java/io/aiven/klaw/service/AclControllerService.java
+++ b/core/src/main/java/io/aiven/klaw/service/AclControllerService.java
@@ -73,6 +73,11 @@ public class AclControllerService {
     aclRequestsModel.setRequestor(currentUserName);
     int tenantId = commonUtilsService.getTenantId(currentUserName);
 
+    if (aclRequestsModel.getTeamname() != null) {
+      aclRequestsModel.setTeamId(
+          manageDatabase.getTeamIdFromTeamName(
+              tenantId, aclRequestsModel.getTeamname())); // OPENAPI Remove
+    }
     aclRequestsModel.setRequestingteam(commonUtilsService.getTeamId(currentUserName));
 
     if (commonUtilsService.isNotAuthorizedUser(
@@ -244,6 +249,7 @@ public class AclControllerService {
       for (AclRequests aclRequests : aclReqs) {
         aclRequestsModel = new AclRequestsResponseModel();
         copyProperties(aclRequests, aclRequestsModel);
+        aclRequestsModel.setUsername(aclRequests.getRequestor()); // OPENAPI Remove
         aclRequestsModel.setRequestOperationType(
             RequestOperationType.of(aclRequests.getRequestOperationType()));
         aclRequestsModel.setAclType(AclType.of(aclRequests.getAclType()));

--- a/core/src/main/java/io/aiven/klaw/service/SchemaRegstryControllerService.java
+++ b/core/src/main/java/io/aiven/klaw/service/SchemaRegstryControllerService.java
@@ -96,6 +96,7 @@ public class SchemaRegstryControllerService {
                 .selectEnvDetails(schemaReq.getEnvironment(), tenantId)
                 .getName());
         copyProperties(schemaReq, schemaRequestModel);
+        schemaRequestModel.setUsername(schemaReq.getRequestor()); // OPENAPI Remove
         schemaRequestModel.setRequestStatus(RequestStatus.of(schemaReq.getRequestStatus()));
         schemaRequestModel.setRequestOperationType(
             RequestOperationType.of(schemaReq.getRequestOperationType()));

--- a/core/src/main/java/io/aiven/klaw/service/TopicControllerService.java
+++ b/core/src/main/java/io/aiven/klaw/service/TopicControllerService.java
@@ -508,6 +508,7 @@ public class TopicControllerService {
     for (TopicRequest topicReq : topicsList) {
       topicRequestModel = new TopicRequestsResponseModel();
       copyProperties(topicReq, topicRequestModel);
+      topicRequestModel.setUsername(topicReq.getRequestor()); // OPENAPI Remove
       topicRequestModel.setRequestStatus(RequestStatus.of(topicReq.getRequestStatus()));
       topicRequestModel.setRequestOperationType(
           RequestOperationType.of(topicReq.getRequestOperationType()));

--- a/core/src/main/resources/application.properties
+++ b/core/src/main/resources/application.properties
@@ -193,6 +193,9 @@ management.endpoints.web.exposure.exclude=
 management.health.ldap.enabled=false
 management.endpoint.shutdown.enabled=false
 
+# global settings on api responses
+spring.jackson.default-property-inclusion=non_null
+
 # log file settings
 logging.level.root=info
 logging.level.org.hibernate.SQL=off

--- a/core/src/main/resources/openapi.yaml
+++ b/core/src/main/resources/openapi.yaml
@@ -4895,6 +4895,9 @@
           "requestor" : {
             "type" : "string"
           },
+          "username" : {
+            "type" : "string"
+          },
           "topicname" : {
             "type" : "string",
             "pattern" : "^[a-zA-Z0-9._-]{3,}$"
@@ -4915,7 +4918,7 @@
             "format" : "int32"
           }
         },
-        "required" : [ "environment", "requestOperationType", "schemafull", "topicname" ]
+        "required" : [ "environment", "schemafull", "topicname" ]
       },
       "TopicConfigEntry" : {
         "properties" : {
@@ -4943,6 +4946,9 @@
             "type" : "string"
           },
           "requestor" : {
+            "type" : "string"
+          },
+          "username" : {
             "type" : "string"
           },
           "topicname" : {
@@ -4981,7 +4987,7 @@
             "type" : "string"
           }
         },
-        "required" : [ "description", "environment", "replicationfactor", "requestOperationType", "topicname", "topicpartitions" ]
+        "required" : [ "description", "environment", "replicationfactor", "topicname", "topicpartitions" ]
       },
       "TeamModel" : {
         "properties" : {
@@ -5495,6 +5501,9 @@
           "requestor" : {
             "type" : "string"
           },
+          "username" : {
+            "type" : "string"
+          },
           "topicname" : {
             "type" : "string",
             "pattern" : "^[a-zA-Z0-9._-]{3,}$"
@@ -5531,7 +5540,7 @@
             "type" : "string"
           }
         },
-        "required" : [ "description", "environment", "replicationfactor", "requestOperationType", "topicname", "topicpartitions" ]
+        "required" : [ "description", "environment", "replicationfactor", "topicname", "topicpartitions" ]
       },
       "KafkaConnectorRequestModel" : {
         "properties" : {
@@ -5549,6 +5558,9 @@
             "type" : "string"
           },
           "requestor" : {
+            "type" : "string"
+          },
+          "username" : {
             "type" : "string"
           },
           "connectorName" : {
@@ -5570,7 +5582,7 @@
             "type" : "string"
           }
         },
-        "required" : [ "connectorConfig", "connectorName", "description", "environment", "requestOperationType" ]
+        "required" : [ "connectorConfig", "connectorName", "description", "environment" ]
       },
       "AclRequestsModel" : {
         "properties" : {
@@ -5588,6 +5600,9 @@
             "type" : "string"
           },
           "requestor" : {
+            "type" : "string"
+          },
+          "username" : {
             "type" : "string"
           },
           "topicname" : {
@@ -5621,6 +5636,9 @@
             "type" : "integer",
             "format" : "int32"
           },
+          "teamname" : {
+            "type" : "string"
+          },
           "aclType" : {
             "type" : "string",
             "enum" : [ "PRODUCER", "CONSUMER" ]
@@ -5640,7 +5658,7 @@
             "type" : "string"
           }
         },
-        "required" : [ "aclIpPrincipleType", "aclPatternType", "aclType", "environment", "requestOperationType", "teamId", "topicname" ]
+        "required" : [ "aclIpPrincipleType", "aclPatternType", "aclType", "environment", "topicname" ]
       },
       "KwTenantModel" : {
         "properties" : {
@@ -5981,6 +5999,9 @@
             "type" : "string"
           },
           "otherParams" : {
+            "type" : "string"
+          },
+          "username" : {
             "type" : "string"
           },
           "topicname" : {
@@ -6377,6 +6398,9 @@
           "otherParams" : {
             "type" : "string"
           },
+          "username" : {
+            "type" : "string"
+          },
           "topicname" : {
             "type" : "string"
           },
@@ -6515,6 +6539,9 @@
             "type" : "string"
           },
           "otherParams" : {
+            "type" : "string"
+          },
+          "username" : {
             "type" : "string"
           },
           "connectorName" : {
@@ -6802,6 +6829,9 @@
             "type" : "string"
           },
           "otherParams" : {
+            "type" : "string"
+          },
+          "username" : {
             "type" : "string"
           },
           "topicname" : {


### PR DESCRIPTION
About this change - What it does

- On requests, requestOperationType is optional
- username field now exists on both requests and responses
- teamname is required for AclRequests

Resolves: #xxxxx
Why this way

With this change, few breaking changes in FE are reduced.
