### PR TITLE
refactoring(coral): Remove Edit column from my topic requests #838

### DIFF
--- a/coral/src/app/features/requests/components/topics/TopicRequests.tsx
+++ b/coral/src/app/features/requests/components/topics/TopicRequests.tsx
@@ -25,7 +25,6 @@ function TopicRequests() {
         <TopicRequestsTable
           requests={data?.entries ?? []}
           onDetails={() => null}
-          onEdit={() => null}
           onDelete={() => null}
         />
       }

--- a/coral/src/app/features/requests/components/topics/components/TopicRequestsTable.test.tsx
+++ b/coral/src/app/features/requests/components/topics/components/TopicRequestsTable.test.tsx
@@ -77,7 +77,6 @@ describe("TopicRequestsTable", () => {
       <TopicRequestsTable
         requests={mockedRequests}
         onDetails={jest.fn()}
-        onEdit={jest.fn()}
         onDelete={jest.fn()}
         {...props}
       />
@@ -184,25 +183,11 @@ describe("TopicRequestsTable", () => {
     );
   });
 
-  it("has column for action to edit request", async () => {
-    const onEdit = jest.fn();
-    renderFromProps({ onEdit });
-    await userEvent.click(
-      within(within(getNthRow(1)).getAllByRole("cell")[8]).getByRole("button", {
-        name: "Edit",
-      })
-    );
-    expect(onEdit).toHaveBeenNthCalledWith(
-      1,
-      String(mockedRequests[0].topicid)
-    );
-  });
-
   it("has column for action to delete request", async () => {
     const onDelete = jest.fn();
     renderFromProps({ onDelete });
     await userEvent.click(
-      within(within(getNthRow(1)).getAllByRole("cell")[9]).getByRole("button", {
+      within(within(getNthRow(1)).getAllByRole("cell")[8]).getByRole("button", {
         name: "Delete",
       })
     );
@@ -212,23 +197,12 @@ describe("TopicRequestsTable", () => {
     );
   });
 
-  it("disables the edit button for a request if the request is not editable", () => {
-    const onEdit = jest.fn();
-    const nonEditableRequest = { ...mockedRequests[0], editable: false };
-    renderFromProps({ requests: [nonEditableRequest], onEdit });
-    expect(
-      within(within(getNthRow(1)).getAllByRole("cell")[8]).getByRole("button", {
-        name: "Edit",
-      })
-    ).toBeDisabled();
-  });
-
   it("disables the delete button for a request if the request is not deletable", () => {
     const onDelete = jest.fn();
     const nonDeletableRequest = { ...mockedRequests[0], deletable: false };
     renderFromProps({ requests: [nonDeletableRequest], onDelete });
     expect(
-      within(within(getNthRow(1)).getAllByRole("cell")[9]).getByRole("button", {
+      within(within(getNthRow(1)).getAllByRole("cell")[8]).getByRole("button", {
         name: "Delete",
       })
     ).toBeDisabled();

--- a/coral/src/app/features/requests/components/topics/components/TopicRequestsTable.tsx
+++ b/coral/src/app/features/requests/components/topics/components/TopicRequestsTable.tsx
@@ -1,6 +1,5 @@
 import { DataTable, DataTableColumn, EmptyState } from "@aivenio/aquarium";
 import infoIcon from "@aivenio/aquarium/dist/src/icons/infoSign";
-import editIcon from "@aivenio/aquarium/dist/src/icons/edit";
 import deleteIcon from "@aivenio/aquarium/dist/src/icons/delete";
 import { TopicRequest } from "src/domain/topic/topic-types";
 import {
@@ -22,20 +21,17 @@ interface TopicRequestTableRow {
   requestor: TopicRequest["requestor"];
   requesttimestring: TopicRequest["requesttimestring"];
   deletable: TopicRequest["deletable"];
-  editable: TopicRequest["editable"];
 }
 
 type TopicRequestsTableProps = {
   requests: TopicRequest[];
   onDetails: (topicId: string) => void;
-  onEdit: (topicId: string) => void;
   onDelete: (topicId: string) => void;
 };
 
 function TopicRequestsTable({
   requests,
   onDetails,
-  onEdit,
   onDelete,
 }: TopicRequestsTableProps) {
   const columns: Array<DataTableColumn<TopicRequestTableRow>> = [
@@ -94,18 +90,6 @@ function TopicRequestsTable({
     },
     {
       type: "action",
-      headerName: "Edit",
-      headerInvisible: true,
-      width: 30,
-      action: ({ id, editable }) => ({
-        text: "Edit",
-        icon: editIcon,
-        onClick: () => onEdit(String(id)),
-        disabled: !editable,
-      }),
-    },
-    {
-      type: "action",
       headerName: "Delete",
       headerInvisible: true,
       width: 30,
@@ -129,7 +113,6 @@ function TopicRequestsTable({
       requestor: request.requestor,
       requesttimestring: request.requesttimestring,
       deletable: request.deletable,
-      editable: request.editable,
     };
   });
 


### PR DESCRIPTION
The edit feature for requests will not be implemented in the backend for this sprint. Remove the action column to edit request.

Resolves: #838

![image](https://user-images.githubusercontent.com/15416578/225545434-eebb29c0-1997-4d0f-8a98-ff550c5544b3.png)
