### PR TITLE
feat(coral): add preview banner in Coral and in Angular

### DIFF
--- a/coral/src/app/features/requests/acls/AclRequests.test.tsx
+++ b/coral/src/app/features/requests/acls/AclRequests.test.tsx
@@ -631,6 +631,7 @@ describe("AclRequests", () => {
     beforeEach(async () => {
       mockGetAclRequests.mockResolvedValue(mockGetAclRequestsResponse);
       mockGetEnvironments.mockResolvedValue(mockGetEnvironmentsResponse);
+      mockDeleteAclRequests.mockResolvedValue([{ result: "Success" }]);
 
       customRender(<AclRequests />, {
         queryClient: true,

--- a/coral/src/app/pages/requests/schemas/index.test.tsx
+++ b/coral/src/app/pages/requests/schemas/index.test.tsx
@@ -1,7 +1,7 @@
 import { getSchemaRequests } from "src/domain/schema-request";
 import { customRender } from "src/services/test-utils/render-with-wrappers";
 import SchemaRequestsPage from "src/app/pages/requests/schemas/index";
-import { cleanup, screen } from "@testing-library/react";
+import { cleanup, screen, within } from "@testing-library/react";
 import { waitForElementToBeRemoved } from "@testing-library/react/pure";
 import { getSchemaRegistryEnvironments } from "src/domain/environment";
 
@@ -17,7 +17,7 @@ const mockGetSchemaRequests = getSchemaRequests as jest.MockedFunction<
 >;
 
 describe("SchemaRequestPage", () => {
-  beforeAll(() => {
+  beforeAll(async () => {
     mockGetSchemaRegistryEnvironments.mockResolvedValue([]);
     mockGetSchemaRequests.mockResolvedValue({
       entries: [],
@@ -29,12 +29,31 @@ describe("SchemaRequestPage", () => {
       queryClient: true,
       memoryRouter: true,
     });
+    await waitForElementToBeRemoved(screen.getByTestId("skeleton-table"));
   });
 
   afterAll(cleanup);
 
-  it("renders the schema request view", async () => {
-    await waitForElementToBeRemoved(screen.getByTestId("skeleton-table"));
+  it("shows a preview banner to inform users about the early version of the view", () => {
+    const previewBanner = screen.getByLabelText("Preview disclaimer");
+
+    expect(previewBanner).toBeVisible();
+    expect(previewBanner).toHaveTextContent(
+      "You are viewing a preview of the redesigned user interface. You are one of our early reviewers, and your feedback will help us improve the product. You can always go back to the old interface."
+    );
+  });
+
+  it("shows link back back to the original Klaw app for this view in the preview banner", () => {
+    const previewBanner = screen.getByLabelText("Preview disclaimer");
+    const link = within(previewBanner).getByRole("link", {
+      name: "old interface",
+    });
+
+    expect(link).toBeVisible();
+    expect(link).toHaveAttribute("href", "/mySchemaRequests");
+  });
+
+  it("renders the schema request view", () => {
     const emptyRequests = screen.getByText(
       "No Schema request matched your criteria."
     );

--- a/coral/src/app/pages/requests/schemas/index.tsx
+++ b/coral/src/app/pages/requests/schemas/index.tsx
@@ -1,7 +1,13 @@
 import { SchemaRequests } from "src/app/features/requests/schemas/SchemaRequests";
+import PreviewBanner from "src/app/components/PreviewBanner";
 
 const SchemaRequestsPage = () => {
-  return <SchemaRequests />;
+  return (
+    <>
+      <PreviewBanner linkTarget={"/mySchemaRequests"} />
+      <SchemaRequests />
+    </>
+  );
 };
 
 export default SchemaRequestsPage;

--- a/core/src/main/resources/templates/mySchemaRequests.html
+++ b/core/src/main/resources/templates/mySchemaRequests.html
@@ -428,6 +428,17 @@
 
 			<!-- Row -->
 
+			<div class="row" ng-if="dashboardDetails.coralEnabled === 'true'">
+				<div class="ribbon-wrapper card col-lg-6 col-md-6 col-xlg-2 col-xs-6">
+					<div class="ribbon ribbon-success">New user interface available</div>
+					<p class="ribbon-content">
+						Check out the new interface for <a href="coral/requests/schemas">My team's requests.</a>
+					</p>
+				</div>
+			</div>
+
+			<!-- Row -->
+
 			<div class="row" ng-show="alert != null && alert != ''" ng-init="">
 				<div  class="col-lg-12 col-md-6 col-xlg-2 col-xs-12" >
 					<div class="ribbon-wrapper card">


### PR DESCRIPTION
# About this change - What it does

- adds preview banner to Coral
- adds banner with info about new interface to Klaw Angular
- 🧹 adds a missing resolved value for mock that caused console.error


Resolves: #854



https://user-images.githubusercontent.com/943800/226857868-b079e9e1-2887-4847-98e7-a845670daaeb.mov


