### PR TITLE
Service acnts

### DIFF
--- a/core/src/main/java/io/aiven/klaw/dao/Env.java
+++ b/core/src/main/java/io/aiven/klaw/dao/Env.java
@@ -1,6 +1,6 @@
 package io.aiven.klaw.dao;
 
-import io.aiven.klaw.converter.EnvTagConverter;
+import io.aiven.klaw.helpers.EnvTagConverter;
 import jakarta.persistence.Column;
 import jakarta.persistence.Convert;
 import jakarta.persistence.Entity;

--- a/core/src/main/java/io/aiven/klaw/dao/ServiceAccounts.java
+++ b/core/src/main/java/io/aiven/klaw/dao/ServiceAccounts.java
@@ -1,0 +1,15 @@
+package io.aiven.klaw.dao;
+
+import java.io.Serializable;
+import java.util.Set;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+
+@Data
+@EqualsAndHashCode
+public class ServiceAccounts implements Serializable {
+
+  private int numberOfAllowedAccounts;
+
+  private Set<String> serviceAccountsList;
+}

--- a/core/src/main/java/io/aiven/klaw/dao/Team.java
+++ b/core/src/main/java/io/aiven/klaw/dao/Team.java
@@ -1,6 +1,8 @@
 package io.aiven.klaw.dao;
 
+import io.aiven.klaw.helpers.ServiceAccountsConverter;
 import jakarta.persistence.Column;
+import jakarta.persistence.Convert;
 import jakarta.persistence.Entity;
 import jakarta.persistence.Id;
 import jakarta.persistence.IdClass;
