### PR TITLE
feat(coral): Acl Requests: add filter functionality (Environment, ACL type, Request type, Status)

### DIFF
--- a/coral/src/app/features/approvals/acls/components/AclApprovalsTable.tsx
+++ b/coral/src/app/features/approvals/acls/components/AclApprovalsTable.tsx
@@ -138,6 +138,7 @@ export default function AclApprovalsTable({
           <Flexbox wrap={"wrap"} gap={"2"}>
             {acl_ssl.map((ssl, index) => (
               <StatusChip
+                dense
                 status="neutral"
                 key={`${ssl}-${index}`}
                 // We need to add a space after text value
@@ -159,6 +160,7 @@ export default function AclApprovalsTable({
           <Flexbox wrap={"wrap"} gap={"2"}>
             {acl_ip.map((ip, index) => (
               <StatusChip
+                dense
                 status="neutral"
                 key={`${ip}-${index}`}
                 // We need to add a space after text value

--- a/coral/src/app/features/requests/components/acls/AclRequests.test.tsx
+++ b/coral/src/app/features/requests/components/acls/AclRequests.test.tsx
@@ -303,7 +303,7 @@ describe("AclRequests", () => {
       });
     });
 
-    it("applies the topic filter by typing into to the search input", async () => {
+    it("enables user to filter ACL requests by Topic name", async () => {
       customRender(<AclRequests />, {
         queryClient: true,
         memoryRouter: true,
@@ -357,7 +357,7 @@ describe("AclRequests", () => {
       });
     });
 
-    it("applies the topic filter by selecting a value", async () => {
+    it("enables user to filter ACL requests by Environment", async () => {
       customRender(<AclRequests />, {
         queryClient: true,
         memoryRouter: true,
@@ -412,7 +412,7 @@ describe("AclRequests", () => {
       });
     });
 
-    it("applies the topic filter by selecting a value", async () => {
+    it("enables user to filter ACL requests by ACL type", async () => {
       customRender(<AclRequests />, {
         queryClient: true,
         memoryRouter: true,
@@ -463,7 +463,7 @@ describe("AclRequests", () => {
       });
     });
 
-    it("applies the topic filter by selecting a value", async () => {
+    it("enables user to filter ACL requests by status", async () => {
       customRender(<AclRequests />, {
         queryClient: true,
         memoryRouter: true,

--- a/coral/src/app/features/requests/components/acls/AclRequests.test.tsx
+++ b/coral/src/app/features/requests/components/acls/AclRequests.test.tsx
@@ -137,6 +137,9 @@ describe("AclRequests", () => {
       expect(mockGetAclRequests).toHaveBeenCalledWith({
         pageNo: "100",
         topic: "",
+        env: "ALL",
+        aclType: "ALL",
+        requestStatus: "ALL",
       });
     });
 
@@ -151,6 +154,9 @@ describe("AclRequests", () => {
       expect(mockGetAclRequests).toHaveBeenCalledWith({
         pageNo: "1",
         topic: "",
+        env: "ALL",
+        aclType: "ALL",
+        requestStatus: "ALL",
       });
     });
 
@@ -255,6 +261,9 @@ describe("AclRequests", () => {
       expect(mockGetAclRequests).toHaveBeenNthCalledWith(2, {
         pageNo: "2",
         topic: "",
+        env: "ALL",
+        aclType: "ALL",
+        requestStatus: "ALL",
       });
     });
   });
@@ -274,6 +283,9 @@ describe("AclRequests", () => {
       expect(getAclRequests).toHaveBeenNthCalledWith(1, {
         pageNo: "1",
         topic: "abc",
+        env: "ALL",
+        aclType: "ALL",
+        requestStatus: "ALL",
       });
     });
 
@@ -292,6 +304,9 @@ describe("AclRequests", () => {
         expect(getAclRequests).toHaveBeenLastCalledWith({
           pageNo: "1",
           topic: "abc",
+          env: "ALL",
+          aclType: "ALL",
+          requestStatus: "ALL",
         });
       });
     });

--- a/coral/src/app/features/requests/components/acls/AclRequests.test.tsx
+++ b/coral/src/app/features/requests/components/acls/AclRequests.test.tsx
@@ -98,10 +98,18 @@ const mockGetAclRequestsResponse = transformAclRequestApiResponse([
   },
 ]);
 
+const mockGetEnvironmentsResponse = [
+  createEnvironment({
+    name: "DEV",
+    id: "1",
+  }),
+];
+
 describe("AclRequests", () => {
   beforeEach(() => {
-    mockIntersectionObserver();
     mockGetAclRequests.mockResolvedValue(mockGetAclRequestsResponse);
+    mockGetEnvironments.mockResolvedValue(mockGetEnvironmentsResponse);
+    mockIntersectionObserver();
   });
 
   afterEach(() => {
@@ -324,13 +332,6 @@ describe("AclRequests", () => {
     });
 
     it("populates the filter from the url search parameters", async () => {
-      mockGetEnvironments.mockResolvedValue([
-        createEnvironment({
-          name: "DEV",
-          id: "1",
-        }),
-      ]);
-
       customRender(<AclRequests />, {
         queryClient: true,
         memoryRouter: true,
@@ -357,13 +358,6 @@ describe("AclRequests", () => {
     });
 
     it("applies the topic filter by selecting a value", async () => {
-      mockGetEnvironments.mockResolvedValue([
-        createEnvironment({
-          name: "DEV",
-          id: "1",
-        }),
-      ]);
-
       customRender(<AclRequests />, {
         queryClient: true,
         memoryRouter: true,

--- a/coral/src/app/features/requests/components/acls/AclRequests.tsx
+++ b/coral/src/app/features/requests/components/acls/AclRequests.tsx
@@ -2,9 +2,13 @@ import { useQuery } from "@tanstack/react-query";
 import { useSearchParams } from "react-router-dom";
 import { Pagination } from "src/app/components/Pagination";
 import { TableLayout } from "src/app/features/components/layouts/TableLayout";
+import AclTypeFilter from "src/app/features/components/table-filters/AclTypeFilter";
+import EnvironmentFilter from "src/app/features/components/table-filters/EnvironmentFilter";
+import StatusFilter from "src/app/features/components/table-filters/StatusFilter";
 import TopicFilter from "src/app/features/components/table-filters/TopicFilter";
 import { AclRequestsTable } from "src/app/features/requests/components/acls/components/AclRequestsTable";
 import { getAclRequests } from "src/domain/acl/acl-api";
+import { AclRequest } from "src/domain/acl/acl-types";
 
 function AclRequests() {
   const [searchParams, setSearchParams] = useSearchParams();
@@ -13,13 +17,28 @@ function AclRequests() {
     ? Number(searchParams.get("page"))
     : 1;
   const currentTopic = searchParams.get("topic") ?? "";
+  const currentEnvironment = searchParams.get("environment") ?? "ALL";
+  const currentAclType =
+    (searchParams.get("aclType") as AclRequest["aclType"]) ?? "ALL";
+  const currentStatus =
+    (searchParams.get("status") as AclRequest["requestStatus"]) ?? "ALL";
 
   const { data, isLoading, isError, error } = useQuery({
-    queryKey: ["aclRequests", currentPage, currentTopic],
+    queryKey: [
+      "aclRequests",
+      currentPage,
+      currentTopic,
+      currentEnvironment,
+      currentAclType,
+      currentStatus,
+    ],
     queryFn: () =>
       getAclRequests({
         pageNo: String(currentPage),
         topic: currentTopic,
+        env: currentEnvironment,
+        aclType: currentAclType,
+        requestStatus: currentStatus,
       }),
     keepPreviousData: true,
   });
@@ -40,7 +59,12 @@ function AclRequests() {
 
   return (
     <TableLayout
-      filters={[<TopicFilter key="search" />]}
+      filters={[
+        <EnvironmentFilter key="environment" />,
+        <AclTypeFilter key="aclType" />,
+        <StatusFilter key="status" defaultStatus="ALL" />,
+        <TopicFilter key="search" />,
+      ]}
       table={
         <AclRequestsTable
           requests={data?.entries ?? []}

--- a/coral/src/app/features/requests/components/acls/components/AclRequestsTable.tsx
+++ b/coral/src/app/features/requests/components/acls/components/AclRequestsTable.tsx
@@ -88,6 +88,7 @@ function AclRequestsTable({
           <Flexbox wrap={"wrap"} gap={"2"}>
             {acl_ssl.map((ssl, index) => (
               <StatusChip
+                dense
                 status="neutral"
                 key={`${ssl}-${index}`}
                 // We need to add a space after text value
@@ -109,6 +110,7 @@ function AclRequestsTable({
           <Flexbox wrap={"wrap"} gap={"2"}>
             {acl_ip.map((ip, index) => (
               <StatusChip
+                dense
                 status="neutral"
                 key={`${ip}-${index}`}
                 // We need to add a space after text value


### PR DESCRIPTION
## About this change - What it does
- add filters to ACL Requests page (Environment, ACL type, Request type, Status)
- harmonize chip components for `acl_ssl` and `acl_ip`: make them `dense`, like the other chip components in tables

**Before:**

<img width="764" alt="Screenshot 2023-03-17 at 11 01 23" src="https://user-images.githubusercontent.com/20607294/225873690-29ca61b6-8c9a-4ff5-a46a-1df491381cc1.png">


**Now:**

<img width="655" alt="Screenshot 2023-03-17 at 11 01 31" src="https://user-images.githubusercontent.com/20607294/225873735-316ae4d3-6624-4a4b-ab4c-c88576abf938.png">



Resolves: #830
