### PR TITLE
feat(coral): ACL requests: add API definition and types for /delete/request

### DIFF
--- a/coral/src/app/features/approvals/acls/AclApprovals.tsx
+++ b/coral/src/app/features/approvals/acls/AclApprovals.tsx
@@ -158,7 +158,6 @@ function AclApprovals() {
 
   function handleApproveRequest(reqNo: string): void {
     approveRequest({
-      requestEntityType: "ACL",
       reqIds: [reqNo],
     });
   }
@@ -181,7 +180,6 @@ function AclApprovals() {
               text: "Approve",
               onClick: () => {
                 approveRequest({
-                  requestEntityType: "ACL",
                   reqIds: [detailsModal.reqNo],
                 });
               },
@@ -210,7 +208,6 @@ function AclApprovals() {
           onCancel={() => setDeclineModal({ isOpen: false, reqNo: "" })}
           onSubmit={(message: string) => {
             declineRequest({
-              requestEntityType: "ACL",
               reqIds: [declineModal.reqNo],
               reason: message,
             });

--- a/coral/src/domain/acl/acl-api.ts
+++ b/coral/src/domain/acl/acl-api.ts
@@ -62,27 +62,33 @@ const getAclRequests = (params: GetCreatedAclRequestParameters) => {
 };
 
 type ApproveAclRequestPayload = RequestVerdictApproval<"ACL">;
-const approveAclRequest = (payload: ApproveAclRequestPayload) => {
+type ApproveRequestParams = {
+  reqIds: ApproveAclRequestPayload["reqIds"];
+};
+const approveAclRequest = ({ reqIds }: ApproveRequestParams) => {
   return api.post<KlawApiResponse<"approveRequest">, ApproveAclRequestPayload>(
     `/request/approve`,
-    payload
+    { requestEntityType: "ACL", reqIds }
   );
 };
 
 type DeclineAclRequestPayload = RequestVerdictDecline<"ACL">;
-const declineAclRequest = (payload: DeclineAclRequestPayload) => {
+type DeclineRequestParams = {
+  reqIds: DeclineAclRequestPayload["reqIds"];
+  reason: DeclineAclRequestPayload["reason"];
+};
+const declineAclRequest = ({ reqIds, reason }: DeclineRequestParams) => {
   return api.post<KlawApiResponse<"declineRequest">, DeclineAclRequestPayload>(
     `/request/decline`,
-    payload
+    { requestEntityType: "ACL", reqIds, reason }
   );
 };
 
 type DeleteAclRequestPayload = RequestVerdictDelete<"ACL">;
-const deleteAclRequest = ({
-  reqIds,
-}: {
+type DeleteRequestParams = {
   reqIds: DeleteAclRequestPayload["reqIds"];
-}) => {
+};
+const deleteAclRequest = ({ reqIds }: DeleteRequestParams) => {
   return api.post<KlawApiResponse<"deleteRequest">, DeleteAclRequestPayload>(
     `/request/delete`,
     { requestEntityType: "ACL", reqIds }

--- a/coral/src/domain/acl/acl-api.ts
+++ b/coral/src/domain/acl/acl-api.ts
@@ -9,6 +9,7 @@ import {
 import {
   RequestVerdictApproval,
   RequestVerdictDecline,
+  RequestVerdictDelete,
 } from "src/domain/requests/requests-types";
 import api from "src/services/api";
 import { KlawApiRequest, KlawApiResponse } from "types/utils";
@@ -76,10 +77,23 @@ const declineAclRequest = (payload: DeclineAclRequestPayload) => {
   );
 };
 
+type DeleteAclRequestPayload = RequestVerdictDelete<"ACL">;
+const deleteAclRequest = ({
+  reqIds,
+}: {
+  reqIds: DeleteAclRequestPayload["reqIds"];
+}) => {
+  return api.post<KlawApiResponse<"deleteRequest">, DeleteAclRequestPayload>(
+    `/request/delete`,
+    { requestEntityType: "ACL", reqIds }
+  );
+};
+
 export {
   createAclRequest,
   getAclRequestsForApprover,
   getAclRequests,
   approveAclRequest,
   declineAclRequest,
+  deleteAclRequest,
 };

--- a/coral/src/domain/requests/requests-types.ts
+++ b/coral/src/domain/requests/requests-types.ts
@@ -27,6 +27,13 @@ type RequestVerdictDecline<T extends RequestEntityType> =
       }
   >;
 
+type RequestVerdictDelete<T extends RequestEntityType> =
+  ResolveIntersectionTypes<
+    Omit<RequestVerdict, "reason"> & {
+      requestEntityType: T;
+    }
+  >;
+
 type RequestsWaitingForApproval = {
   [key in RequestEntityType]: number;
 };
@@ -37,5 +44,6 @@ export type {
   RequestEntityType,
   RequestVerdictApproval,
   RequestVerdictDecline,
+  RequestVerdictDelete,
   RequestsWaitingForApproval,
 };


### PR DESCRIPTION
## About this change - What it does

- add `deleteRequest` to `acl-api.ts`

## Other changes

- refactor `approveAclRequest` and `declineAclRequest` to take only the relevant argument for the operation

Resolves: #796

