### PR TITLE
feat(coral): My Schema Requests - add Toggle for "Show only my requests"

### DIFF
--- a/coral/src/app/features/components/layouts/TableLayout.tsx
+++ b/coral/src/app/features/components/layouts/TableLayout.tsx
@@ -29,7 +29,12 @@ function TableLayout(props: TableLayoutProps) {
       >
         {filters.map((element) => {
           return (
-            <Box grow={1} key={element.key}>
+            <Box
+              key={element.key}
+              grow={1}
+              display={"flex"}
+              flexDirection={"column"}
+            >
               {element}
             </Box>
           );

--- a/coral/src/app/features/requests/components/schemas/SchemaRequests.test.tsx
+++ b/coral/src/app/features/requests/components/schemas/SchemaRequests.test.tsx
@@ -142,6 +142,14 @@ describe("SchemaRequest", () => {
       );
     });
 
+    it("shows a toggle to only show users own requests", () => {
+      const toggle = screen.getByRole("checkbox", {
+        name: "Show only my requests",
+      });
+
+      expect(toggle).toBeVisible();
+    });
+
     it("shows a table with all schema requests", () => {
       const table = screen.getByRole("table", { name: "Schema requests" });
       const rows = within(table).getAllByRole("row");
@@ -369,6 +377,7 @@ describe("SchemaRequest", () => {
         requestStatus: newStatus,
       });
     });
+
     it("enables user to search for topic", async () => {
       expect(mockGetSchemaRequests).toHaveBeenNthCalledWith(
         1,
@@ -383,6 +392,26 @@ describe("SchemaRequest", () => {
         expect(mockGetSchemaRequests).toHaveBeenNthCalledWith(2, {
           ...defaultApiParams,
           topic: "myNiceTopic",
+        });
+      });
+    });
+
+    it("enables user to show only their own requests", async () => {
+      expect(mockGetSchemaRequests).toHaveBeenNthCalledWith(
+        1,
+        defaultApiParams
+      );
+
+      const toggle = screen.getByRole("checkbox", {
+        name: "Show only my requests",
+      });
+
+      await userEvent.click(toggle);
+
+      await waitFor(() => {
+        expect(mockGetSchemaRequests).toHaveBeenNthCalledWith(2, {
+          ...defaultApiParams,
+          isMyRequest: true,
         });
       });
     });

--- a/coral/src/app/features/requests/components/schemas/SchemaRequests.tsx
+++ b/coral/src/app/features/requests/components/schemas/SchemaRequests.tsx
@@ -8,6 +8,7 @@ import EnvironmentFilter from "src/app/features/components/table-filters/Environ
 import { RequestStatus } from "src/domain/requests/requests-types";
 import StatusFilter from "src/app/features/components/table-filters/StatusFilter";
 import TopicFilter from "src/app/features/components/table-filters/TopicFilter";
+import { MyRequestFilter } from "src/app/features/components/table-filters/MyRequestFilter";
 
 const defaultStatus = "ALL";
 
@@ -18,10 +19,11 @@ function SchemaRequests() {
     ? Number(searchParams.get("page"))
     : 1;
   const currentTopic = searchParams.get("topic") ?? undefined;
-
   const currentEnvironment = searchParams.get("environment") ?? "ALL";
   const currentStatus =
     (searchParams.get("status") as RequestStatus) ?? defaultStatus;
+  const showOnlyMyRequests =
+    searchParams.get("showOnlyMyRequests") === "true" ? true : undefined;
 
   const {
     data: schemaRequests,
@@ -35,6 +37,7 @@ function SchemaRequests() {
       currentEnvironment,
       currentStatus,
       currentTopic,
+      showOnlyMyRequests,
     ],
     queryFn: () =>
       getSchemaRequests({
@@ -42,6 +45,7 @@ function SchemaRequests() {
         env: currentEnvironment,
         requestStatus: currentStatus,
         topic: currentTopic,
+        isMyRequest: showOnlyMyRequests,
       }),
   });
 
@@ -65,6 +69,7 @@ function SchemaRequests() {
         <EnvironmentFilter key={"environments"} isSchemaRegistryEnvironments />,
         <StatusFilter key={"request-status"} defaultStatus={defaultStatus} />,
         <TopicFilter key={"topic"} />,
+        <MyRequestFilter key={"show-only-my-requests"} />,
       ]}
       table={<SchemaRequestTable requests={schemaRequests?.entries || []} />}
       pagination={pagination}

--- a/coral/src/app/features/requests/components/schemas/SchemaRequests.tsx
+++ b/coral/src/app/features/requests/components/schemas/SchemaRequests.tsx
@@ -47,6 +47,7 @@ function SchemaRequests() {
         topic: currentTopic,
         isMyRequest: showOnlyMyRequests,
       }),
+    keepPreviousData: true,
   });
 
   const setCurrentPage = (page: number) => {


### PR DESCRIPTION
# About this change - What it does

- Wraps the filter elements in `TableLayout` in a flexbox component to align them correctly (the toggle was misaligned before)

https://user-images.githubusercontent.com/943800/225877373-3b108986-da4c-4d25-8054-fee7b9d739cf.mov

- adds the toggle to filter request by users own requests
- extends tests for `SchemaRequest` to cover components responsibility to populate filters through url params


Resolves: #812 


https://user-images.githubusercontent.com/943800/225877954-186cf2fd-d0ed-467d-bf31-b381209eb941.mov