@@ -46,6 +48,10 @@ public class Team implements Serializable {
 
   @Column(name = "restrictionsobj")
   private String restrictionsObj;
+
+  @Convert(converter = ServiceAccountsConverter.class)
+  @Column(name = "serviceaccounts")
+  private ServiceAccounts serviceAccounts;
 
   @Column(name = "otherparams")
   private String otherParams;

--- a/core/src/main/java/io/aiven/klaw/helpers/EnvTagConverter.java
+++ b/core/src/main/java/io/aiven/klaw/helpers/EnvTagConverter.java
@@ -1,4 +1,4 @@
-package io.aiven.klaw.converter;
+package io.aiven.klaw.helpers;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;

--- a/core/src/main/java/io/aiven/klaw/helpers/ServiceAccountsConverter.java
+++ b/core/src/main/java/io/aiven/klaw/helpers/ServiceAccountsConverter.java
@@ -1,0 +1,41 @@
+package io.aiven.klaw.helpers;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.aiven.klaw.dao.ServiceAccounts;
+import jakarta.persistence.AttributeConverter;
+import jakarta.persistence.Converter;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Converter
+public class ServiceAccountsConverter implements AttributeConverter<ServiceAccounts, String> {
+
+  ObjectMapper mapper = new ObjectMapper();
+
+  @Override
+  public String convertToDatabaseColumn(ServiceAccounts serviceAccounts) {
+    String serviceAccountsStr = null;
+    try {
+      if (serviceAccounts != null) {
+        serviceAccountsStr = mapper.writeValueAsString(serviceAccounts);
+      }
+    } catch (JsonProcessingException e) {
+      log.error("Exception converting object to json: {}", e.getMessage());
+    }
+    return serviceAccountsStr;
+  }
+
+  @Override
+  public ServiceAccounts convertToEntityAttribute(String serviceAccountsStr) {
+    ServiceAccounts serviceAccounts = null;
+    try {
+      if (serviceAccountsStr != null) {
+        serviceAccounts = mapper.readValue(serviceAccountsStr, ServiceAccounts.class);
+      }
+    } catch (JsonProcessingException e) {
+      log.error("Exception converting json to object: {}", e.getMessage());
+    }
+    return serviceAccounts;
+  }
+}

--- a/core/src/main/java/io/aiven/klaw/model/response/TeamModelResponse.java
+++ b/core/src/main/java/io/aiven/klaw/model/response/TeamModelResponse.java
@@ -1,5 +1,6 @@
 package io.aiven.klaw.model.response;
 
+import io.aiven.klaw.dao.ServiceAccounts;
 import jakarta.validation.constraints.NotNull;
 import java.io.Serializable;
 import java.util.List;
@@ -25,6 +26,8 @@ public class TeamModelResponse implements Serializable {
   @NotNull private boolean showDeleteTeam;
 
   @NotNull private String tenantName;
+
+  private ServiceAccounts serviceAccounts;
 
   private String app;
 

--- a/core/src/main/java/io/aiven/klaw/service/AclControllerService.java
+++ b/core/src/main/java/io/aiven/klaw/service/AclControllerService.java
@@ -47,6 +47,7 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Service;
@@ -56,8 +57,8 @@ import org.springframework.stereotype.Service;
 public class AclControllerService {
   public static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
   public static final String SEPARATOR_ACL = "<ACL>";
-
-  private static final int ALLOWED_SERVICE_ACCOUNTS_PER_TEAM = 25;
+  @Value("${klaw.service.accounts.perteam:25}")
+  private int allowedServiceAccountsPerTeam;
   @Autowired ManageDatabase manageDatabase;
 
   @Autowired private final MailUtils mailService;
@@ -667,7 +668,7 @@ public class AclControllerService {
         serviceAccounts.getServiceAccountsList().add(aclRequest.getAcl_ssl());
       } else {
         serviceAccounts = new ServiceAccounts();
-        serviceAccounts.setNumberOfAllowedAccounts(ALLOWED_SERVICE_ACCOUNTS_PER_TEAM);
+        serviceAccounts.setNumberOfAllowedAccounts(allowedServiceAccountsPerTeam);
         serviceAccounts.setServiceAccountsList(new HashSet<>());
         serviceAccounts.getServiceAccountsList().add(aclRequest.getAcl_ssl());
         optionalTeam.get().setServiceAccounts(serviceAccounts);

--- a/core/src/main/java/io/aiven/klaw/service/AclControllerService.java
+++ b/core/src/main/java/io/aiven/klaw/service/AclControllerService.java
@@ -57,8 +57,10 @@ import org.springframework.stereotype.Service;
 public class AclControllerService {
   public static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
   public static final String SEPARATOR_ACL = "<ACL>";
+
   @Value("${klaw.service.accounts.perteam:25}")
   private int allowedServiceAccountsPerTeam;
+
   @Autowired ManageDatabase manageDatabase;
 
   @Autowired private final MailUtils mailService;

--- a/core/src/main/resources/application.properties
+++ b/core/src/main/resources/application.properties
@@ -155,6 +155,9 @@ klaw.max.tenants=200
 # ClusterApi access
 klaw.clusterapi.access.username=kwclusterapiuser
 
+# Number of service accounts for a team
+klaw.service.accounts.perteam=25
+
 # Monitoring
 klaw.monitoring.metrics.enable=false
 klaw.monitoring.metrics.collectinterval.ms=60000

--- a/core/src/main/resources/db/changelog/changelog.yaml
+++ b/core/src/main/resources/db/changelog/changelog.yaml
@@ -1013,3 +1013,13 @@ databaseChangeLog:
                     name: complete
                     type: boolean
               tableName: kwdatamigration
+    - changeSet:
+        id: 24-03-2023 New Column - to store service accounts of a team
+        author: muralibasani
+        changes:
+          - addColumn:
+              tableName: kwteams
+              columns:
+                - column:
+                    name: serviceaccounts
+                    type: CLOB

--- a/core/src/main/resources/templates/requestAcls.html
+++ b/core/src/main/resources/templates/requestAcls.html
@@ -717,7 +717,7 @@
 												<br>
 												<small class="form-control-feedback" ng-if = "serviceAccounts != null && serviceAccounts.length > 0">
 													<b>Note:</b>
-													The following service accounts exist for this environment !!
+													The following service accounts exist for your team in this environment !!
 													<table style="border: 1px gray;">
 														<tr valign="top" ng-repeat="serviceAccount in serviceAccounts track by $index">
 															<td>{{ serviceAccount }}</td>

--- a/core/src/test/java/io/aiven/klaw/MockMethods.java
+++ b/core/src/test/java/io/aiven/klaw/MockMethods.java
@@ -3,6 +3,7 @@ package io.aiven.klaw;
 import io.aiven.klaw.model.*;
 import io.aiven.klaw.model.KafkaSupportedProtocol;
 import io.aiven.klaw.model.enums.KafkaClustersType;
+import io.aiven.klaw.model.enums.KafkaFlavors;
 import io.aiven.klaw.model.requests.EnvModel;
 import io.aiven.klaw.model.requests.TeamModel;
 import java.util.HashSet;
@@ -79,7 +80,18 @@ public class MockMethods {
     kwClustersModel.setBootstrapServers("localhost:9092");
     kwClustersModel.setProtocol(KafkaSupportedProtocol.PLAINTEXT);
     kwClustersModel.setClusterType(KafkaClustersType.KAFKA.value);
-    kwClustersModel.setKafkaFlavor("Apache Kafka");
+    kwClustersModel.setKafkaFlavor(KafkaFlavors.APACHE_KAFKA.value);
+
+    return kwClustersModel;
+  }
+
+  public KwClustersModel getAivenKafkaClusterModel(String dev_cluster) {
+    KwClustersModel kwClustersModel = new KwClustersModel();
+    kwClustersModel.setClusterName(dev_cluster);
+    kwClustersModel.setBootstrapServers("localhost:9092");
+    kwClustersModel.setProtocol(KafkaSupportedProtocol.PLAINTEXT);
+    kwClustersModel.setClusterType(KafkaClustersType.KAFKA.value);
+    kwClustersModel.setKafkaFlavor(KafkaFlavors.AIVEN_FOR_APACHE_KAFKA.value);
 
     return kwClustersModel;
   }

--- a/core/src/test/java/io/aiven/klaw/UtilMethods.java
+++ b/core/src/test/java/io/aiven/klaw/UtilMethods.java
@@ -7,6 +7,7 @@ import io.aiven.klaw.dao.Env;
 import io.aiven.klaw.dao.KwClusters;
 import io.aiven.klaw.dao.MessageSchema;
 import io.aiven.klaw.dao.SchemaRequest;
+import io.aiven.klaw.dao.ServiceAccounts;
 import io.aiven.klaw.dao.Team;
 import io.aiven.klaw.dao.Topic;
 import io.aiven.klaw.dao.TopicRequest;
@@ -303,7 +304,15 @@ public class UtilMethods {
     team.setTeamphone("3142342343242");
     team.setTeammail("test@test.com");
 
+    ServiceAccounts serviceAccounts = new ServiceAccounts();
+    Set<String> serviceAccountsList = new HashSet<>();
+    serviceAccountsList.add("user1");
+    serviceAccountsList.add("user2");
+    serviceAccounts.setNumberOfAllowedAccounts(25);
+    serviceAccounts.setServiceAccountsList(serviceAccountsList);
+    team.setServiceAccounts(serviceAccounts);
     allTopicReqs.add(team);
+
     return allTopicReqs;
   }
 

--- a/core/src/test/java/io/aiven/klaw/UtilMethods.java
+++ b/core/src/test/java/io/aiven/klaw/UtilMethods.java
@@ -595,6 +595,25 @@ public class UtilMethods {
     return aclRequest;
   }
 
+  public AclRequestsModel getAivenAclRequestModel(String topic) {
+    AclRequestsModel aclRequest = new AclRequestsModel();
+    aclRequest.setTeamId(1001);
+    aclRequest.setEnvironment("2");
+    aclRequest.setTopicname(topic);
+    aclRequest.setRequestor("kwusera");
+    aclRequest.setAclType(AclType.CONSUMER);
+    ArrayList<String> sslList = new ArrayList<>();
+    sslList.add("user1");
+    aclRequest.setAcl_ip(null);
+    aclRequest.setAcl_ssl(sslList);
+    aclRequest.setAclPatternType(AclPatternType.LITERAL.value);
+    aclRequest.setRequestingteam(1);
+    aclRequest.setAclIpPrincipleType(AclIPPrincipleType.PRINCIPAL);
+    aclRequest.setRequestOperationType(RequestOperationType.CREATE);
+
+    return aclRequest;
+  }
+
   public List<Map<String, String>> getClusterApiTopics(String topicPrefix, int size) {
     List<Map<String, String>> listTopics = new ArrayList<>();
     HashMap<String, String> hashMap;


### PR DESCRIPTION
About this change - What it does
As part of Acl request for Aiven system, service accounts are created. To maintain security of those accounts, and prevents from being used by other teams, they are assigned to teams.

Resolves: #723
Why this way

This prevents users from teams to use the service accounts of different teams.