### PR TITLE
refactor(coral): Set default value for StatusFilter per prop.

### DIFF
--- a/coral/src/app/features/approvals/acls/AclApprovals.tsx
+++ b/coral/src/app/features/approvals/acls/AclApprovals.tsx
@@ -219,7 +219,7 @@ function AclApprovals() {
       <TableLayout
         filters={[
           <EnvironmentFilter key={"environment"} />,
-          <StatusFilter key={"status"} />,
+          <StatusFilter key={"status"} defaultStatus={"CREATED"} />,
           <AclTypeFilter key={"aclType"} />,
           <TopicFilter key={"topic"} />,
         ]}

--- a/coral/src/app/features/approvals/schemas/SchemaApprovals.tsx
+++ b/coral/src/app/features/approvals/schemas/SchemaApprovals.tsx
@@ -216,7 +216,7 @@ function SchemaApprovals() {
             key={"environment"}
             isSchemaRegistryEnvironments
           />,
-          <StatusFilter key={"status"} />,
+          <StatusFilter key={"status"} defaultStatus={"CREATED"} />,
           <TopicFilter key={"topic"} />,
         ]}
         table={table}

--- a/coral/src/app/features/approvals/topics/TopicApprovals.tsx
+++ b/coral/src/app/features/approvals/topics/TopicApprovals.tsx
@@ -244,7 +244,7 @@ function TopicApprovals() {
       <TableLayout
         filters={[
           <EnvironmentFilter key={"environment"} />,
-          <StatusFilter key={"status"} />,
+          <StatusFilter key={"status"} defaultStatus={"CREATED"} />,
           <TeamFilter key={"team"} />,
           <TopicFilter key={"topic"} />,
         ]}

--- a/coral/src/app/features/components/table-filters/StatusFilter.tsx
+++ b/coral/src/app/features/components/table-filters/StatusFilter.tsx
@@ -6,10 +6,15 @@ import {
 } from "src/app/features/approvals/utils/request-status-helper";
 import { RequestStatus } from "src/domain/requests/requests-types";
 
-function StatusFilter() {
+type StatusFilterProps = {
+  defaultStatus: RequestStatus;
+};
+
+function StatusFilter(props: StatusFilterProps) {
+  const { defaultStatus } = props;
   const [searchParams, setSearchParams] = useSearchParams();
   const status =
-    (searchParams.get("status") as RequestStatus | null) ?? "CREATED";
+    (searchParams.get("status") as RequestStatus | null) ?? defaultStatus;
 
   const handleChangeStatus = (nextStatus: RequestStatus) => {
     searchParams.set("status", nextStatus);


### PR DESCRIPTION
# About this change - What it does

`StatusFilter` did set the status `"CREATED"` as a default. For the My-Requests views, the default should be `"ALL"`. 

This PR removes the hard set default and adds a prop for that instead. 

