### PR TITLE
Configure pom to build the openapi.yaml off port 8097

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -266,7 +266,7 @@
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-maven-plugin</artifactId>
                 <configuration>
-                    <jvmArguments>-Dspringdoc.writer-with-default-pretty-printer=true </jvmArguments>
+                    <jvmArguments>-Dspringdoc.writer-with-default-pretty-printer=true -Dserver.port=8097</jvmArguments>
                 </configuration>
                 <executions>
                     <execution>
@@ -275,6 +275,7 @@
                             <goal>stop</goal>
                         </goals>
                         <configuration>
+
                             <maxAttempts>${spring.integration.test.timeout}</maxAttempts>
                         </configuration>
                     </execution>
@@ -285,7 +286,7 @@
                 <artifactId>springdoc-openapi-maven-plugin</artifactId>
                 <version>${springdoc-openapi-maven-plugin.version}</version>
                 <configuration>
-                    <apiDocsUrl>http://localhost:9097/v3/api-docs</apiDocsUrl>
+                    <apiDocsUrl>http://localhost:8097/v3/api-docs</apiDocsUrl>
                     <outputFileName>openapi.yaml</outputFileName>
                     <outputDir>${project.parent.basedir}</outputDir>
                     <skip>false</skip>

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -17,7 +17,7 @@
     "url" : "https://www.klaw-project.io/docs"
   },
   "servers" : [ {
-    "url" : "http://localhost:9097",
+    "url" : "http://localhost:8097",
     "description" : "Generated server url"
   } ],
   "paths" : {


### PR DESCRIPTION
About this change - What it does
This change allowsklaw to be built on a system that is already running an existing version of klaw by changing the openapi port to the non standard 8097.
Resolves: #741 
Why this way
This allows users to pull and build changes on a server or device without having to take down an existing running version of Klaw.