### PR TITLE
fix(coral): Fix scrollbars showing inappropriately in Modals

### DIFF
--- a/coral/src/app/components/Modal.module.css
+++ b/coral/src/app/components/Modal.module.css
@@ -7,6 +7,6 @@
 }
 
 .modalTextBlock {
-  overflow: scroll;
+  overflow: auto;
   max-height: 70vh;
 }


### PR DESCRIPTION
## About this change - What it does

**Problem**: if OS sets "always show scrollbars" behaviour, then scrollbars always show in modals, even when not needed:

https://user-images.githubusercontent.com/20607294/227497279-a1cee8bd-5d9c-4ff5-bf5a-2583d504d18b.mov





**Solution**: set `overflow: auto` instead of `overflow: scroll` in Modal css

https://user-images.githubusercontent.com/20607294/227497507-23847d86-7986-4ffb-b027-5bd08be0f4cb.mov



