### PR TITLE
refactor(coral): Rename url param for only showing my requests.

### DIFF
--- a/coral/src/app/features/components/table-filters/MyRequestFilter.test.tsx
+++ b/coral/src/app/features/components/table-filters/MyRequestFilter.test.tsx
@@ -9,13 +9,13 @@ describe("MyRequestFilter", () => {
     window.history.replaceState(null, "", "/");
   });
 
-  it("is checked if isMyRequest is true in the url search parameters", async () => {
-    window.history.replaceState(null, "", "/?isMyRequest=true");
+  it("is checked if showOnlyMyRequests is true in the url search parameters", async () => {
+    window.history.replaceState(null, "", "/?showOnlyMyRequests=true");
     customRender(<MyRequestFilter />, {
       browserRouter: true,
     });
     await waitFor(() =>
-      expect(window.location.search).toEqual("?isMyRequest=true")
+      expect(window.location.search).toEqual("?showOnlyMyRequests=true")
     );
     await waitFor(() => {
       expect(
@@ -26,13 +26,13 @@ describe("MyRequestFilter", () => {
     });
   });
 
-  it("is unchecked if isMyRequest in the url search parameters has other value than true", async () => {
-    window.history.replaceState(null, "", "/?isMyRequest=abc");
+  it("is unchecked if showOnlyMyRequests in the url search parameters has other value than true", async () => {
+    window.history.replaceState(null, "", "/?showOnlyMyRequests=abc");
     customRender(<MyRequestFilter />, {
       browserRouter: true,
     });
     await waitFor(() =>
-      expect(window.location.search).toEqual("?isMyRequest=abc")
+      expect(window.location.search).toEqual("?showOnlyMyRequests=abc")
     );
     await waitFor(() => {
       expect(
@@ -43,7 +43,7 @@ describe("MyRequestFilter", () => {
     });
   });
 
-  it("sets the isMyRequest and page search parameter when user toggles the switch", async () => {
+  it("sets the showOnlyMyRequests and page search parameter when user toggles the switch", async () => {
     window.history.replaceState(null, "", "/");
     customRender(<MyRequestFilter />, {
       browserRouter: true,
@@ -55,17 +55,17 @@ describe("MyRequestFilter", () => {
     await userEvent.click(showMyRequests);
     await waitFor(() => expect(showMyRequests).toBeChecked());
     await waitFor(() =>
-      expect(window.location.search).toEqual("?isMyRequest=true&page=1")
+      expect(window.location.search).toEqual("?showOnlyMyRequests=true&page=1")
     );
   });
 
-  it("unsets the isMyRequest and page search parameter when user untoggles the switch", async () => {
-    window.history.replaceState(null, "", "/?isMyRequest=true");
+  it("unsets the showOnlyMyRequests and page search parameter when user untoggles the switch", async () => {
+    window.history.replaceState(null, "", "/?showOnlyMyRequests=true");
     customRender(<MyRequestFilter />, {
       browserRouter: true,
     });
     await waitFor(() =>
-      expect(window.location.search).toEqual("?isMyRequest=true")
+      expect(window.location.search).toEqual("?showOnlyMyRequests=true")
     );
     const showMyRequests = screen.getByRole("checkbox", {
       name: "Show only my requests",

--- a/coral/src/app/features/components/table-filters/MyRequestFilter.tsx
+++ b/coral/src/app/features/components/table-filters/MyRequestFilter.tsx
@@ -3,15 +3,15 @@ import { useSearchParams } from "react-router-dom";
 
 function MyRequestFilter() {
   const [searchParams, setSearchParams] = useSearchParams();
-  const isMyRequest = searchParams.get("isMyRequest") === "true";
+  const isMyRequest = searchParams.get("showOnlyMyRequests") === "true";
 
   const handleChangeIsMyRequest = (
     event: React.ChangeEvent<HTMLInputElement>
   ) => {
     if (event.target.checked) {
-      searchParams.set("isMyRequest", "true");
+      searchParams.set("showOnlyMyRequests", "true");
     } else {
-      searchParams.delete("isMyRequest");
+      searchParams.delete("showOnlyMyRequests");
     }
     searchParams.set("page", "1");
     setSearchParams(searchParams);

--- a/coral/src/app/features/requests/components/topics/TopicRequests.test.tsx
+++ b/coral/src/app/features/requests/components/topics/TopicRequests.test.tsx
@@ -116,11 +116,11 @@ describe("TopicRequests", () => {
       jest.resetAllMocks();
     });
 
-    it("populates the isMyRequest filter from the url search parameters", () => {
+    it("populates the MyRequests filter from the url search parameters", () => {
       customRender(<TopicRequests />, {
         queryClient: true,
         memoryRouter: true,
-        customRoutePath: "/?isMyRequest=true",
+        customRoutePath: "/?showOnlyMyRequests=true",
       });
       expect(getTopicRequests).toHaveBeenNthCalledWith(1, {
         pageNo: "1",
@@ -129,7 +129,7 @@ describe("TopicRequests", () => {
       });
     });
 
-    it("applies the isMyRequest filter by toggling the switch", async () => {
+    it("applies the MyRequest filter by toggling the switch", async () => {
       customRender(<TopicRequests />, {
         queryClient: true,
         memoryRouter: true,
@@ -147,11 +147,11 @@ describe("TopicRequests", () => {
       });
     });
 
-    it("unapplies the isMyRequest filter by untoggling the switch", async () => {
+    it("unapplies the MyRequest filter by untoggling the switch", async () => {
       customRender(<TopicRequests />, {
         queryClient: true,
         memoryRouter: true,
-        customRoutePath: "/?isMyRequest=true",
+        customRoutePath: "/?showOnlyMyRequests=true",
       });
       const isMyRequestSwitch = screen.getByRole("checkbox", {
         name: "Show only my requests",

--- a/coral/src/app/features/requests/components/topics/TopicRequests.tsx
+++ b/coral/src/app/features/requests/components/topics/TopicRequests.tsx
@@ -10,20 +10,20 @@ import { MyRequestFilter } from "src/app/features/components/table-filters/MyReq
 function TopicRequests() {
   const [searchParams, setSearchParams] = useSearchParams();
   const currentTopic = searchParams.get("topic") ?? undefined;
-  const isMyRequest =
-    searchParams.get("isMyRequest") === "true" ? true : undefined;
+  const showOnlyMyRequests =
+    searchParams.get("showOnlyMyRequests") === "true" ? true : undefined;
   const currentPage = searchParams.get("page")
     ? Number(searchParams.get("page"))
     : 1;
 
   const { data, isLoading, isError, error } = useQuery({
-    queryKey: ["topicRequests", currentTopic, currentPage, isMyRequest],
+    queryKey: ["topicRequests", currentTopic, currentPage, showOnlyMyRequests],
     queryFn: () =>
       getTopicRequests({
         pageNo: String(currentPage),
         // search is not yet implemented as a param to getTopicRequests
         // search: currentTopic,
-        isMyRequest,
+        isMyRequest: showOnlyMyRequests,
       }),
     keepPreviousData: true,
   });


### PR DESCRIPTION
# About this change - What it does

This PR renames the url-query-parameter for the toggle "Show only my requests" to `showOnlyMyRequests` (instead of `isMyRequest`).  It's a more precise/descriptive name in context of the UI. 

It also decouples a bit FE code from backend-api, because if BE e.g. would rename `isMyRequest` to `isReallyMyRequest` we only need to update it in one place.


