### PR TITLE
fix(coral): 🐛 Error identification in Coral fails 

### DIFF
--- a/coral/src/services/api.test.ts
+++ b/coral/src/services/api.test.ts
@@ -27,22 +27,16 @@ type HTTPScenario = {
 // Klaw currently does not return ERRORs from the API but always a 200
 // An error is always following this patter:
 // {
-//   status: null,
-//   timestamp: null,
-//   message: null,
-//   debugMessage: null,
-//   result: "Failure. <SOME MORE TEXT>",
-//   data: null,
+// status?: "100 CONTINUE" ...(etc._
+// timestamp?: string;
+// message?: string;
+// debugMessage?: string;
+// result: string;
+// data?: Record<string, never>;
 // };
-// to provide error messages for the user, we added a temp fix
-// see `checkForFailureHiddenAsSuccess` in api.ts
-// the HTTPScenario "fakeOk" is responsible for testing the fix
-// until it's removed
+// to provide error messages for the user, we added this
+// temp fix. It can be removed once the API is updated
 const klawResponseResultWithHiddenError: GenericApiResponse = {
-  data: {},
-  timestamp: "",
-  debugMessage: "",
-  message: "",
   result: "Failure. A request already exists for this topic.",
   status: "200 OK",
 };

--- a/coral/src/services/api.ts
+++ b/coral/src/services/api.ts
@@ -207,28 +207,22 @@ const checkStatus = (response: Response): Promise<Response> => {
 function isGenericApiResponse(
   response: unknown | unknown[]
 ): response is GenericApiResponse {
-  return (
-    objectHasProperty(response, "timestamp") &&
-    objectHasProperty(response, "data") &&
-    objectHasProperty(response, "debugMessage") &&
-    objectHasProperty(response, "message") &&
-    objectHasProperty(response, "result") &&
-    objectHasProperty(response, "status")
-  );
+  return objectHasProperty(response, "result");
 }
 
 // Klaw currently does not return ERRORs from the API but always a 200
 // An error is always following this patter:
 // {
-//   status: null,
-//   timestamp: null,
-//   message: null,
-//   debugMessage: null,
-//   result: "Failure. <SOME MORE TEXT>",
-//   data: null,
+// status?: "100 CONTINUE" ...(etc._
+// timestamp?: string;
+// message?: string;
+// debugMessage?: string;
+// result: string;
+// data?: Record<string, never>;
 // };
 // to provide error messages for the user, we added this
 // temp fix. It can be removed once the API is updated
+
 async function checkForFailureHiddenAsSuccess<TResponse extends SomeObject>(
   response: TResponse
 ): Promise<TResponse> {


### PR DESCRIPTION
Resolves: #906

# About this change - What it does

- Updates the `isGenericApiResponse` check to match the updated api. (description in linked issue)

## Why this way
We now treat nullable properties differently and get different types. Before, an `ApiResponse` hiding an error would always follow this pattern:

```
 {
   status: null,
   timestamp: null,
   message: null,
   debugMessage: null,
   result: "Failure. <SOME MORE TEXT>",
   data: null,
 };
```
 
 Now, e.g. `status` is a property on the response when it's not set (and not `null` like before). That's why `isGenericApiResponse` returned `false`, so we didn't check it for the error pattern.
 
 ## Error behaviour in "create new schema request"
- request a schema where there's already an existing one
- hit "submit"
- coral think's it's a success and redirects user, even tho there is a hidden error 
- 
<img width="1458" alt="Screenshot 2023-03-24 at 12 41 03" src="https://user-images.githubusercontent.com/943800/227512628-67ef8bed-80e6-4aed-9147-9a2a2f79d814.png">

## Error behaviour after the change 
- request a schema where there's already an existing one
- hit "submit"
- our api identifies the error, rejects it interally and the UI behaves as if the api would have returned a `400`

<img width="1472" alt="Screenshot 2023-03-24 at 12 40 24" src="https://user-images.githubusercontent.com/943800/227514479-a50f1b8e-29c8-4a6f-aec5-12a4f221edd5.png">
