### PR TITLE
Resolves a defect where the schema environments were not returned in …

### DIFF
--- a/core/src/main/java/io/aiven/klaw/service/ServerConfigService.java
+++ b/core/src/main/java/io/aiven/klaw/service/ServerConfigService.java
@@ -319,6 +319,19 @@ public class ServerConfigService {
                 });
         tenant.setRequestConnectorsEnvironmentsList(tmpReqTopicList1);
       }
+      // Schema
+      if (tenant.getRequestSchemaEnvironmentsList() != null) {
+        List<String> tmpSchemaReqList = new ArrayList<>();
+        tenant
+            .getRequestSchemaEnvironmentsList()
+            .forEach(
+                a -> {
+                  if (getSchemaEnvDetails(a, tenantId) != null) {
+                    tmpSchemaReqList.add(getSchemaEnvDetails(a, tenantId).getName());
+                  }
+                });
+        tenant.setRequestSchemaEnvironmentsList(tmpSchemaReqList);
+      }
     }
   }
 
@@ -396,6 +409,20 @@ public class ServerConfigService {
                                 a, getTenantIdFromName(tenantModel.getTenantName()))
                             .getId()));
         tenantModel.setRequestConnectorsEnvironmentsList(tmpReqTopicList1);
+      }
+
+      // kafka
+      if (tenantModel.getRequestSchemaEnvironmentsList() != null) {
+        List<String> tmpSchemaReqList = new ArrayList<>();
+        tenantModel
+            .getRequestSchemaEnvironmentsList()
+            .forEach(
+                a ->
+                    tmpSchemaReqList.add(
+                        getSchemaEnvDetailsFromName(
+                                a, getTenantIdFromName(tenantModel.getTenantName()))
+                            .getId()));
+        tenantModel.setRequestSchemaEnvironmentsList(tmpSchemaReqList);
       }
     }
   }


### PR DESCRIPTION
Resolves a defect where the schema environments were not returned in the dropdown when requesting a schema or tenant model

About this change - What it does

Why this way
This mirrors how other envs are treated in the tenant env.