### PR TITLE
feat(coral): ACL requests: add Toggle for "Only my requests"

### DIFF
--- a/coral/src/app/features/components/table-filters/MyRequestsFilter.test.tsx
+++ b/coral/src/app/features/components/table-filters/MyRequestsFilter.test.tsx
@@ -1,9 +1,9 @@
 import { customRender } from "src/services/test-utils/render-with-wrappers";
-import { MyRequestFilter } from "src/app/features/components/table-filters/MyRequestFilter";
+import { MyRequestsFilter } from "src/app/features/components/table-filters/MyRequestsFilter";
 import { cleanup, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 
-describe("MyRequestFilter", () => {
+describe("MyRequestsFilter", () => {
   afterEach(() => {
     cleanup();
     window.history.replaceState(null, "", "/");
@@ -11,7 +11,7 @@ describe("MyRequestFilter", () => {
 
   it("is checked if showOnlyMyRequests is true in the url search parameters", async () => {
     window.history.replaceState(null, "", "/?showOnlyMyRequests=true");
-    customRender(<MyRequestFilter />, {
+    customRender(<MyRequestsFilter />, {
       browserRouter: true,
     });
     await waitFor(() =>
@@ -28,7 +28,7 @@ describe("MyRequestFilter", () => {
 
   it("is unchecked if showOnlyMyRequests in the url search parameters has other value than true", async () => {
     window.history.replaceState(null, "", "/?showOnlyMyRequests=abc");
-    customRender(<MyRequestFilter />, {
+    customRender(<MyRequestsFilter />, {
       browserRouter: true,
     });
     await waitFor(() =>
@@ -45,7 +45,7 @@ describe("MyRequestFilter", () => {
 
   it("sets the showOnlyMyRequests and page search parameter when user toggles the switch", async () => {
     window.history.replaceState(null, "", "/");
-    customRender(<MyRequestFilter />, {
+    customRender(<MyRequestsFilter />, {
       browserRouter: true,
     });
     await waitFor(() => expect(window.location.search).toEqual(""));
@@ -61,7 +61,7 @@ describe("MyRequestFilter", () => {
 
   it("unsets the showOnlyMyRequests and page search parameter when user untoggles the switch", async () => {
     window.history.replaceState(null, "", "/?showOnlyMyRequests=true");
-    customRender(<MyRequestFilter />, {
+    customRender(<MyRequestsFilter />, {
       browserRouter: true,
     });
     await waitFor(() =>

--- a/coral/src/app/features/components/table-filters/MyRequestsFilter.tsx
+++ b/coral/src/app/features/components/table-filters/MyRequestsFilter.tsx
@@ -1,7 +1,7 @@
 import { Switch } from "@aivenio/aquarium";
 import { useSearchParams } from "react-router-dom";
 
-function MyRequestFilter() {
+function MyRequestsFilter() {
   const [searchParams, setSearchParams] = useSearchParams();
   const isMyRequest = searchParams.get("showOnlyMyRequests") === "true";
 
@@ -24,4 +24,4 @@ function MyRequestFilter() {
   );
 }
 
-export { MyRequestFilter };
+export { MyRequestsFilter };

--- a/coral/src/app/features/requests/components/acls/AclRequests.test.tsx
+++ b/coral/src/app/features/requests/components/acls/AclRequests.test.tsx
@@ -487,4 +487,61 @@ describe("AclRequests", () => {
       });
     });
   });
+
+  describe("user can filter ACL requests by only showing their own requests ", () => {
+    afterEach(() => {
+      cleanup();
+    });
+
+    it("renders proper state of toggle and filters correctly from the url search parameters", () => {
+      customRender(<AclRequests />, {
+        queryClient: true,
+        memoryRouter: true,
+        customRoutePath: "/?showOnlyMyRequests=true",
+      });
+
+      const toggle = screen.getByRole("checkbox", {
+        name: "Show only my requests",
+      });
+
+      expect(toggle).toBeChecked();
+
+      expect(getAclRequests).toHaveBeenNthCalledWith(1, {
+        pageNo: "1",
+        topic: "",
+        env: "ALL",
+        aclType: "ALL",
+        requestStatus: "ALL",
+        isMyRequest: true,
+      });
+    });
+
+    it("enables user to filter ACL requests by only showing their own requests", async () => {
+      customRender(<AclRequests />, {
+        queryClient: true,
+        memoryRouter: true,
+      });
+
+      const toggle = screen.getByRole("checkbox", {
+        name: "Show only my requests",
+      });
+
+      expect(toggle).not.toBeChecked();
+
+      await userEvent.click(toggle);
+
+      expect(toggle).toBeChecked();
+
+      await waitFor(() => {
+        expect(getAclRequests).toHaveBeenLastCalledWith({
+          pageNo: "1",
+          topic: "",
+          env: "ALL",
+          aclType: "ALL",
+          requestStatus: "ALL",
+          isMyRequest: true,
+        });
+      });
+    });
+  });
 });

--- a/coral/src/app/features/requests/components/acls/AclRequests.tsx
+++ b/coral/src/app/features/requests/components/acls/AclRequests.tsx
@@ -4,6 +4,7 @@ import { Pagination } from "src/app/components/Pagination";
 import { TableLayout } from "src/app/features/components/layouts/TableLayout";
 import AclTypeFilter from "src/app/features/components/table-filters/AclTypeFilter";
 import EnvironmentFilter from "src/app/features/components/table-filters/EnvironmentFilter";
+import { MyRequestsFilter } from "src/app/features/components/table-filters/MyRequestsFilter";
 import StatusFilter from "src/app/features/components/table-filters/StatusFilter";
 import TopicFilter from "src/app/features/components/table-filters/TopicFilter";
 import { AclRequestsTable } from "src/app/features/requests/components/acls/components/AclRequestsTable";
@@ -22,6 +23,8 @@ function AclRequests() {
     (searchParams.get("aclType") as AclRequest["aclType"]) ?? "ALL";
   const currentStatus =
     (searchParams.get("status") as AclRequest["requestStatus"]) ?? "ALL";
+  const showOnlyMyRequests =
+    searchParams.get("showOnlyMyRequests") === "true" ? true : undefined;
 
   const { data, isLoading, isError, error } = useQuery({
     queryKey: [
@@ -31,6 +34,7 @@ function AclRequests() {
       currentEnvironment,
       currentAclType,
       currentStatus,
+      showOnlyMyRequests,
     ],
     queryFn: () =>
       getAclRequests({
@@ -39,6 +43,7 @@ function AclRequests() {
         env: currentEnvironment,
         aclType: currentAclType,
         requestStatus: currentStatus,
+        isMyRequest: showOnlyMyRequests,
       }),
     keepPreviousData: true,
   });
@@ -64,6 +69,7 @@ function AclRequests() {
         <AclTypeFilter key="aclType" />,
         <StatusFilter key="status" defaultStatus="ALL" />,
         <TopicFilter key="search" />,
+        <MyRequestsFilter key="myRequests" />,
       ]}
       table={
         <AclRequestsTable

--- a/coral/src/app/features/requests/components/schemas/SchemaRequests.tsx
+++ b/coral/src/app/features/requests/components/schemas/SchemaRequests.tsx
@@ -1,17 +1,17 @@
 import { useQuery } from "@tanstack/react-query";
-import { getSchemaRequests } from "src/domain/schema-request";
-import { SchemaRequestTable } from "src/app/features/requests/components/schemas/components/SchemaRequestTable";
-import { TableLayout } from "src/app/features/components/layouts/TableLayout";
+import { useState } from "react";
 import { useSearchParams } from "react-router-dom";
 import { Pagination } from "src/app/components/Pagination";
-import EnvironmentFilter from "src/app/features/components/table-filters/EnvironmentFilter";
-import { RequestStatus } from "src/domain/requests/requests-types";
-import StatusFilter from "src/app/features/components/table-filters/StatusFilter";
-import TopicFilter from "src/app/features/components/table-filters/TopicFilter";
-import { MyRequestFilter } from "src/app/features/components/table-filters/MyRequestFilter";
-import { useState } from "react";
+import { TableLayout } from "src/app/features/components/layouts/TableLayout";
 import RequestDetailsModal from "src/app/features/components/RequestDetailsModal";
 import { SchemaRequestDetails } from "src/app/features/components/SchemaRequestDetails";
+import EnvironmentFilter from "src/app/features/components/table-filters/EnvironmentFilter";
+import { MyRequestsFilter } from "src/app/features/components/table-filters/MyRequestsFilter";
+import StatusFilter from "src/app/features/components/table-filters/StatusFilter";
+import TopicFilter from "src/app/features/components/table-filters/TopicFilter";
+import { SchemaRequestTable } from "src/app/features/requests/components/schemas/components/SchemaRequestTable";
+import { RequestStatus } from "src/domain/requests/requests-types";
+import { getSchemaRequests } from "src/domain/schema-request";
 
 const defaultStatus = "ALL";
 
@@ -115,7 +115,7 @@ function SchemaRequests() {
           />,
           <StatusFilter key={"request-status"} defaultStatus={defaultStatus} />,
           <TopicFilter key={"topic"} />,
-          <MyRequestFilter key={"show-only-my-requests"} />,
+          <MyRequestsFilter key={"show-only-my-requests"} />,
         ]}
         table={
           <SchemaRequestTable

--- a/coral/src/app/features/requests/components/topics/TopicRequests.tsx
+++ b/coral/src/app/features/requests/components/topics/TopicRequests.tsx
@@ -5,7 +5,7 @@ import { TopicRequestsTable } from "src/app/features/requests/components/topics/
 import { useSearchParams } from "react-router-dom";
 import TopicFilter from "src/app/features/components/table-filters/TopicFilter";
 import { Pagination } from "src/app/components/Pagination";
-import { MyRequestFilter } from "src/app/features/components/table-filters/MyRequestFilter";
+import { MyRequestsFilter } from "src/app/features/components/table-filters/MyRequestsFilter";
 
 function TopicRequests() {
   const [searchParams, setSearchParams] = useSearchParams();
@@ -46,7 +46,7 @@ function TopicRequests() {
     <TableLayout
       filters={[
         <TopicFilter key={"topic"} />,
-        <MyRequestFilter key={"isMyRequest"} />,
+        <MyRequestsFilter key={"isMyRequest"} />,
       ]}
       table={
         <TopicRequestsTable

--- a/coral/src/domain/acl/acl-api.ts
+++ b/coral/src/domain/acl/acl-api.ts
@@ -3,6 +3,7 @@ import transformAclRequestApiResponse from "src/domain/acl/acl-transformer";
 import {
   CreateAclRequestTopicTypeConsumer,
   CreateAclRequestTopicTypeProducer,
+  GetCreatedAclRequestForApproverParameters,
   GetCreatedAclRequestParameters,
 } from "src/domain/acl/acl-types";
 import {
@@ -24,16 +25,22 @@ const createAclRequest = (
 };
 
 const filterGetAclRequestParams = (params: GetCreatedAclRequestParameters) => {
-  return omitBy(params, (value, property) => {
-    const omitEnv = property === "env" && value === "ALL";
-    const omitAclType = property === "aclType" && value === "ALL";
-    const omitTopic = property === "topic" && value === "";
+  return omitBy(
+    { ...params, isMyRequest: String(Boolean(params.isMyRequest)) },
+    (value, property) => {
+      const omitEnv = property === "env" && value === "ALL";
+      const omitAclType = property === "aclType" && value === "ALL";
+      const omitTopic = property === "topic" && value === "";
+      const omitIsMyRequest = property === "isMyRequest" && value !== "true";
 
-    return omitEnv || omitAclType || omitTopic;
-  });
+      return omitEnv || omitAclType || omitTopic || omitIsMyRequest;
+    }
+  );
 };
 
-const getAclRequestsForApprover = (params: GetCreatedAclRequestParameters) => {
+const getAclRequestsForApprover = (
+  params: GetCreatedAclRequestForApproverParameters
+) => {
   const filteredParams = filterGetAclRequestParams(params);
 
   return api

--- a/coral/src/domain/acl/acl-types.ts
+++ b/coral/src/domain/acl/acl-types.ts
@@ -43,8 +43,14 @@ type CreateAclRequestTopicTypeConsumer = ResolveIntersectionTypes<
   }
 >;
 
-type GetCreatedAclRequestParameters = ResolveIntersectionTypes<
+type GetCreatedAclRequestForApproverParameters = ResolveIntersectionTypes<
   Omit<KlawApiRequestQueryParameters<"getAclRequestsForApprover">, "aclType">
+> & {
+  aclType?: "ALL" | "PRODUCER" | "CONSUMER";
+};
+
+type GetCreatedAclRequestParameters = ResolveIntersectionTypes<
+  Omit<KlawApiRequestQueryParameters<"getAclRequests">, "aclType">
 > & {
   aclType?: "ALL" | "PRODUCER" | "CONSUMER";
 };
@@ -59,6 +65,7 @@ export type {
   CreateAclRequestTopicTypeProducer,
   CreateAclRequestTopicTypeConsumer,
   GetCreatedAclRequestParameters,
+  GetCreatedAclRequestForApproverParameters,
   AclRequest,
   AclRequestsForApprover,
   AclType,


### PR DESCRIPTION
## About this change - What it does

- Add toggle to show only the ACL requests submitted by current user


## Other changes

- rename MyRequestFilter -> MyRequestsFilter (more accurate)
- fix API and types for `getAclRequests` and `getAclRequestsForApprover`

Resolves: #856

