### PR TITLE
fix(coral): Approvals - Add missing refetch calls for tab tag number

### DIFF
--- a/coral/src/app/features/approvals/acls/AclApprovals.tsx
+++ b/coral/src/app/features/approvals/acls/AclApprovals.tsx
@@ -82,8 +82,6 @@ function AclApprovals() {
   } = useMutation({
     mutationFn: approveAclRequest,
     onSuccess: (responses) => {
-      queryClient.refetchQueries(["getRequestsWaitingForApproval"]);
-
       const response = responses[0];
       if (response.result !== "success") {
         return setErrorMessage(
@@ -92,6 +90,9 @@ function AclApprovals() {
       }
       setErrorMessage("");
       setDetailsModal({ isOpen: false, reqNo: "" });
+
+      // Refetch to update the tag number in the tabs
+      queryClient.refetchQueries(["getRequestsWaitingForApproval"]);
 
       // If approved request is last in the page, go back to previous page
       // This avoids staying on a non-existent page of entries, which makes the table bug hard
@@ -102,7 +103,7 @@ function AclApprovals() {
         return handleChangePage(currentPage - 1);
       }
 
-      // We need to refetch all aclrequests queries to keep Table state in sync
+      // Refetch to keep Table state in sync
       queryClient.refetchQueries(["aclRequests"]);
     },
     onError: (error: Error) => {
@@ -121,6 +122,9 @@ function AclApprovals() {
       }
       setErrorMessage("");
       setDeclineModal({ isOpen: false, reqNo: "" });
+
+      // Refetch to update the tag number in the tabs
+      queryClient.refetchQueries(["getRequestsWaitingForApproval"]);
 
       // If approved request is last in the page, go back to previous page
       // This avoids staying on a non-existent page of entries, which makes the table bug hard

--- a/coral/src/app/features/approvals/schemas/SchemaApprovals.tsx
+++ b/coral/src/app/features/approvals/schemas/SchemaApprovals.tsx
@@ -3,19 +3,19 @@ import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { useState } from "react";
 import { useSearchParams } from "react-router-dom";
 import { Pagination } from "src/app/components/Pagination";
-import { TableLayout } from "src/app/features/components/layouts/TableLayout";
 import RequestDeclineModal from "src/app/features/approvals/components/RequestDeclineModal";
-import RequestDetailsModal from "src/app/features/components/RequestDetailsModal";
 import SchemaApprovalsTable from "src/app/features/approvals/schemas/components/SchemaApprovalsTable";
+import { TableLayout } from "src/app/features/components/layouts/TableLayout";
+import RequestDetailsModal from "src/app/features/components/RequestDetailsModal";
 import { SchemaRequestDetails } from "src/app/features/components/SchemaRequestDetails";
 import EnvironmentFilter from "src/app/features/components/table-filters/EnvironmentFilter";
 import StatusFilter from "src/app/features/components/table-filters/StatusFilter";
 import TopicFilter from "src/app/features/components/table-filters/TopicFilter";
 import { RequestStatus } from "src/domain/requests/requests-types";
 import {
-  getSchemaRequestsForApprover,
   approveSchemaRequest,
   declineSchemaRequest,
+  getSchemaRequestsForApprover,
 } from "src/domain/schema-request";
 import { parseErrorMsg } from "src/services/mutation-utils";
 
@@ -66,32 +66,35 @@ function SchemaApprovals() {
   const { mutate: declineRequest, isLoading: declineRequestIsLoading } =
     useMutation(declineSchemaRequest, {
       onSuccess: (responses) => {
-        queryClient.refetchQueries(["getRequestsWaitingForApproval"]);
-
         // @TODO follow up ticket #707
         // (for all approval tables)
         const response = responses[0];
         if (response.result !== "success") {
-          setErrorQuickActions(
+          return setErrorQuickActions(
             response.message || response.result || "Unexpected error"
           );
-        } else {
-          setErrorQuickActions("");
-          // If declined request is last in the page, go back to previous page
-          // This avoids staying on a non-existent page of entries, which makes the table bug hard
-          // With pagination being 0 of 0, and clicking Previous button sets active page at -1
-          // We also do not need to invalidate the query, as the activePage does not exist any more
-          // And there is no need to update anything on it
-          if (
-            schemaRequests?.entries.length === 1 &&
-            schemaRequests?.currentPage > 1
-          ) {
-            return setCurrentPage(schemaRequests?.currentPage - 1);
-          }
-
-          // We need to refetch all aclrequests queries to keep Table state in sync
-          queryClient.refetchQueries(["schemaRequestsForApprover"]);
         }
+
+        setErrorQuickActions("");
+        setModals({ open: "NONE", req_no: null });
+
+        // Refetch to update the tag number in the tabs
+        queryClient.refetchQueries(["getRequestsWaitingForApproval"]);
+
+        // If declined request is last in the page, go back to previous page
+        // This avoids staying on a non-existent page of entries, which makes the table bug hard
+        // With pagination being 0 of 0, and clicking Previous button sets active page at -1
+        // We also do not need to invalidate the query, as the activePage does not exist any more
+        // And there is no need to update anything on it
+        if (
+          schemaRequests?.entries.length === 1 &&
+          schemaRequests?.currentPage > 1
+        ) {
+          return setCurrentPage(schemaRequests?.currentPage - 1);
+        }
+
+        // We need to refetch all aclrequests queries to keep Table state in sync
+        queryClient.refetchQueries(["schemaRequestsForApprover"]);
       },
       onError(error: Error) {
         setErrorQuickActions(parseErrorMsg(error));
@@ -108,26 +111,31 @@ function SchemaApprovals() {
         // (for all approval tables)
         const response = responses[0];
         if (response.result !== "success") {
-          setErrorQuickActions(
+          return setErrorQuickActions(
             response.message || response.result || "Unexpected error"
           );
-        } else {
-          setErrorQuickActions("");
-          // If declined request is last in the page, go back to previous page
-          // This avoids staying on a non-existent page of entries, which makes the table bug hard
-          // With pagination being 0 of 0, and clicking Previous button sets active page at -1
-          // We also do not need to invalidate the query, as the activePage does not exist any more
-          // And there is no need to update anything on it
-          if (
-            schemaRequests?.entries.length === 1 &&
-            schemaRequests?.currentPage > 1
-          ) {
-            return setCurrentPage(schemaRequests?.currentPage - 1);
-          }
-
-          // We need to refetch all aclrequests queries to keep Table state in sync
-          queryClient.refetchQueries(["schemaRequestsForApprover"]);
         }
+
+        setErrorQuickActions("");
+        setModals({ open: "NONE", req_no: null });
+
+        // Refetch to update the tag number in the tabs
+        queryClient.refetchQueries(["getRequestsWaitingForApproval"]);
+
+        // If declined request is last in the page, go back to previous page
+        // This avoids staying on a non-existent page of entries, which makes the table bug hard
+        // With pagination being 0 of 0, and clicking Previous button sets active page at -1
+        // We also do not need to invalidate the query, as the activePage does not exist any more
+        // And there is no need to update anything on it
+        if (
+          schemaRequests?.entries.length === 1 &&
+          schemaRequests?.currentPage > 1
+        ) {
+          return setCurrentPage(schemaRequests?.currentPage - 1);
+        }
+
+        // We need to refetch all aclrequests queries to keep Table state in sync
+        queryClient.refetchQueries(["schemaRequestsForApprover"]);
       },
       onError(error: Error) {
         setErrorQuickActions(parseErrorMsg(error));

--- a/coral/src/app/features/approvals/topics/TopicApprovals.tsx
+++ b/coral/src/app/features/approvals/topics/TopicApprovals.tsx
@@ -86,8 +86,6 @@ function TopicApprovals() {
   const { isLoading: approveIsLoading, mutate: approveRequest } = useMutation({
     mutationFn: approveTopicRequest,
     onSuccess: (responses) => {
-      queryClient.refetchQueries(["getRequestsWaitingForApproval"]);
-
       // This mutation is used on a single request, so we always want the first response in the array
       const response = responses[0];
 
@@ -96,8 +94,12 @@ function TopicApprovals() {
           response.message || response.result || "Unexpected error"
         );
       }
+
       setErrorMessage("");
       setDetailsModal({ isOpen: false, topicId: null });
+
+      // Refetch to update the tag number in the tabs
+      queryClient.refetchQueries(["getRequestsWaitingForApproval"]);
 
       // If approved request is last in the page, go back to previous page
       // This avoids staying on a non-existent page of entries, which makes the table bug hard
@@ -126,8 +128,6 @@ function TopicApprovals() {
   const { isLoading: declineIsLoading, mutate: declineRequest } = useMutation({
     mutationFn: declineTopicRequest,
     onSuccess: (responses) => {
-      queryClient.refetchQueries(["getRequestsWaitingForApproval"]);
-
       // This mutation is used on a single request, so we always want the first response in the array
       const response = responses[0];
 
@@ -138,6 +138,9 @@ function TopicApprovals() {
       }
       setErrorMessage("");
       setDeclineModal({ isOpen: false, topicId: null });
+
+      // Refetch to update the tag number in the tabs
+      queryClient.refetchQueries(["getRequestsWaitingForApproval"]);
 
       // If approved request is last in the page, go back to previous page
       // This avoids staying on a non-existent page of entries, which makes the table bug hard


### PR DESCRIPTION
## About this change - What it does

When approving or declining a requests in the Approvals UI, we need to trigger a refetch of the `getRequestsWaitingForApproval` call in `ApprovalresourceTabs` to keep the number in the tabs in sync (https://github.com/aiven/klaw/blob/main/coral/src/app/features/approvals/components/ApprovalResourceTabs.tsx#L18-L20)

It looks like this:

```tsx
queryClient.refetchQueries(["getRequestsWaitingForApproval"]);
```

This refetch was missing in a number of situations, so it was added.

Additionally, this refetch was happening before we checked for errors, which makes it sometimes superfluous. It was moved after the error check.

