### PR TITLE
refactor(coral): Add "success" information "Request new..." workflows

### DIFF
--- a/coral/src/app/components/Dialog.test.tsx
+++ b/coral/src/app/components/Dialog.test.tsx
@@ -3,6 +3,7 @@ import { Dialog } from "src/app/components/Dialog";
 import confirm from "@aivenio/aquarium/dist/src/icons/confirm";
 import warningSign from "@aivenio/aquarium/dist/src/icons/warningSign";
 import error from "@aivenio/aquarium/dist/src/icons/error";
+import userEvent from "@testing-library/user-event";
 
 describe("Dialog.tsx", () => {
   const testTitle = "Dialog title";
@@ -11,14 +12,10 @@ describe("Dialog.tsx", () => {
     text: "Primary action 1",
     onClick: jest.fn(),
   };
-  const mockSecondary = {
-    text: "Secondary action 1",
-    onClick: jest.fn(),
-  };
 
   afterEach(jest.clearAllMocks);
 
-  describe("renders all necessary elements", () => {
+  describe("shows a default modal with headline, text and one button", () => {
     beforeAll(() => {
       render(
         <>
@@ -27,7 +24,6 @@ describe("Dialog.tsx", () => {
             type="confirmation"
             title={testTitle}
             primaryAction={mockPrimary}
-            secondaryAction={mockSecondary}
           >
             {textContent}
           </Dialog>
@@ -61,6 +57,31 @@ describe("Dialog.tsx", () => {
 
       expect(button).toBeEnabled();
     });
+  });
+
+  describe("shows a second button dependent on a prop", () => {
+    const mockSecondary = {
+      text: "Secondary action 1",
+      onClick: jest.fn(),
+    };
+
+    beforeAll(() => {
+      render(
+        <>
+          <div id={"root"}></div>
+          <Dialog
+            type="confirmation"
+            title={testTitle}
+            primaryAction={mockPrimary}
+            secondaryAction={mockSecondary}
+          >
+            {textContent}
+          </Dialog>
+        </>
+      );
+    });
+
+    afterAll(cleanup);
 
     it("shows a button with a given secondary action", () => {
       const button = screen.getByRole("button", { name: mockPrimary.text });
@@ -77,7 +98,7 @@ describe("Dialog.tsx", () => {
     });
   });
 
-  describe("renders header icon and color dependent on type prop", () => {
+  describe("shows different header icons and colors dependent on type prop", () => {
     afterEach(cleanup);
 
     it("shows a confirmation header", () => {
@@ -88,7 +109,6 @@ describe("Dialog.tsx", () => {
             type="confirmation"
             title={testTitle}
             primaryAction={mockPrimary}
-            secondaryAction={mockSecondary}
           >
             {textContent}
           </Dialog>
@@ -106,12 +126,7 @@ describe("Dialog.tsx", () => {
       render(
         <>
           <div id={"root"}></div>
-          <Dialog
-            type="warning"
-            title={testTitle}
-            primaryAction={mockPrimary}
-            secondaryAction={mockSecondary}
-          >
+          <Dialog type="warning" title={testTitle} primaryAction={mockPrimary}>
             {textContent}
           </Dialog>
         </>
@@ -128,12 +143,7 @@ describe("Dialog.tsx", () => {
       render(
         <>
           <div id={"root"}></div>
-          <Dialog
-            type="danger"
-            title={testTitle}
-            primaryAction={mockPrimary}
-            secondaryAction={mockSecondary}
-          >
+          <Dialog type="danger" title={testTitle} primaryAction={mockPrimary}>
             {textContent}
           </Dialog>
         </>
@@ -144,6 +154,50 @@ describe("Dialog.tsx", () => {
 
       expect(headline).toHaveClass("text-error-70");
       expect(icon).toHaveAttribute("data-icon", error.body);
+    });
+  });
+
+  describe("enables user to use buttons", () => {
+    const mockSecondary = {
+      text: "Secondary action 1",
+      onClick: jest.fn(),
+    };
+
+    beforeEach(() => {
+      render(
+        <>
+          <div id={"root"}></div>
+          <Dialog
+            type="confirmation"
+            title={testTitle}
+            primaryAction={mockPrimary}
+            secondaryAction={mockSecondary}
+          >
+            {textContent}
+          </Dialog>
+        </>
+      );
+    });
+
+    afterEach(() => {
+      jest.resetAllMocks();
+      cleanup();
+    });
+
+    it("user can click the button for the primary action", async () => {
+      const button = screen.getByRole("button", { name: mockPrimary.text });
+
+      await userEvent.click(button);
+
+      expect(mockPrimary.onClick).toHaveBeenCalled();
+    });
+
+    it("user can click the button for the secondary action", async () => {
+      const button = screen.getByRole("button", { name: mockSecondary.text });
+
+      await userEvent.click(button);
+
+      expect(mockSecondary.onClick).toHaveBeenCalled();
     });
   });
 });

--- a/coral/src/app/components/Dialog.tsx
+++ b/coral/src/app/components/Dialog.tsx
@@ -8,12 +8,11 @@ import { Box, Icon, Typography } from "@aivenio/aquarium";
 import { ResolveIntersectionTypes } from "types/utils";
 
 type DialogProps = ResolveIntersectionTypes<
-  Omit<ModalProps, "isDialog" | "dialogTitle" | "close" | "children"> &
-    Required<Pick<ModalProps, "secondaryAction">> & {
-      type: DialogType;
-    } & {
-      children: string;
-    }
+  Omit<ModalProps, "isDialog" | "dialogTitle" | "close" | "children"> & {
+    type: DialogType;
+  } & {
+    children: string;
+  }
 >;
 
 const dialogTypeMap: Record<

--- a/coral/src/app/features/approvals/acls/AclApprovals.tsx
+++ b/coral/src/app/features/approvals/acls/AclApprovals.tsx
@@ -89,7 +89,9 @@ function AclApprovals() {
     mutationFn: approveAclRequest,
     onSuccess: (responses) => {
       const response = responses[0];
-      if (response.result !== "success") {
+      const responseIsAHiddenError =
+        response?.result.toLowerCase() !== "success";
+      if (responseIsAHiddenError) {
         return setErrorMessage(
           response.message || response.result || "Unexpected error"
         );
@@ -125,7 +127,9 @@ function AclApprovals() {
     mutationFn: declineAclRequest,
     onSuccess: (responses) => {
       const response = responses[0];
-      if (response.result !== "success") {
+      const responseIsAHiddenError =
+        response?.result.toLowerCase() !== "success";
+      if (responseIsAHiddenError) {
         return setErrorMessage(
           response.message || response.result || "Unexpected error"
         );

--- a/coral/src/app/features/approvals/schemas/SchemaApprovals.tsx
+++ b/coral/src/app/features/approvals/schemas/SchemaApprovals.tsx
@@ -82,7 +82,9 @@ function SchemaApprovals() {
       // @TODO follow up ticket #707
       // (for all approval tables)
       const response = responses[0];
-      if (response.result !== "success") {
+      const responseIsAHiddenError =
+        response?.result.toLowerCase() !== "success";
+      if (responseIsAHiddenError) {
         return setErrorQuickActions(
           response.message || response.result || "Unexpected error"
         );
@@ -127,7 +129,9 @@ function SchemaApprovals() {
       // @TODO follow up ticket #707
       // (for all approval tables)
       const response = responses[0];
-      if (response.result !== "success") {
+      const responseIsAHiddenError =
+        response?.result.toLowerCase() !== "success";
+      if (responseIsAHiddenError) {
         return setErrorQuickActions(
           response.message || response.result || "Unexpected error"
         );

--- a/coral/src/app/features/approvals/topics/TopicApprovals.tsx
+++ b/coral/src/app/features/approvals/topics/TopicApprovals.tsx
@@ -92,8 +92,9 @@ function TopicApprovals() {
     onSuccess: (responses) => {
       // This mutation is used on a single request, so we always want the first response in the array
       const response = responses[0];
-
-      if (response.result !== "success") {
+      const responseIsAHiddenError =
+        response?.result.toLowerCase() !== "success";
+      if (responseIsAHiddenError) {
         return setErrorMessage(
           response.message || response.result || "Unexpected error"
         );
@@ -138,8 +139,9 @@ function TopicApprovals() {
     onSuccess: (responses) => {
       // This mutation is used on a single request, so we always want the first response in the array
       const response = responses[0];
-
-      if (response.result !== "success") {
+      const responseIsAHiddenError =
+        response?.result.toLowerCase() !== "success";
+      if (responseIsAHiddenError) {
         return setErrorMessage(
           response.message || response.result || "Unexpected error"
         );

--- a/coral/src/app/features/requests/acls/AclRequests.tsx
+++ b/coral/src/app/features/requests/acls/AclRequests.tsx
@@ -92,7 +92,9 @@ function AclRequests() {
     onSuccess: async (responses) => {
       const response = responses[0];
 
-      if (response.result !== "success") {
+      const responseIsAHiddenError =
+        response?.result.toLowerCase() !== "success";
+      if (responseIsAHiddenError) {
         throw Error(response.message || response.result || "Unexpected error");
       }
 

--- a/coral/src/app/features/requests/schemas/SchemaRequests.tsx
+++ b/coral/src/app/features/requests/schemas/SchemaRequests.tsx
@@ -87,7 +87,8 @@ function SchemaRequests() {
         // @TODO follow up ticket #707
         // (for all approval and request tables)
         const response = responses[0];
-        const responseIsAHiddenError = response?.result !== "success";
+        const responseIsAHiddenError =
+          response?.result.toLowerCase() !== "success";
         if (responseIsAHiddenError) {
           throw new Error(response?.message || response?.result);
         }

--- a/coral/src/app/features/topics/acl-request/forms/TopicConsumerForm.tsx
+++ b/coral/src/app/features/topics/acl-request/forms/TopicConsumerForm.tsx
@@ -44,6 +44,7 @@ const TopicConsumerForm = ({
   isAivenCluster,
 }: TopicConsumerFormProps) => {
   const [cancelDialogVisible, setCancelDialogVisible] = useState(false);
+  const [successModalOpen, setSuccessModalOpen] = useState(false);
 
   const navigate = useNavigate();
   const { aclIpPrincipleType } = topicConsumerForm.getValues();
@@ -64,8 +65,17 @@ const TopicConsumerForm = ({
 
   const { mutate, isLoading, isError, error } = useMutation({
     mutationFn: createAclRequest,
-    onSuccess: () => navigate("/requests/acls?status=CREATED"),
+    onSuccess: () => {
+      setSuccessModalOpen(true);
+      setTimeout(() => {
+        redirectToMyRequests();
+      }, 5 * 1000);
+    },
   });
+
+  function redirectToMyRequests() {
+    navigate("/requests/acls?status=CREATED");
+  }
 
   const onSubmitTopicConsumer: SubmitHandler<TopicConsumerFormSchema> = (
     formData
@@ -104,6 +114,19 @@ const TopicConsumerForm = ({
         <Box marginBottom={"l1"} role="alert">
           <Alert type="error">{parseErrorMsg(error)}</Alert>
         </Box>
+      )}
+      {successModalOpen && (
+        <Dialog
+          title={"Acl request successful!"}
+          primaryAction={{
+            text: "Continue",
+            onClick: redirectToMyRequests,
+          }}
+          type={"confirmation"}
+        >
+          Redirecting to My team&apos;s request page shortly. Select
+          &quot;Continue&quot; for an immediate redirect.
+        </Dialog>
       )}
       <Form
         {...topicConsumerForm}

--- a/coral/src/app/features/topics/acl-request/forms/TopicProducerForm.tsx
+++ b/coral/src/app/features/topics/acl-request/forms/TopicProducerForm.tsx
@@ -46,6 +46,7 @@ const TopicProducerForm = ({
   isAivenCluster,
 }: TopicProducerFormProps) => {
   const [cancelDialogVisible, setCancelDialogVisible] = useState(false);
+  const [successModalOpen, setSuccessModalOpen] = useState(false);
 
   const navigate = useNavigate();
   const { aclIpPrincipleType, aclPatternType, topicname } =
@@ -81,8 +82,17 @@ const TopicProducerForm = ({
 
   const { mutate, isLoading, isError, error } = useMutation({
     mutationFn: createAclRequest,
-    onSuccess: () => navigate("/requests/acls?status=CREATED"),
+    onSuccess: () => {
+      setSuccessModalOpen(true);
+      setTimeout(() => {
+        redirectToMyRequests();
+      }, 5 * 1000);
+    },
   });
+
+  function redirectToMyRequests() {
+    navigate("/requests/acls?status=CREATED");
+  }
 
   const onSubmitTopicProducer: SubmitHandler<TopicProducerFormSchema> = (
     formData
@@ -105,6 +115,19 @@ const TopicProducerForm = ({
         <Box marginBottom={"l1"} role="alert">
           <Alert type="error">{parseErrorMsg(error)}</Alert>
         </Box>
+      )}
+      {successModalOpen && (
+        <Dialog
+          title={"Acl request successful!"}
+          primaryAction={{
+            text: "Continue",
+            onClick: redirectToMyRequests,
+          }}
+          type={"confirmation"}
+        >
+          Redirecting to My team&apos;s request page shortly. Select
+          &quot;Continue&quot; for an immediate redirect.
+        </Dialog>
       )}
       <Form
         {...topicProducerForm}

--- a/coral/src/app/features/topics/request/TopicRequest.test.tsx
+++ b/coral/src/app/features/topics/request/TopicRequest.test.tsx
@@ -736,7 +736,7 @@ describe("<TopicRequest />", () => {
       jest.clearAllMocks();
     });
 
-    describe("when API returns an error", () => {
+    describe("handles an error from the api", () => {
       beforeEach(async () => {
         mockRequestTopic({
           mswInstance: server,
@@ -775,7 +775,8 @@ describe("<TopicRequest />", () => {
         expect(alert).toHaveTextContent("Topic with such name already exists!");
       });
     });
-    describe("when API request is successful", () => {
+
+    describe("enables user to create a new topic request", () => {
       beforeEach(async () => {
         mockRequestTopic({
           mswInstance: server,
@@ -783,7 +784,7 @@ describe("<TopicRequest />", () => {
         });
       });
 
-      it("redirects user to previous page", async () => {
+      it("creates a new topic request when input was valid", async () => {
         const spyPost = jest.spyOn(api, "post");
 
         await user.click(
@@ -806,13 +807,51 @@ describe("<TopicRequest />", () => {
           remarks: "",
           requestOperationType: "CREATE",
         });
+      });
+
+      it("shows a dialog informing user that request was successful", async () => {
+        const spyPost = jest.spyOn(api, "post");
+
+        await user.click(
+          screen.getByRole("button", { name: "Submit request" })
+        );
 
         await waitFor(() => {
-          expect(mockedUsedNavigate).toHaveBeenCalledTimes(1);
-          expect(mockedUsedNavigate).toHaveBeenCalledWith(
-            "/requests/topics?status=CREATED"
-          );
+          const btn = screen.getByRole("button", { name: "Submit request" });
+          expect(btn).toBeDisabled();
         });
+
+        expect(spyPost).toHaveBeenCalledTimes(1);
+
+        const successModal = await screen.findByRole("dialog");
+
+        expect(successModal).toBeVisible();
+      });
+
+      it("user can continue to the next page without waiting for redirect in the dialog", async () => {
+        const spyPost = jest.spyOn(api, "post");
+
+        await user.click(
+          screen.getByRole("button", { name: "Submit request" })
+        );
+
+        await waitFor(() => {
+          const btn = screen.getByRole("button", { name: "Submit request" });
+          expect(btn).toBeDisabled();
+        });
+
+        expect(spyPost).toHaveBeenCalledTimes(1);
+
+        const successModal = await screen.findByRole("dialog");
+        const button = within(successModal).getByRole("button", {
+          name: "Continue",
+        });
+
+        await userEvent.click(button);
+
+        expect(mockedUsedNavigate).toHaveBeenCalledWith(
+          "/requests/topics?status=CREATED"
+        );
       });
     });
   });

--- a/coral/src/app/features/topics/request/TopicRequest.test.tsx
+++ b/coral/src/app/features/topics/request/TopicRequest.test.tsx
@@ -826,6 +826,7 @@ describe("<TopicRequest />", () => {
         const successModal = await screen.findByRole("dialog");
 
         expect(successModal).toBeVisible();
+        expect(successModal).toHaveTextContent("Topic request successful!");
       });
 
       it("user can continue to the next page without waiting for redirect in the dialog", async () => {

--- a/coral/src/app/features/topics/request/TopicRequest.tsx
+++ b/coral/src/app/features/topics/request/TopicRequest.tsx
@@ -36,6 +36,8 @@ function TopicRequest() {
   const [cancelDialogVisible, setCancelDialogVisible] = useState(false);
   const navigate = useNavigate();
 
+  const [successModalOpen, setSuccessModalOpen] = useState(false);
+
   const { data: environments } = useQuery<Environment[], Error>(
     ["environments-for-team"],
     getEnvironmentsForTeam
@@ -59,8 +61,16 @@ function TopicRequest() {
   });
 
   const { mutate, isLoading, isError, error } = useMutation(requestTopic, {
-    onSuccess: () => navigate("/requests/topics?status=CREATED"),
+    onSuccess: () => {
+      setSuccessModalOpen(true);
+      setTimeout(() => {
+        redirectToMyRequests();
+      }, 5 * 1000);
+    },
   });
+
+  const redirectToMyRequests = () =>
+    navigate("/requests/topics?status=CREATED");
 
   const onSubmit: SubmitHandler<Schema> = (data) =>
     mutate(createTopicRequestPayload(data));
@@ -77,6 +87,19 @@ function TopicRequest() {
 
   return (
     <>
+      {successModalOpen && (
+        <Dialog
+          title={"Topic request successful!"}
+          primaryAction={{
+            text: "Continue",
+            onClick: redirectToMyRequests,
+          }}
+          type={"confirmation"}
+        >
+          Redirecting to My team&apos;s request page shortly. Select
+          &quot;Continue&quot; for an immediate redirect.
+        </Dialog>
+      )}
       <Box maxWidth={"7xl"}>
         {isError && (
           <Box marginBottom={"l1"} role="alert">

--- a/coral/src/app/features/topics/schema-request/TopicSchemaRequest.tsx
+++ b/coral/src/app/features/topics/schema-request/TopicSchemaRequest.tsx
@@ -40,6 +40,7 @@ function TopicSchemaRequest(props: TopicSchemaRequestProps) {
   const { topicName } = props;
 
   const [cancelDialogVisible, setCancelDialogVisible] = useState(false);
+  const [successModalOpen, setSuccessModalOpen] = useState(false);
 
   const navigate = useNavigate();
   const form = useForm<TopicRequestFormSchema>({
@@ -70,8 +71,17 @@ function TopicSchemaRequest(props: TopicSchemaRequestProps) {
   });
 
   const schemaRequestMutation = useMutation(createSchemaRequest, {
-    onSuccess: () => navigate("/requests/schemas?status=CREATED"),
+    onSuccess: () => {
+      setSuccessModalOpen(true);
+      setTimeout(() => {
+        redirectToMyRequests();
+      }, 5 * 1000);
+    },
   });
+
+  function redirectToMyRequests() {
+    navigate("/requests/schemas?status=CREATED");
+  }
 
   function onSubmitForm(userInput: TopicRequestFormSchema) {
     schemaRequestMutation.mutate(userInput);
@@ -84,6 +94,19 @@ function TopicSchemaRequest(props: TopicSchemaRequestProps) {
 
   return (
     <>
+      {successModalOpen && (
+        <Dialog
+          title={"Schema request successful!"}
+          primaryAction={{
+            text: "Continue",
+            onClick: redirectToMyRequests,
+          }}
+          type={"confirmation"}
+        >
+          Redirecting to My team&apos;s request page shortly. Select
+          &quot;Continue&quot; for an immediate redirect.
+        </Dialog>
+      )}
       <Box maxWidth={"7xl"}>
         {schemaRequestMutation.isError && (
           <Box marginBottom={"l1"} role="alert">


### PR DESCRIPTION
# About this change - What it does

Adds "success" workflow when user creates a new: 
- topic request
- ACL request
- Schema request

(note: this is a temporary solution to not redirect users without any notice what happened. We'll use a toast notification for that as soon as it's available from the DS) 

The PR also updated the check for our hidden error to be more readable and safe (I noticed an console error in a test, where the success case was mocked by `[ { result: "Success" } ]` -> which was not a success case for our app. 


Resolves: #583

## recording implementation


https://user-images.githubusercontent.com/943800/227460687-60a9af5c-8d62-40c1-932a-8cc94c82f287.mov





### First version used to get feedback

<img width="749" alt="version-1" src="https://user-images.githubusercontent.com/943800/226944784-56531ef7-9066-4d56-9fbd-213aeb51c5b9.png">

https://user-images.githubusercontent.com/943800/226944793-f515a1f6-7c9d-4aff-a8da-b50e54af91fa.mov


