### PR TITLE
refactoring(coral): Use DataTable action column type for table actions #797

### DIFF
--- a/coral/src/app/features/approvals/topics/components/DetailsModalContent.tsx
+++ b/coral/src/app/features/approvals/topics/components/DetailsModalContent.tsx
@@ -55,8 +55,7 @@ const DetailsModalContent = ({ topicRequest }: DetailsModalContentProps) => {
   } = topicRequest;
 
   const hasAdvancedConfig =
-    advancedTopicConfigEntries.length > 0 &&
-    advancedTopicConfigEntries !== null &&
+    advancedTopicConfigEntries?.length > 0 &&
     !isEmpty(advancedTopicConfigEntries);
 
   return (

--- a/coral/src/app/features/approvals/topics/components/TopicApprovalsTable.tsx
+++ b/coral/src/app/features/approvals/topics/components/TopicApprovalsTable.tsx
@@ -1,18 +1,9 @@
-import {
-  DataTable,
-  DataTableColumn,
-  EmptyState,
-  GhostButton,
-  Icon,
-} from "@aivenio/aquarium";
+import { DataTable, DataTableColumn, EmptyState } from "@aivenio/aquarium";
 import deleteIcon from "@aivenio/aquarium/dist/src/icons/delete";
 import infoSign from "@aivenio/aquarium/dist/src/icons/infoSign";
 import loadingIcon from "@aivenio/aquarium/dist/src/icons/loading";
 import tickCircle from "@aivenio/aquarium/dist/src/icons/tickCircle";
-import { UseMutateFunction } from "@tanstack/react-query";
-import { Dispatch, SetStateAction, useState } from "react";
 import { TopicRequest } from "src/domain/topic/topic-types";
-import { GenericApiResponse, HTTPError } from "src/services/api";
 import {
   requestStatusChipStatusMap,
   requestStatusNameMap,
@@ -35,34 +26,22 @@ interface TopicRequestTableRow {
 
 type TopicApprovalsTableProp = {
   requests: TopicRequest[];
-  setDetailsModal: Dispatch<
-    SetStateAction<{
-      isOpen: boolean;
-      topicId: number | null;
-    }>
-  >;
-  setDeclineModal: Dispatch<
-    SetStateAction<{
-      isOpen: boolean;
-      topicId: number | null;
-    }>
-  >;
-  approveRequest: UseMutateFunction<
-    GenericApiResponse[],
-    HTTPError,
-    { requestEntityType: "TOPIC"; reqIds: string[] }
-  >;
-  quickActionLoading: boolean;
+  actionsDisabled?: boolean;
+  onDetails: (req_no: number) => void;
+  onApprove: (req_no: number) => void;
+  onDecline: (req_no: number) => void;
+  isBeingApproved: (req_no: number) => boolean;
+  isBeingDeclined: (req_no: number) => boolean;
 };
-function TopicApprovalsTable(props: TopicApprovalsTableProp) {
-  const {
-    requests,
-    setDetailsModal,
-    setDeclineModal,
-    approveRequest,
-    quickActionLoading,
-  } = props;
-
+function TopicApprovalsTable({
+  requests,
+  actionsDisabled = false,
+  onDetails,
+  onApprove,
+  onDecline,
+  isBeingApproved,
+  isBeingDeclined,
+}: TopicApprovalsTableProp) {
   const columns: Array<DataTableColumn<TopicRequestTableRow>> = [
     { type: "text", field: "topicname", headerName: "Topic" },
     {
@@ -107,82 +86,59 @@ function TopicApprovalsTable(props: TopicApprovalsTableProp) {
       },
     },
     {
-      type: "custom",
+      type: "action",
       headerName: "Details",
       headerInvisible: true,
       width: 30,
-      UNSAFE_render: ({ id, topicname }: TopicRequestTableRow) => {
-        return (
-          <GhostButton
-            onClick={() => setDetailsModal({ isOpen: true, topicId: id })}
-            icon={infoSign}
-            dense
-          >
-            <span aria-hidden={"true"}>View details</span>
-            <span className={"visually-hidden"}>
-              View topic request for {topicname}
-            </span>
-          </GhostButton>
-        );
-      },
+      action: (request) => ({
+        onClick: () => onDetails(request.id),
+        icon: infoSign,
+        text: "View",
+        "aria-label": `View topic request for ${request.topicname}`,
+      }),
     },
     {
-      type: "custom",
+      type: "action",
       headerName: "Approve",
       headerInvisible: true,
       width: 30,
-      UNSAFE_render: ({
-        topicname,
-        id,
-        requestStatus,
-      }: TopicRequestTableRow) => {
-        const [isLoading, setIsLoading] = useState(false);
-        if (requestStatus === "CREATED") {
-          return (
-            <GhostButton
-              onClick={() => {
-                setIsLoading(true);
-                return approveRequest({
-                  requestEntityType: "TOPIC",
-                  reqIds: [String(id)],
-                });
-              }}
-              title={`Approve topic request`}
-              aria-label={`Approve topic request for ${topicname}`}
-              disabled={quickActionLoading}
-            >
-              {isLoading && quickActionLoading ? (
-                <Icon color="grey-70" icon={loadingIcon} />
-              ) : (
-                <Icon color="grey-70" icon={tickCircle} />
-              )}
-            </GhostButton>
-          );
-        }
+      action: (request) => {
+        const approveInProgress = isBeingApproved(request.id);
+        const declineInProgress = isBeingDeclined(request.id);
+        return {
+          onClick: () => onApprove(request.id),
+          text: "Approve",
+          "aria-label": `Approve topic request for ${request.topicname}`,
+          disabled:
+            approveInProgress ||
+            declineInProgress ||
+            actionsDisabled ||
+            request.requestStatus !== "CREATED",
+          icon: approveInProgress ? loadingIcon : tickCircle,
+          loading: approveInProgress,
+        };
       },
     },
     {
-      type: "custom",
+      type: "action",
       headerName: "Decline",
       headerInvisible: true,
       width: 30,
-      UNSAFE_render: ({
-        id,
-        requestStatus,
-        topicname,
-      }: TopicRequestTableRow) => {
-        if (requestStatus === "CREATED") {
-          return (
-            <GhostButton
-              onClick={() => setDeclineModal({ isOpen: true, topicId: id })}
-              title={`Decline topic request`}
-              aria-label={`Decline topic request for ${topicname}`}
-              disabled={quickActionLoading}
-            >
-              <Icon color="grey-70" icon={deleteIcon} />
-            </GhostButton>
-          );
-        }
+      action: (request) => {
+        const approveInProgress = isBeingApproved(request.id);
+        const declineInProgress = isBeingDeclined(request.id);
+        return {
+          onClick: () => onDecline(request.id),
+          "aria-label": `Decline topic request for ${request.topicname}`,
+          text: "Decline",
+          disabled:
+            declineInProgress ||
+            approveInProgress ||
+            actionsDisabled ||
+            request.requestStatus !== "CREATED",
+          icon: isBeingDeclined(request.id) ? loadingIcon : deleteIcon,
+          loading: isBeingDeclined(request.id),
+        };
       },
     },
   ];


### PR DESCRIPTION
Unifies the usage of the DataTable actions in the approvals views for more unified experience. In practice, changes from column type "custom" into "action".

Fixes couple of corner cases:
- the ` isBeing*` check per request did not consider if the request was loading. This made it "loading" for example in case where the request failed.
- when request was declined, it was technically possible to click the button again after modal closed. It now disables the row's decline button as well until the decline request in finished.

Tries to do minimal changes to tests to ease review process. Adds couple more test cases per table.

Note*: prior to this commit, we hide the action button if it's not feasible per request, for example: not in `CREATED` state. After this change, the button will always visible but will be disabled if the status is not `CREATED`. This is due to the action column api, it does not support hiding the column content.

Resolves: #797
