### PR TITLE
fix(coral): Wrap filter components in TableLayout

### DIFF
--- a/coral/src/app/features/components/layouts/TableLayout.tsx
+++ b/coral/src/app/features/components/layouts/TableLayout.tsx
@@ -22,6 +22,7 @@ function TableLayout(props: TableLayoutProps) {
       <Box
         display={"flex"}
         flexDirection={"row"}
+        flexWrap={"wrap"}
         alignItems={"center"}
         justifyContent={"stretch"}
         colGap={"l1"}


### PR DESCRIPTION
## About this change - What it does

Implement wrapping behaviour for the filters in `TableLayout` so they stay usable in small vieports

https://user-images.githubusercontent.com/20607294/227160661-9af2149f-4141-46c8-ac06-367e25119b05.mov



