### PR TITLE
feat(coral): My Schema Requests - add delete functionality

### DIFF
--- a/coral/src/app/features/requests/components/DeleteRequestDialog.test.tsx
+++ b/coral/src/app/features/requests/components/DeleteRequestDialog.test.tsx
@@ -59,6 +59,54 @@ describe("DeleteRequestDialog", () => {
     });
   });
 
+  describe("shows a loading animation dependent on prop", () => {
+    beforeAll(() => {
+      render(
+        <DeleteRequestDialog
+          cancel={cancelMock}
+          deleteRequest={deleteRequestMock}
+          isLoading={true}
+        />
+      );
+    });
+
+    afterAll(cleanup);
+
+    it("disables button to cancel the deletion of the request while loading", () => {
+      const dialog = screen.getByRole("dialog");
+      const button = within(dialog).getByRole("button", { name: "Cancel" });
+
+      expect(button).toBeDisabled();
+    });
+
+    it("disables the button to confirm deletion of the request while loading", () => {
+      const dialog = screen.getByRole("dialog");
+      const button = within(dialog).getByRole("button", {
+        name: "Delete request",
+      });
+
+      expect(button).toBeDisabled();
+    });
+
+    it("user can't cancel while and close the modal while loading", async () => {
+      const dialog = screen.getByRole("dialog");
+      const button = within(dialog).getByRole("button", { name: "Cancel" });
+
+      await userEvent.click(button);
+      expect(cancelMock).not.toHaveBeenCalled();
+    });
+
+    it("user can't confirm deletion of the request while loading", async () => {
+      const dialog = screen.getByRole("dialog");
+      const button = within(dialog).getByRole("button", {
+        name: "Delete request",
+      });
+
+      await userEvent.click(button);
+      expect(deleteRequestMock).not.toHaveBeenCalled();
+    });
+  });
+
   describe("handles user interaction", () => {
     beforeEach(() => {
       render(

--- a/coral/src/app/features/requests/components/DeleteRequestDialog.tsx
+++ b/coral/src/app/features/requests/components/DeleteRequestDialog.tsx
@@ -3,6 +3,11 @@ import { Dialog } from "src/app/components/Dialog";
 type DeleteRequestModalProps = {
   deleteRequest: () => void;
   cancel: () => void;
+  // @TODO will be required later, will add it as optional
+  // for now, since we're still aligning on the approach
+  // and I don't want to break other component using this once
+  // if we want to do it that way, I'll update the prop in a
+  // separate PR
   isLoading?: boolean;
 };
 

--- a/coral/src/app/features/requests/schemas/SchemaRequests.tsx
+++ b/coral/src/app/features/requests/schemas/SchemaRequests.tsx
@@ -62,6 +62,10 @@ function SchemaRequests() {
     setModals({ open: "NONE", req_no: null });
   }
 
+  const openDetailsModal = (req_no: number) => {
+    setModals({ open: "DETAILS", req_no });
+  };
+
   function setCurrentPage(page: number) {
     searchParams.set("page", page.toString());
     setSearchParams(searchParams);
@@ -107,6 +111,7 @@ function SchemaRequests() {
           />
         </RequestDetailsModal>
       )}
+
       <TableLayout
         filters={[
           <EnvironmentFilter
@@ -120,7 +125,7 @@ function SchemaRequests() {
         table={
           <SchemaRequestTable
             requests={schemaRequests?.entries || []}
-            setModals={setModals}
+            showDetails={openDetailsModal}
           />
         }
         pagination={pagination}

--- a/coral/src/app/features/requests/schemas/SchemaRequests.tsx
+++ b/coral/src/app/features/requests/schemas/SchemaRequests.tsx
@@ -74,25 +74,14 @@ function SchemaRequests() {
         // @TODO follow up ticket #707
         // (for all approval and request tables)
         const response = responses[0];
-        if (response.result !== "success") {
+        const responseIsAHiddenError = response.result !== "success";
+        if (responseIsAHiddenError) {
           //@TODO error handling
           setErrorQuickActions(
             response.message || response.result || "Unexpected error"
           );
         } else {
           setErrorQuickActions("");
-          // If declined request is last in the page, go back to previous page
-          // This avoids staying on a non-existent page of entries, which makes the table bug hard
-          // With pagination being 0 of 0, and clicking Previous button sets active page at -1
-          // We also do not need to invalidate the query, as the activePage does not exist any more
-          // And there is no need to update anything on it
-          if (
-            schemaRequests?.entries.length === 1 &&
-            schemaRequests?.currentPage > 1
-          ) {
-            return setCurrentPage(schemaRequests?.currentPage - 1);
-          }
-
           // We need to refetch all requests to keep Table state in sync
           queryClient.refetchQueries(["getSchemaRequests"]);
         }

--- a/coral/src/app/features/requests/schemas/components/SchemaRequestTable.tsx
+++ b/coral/src/app/features/requests/schemas/components/SchemaRequestTable.tsx
@@ -10,7 +10,6 @@ import {
   requestOperationTypeNameMap,
 } from "src/app/features/approvals/utils/request-operation-type-helper";
 import { SchemaRequest } from "src/domain/schema-request";
-import { Dispatch, SetStateAction } from "react";
 
 interface SchemaRequestTableRow {
   deletable: SchemaRequest["deletable"];
@@ -26,15 +25,15 @@ interface SchemaRequestTableRow {
 
 type SchemaRequestTableProps = {
   requests: SchemaRequest[];
-  setModals: Dispatch<
-    SetStateAction<{
-      open: "DETAILS" | "DELETE" | "NONE";
-      req_no: number | null;
-    }>
-  >;
+  showDetails: (req_no: number) => void;
+  showDeleteDialog: (req_no: number) => void;
 };
 
-function SchemaRequestTable({ requests, setModals }: SchemaRequestTableProps) {
+function SchemaRequestTable({
+  requests,
+  showDetails,
+  showDeleteDialog,
+}: SchemaRequestTableProps) {
   const columns: Array<DataTableColumn<SchemaRequestTableRow>> = [
     { type: "text", field: "topic", headerName: "Topic" },
     {
@@ -85,7 +84,7 @@ function SchemaRequestTable({ requests, setModals }: SchemaRequestTableProps) {
       action: ({ id, topic }) => ({
         text: "View",
         icon: infoIcon,
-        onClick: () => setModals({ open: "DETAILS", req_no: id }),
+        onClick: () => showDetails(id),
         "aria-label": `View schema request for ${topic}`,
       }),
     },
@@ -97,7 +96,7 @@ function SchemaRequestTable({ requests, setModals }: SchemaRequestTableProps) {
       action: ({ id, deletable, topic }) => ({
         text: "Delete",
         icon: deleteIcon,
-        onClick: () => console.log("DELETE", id),
+        onClick: () => showDeleteDialog(id),
         disabled: !deletable,
         "aria-label": `Delete schema request for ${topic}`,
       }),

--- a/coral/src/domain/schema-request/index.ts
+++ b/coral/src/domain/schema-request/index.ts
@@ -4,6 +4,7 @@ import {
   declineSchemaRequest,
   getSchemaRequests,
   getSchemaRequestsForApprover,
+  deleteSchemaRequest,
 } from "src/domain/schema-request/schema-request-api";
 import {
   CreatedSchemaRequests,
@@ -17,4 +18,5 @@ export {
   getSchemaRequests,
   approveSchemaRequest,
   declineSchemaRequest,
+  deleteSchemaRequest,
 };

--- a/coral/src/domain/schema-request/schema-request-api.ts
+++ b/coral/src/domain/schema-request/schema-request-api.ts
@@ -1,6 +1,7 @@
 import {
   RequestVerdictApproval,
   RequestVerdictDecline,
+  RequestVerdictDelete,
 } from "src/domain/requests/requests-types";
 import { transformGetSchemaRequests } from "src/domain/schema-request/schema-request-transformer";
 import { SchemaRequestApiResponse } from "src/domain/schema-request/schema-request-types";
@@ -124,10 +125,23 @@ const declineSchemaRequest = ({
   });
 };
 
+const deleteSchemaRequest = ({
+  reqIds,
+}: Omit<RequestVerdictDelete<"SCHEMA">, "requestEntityType">) => {
+  return api.post<
+    KlawApiResponse<"declineRequest">,
+    RequestVerdictDelete<"SCHEMA">
+  >(`/request/decline`, {
+    reqIds,
+    requestEntityType: "SCHEMA",
+  });
+};
+
 export {
   createSchemaRequest,
   getSchemaRequestsForApprover,
   approveSchemaRequest,
   declineSchemaRequest,
   getSchemaRequests,
+  deleteSchemaRequest,
 };

--- a/coral/src/domain/schema-request/schema-request-api.ts
+++ b/coral/src/domain/schema-request/schema-request-api.ts
@@ -129,9 +129,9 @@ const deleteSchemaRequest = ({
   reqIds,
 }: Omit<RequestVerdictDelete<"SCHEMA">, "requestEntityType">) => {
   return api.post<
-    KlawApiResponse<"declineRequest">,
+    KlawApiResponse<"deleteRequest">,
     RequestVerdictDelete<"SCHEMA">
-  >(`/request/decline`, {
+  >(`/request/delete`, {
     reqIds,
     requestEntityType: "SCHEMA",
   });


### PR DESCRIPTION
# About this change - What it does

- adds api call to delete a schema request
- adds delete process flow from quick action button as well as from details modal
- add additional (for now optional, will change that in a later PR) property `isLoading` to the delete modal that shows a loading animation on the delete button and disables the cancel button. (`isLoading` is active while either the deletion or the refetching of schema requests is in process)
- only close the delete modal after the re-fetch of the schema-requests was successful. That way, user can't manipulate other request while there are still api calls in process. 

Resolves: #814


https://user-images.githubusercontent.com/943800/226834599-49e34681-6161-4189-8a27-3d52416469ca.mov

