### PR TITLE
feat(coral): Update redirect routes after creating new requests

### DIFF
--- a/coral/src/app/features/topics/acl-request/TopicAclRequest.test.tsx
+++ b/coral/src/app/features/topics/acl-request/TopicAclRequest.test.tsx
@@ -1057,10 +1057,9 @@ describe("<TopicAclRequest />", () => {
           teamId: 1,
         });
 
-        // @TODO use when Klaw migration is completed and redirect is handling with react-router
         await waitFor(() => {
-          expect(locationAssignSpy).toHaveBeenLastCalledWith(
-            "/myAclRequests?reqsType=CREATED&aclCreated=true"
+          expect(mockedNavigate).toHaveBeenLastCalledWith(
+            "/requests/acls?status=CREATED"
           );
         });
       });
@@ -1068,23 +1067,6 @@ describe("<TopicAclRequest />", () => {
   });
 
   describe("Form submission (TopicConsumerForm)", () => {
-    const locationAssignSpy = jest.fn();
-    let originalLocation: Location;
-
-    beforeAll(() => {
-      originalLocation = window.location;
-      Object.defineProperty(global.window, "location", {
-        writable: true,
-        value: {
-          assign: locationAssignSpy,
-        },
-      });
-    });
-
-    afterAll(() => {
-      global.window.location = originalLocation;
-    });
-
     beforeEach(async () => {
       dataSetup({ isAivenCluster: false });
 
@@ -1370,10 +1352,9 @@ describe("<TopicAclRequest />", () => {
           consumergroup: "group",
         });
 
-        // @TODO use when Klaw migration is completed and redirect is handling with react-router
         await waitFor(() => {
-          expect(locationAssignSpy).toHaveBeenLastCalledWith(
-            "/myAclRequests?reqsType=CREATED&aclCreated=true"
+          expect(mockedNavigate).toHaveBeenLastCalledWith(
+            "/requests/acls?status=CREATED"
           );
         });
       });

--- a/coral/src/app/features/topics/acl-request/forms/TopicConsumerForm.tsx
+++ b/coral/src/app/features/topics/acl-request/forms/TopicConsumerForm.tsx
@@ -64,8 +64,7 @@ const TopicConsumerForm = ({
 
   const { mutate, isLoading, isError, error } = useMutation({
     mutationFn: createAclRequest,
-    onSuccess: () =>
-      window.location.assign("/myAclRequests?reqsType=CREATED&aclCreated=true"),
+    onSuccess: () => navigate("/requests/acls?status=CREATED"),
   });
 
   const onSubmitTopicConsumer: SubmitHandler<TopicConsumerFormSchema> = (

--- a/coral/src/app/features/topics/acl-request/forms/TopicProducerForm.tsx
+++ b/coral/src/app/features/topics/acl-request/forms/TopicProducerForm.tsx
@@ -81,8 +81,7 @@ const TopicProducerForm = ({
 
   const { mutate, isLoading, isError, error } = useMutation({
     mutationFn: createAclRequest,
-    onSuccess: () =>
-      window.location.assign("/myAclRequests?reqsType=CREATED&aclCreated=true"),
+    onSuccess: () => navigate("/requests/acls?status=CREATED"),
   });
 
   const onSubmitTopicProducer: SubmitHandler<TopicProducerFormSchema> = (

--- a/coral/src/app/features/topics/request/TopicRequest.test.tsx
+++ b/coral/src/app/features/topics/request/TopicRequest.test.tsx
@@ -776,22 +776,6 @@ describe("<TopicRequest />", () => {
       });
     });
     describe("when API request is successful", () => {
-      const locationAssignSpy = jest.fn();
-      let originalLocation: Location;
-
-      beforeAll(() => {
-        originalLocation = window.location;
-        Object.defineProperty(global.window, "location", {
-          writable: true,
-          value: {
-            assign: locationAssignSpy,
-          },
-        });
-      });
-
-      afterAll(() => {
-        global.window.location = originalLocation;
-      });
       beforeEach(async () => {
         mockRequestTopic({
           mswInstance: server,
@@ -824,9 +808,9 @@ describe("<TopicRequest />", () => {
         });
 
         await waitFor(() => {
-          expect(locationAssignSpy).toHaveBeenCalledTimes(1);
-          expect(locationAssignSpy).toHaveBeenCalledWith(
-            "/myTopicRequests?reqsType=CREATED&topicCreated=true"
+          expect(mockedUsedNavigate).toHaveBeenCalledTimes(1);
+          expect(mockedUsedNavigate).toHaveBeenCalledWith(
+            "/requests/topics?status=CREATED"
           );
         });
       });

--- a/coral/src/app/features/topics/request/TopicRequest.tsx
+++ b/coral/src/app/features/topics/request/TopicRequest.tsx
@@ -59,10 +59,7 @@ function TopicRequest() {
   });
 
   const { mutate, isLoading, isError, error } = useMutation(requestTopic, {
-    onSuccess: () =>
-      window.location.assign(
-        "/myTopicRequests?reqsType=CREATED&topicCreated=true"
-      ),
+    onSuccess: () => navigate("/requests/topics?status=CREATED"),
   });
 
   const onSubmit: SubmitHandler<Schema> = (data) =>

--- a/coral/src/app/features/topics/schema-request/TopicSchemaRequest.test.tsx
+++ b/coral/src/app/features/topics/schema-request/TopicSchemaRequest.test.tsx
@@ -564,23 +564,6 @@ describe("TopicSchemaRequest", () => {
   });
 
   describe("enables user to send a schema request", () => {
-    const locationAssignSpy = jest.fn();
-    let originalLocation: Location;
-
-    beforeAll(() => {
-      originalLocation = window.location;
-      Object.defineProperty(global.window, "location", {
-        writable: true,
-        value: {
-          assign: locationAssignSpy,
-        },
-      });
-    });
-
-    afterAll(() => {
-      global.window.location = originalLocation;
-    });
-
     beforeEach(async () => {
       mockGetSchemaRegistryEnvironments.mockResolvedValue(
         mockedGetSchemaRegistryEnvironments
@@ -726,9 +709,9 @@ describe("TopicSchemaRequest", () => {
       await userEvent.click(button);
 
       await waitFor(() => {
-        expect(locationAssignSpy).toHaveBeenCalledTimes(1);
-        expect(locationAssignSpy).toHaveBeenCalledWith(
-          "/mySchemaRequests?reqsType=CREATED&schemaCreated=true"
+        expect(mockedUsedNavigate).toHaveBeenCalledTimes(1);
+        expect(mockedUsedNavigate).toHaveBeenCalledWith(
+          "/requests/schemas?status=CREATED"
         );
       });
     });

--- a/coral/src/app/features/topics/schema-request/TopicSchemaRequest.tsx
+++ b/coral/src/app/features/topics/schema-request/TopicSchemaRequest.tsx
@@ -70,10 +70,7 @@ function TopicSchemaRequest(props: TopicSchemaRequestProps) {
   });
 
   const schemaRequestMutation = useMutation(createSchemaRequest, {
-    onSuccess: () =>
-      window.location.assign(
-        "/mySchemaRequests?reqsType=CREATED&schemaCreated=true"
-      ),
+    onSuccess: () => navigate("/requests/schemas?status=CREATED"),
   });
 
   function onSubmitForm(userInput: TopicRequestFormSchema) {


### PR DESCRIPTION
# About this change - What it does

Since the next release will include the new views for "My team's" requests, we can now change the redirects after user successfully created a new topic, schema or acl request. 

Instead of directing to: `/my[Acl/Topic/Schema]Requests?reqsType=CREATED&aclCreated=true` we now redirect to `/requests/[Acl/Topic/Schema]?status=CREATED`


## test

https://user-images.githubusercontent.com/943800/226919006-c986d301-2c41-4daf-a7d5-336bb59fbc56.mov


