### PR TITLE
feat(coral): My Schema Requests - add filter functionality for Type 

### DIFF
--- a/coral/src/app/features/requests/schemas/SchemaRequests.test.tsx
+++ b/coral/src/app/features/requests/schemas/SchemaRequests.test.tsx
@@ -127,14 +127,25 @@ describe("SchemaRequest", () => {
     });
 
     it("shows a select to filter by environment with default", () => {
-      const select = screen.getByLabelText("Filter by Environment");
+      const select = screen.getByRole("combobox", {
+        name: "Filter by Environment",
+      });
 
       expect(select).toBeVisible();
       expect(select).toHaveDisplayValue("All Environments");
     });
 
+    it("shows a select to filter by request type with default", () => {
+      const select = screen.getByRole("combobox", {
+        name: "Filter by operation type",
+      });
+
+      expect(select).toBeVisible();
+      expect(select).toHaveDisplayValue("All operation types");
+    });
+
     it("shows a select to filter by request status with default", () => {
-      const select = screen.getByLabelText("Filter by status");
+      const select = screen.getByRole("combobox", { name: "Filter by status" });
 
       expect(select).toBeVisible();
       expect(select).toHaveDisplayValue("All statuses");

--- a/coral/src/app/features/requests/schemas/SchemaRequests.tsx
+++ b/coral/src/app/features/requests/schemas/SchemaRequests.tsx
@@ -10,7 +10,10 @@ import { MyRequestsFilter } from "src/app/features/components/table-filters/MyRe
 import StatusFilter from "src/app/features/components/table-filters/StatusFilter";
 import TopicFilter from "src/app/features/components/table-filters/TopicFilter";
 import { SchemaRequestTable } from "src/app/features/requests/schemas/components/SchemaRequestTable";
-import { RequestStatus } from "src/domain/requests/requests-types";
+import {
+  RequestOperationType,
+  RequestStatus,
+} from "src/domain/requests/requests-types";
 import {
   getSchemaRequests,
   deleteSchemaRequest,
@@ -22,6 +25,7 @@ import { objectHasProperty } from "src/services/type-utils";
 import { OperationTypeFilter } from "src/app/features/components/table-filters/OperationTypeFilter";
 
 const defaultStatus = "ALL";
+const defaultType = "ALL";
 
 function SchemaRequests() {
   const queryClient = useQueryClient();
@@ -32,6 +36,9 @@ function SchemaRequests() {
     : 1;
   const currentTopic = searchParams.get("topic") ?? undefined;
   const currentEnvironment = searchParams.get("environment") ?? "ALL";
+  const currentType =
+    (searchParams.get("operationType") as RequestOperationType | "ALL") ??
+    defaultType;
   const currentStatus =
     (searchParams.get("status") as RequestStatus) ?? defaultStatus;
   const showOnlyMyRequests =
@@ -58,14 +65,17 @@ function SchemaRequests() {
       currentStatus,
       currentTopic,
       showOnlyMyRequests,
+      currentType,
     ],
     queryFn: () =>
       getSchemaRequests({
         pageNo: String(currentPage),
         env: currentEnvironment,
-        requestStatus: currentStatus,
+        requestStatus:
+          currentStatus !== defaultStatus ? currentStatus : undefined,
         topic: currentTopic,
         isMyRequest: showOnlyMyRequests,
+        operationType: currentType !== defaultType ? currentType : undefined,
       }),
     keepPreviousData: true,
   });

--- a/coral/src/app/features/requests/schemas/SchemaRequests.tsx
+++ b/coral/src/app/features/requests/schemas/SchemaRequests.tsx
@@ -19,6 +19,7 @@ import { DeleteRequestDialog } from "src/app/features/requests/components/Delete
 import { parseErrorMsg } from "src/services/mutation-utils";
 import { Alert } from "@aivenio/aquarium";
 import { objectHasProperty } from "src/services/type-utils";
+import { OperationTypeFilter } from "src/app/features/components/table-filters/OperationTypeFilter";
 
 const defaultStatus = "ALL";
 
@@ -188,6 +189,7 @@ function SchemaRequests() {
             key={"environments"}
             isSchemaRegistryEnvironments
           />,
+          <OperationTypeFilter key={"request-type"} />,
           <StatusFilter key={"request-status"} defaultStatus={defaultStatus} />,
           <TopicFilter key={"topic"} />,
           <MyRequestsFilter key={"show-only-my-requests"} />,

--- a/coral/src/app/features/requests/schemas/components/SchemaRequestTable.test.tsx
+++ b/coral/src/app/features/requests/schemas/components/SchemaRequestTable.test.tsx
@@ -22,8 +22,8 @@ describe("SchemaRequestTable", () => {
   const columnsFieldMap = [
     { columnHeader: "Topic", relatedField: "topicname" },
     { columnHeader: "Environment", relatedField: "environmentName" },
+    { columnHeader: "Request type", relatedField: "requestOperationType" },
     { columnHeader: "Status", relatedField: "requestStatus" },
-    { columnHeader: "Type", relatedField: "requestOperationType" },
     { columnHeader: "Requested by", relatedField: "requestor" },
     { columnHeader: "Requested on", relatedField: "requesttimestring" },
     { columnHeader: "Details", relatedField: null },
@@ -193,7 +193,7 @@ describe("SchemaRequestTable", () => {
               text = requestStatusNameMap[field as RequestStatus];
             }
 
-            if (column.columnHeader === "Type") {
+            if (column.columnHeader === "Request type") {
               text = requestOperationTypeNameMap[field as RequestOperationType];
             }
             const cell = within(table).getByRole("cell", { name: text });

--- a/coral/src/app/features/requests/schemas/components/SchemaRequestTable.tsx
+++ b/coral/src/app/features/requests/schemas/components/SchemaRequestTable.tsx
@@ -47,23 +47,23 @@ function SchemaRequestTable({
     },
     {
       type: "status",
+      field: "requestType",
+      headerName: "Request type",
+      status: ({ requestType }) => {
+        return {
+          status: requestOperationTypeChipStatusMap[requestType],
+          text: requestOperationTypeNameMap[requestType],
+        };
+      },
+    },
+    {
+      type: "status",
       field: "requestStatus",
       headerName: "Status",
       status: ({ requestStatus }) => {
         return {
           status: requestStatusChipStatusMap[requestStatus],
           text: requestStatusNameMap[requestStatus],
-        };
-      },
-    },
-    {
-      type: "status",
-      field: "requestType",
-      headerName: "Type",
-      status: ({ requestType }) => {
-        return {
-          status: requestOperationTypeChipStatusMap[requestType],
-          text: requestOperationTypeNameMap[requestType],
         };
       },
     },

--- a/coral/src/domain/schema-request/schema-request-api.ts
+++ b/coral/src/domain/schema-request/schema-request-api.ts
@@ -73,7 +73,12 @@ const getSchemaRequestsForApprover = (
 type GetSchemaRequestsQueryParams = ResolveIntersectionTypes<
   Pick<
     KlawApiRequestQueryParameters<"getSchemaRequests">,
-    "pageNo" | "requestStatus" | "topic" | "env" | "isMyRequest"
+    | "pageNo"
+    | "requestStatus"
+    | "topic"
+    | "env"
+    | "isMyRequest"
+    | "operationType"
   >
 >;
 
@@ -84,6 +89,7 @@ const getSchemaRequests = (
     myRequest?: "true" | "false";
   } = {
     pageNo: args.pageNo,
+    ...(args.operationType && { operationType: args.operationType }),
     ...(args.requestStatus && { requestStatus: args.requestStatus }),
     ...(args.topic && { topic: args.topic }),
     ...(args.env && args.env !== "ALL" && { env: args.env }),


### PR DESCRIPTION
# About this change - What it does

Adds filter for Request type in "My team's requests" for schemas. 

Notes: 

- the naming should be "Request type" everywhere, we decided to make that change in the end when all views are done to avoid conflicts etc. (issue for that #896)
- In this PR I changes the order of the columns in the table to match the order in the designs. I included that as a not in #896 so we can make that consistent through all tables)
- `operationType` does not have an "ALL" value like status -> which is more correct and we'll streamline status to follow that approach (follow up issue and more infos: #900) 
    - the handling of "ALL" value is a "for now working" solution here, in scope of the follow up we should check how we want to handle types and "who is responsible for creating what parameter" in frontend

Resolves: #847

Note: The screen recording is not super useful because all schema requests in staging for me are of type "create" :D 

https://user-images.githubusercontent.com/943800/227213483-16086baa-6031-4b74-bc48-49f54043ff86.mov


