### PR TITLE
Fix: fix typo `SchemaRegstry[x]`

### DIFF
--- a/core/src/main/java/io/aiven/klaw/controller/SchemaRegistryController.java
+++ b/core/src/main/java/io/aiven/klaw/controller/SchemaRegistryController.java
@@ -8,7 +8,7 @@ import io.aiven.klaw.model.requests.SchemaPromotion;
 import io.aiven.klaw.model.requests.SchemaRequestModel;
 import io.aiven.klaw.model.response.SchemaRequestsResponseModel;
 import io.aiven.klaw.service.SchemaOverviewService;
-import io.aiven.klaw.service.SchemaRegstryControllerService;
+import io.aiven.klaw.service.SchemaRegistryControllerService;
 import io.aiven.klaw.service.TopicOverviewService;
 import jakarta.validation.Valid;
 import java.util.List;
@@ -27,9 +27,9 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequestMapping("/")
 @Slf4j
-public class SchemaRegstryController {
+public class SchemaRegistryController {
 
-  @Autowired SchemaRegstryControllerService schemaRegstryControllerService;
+  @Autowired SchemaRegistryControllerService schemaRegistryControllerService;
 
   @Autowired TopicOverviewService topicOverviewService;
   @Autowired SchemaOverviewService schemaOverviewService;
@@ -54,7 +54,7 @@ public class SchemaRegstryController {
       @RequestParam(value = "isMyRequest", required = false, defaultValue = "false")
           boolean isMyRequest) {
     return new ResponseEntity<>(
-        schemaRegstryControllerService.getSchemaRequests(
+        schemaRegistryControllerService.getSchemaRequests(
             pageNo, currentPage, requestStatus.value, false, topic, env, null, isMyRequest),
         HttpStatus.OK);
   }
@@ -81,7 +81,7 @@ public class SchemaRegstryController {
       @RequestParam(value = "env", required = false) String env,
       @RequestParam(value = "search", required = false) String search) {
     return new ResponseEntity<>(
-        schemaRegstryControllerService.getSchemaRequests(
+        schemaRegistryControllerService.getSchemaRequests(
             pageNo, currentPage, requestStatus.value, true, topic, env, search, false),
         HttpStatus.OK);
   }
@@ -92,7 +92,7 @@ public class SchemaRegstryController {
   public ResponseEntity<ApiResponse> deleteSchemaRequests(
       @RequestParam("req_no") String avroSchemaReqId) throws KlawException {
     return new ResponseEntity<>(
-        schemaRegstryControllerService.deleteSchemaRequests(avroSchemaReqId), HttpStatus.OK);
+        schemaRegistryControllerService.deleteSchemaRequests(avroSchemaReqId), HttpStatus.OK);
   }
 
   @PostMapping(
@@ -101,7 +101,7 @@ public class SchemaRegstryController {
   public ResponseEntity<ApiResponse> execSchemaRequests(
       @RequestParam("avroSchemaReqId") String avroSchemaReqId) throws KlawException {
     return new ResponseEntity<>(
-        schemaRegstryControllerService.execSchemaRequests(avroSchemaReqId), HttpStatus.OK);
+        schemaRegistryControllerService.execSchemaRequests(avroSchemaReqId), HttpStatus.OK);
   }
 
   @PostMapping(
@@ -112,7 +112,8 @@ public class SchemaRegstryController {
       @RequestParam("reasonForDecline") String reasonForDecline)
       throws KlawException {
     return new ResponseEntity<>(
-        schemaRegstryControllerService.execSchemaRequestsDecline(avroSchemaReqId, reasonForDecline),
+        schemaRegistryControllerService.execSchemaRequestsDecline(
+            avroSchemaReqId, reasonForDecline),
         HttpStatus.OK);
   }
 
@@ -122,7 +123,7 @@ public class SchemaRegstryController {
   public ResponseEntity<ApiResponse> uploadSchema(
       @Valid @RequestBody SchemaRequestModel addSchemaRequest) throws KlawException {
     return new ResponseEntity<>(
-        schemaRegstryControllerService.uploadSchema(addSchemaRequest), HttpStatus.OK);
+        schemaRegistryControllerService.uploadSchema(addSchemaRequest), HttpStatus.OK);
   }
 
   @PostMapping(
@@ -131,7 +132,7 @@ public class SchemaRegstryController {
   public ResponseEntity<ApiResponse> promoteSchema(@RequestBody SchemaPromotion promoteSchemaReq)
       throws Exception {
 
-    return ResponseEntity.ok(schemaRegstryControllerService.promoteSchema(promoteSchemaReq));
+    return ResponseEntity.ok(schemaRegistryControllerService.promoteSchema(promoteSchemaReq));
   }
 
   @RequestMapping(

--- a/core/src/main/java/io/aiven/klaw/service/RequestService.java
+++ b/core/src/main/java/io/aiven/klaw/service/RequestService.java
@@ -13,7 +13,7 @@ import org.springframework.stereotype.Service;
 @Slf4j
 public class RequestService {
 
-  @Autowired private SchemaRegstryControllerService schemaRegstryControllerService;
+  @Autowired private SchemaRegistryControllerService schemaRegistryControllerService;
 
   @Autowired private KafkaConnectControllerService kafkaConnectControllerService;
 
@@ -35,7 +35,7 @@ public class RequestService {
         case ACL:
           return aclControllerService.approveAclRequests(reqId);
         case SCHEMA:
-          return schemaRegstryControllerService.execSchemaRequests(reqId);
+          return schemaRegistryControllerService.execSchemaRequests(reqId);
         case CONNECTOR:
           return kafkaConnectControllerService.approveConnectorRequests(reqId);
         default:
@@ -70,7 +70,7 @@ public class RequestService {
         case ACL:
           return aclControllerService.deleteAclRequests(reqId);
         case SCHEMA:
-          return schemaRegstryControllerService.deleteSchemaRequests(reqId);
+          return schemaRegistryControllerService.deleteSchemaRequests(reqId);
         case CONNECTOR:
           return kafkaConnectControllerService.deleteConnectorRequests(reqId);
         default:
@@ -95,7 +95,7 @@ public class RequestService {
         case ACL:
           return aclControllerService.declineAclRequests(reqId, reason);
         case SCHEMA:
-          return schemaRegstryControllerService.execSchemaRequestsDecline(reqId, reason);
+          return schemaRegistryControllerService.execSchemaRequestsDecline(reqId, reason);
         case CONNECTOR:
           return kafkaConnectControllerService.declineConnectorRequests(reqId, reason);
         default:

--- a/core/src/main/java/io/aiven/klaw/service/SchemaRegistryControllerService.java
+++ b/core/src/main/java/io/aiven/klaw/service/SchemaRegistryControllerService.java
@@ -34,7 +34,7 @@ import org.springframework.stereotype.Service;
 
 @Service
 @Slf4j
-public class SchemaRegstryControllerService {
+public class SchemaRegistryControllerService {
   @Autowired ManageDatabase manageDatabase;
 
   @Autowired ClusterApiService clusterApiService;
@@ -45,7 +45,7 @@ public class SchemaRegstryControllerService {
 
   @Autowired private RolesPermissionsControllerService rolesPermissionsControllerService;
 
-  public SchemaRegstryControllerService(
+  public SchemaRegistryControllerService(
       ClusterApiService clusterApiService, MailUtils mailService) {
     this.clusterApiService = clusterApiService;
     this.mailService = mailService;

--- a/core/src/test/java/io/aiven/klaw/controller/RequestControllerTest.java
+++ b/core/src/test/java/io/aiven/klaw/controller/RequestControllerTest.java
@@ -13,11 +13,8 @@ import io.aiven.klaw.model.ApiResponse;
 import io.aiven.klaw.model.RequestVerdict;
 import io.aiven.klaw.model.enums.ApiResultStatus;
 import io.aiven.klaw.model.enums.RequestEntityType;
-import io.aiven.klaw.service.AclControllerService;
-import io.aiven.klaw.service.KafkaConnectControllerService;
-import io.aiven.klaw.service.RequestService;
-import io.aiven.klaw.service.SchemaRegstryControllerService;
-import io.aiven.klaw.service.TopicControllerService;
+import io.aiven.klaw.service.*;
+import io.aiven.klaw.service.SchemaRegistryControllerService;
 import java.util.Arrays;
 import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
@@ -36,7 +33,7 @@ import org.springframework.test.util.ReflectionTestUtils;
 @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
 class RequestControllerTest {
 
-  @Mock private SchemaRegstryControllerService schemaRegstryControllerService;
+  @Mock private SchemaRegistryControllerService schemaRegistryControllerService;
 
   @Mock private KafkaConnectControllerService kafkaConnectControllerService;
 
@@ -57,7 +54,7 @@ class RequestControllerTest {
     ReflectionTestUtils.setField(
         service, "kafkaConnectControllerService", kafkaConnectControllerService);
     ReflectionTestUtils.setField(
-        service, "schemaRegstryControllerService", schemaRegstryControllerService);
+        service, "schemaRegistryControllerService", schemaRegistryControllerService);
 
     ReflectionTestUtils.setField(controller, "service", service);
   }
@@ -130,13 +127,13 @@ class RequestControllerTest {
   @Test
   public void givenARequestToApproveMulitpleCallCorrectSCHEMAServiceAndReturnSuccessOK()
       throws KlawException {
-    when(schemaRegstryControllerService.execSchemaRequests(anyString()))
+    when(schemaRegistryControllerService.execSchemaRequests(anyString()))
         .thenReturn(getApiResponse(ApiResultStatus.SUCCESS));
     ResponseEntity<List<ApiResponse>> result =
         controller.approveRequest(
             createRequestVerdict(RequestEntityType.SCHEMA, null, "1001", "2001"));
     assertThat(result.getStatusCode()).isEqualTo(HttpStatusCode.valueOf(200));
-    verify(schemaRegstryControllerService, times(2)).execSchemaRequests(anyString());
+    verify(schemaRegistryControllerService, times(2)).execSchemaRequests(anyString());
   }
 
   @Order(6)
@@ -144,39 +141,39 @@ class RequestControllerTest {
   public void
       givenARequestToApproveMulitpleCallCorrectSCHEMAServiceAndReturnSuccessMultiStatusResponse()
           throws KlawException {
-    when(schemaRegstryControllerService.execSchemaRequests(anyString()))
+    when(schemaRegistryControllerService.execSchemaRequests(anyString()))
         .thenReturn(getApiResponse(ApiResultStatus.SUCCESS))
         .thenReturn(getApiResponse(ApiResultStatus.FAILURE));
     ResponseEntity<List<ApiResponse>> result =
         controller.approveRequest(
             createRequestVerdict(RequestEntityType.SCHEMA, null, "1001", "2001"));
     assertThat(result.getStatusCode()).isEqualTo(HttpStatusCode.valueOf(207));
-    verify(schemaRegstryControllerService, times(2)).execSchemaRequests(anyString());
+    verify(schemaRegistryControllerService, times(2)).execSchemaRequests(anyString());
   }
 
   @Order(7)
   @Test
   public void givenARequestToApproveCallCorrectSCHEMAServiceAndReturnISEResponse()
       throws KlawException {
-    when(schemaRegstryControllerService.execSchemaRequests(anyString()))
+    when(schemaRegistryControllerService.execSchemaRequests(anyString()))
         .thenReturn(getApiResponse(ApiResultStatus.FAILURE));
     ResponseEntity<List<ApiResponse>> result =
         controller.approveRequest(createRequestVerdict(RequestEntityType.SCHEMA, null, "1001"));
     assertThat(result.getStatusCode()).isEqualTo(HttpStatusCode.valueOf(500));
-    verify(schemaRegstryControllerService, times(1)).execSchemaRequests(anyString());
+    verify(schemaRegistryControllerService, times(1)).execSchemaRequests(anyString());
   }
 
   @Order(8)
   @Test
   public void givenMultipleRequestToApproveCallCorrectSCHEMAServiceAndReturnISEResponse()
       throws KlawException {
-    when(schemaRegstryControllerService.execSchemaRequests(anyString()))
+    when(schemaRegistryControllerService.execSchemaRequests(anyString()))
         .thenReturn(getApiResponse(ApiResultStatus.FAILURE));
     ResponseEntity<List<ApiResponse>> result =
         controller.approveRequest(
             createRequestVerdict(RequestEntityType.SCHEMA, null, "1001", "2001"));
     assertThat(result.getStatusCode()).isEqualTo(HttpStatusCode.valueOf(500));
-    verify(schemaRegstryControllerService, times(2)).execSchemaRequests(anyString());
+    verify(schemaRegistryControllerService, times(2)).execSchemaRequests(anyString());
   }
 
   @Order(9)
@@ -296,7 +293,7 @@ class RequestControllerTest {
     assertThat(result.getStatusCode()).isEqualTo(HttpStatusCode.valueOf(500));
     verify(aclControllerService, times(0)).approveAclRequests(anyString());
     verify(kafkaConnectControllerService, times(0)).approveConnectorRequests(anyString());
-    verify(schemaRegstryControllerService, times(0)).execSchemaRequests(anyString());
+    verify(schemaRegistryControllerService, times(0)).execSchemaRequests(anyString());
     verify(topicControllerService, times(0)).approveTopicRequests(anyString());
   }
 
@@ -374,13 +371,13 @@ class RequestControllerTest {
   @Test
   public void givenARequestToDeclineCMulitpleCallCorrectSCHEMAServiceAndReturnSuccessOK()
       throws KlawException, KlawRestException {
-    when(schemaRegstryControllerService.execSchemaRequestsDecline(anyString(), anyString()))
+    when(schemaRegistryControllerService.execSchemaRequestsDecline(anyString(), anyString()))
         .thenReturn(getApiResponse(ApiResultStatus.SUCCESS));
     ResponseEntity<List<ApiResponse>> result =
         controller.declineRequest(
             createRequestVerdict(RequestEntityType.SCHEMA, "Schema is Invalid", "1001", "2001"));
     assertThat(result.getStatusCode()).isEqualTo(HttpStatusCode.valueOf(200));
-    verify(schemaRegstryControllerService, times(2))
+    verify(schemaRegistryControllerService, times(2))
         .execSchemaRequestsDecline(anyString(), anyString());
   }
 
@@ -389,14 +386,14 @@ class RequestControllerTest {
   public void
       givenARequestToDeclineCMulitpleCallCorrectSCHEMAServiceAndReturnSuccessMultiStatusResponse()
           throws KlawException, KlawRestException {
-    when(schemaRegstryControllerService.execSchemaRequestsDecline(anyString(), anyString()))
+    when(schemaRegistryControllerService.execSchemaRequestsDecline(anyString(), anyString()))
         .thenReturn(getApiResponse(ApiResultStatus.SUCCESS))
         .thenReturn(getApiResponse(ApiResultStatus.FAILURE));
     ResponseEntity<List<ApiResponse>> result =
         controller.declineRequest(
             createRequestVerdict(RequestEntityType.SCHEMA, "Schema is Invalid", "1001", "2001"));
     assertThat(result.getStatusCode()).isEqualTo(HttpStatusCode.valueOf(207));
-    verify(schemaRegstryControllerService, times(2))
+    verify(schemaRegistryControllerService, times(2))
         .execSchemaRequestsDecline(anyString(), anyString());
   }
 
@@ -404,13 +401,13 @@ class RequestControllerTest {
   @Test
   public void givenARequestToDeclineCCallCorrectSCHEMAServiceAndReturnISEResponse()
       throws KlawException, KlawRestException {
-    when(schemaRegstryControllerService.execSchemaRequestsDecline(anyString(), anyString()))
+    when(schemaRegistryControllerService.execSchemaRequestsDecline(anyString(), anyString()))
         .thenReturn(getApiResponse(ApiResultStatus.FAILURE));
     ResponseEntity<List<ApiResponse>> result =
         controller.declineRequest(
             createRequestVerdict(RequestEntityType.SCHEMA, "Schema is Invalid", "1001"));
     assertThat(result.getStatusCode()).isEqualTo(HttpStatusCode.valueOf(500));
-    verify(schemaRegstryControllerService, times(1))
+    verify(schemaRegistryControllerService, times(1))
         .execSchemaRequestsDecline(anyString(), anyString());
   }
 
@@ -418,13 +415,13 @@ class RequestControllerTest {
   @Test
   public void givenMultipleRequestToDeclineCCallCorrectSCHEMAServiceAndReturnISEResponse()
       throws KlawException, KlawRestException {
-    when(schemaRegstryControllerService.execSchemaRequestsDecline(anyString(), anyString()))
+    when(schemaRegistryControllerService.execSchemaRequestsDecline(anyString(), anyString()))
         .thenReturn(getApiResponse(ApiResultStatus.FAILURE));
     ResponseEntity<List<ApiResponse>> result =
         controller.declineRequest(
             createRequestVerdict(RequestEntityType.SCHEMA, "Schema is Invalid", "1001", "2001"));
     assertThat(result.getStatusCode()).isEqualTo(HttpStatusCode.valueOf(500));
-    verify(schemaRegstryControllerService, times(2))
+    verify(schemaRegistryControllerService, times(2))
         .execSchemaRequestsDecline(anyString(), anyString());
   }
 
@@ -552,7 +549,7 @@ class RequestControllerTest {
     verify(aclControllerService, times(0)).declineAclRequests(anyString(), anyString());
     verify(kafkaConnectControllerService, times(0))
         .declineConnectorRequests(anyString(), anyString());
-    verify(schemaRegstryControllerService, times(0))
+    verify(schemaRegistryControllerService, times(0))
         .execSchemaRequestsDecline(anyString(), anyString());
     verify(topicControllerService, times(0)).declineTopicRequests(anyString(), anyString());
   }
@@ -626,13 +623,13 @@ class RequestControllerTest {
   @Test
   public void givenARequestToDeleteMulitpleCallCorrectSCHEMAServiceAndReturnSuccessOK()
       throws KlawException, KlawRestException {
-    when(schemaRegstryControllerService.deleteSchemaRequests(anyString()))
+    when(schemaRegistryControllerService.deleteSchemaRequests(anyString()))
         .thenReturn(getApiResponse(ApiResultStatus.SUCCESS));
     ResponseEntity<List<ApiResponse>> result =
         controller.deleteRequest(
             createRequestVerdict(RequestEntityType.SCHEMA, null, "1001", "2001"));
     assertThat(result.getStatusCode()).isEqualTo(HttpStatusCode.valueOf(200));
-    verify(schemaRegstryControllerService, times(2)).deleteSchemaRequests(anyString());
+    verify(schemaRegistryControllerService, times(2)).deleteSchemaRequests(anyString());
   }
 
   @Order(42)
@@ -640,39 +637,39 @@ class RequestControllerTest {
   public void
       givenARequestToDeleteMulitpleCallCorrectSCHEMAServiceAndReturnSuccessMultiStatusResponse()
           throws KlawException, KlawRestException {
-    when(schemaRegstryControllerService.deleteSchemaRequests(anyString()))
+    when(schemaRegistryControllerService.deleteSchemaRequests(anyString()))
         .thenReturn(getApiResponse(ApiResultStatus.SUCCESS))
         .thenReturn(getApiResponse(ApiResultStatus.FAILURE));
     ResponseEntity<List<ApiResponse>> result =
         controller.deleteRequest(
             createRequestVerdict(RequestEntityType.SCHEMA, null, "1001", "2001"));
     assertThat(result.getStatusCode()).isEqualTo(HttpStatusCode.valueOf(207));
-    verify(schemaRegstryControllerService, times(2)).deleteSchemaRequests(anyString());
+    verify(schemaRegistryControllerService, times(2)).deleteSchemaRequests(anyString());
   }
 
   @Order(43)
   @Test
   public void givenARequestToDeleteCallCorrectSCHEMAServiceAndReturnISEResponse()
       throws KlawException, KlawRestException {
-    when(schemaRegstryControllerService.deleteSchemaRequests(anyString()))
+    when(schemaRegistryControllerService.deleteSchemaRequests(anyString()))
         .thenReturn(getApiResponse(ApiResultStatus.FAILURE));
     ResponseEntity<List<ApiResponse>> result =
         controller.deleteRequest(createRequestVerdict(RequestEntityType.SCHEMA, null, "1001"));
     assertThat(result.getStatusCode()).isEqualTo(HttpStatusCode.valueOf(500));
-    verify(schemaRegstryControllerService, times(1)).deleteSchemaRequests(anyString());
+    verify(schemaRegistryControllerService, times(1)).deleteSchemaRequests(anyString());
   }
 
   @Order(44)
   @Test
   public void givenMultipleRequestToDeleteCallCorrectSCHEMAServiceAndReturnISEResponse()
       throws KlawException, KlawRestException {
-    when(schemaRegstryControllerService.deleteSchemaRequests(anyString()))
+    when(schemaRegistryControllerService.deleteSchemaRequests(anyString()))
         .thenReturn(getApiResponse(ApiResultStatus.FAILURE));
     ResponseEntity<List<ApiResponse>> result =
         controller.deleteRequest(
             createRequestVerdict(RequestEntityType.SCHEMA, null, "1001", "2001"));
     assertThat(result.getStatusCode()).isEqualTo(HttpStatusCode.valueOf(500));
-    verify(schemaRegstryControllerService, times(2)).deleteSchemaRequests(anyString());
+    verify(schemaRegistryControllerService, times(2)).deleteSchemaRequests(anyString());
   }
 
   @Order(45)
@@ -789,7 +786,7 @@ class RequestControllerTest {
     assertThat(result.getStatusCode()).isEqualTo(HttpStatusCode.valueOf(500));
     verify(aclControllerService, times(0)).deleteAclRequests(anyString());
     verify(kafkaConnectControllerService, times(0)).deleteConnectorRequests(anyString());
-    verify(schemaRegstryControllerService, times(0)).deleteSchemaRequests(anyString());
+    verify(schemaRegistryControllerService, times(0)).deleteSchemaRequests(anyString());
     verify(topicControllerService, times(0)).deleteTopicRequests(anyString());
   }
 

--- a/core/src/test/java/io/aiven/klaw/controller/SchemaRegistryControllerTest.java
+++ b/core/src/test/java/io/aiven/klaw/controller/SchemaRegistryControllerTest.java
@@ -15,7 +15,7 @@ import io.aiven.klaw.model.enums.ApiResultStatus;
 import io.aiven.klaw.model.requests.SchemaPromotion;
 import io.aiven.klaw.model.requests.SchemaRequestModel;
 import io.aiven.klaw.model.response.SchemaRequestsResponseModel;
-import io.aiven.klaw.service.SchemaRegstryControllerService;
+import io.aiven.klaw.service.SchemaRegistryControllerService;
 import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.MethodOrderer;
@@ -33,12 +33,12 @@ import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 
 @ExtendWith(SpringExtension.class)
 @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
-public class SchemaRegstryControllerTest {
+public class SchemaRegistryControllerTest {
 
   public static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
-  @MockBean private SchemaRegstryControllerService schemaRegstryControllerService;
+  @MockBean private SchemaRegistryControllerService schemaRegistryControllerService;
 
-  private SchemaRegstryController schemaRegstryController;
+  private SchemaRegistryController schemaRegistryController;
 
   private UtilMethods utilMethods;
 
@@ -46,11 +46,13 @@ public class SchemaRegstryControllerTest {
 
   @BeforeEach
   public void setUp() {
-    schemaRegstryController = new SchemaRegstryController();
-    mvc = MockMvcBuilders.standaloneSetup(schemaRegstryController).dispatchOptions(true).build();
+    schemaRegistryController = new SchemaRegistryController();
+    mvc = MockMvcBuilders.standaloneSetup(schemaRegistryController).dispatchOptions(true).build();
     utilMethods = new UtilMethods();
     ReflectionTestUtils.setField(
-        schemaRegstryController, "schemaRegstryControllerService", schemaRegstryControllerService);
+        schemaRegistryController,
+        "schemaRegistryControllerService",
+        schemaRegistryControllerService);
   }
 
   @Test
@@ -58,7 +60,7 @@ public class SchemaRegstryControllerTest {
   public void getSchemaRequests() throws Exception {
     List<SchemaRequestsResponseModel> schRequests = utilMethods.getSchemaRequestsResponse();
 
-    when(schemaRegstryControllerService.getSchemaRequests(
+    when(schemaRegistryControllerService.getSchemaRequests(
             anyString(),
             anyString(),
             anyString(),
@@ -82,7 +84,7 @@ public class SchemaRegstryControllerTest {
   @Order(2)
   public void deleteSchemaRequests() throws Exception {
     ApiResponse apiResponse = ApiResponse.builder().result(ApiResultStatus.SUCCESS.value).build();
-    when(schemaRegstryControllerService.deleteSchemaRequests(anyString())).thenReturn(apiResponse);
+    when(schemaRegistryControllerService.deleteSchemaRequests(anyString())).thenReturn(apiResponse);
 
     mvc.perform(
             MockMvcRequestBuilders.post("/deleteSchemaRequests")
@@ -97,7 +99,7 @@ public class SchemaRegstryControllerTest {
   @Order(3)
   public void execSchemaRequests() throws Exception {
     ApiResponse apiResponse = ApiResponse.builder().result(ApiResultStatus.SUCCESS.value).build();
-    when(schemaRegstryControllerService.execSchemaRequests(anyString())).thenReturn(apiResponse);
+    when(schemaRegistryControllerService.execSchemaRequests(anyString())).thenReturn(apiResponse);
 
     mvc.perform(
             MockMvcRequestBuilders.post("/execSchemaRequests")
@@ -114,7 +116,7 @@ public class SchemaRegstryControllerTest {
     SchemaRequestModel schemaRequest = utilMethods.getSchemaRequests().get(0);
     String jsonReq = OBJECT_MAPPER.writer().writeValueAsString(schemaRequest);
     ApiResponse apiResponse = ApiResponse.builder().result(ApiResultStatus.SUCCESS.value).build();
-    when(schemaRegstryControllerService.uploadSchema(any())).thenReturn(apiResponse);
+    when(schemaRegistryControllerService.uploadSchema(any())).thenReturn(apiResponse);
 
     mvc.perform(
             MockMvcRequestBuilders.post("/uploadSchema")
@@ -131,7 +133,7 @@ public class SchemaRegstryControllerTest {
     SchemaPromotion schemaPromotion = utilMethods.getSchemaPromotion().get(0);
     String jsonReq = OBJECT_MAPPER.writer().writeValueAsString(schemaPromotion);
     ApiResponse apiResponse = ApiResponse.builder().result(ApiResultStatus.SUCCESS.value).build();
-    when(schemaRegstryControllerService.promoteSchema(any())).thenReturn(apiResponse);
+    when(schemaRegistryControllerService.promoteSchema(any())).thenReturn(apiResponse);
 
     mvc.perform(
             MockMvcRequestBuilders.post("/promote/schema")

--- a/core/src/test/java/io/aiven/klaw/service/SchemaRegistryControllerServiceTest.java
+++ b/core/src/test/java/io/aiven/klaw/service/SchemaRegistryControllerServiceTest.java
@@ -77,7 +77,7 @@ public class SchemaRegistryControllerServiceTest {
 
   @Mock RolesPermissionsControllerService rolesPermissionsControllerService;
 
-  private SchemaRegstryControllerService schemaRegstryControllerService;
+  private SchemaRegistryControllerService schemaRegistryControllerService;
 
   private ObjectMapper mapper = new ObjectMapper();
 
@@ -91,14 +91,14 @@ public class SchemaRegistryControllerServiceTest {
     env.setId("1");
     env.setName("DEV");
 
-    schemaRegstryControllerService =
-        new SchemaRegstryControllerService(clusterApiService, mailService);
-    ReflectionTestUtils.setField(schemaRegstryControllerService, "manageDatabase", manageDatabase);
-    ReflectionTestUtils.setField(schemaRegstryControllerService, "mailService", mailService);
+    schemaRegistryControllerService =
+        new SchemaRegistryControllerService(clusterApiService, mailService);
+    ReflectionTestUtils.setField(schemaRegistryControllerService, "manageDatabase", manageDatabase);
+    ReflectionTestUtils.setField(schemaRegistryControllerService, "mailService", mailService);
     ReflectionTestUtils.setField(
-        schemaRegstryControllerService, "commonUtilsService", commonUtilsService);
+        schemaRegistryControllerService, "commonUtilsService", commonUtilsService);
     ReflectionTestUtils.setField(
-        schemaRegstryControllerService,
+        schemaRegistryControllerService,
         "rolesPermissionsControllerService",
         rolesPermissionsControllerService);
 
@@ -140,7 +140,7 @@ public class SchemaRegistryControllerServiceTest {
     when(manageDatabase.getTeamNameFromTeamId(anyInt(), anyInt())).thenReturn("teamname");
 
     List<SchemaRequestsResponseModel> listReqs =
-        schemaRegstryControllerService.getSchemaRequests(
+        schemaRegistryControllerService.getSchemaRequests(
             "1", "", "all", true, null, null, null, false);
     assertThat(listReqs).hasSize(2);
   }
@@ -153,7 +153,7 @@ public class SchemaRegistryControllerServiceTest {
     stubUserInfo();
     when(handleDbRequests.deleteSchemaRequest(anyInt(), anyString(), anyInt()))
         .thenReturn(ApiResultStatus.SUCCESS.value);
-    ApiResponse resultResp = schemaRegstryControllerService.deleteSchemaRequests("" + schemaReqId);
+    ApiResponse resultResp = schemaRegistryControllerService.deleteSchemaRequests("" + schemaReqId);
     assertThat(resultResp.getResult()).isEqualTo(ApiResultStatus.SUCCESS.value);
   }
 
@@ -166,7 +166,7 @@ public class SchemaRegistryControllerServiceTest {
     when(handleDbRequests.deleteSchemaRequest(anyInt(), anyString(), anyInt()))
         .thenThrow(new RuntimeException("Error from Schema upload"));
     try {
-      schemaRegstryControllerService.deleteSchemaRequests("" + schemaReqId);
+      schemaRegistryControllerService.deleteSchemaRequests("" + schemaReqId);
     } catch (KlawException e) {
       assertThat(e.getMessage()).contains("Error from Schema upload");
     }
@@ -197,7 +197,7 @@ public class SchemaRegistryControllerServiceTest {
     when(commonUtilsService.getTenantId(anyString())).thenReturn(101);
     when(commonUtilsService.isNotAuthorizedUser(any(), any())).thenReturn(false);
 
-    ApiResponse resultResp = schemaRegstryControllerService.execSchemaRequests("" + schemaReqId);
+    ApiResponse resultResp = schemaRegistryControllerService.execSchemaRequests("" + schemaReqId);
     assertThat(resultResp.getResult()).contains(ApiResultStatus.SUCCESS.value);
   }
 
@@ -225,7 +225,7 @@ public class SchemaRegistryControllerServiceTest {
     when(commonUtilsService.getTenantId(anyString())).thenReturn(101);
     when(commonUtilsService.isNotAuthorizedUser(any(), any())).thenReturn(false);
 
-    ApiResponse resultResp = schemaRegstryControllerService.execSchemaRequests("" + schemaReqId);
+    ApiResponse resultResp = schemaRegistryControllerService.execSchemaRequests("" + schemaReqId);
     assertThat(resultResp.getResult()).contains("Schema not registered");
   }
 
@@ -259,7 +259,7 @@ public class SchemaRegistryControllerServiceTest {
     when(commonUtilsService.isNotAuthorizedUser(any(), any())).thenReturn(false);
 
     try {
-      schemaRegstryControllerService.execSchemaRequests("" + schemaReqId);
+      schemaRegistryControllerService.execSchemaRequests("" + schemaReqId);
     } catch (KlawException e) {
       assertThat(e.getMessage()).contains("Error in registering");
     }
@@ -285,7 +285,7 @@ public class SchemaRegistryControllerServiceTest {
     when(handleDbRequests.getTopicTeam(anyString(), anyInt())).thenReturn(List.of(topic));
     when(commonUtilsService.getFilteredTopicsForTenant(any())).thenReturn(List.of(topic));
 
-    ApiResponse resultResp = schemaRegstryControllerService.uploadSchema(schemaRequest);
+    ApiResponse resultResp = schemaRegistryControllerService.uploadSchema(schemaRequest);
     assertThat(resultResp.getResult()).isEqualTo(ApiResultStatus.SUCCESS.value);
   }
 
@@ -310,7 +310,7 @@ public class SchemaRegistryControllerServiceTest {
     when(commonUtilsService.getFilteredTopicsForTenant(any())).thenReturn(List.of(topic));
 
     try {
-      schemaRegstryControllerService.uploadSchema(schemaRequest);
+      schemaRegistryControllerService.uploadSchema(schemaRequest);
     } catch (KlawException e) {
       assertThat(e.getMessage()).contains("Error from schema upload");
     }
@@ -323,7 +323,7 @@ public class SchemaRegistryControllerServiceTest {
     when(commonUtilsService.isNotAuthorizedUser(any(), eq(PermissionType.REQUEST_CREATE_SCHEMAS)))
         .thenReturn(true);
     ApiResponse returnedValue =
-        schemaRegstryControllerService.promoteSchema(buildPromoteSchemaRequest(false, "1"));
+        schemaRegistryControllerService.promoteSchema(buildPromoteSchemaRequest(false, "1"));
     assertThat(returnedValue.getResult()).isEqualTo(ApiResultStatus.NOT_AUTHORIZED.value);
   }
 
@@ -334,7 +334,7 @@ public class SchemaRegistryControllerServiceTest {
     when(handleDbRequests.getTopicTeam(anyString(), anyInt())).thenReturn(List.of(createTopic()));
     when(commonUtilsService.getTeamId(any())).thenReturn(101);
     ApiResponse returnedValue =
-        schemaRegstryControllerService.promoteSchema(buildPromoteSchemaRequest(false, "1"));
+        schemaRegistryControllerService.promoteSchema(buildPromoteSchemaRequest(false, "1"));
     assertThat(returnedValue.getResult())
         .isEqualTo("Unable to find or access the source Schema Registry");
   }
@@ -348,7 +348,7 @@ public class SchemaRegistryControllerServiceTest {
     mockSchemaCreation();
 
     ApiResponse returnedValue =
-        schemaRegstryControllerService.promoteSchema(buildPromoteSchemaRequest(false, "1"));
+        schemaRegistryControllerService.promoteSchema(buildPromoteSchemaRequest(false, "1"));
     assertThat(returnedValue.getResult())
         .isNotEqualTo("Unable to find or access the source Schema Registry");
     assertThat(returnedValue.getResult()).isEqualTo(ApiResultStatus.SUCCESS.value);
@@ -363,7 +363,7 @@ public class SchemaRegistryControllerServiceTest {
     mockSchemaCreation();
 
     ApiResponse returnedValue =
-        schemaRegstryControllerService.promoteSchema(buildPromoteSchemaRequest(false, "1"));
+        schemaRegistryControllerService.promoteSchema(buildPromoteSchemaRequest(false, "1"));
     assertThat(returnedValue.getResult())
         .isNotEqualTo("Unable to find or access the source Schema Registry");
     assertThat(returnedValue.getResult()).isEqualTo(ApiResultStatus.SUCCESS.value);
@@ -382,7 +382,7 @@ public class SchemaRegistryControllerServiceTest {
     mockSchemaCreation();
 
     ApiResponse returnedValue =
-        schemaRegstryControllerService.promoteSchema(buildPromoteSchemaRequest(false, "2"));
+        schemaRegistryControllerService.promoteSchema(buildPromoteSchemaRequest(false, "2"));
     assertThat(returnedValue.getResult())
         .isNotEqualTo("Unable to find or access the source Schema Registry");
     assertThat(returnedValue.getResult()).isEqualTo(ApiResultStatus.SUCCESS.value);
@@ -401,7 +401,7 @@ public class SchemaRegistryControllerServiceTest {
     mockSchemaCreation();
 
     ApiResponse returnedValue =
-        schemaRegstryControllerService.promoteSchema(buildPromoteSchemaRequest(false, "3"));
+        schemaRegistryControllerService.promoteSchema(buildPromoteSchemaRequest(false, "3"));
     assertThat(returnedValue.getResult())
         .isNotEqualTo("Unable to find or access the source Schema Registry");
     assertThat(returnedValue.getResult()).isEqualTo(ApiResultStatus.SUCCESS.value);
@@ -421,7 +421,7 @@ public class SchemaRegistryControllerServiceTest {
     mockSchemaCreation();
 
     ApiResponse returnedValue =
-        schemaRegstryControllerService.promoteSchema(buildPromoteSchemaRequest(false, "4"));
+        schemaRegistryControllerService.promoteSchema(buildPromoteSchemaRequest(false, "4"));
     assertThat(returnedValue.getResult())
         .isNotEqualTo("Unable to find or access the source Schema Registry");
     assertThat(returnedValue.getResult()).isEqualTo(ApiResultStatus.SUCCESS.value);

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -51,7 +51,7 @@
     },
     "/uploadSchema" : {
       "post" : {
-        "tags" : [ "schema-regstry-controller" ],
+        "tags" : [ "schema-registry-controller" ],
         "operationId" : "uploadSchema",
         "requestBody" : {
           "content" : {
@@ -870,7 +870,7 @@
     },
     "/promote/schema" : {
       "post" : {
-        "tags" : [ "schema-regstry-controller" ],
+        "tags" : [ "schema-registry-controller" ],
         "operationId" : "promoteSchema",
         "requestBody" : {
           "content" : {
@@ -978,7 +978,7 @@
     },
     "/execSchemaRequests" : {
       "post" : {
-        "tags" : [ "schema-regstry-controller" ],
+        "tags" : [ "schema-registry-controller" ],
         "operationId" : "execSchemaRequests",
         "parameters" : [ {
           "name" : "avroSchemaReqId",
@@ -1004,7 +1004,7 @@
     },
     "/execSchemaRequestsDecline" : {
       "post" : {
-        "tags" : [ "schema-regstry-controller" ],
+        "tags" : [ "schema-registry-controller" ],
         "operationId" : "execSchemaRequestsDecline",
         "parameters" : [ {
           "name" : "avroSchemaReqId",
@@ -1304,7 +1304,7 @@
     },
     "/deleteSchemaRequests" : {
       "post" : {
-        "tags" : [ "schema-regstry-controller" ],
+        "tags" : [ "schema-registry-controller" ],
         "operationId" : "deleteSchemaRequests",
         "parameters" : [ {
           "name" : "req_no",
@@ -3050,7 +3050,7 @@
     },
     "/getSchemaRequests" : {
       "get" : {
-        "tags" : [ "schema-regstry-controller" ],
+        "tags" : [ "schema-registry-controller" ],
         "operationId" : "getSchemaRequests",
         "parameters" : [ {
           "name" : "pageNo",
@@ -3118,7 +3118,7 @@
     },
     "/getSchemaRequestsForApprover" : {
       "get" : {
-        "tags" : [ "schema-regstry-controller" ],
+        "tags" : [ "schema-registry-controller" ],
         "operationId" : "getSchemaRequestsForApprover",
         "parameters" : [ {
           "name" : "pageNo",
@@ -3206,7 +3206,7 @@
     },
     "/getSchemaOfTopic" : {
       "get" : {
-        "tags" : [ "schema-regstry-controller" ],
+        "tags" : [ "schema-registry-controller" ],
         "operationId" : "getSchemaOfTopic",
         "parameters" : [ {
           "name" : "topicnamesearch",


### PR DESCRIPTION
# About this change - What it does

This PR fixes (HOPEFULLY) a little typo I noticed:

`SchemaRegstry[x]` => `SchemaRegistry[x]`

Since I don't have real experience with working with Springboot, I'm not 100% sure I did everything needed to do this changes safe. 

I did run 
- `mvn spotless:apply`
- `mvn verify`
- `mvn test`
- `mvn clean compile` 

and also did start klaw locally and run coral against the remote-api (i've no data locally) to check the app manually. 

It looks like everything works 🤔 🙏 