### PR TITLE
refactor(coral): Better error handling for ApiResonse[] cases

### DIFF
--- a/coral/src/app/features/approvals/acls/AclApprovals.tsx
+++ b/coral/src/app/features/approvals/acls/AclApprovals.tsx
@@ -77,15 +77,7 @@ function AclApprovals() {
     variables: approveVariables,
   } = useMutation({
     mutationFn: approveAclRequest,
-    onSuccess: (responses) => {
-      const response = responses[0];
-      const responseIsAHiddenError =
-        response?.result.toLowerCase() !== "success";
-      if (responseIsAHiddenError) {
-        return setErrorMessage(
-          response.message || response.result || "Unexpected error"
-        );
-      }
+    onSuccess: () => {
       setErrorMessage("");
       setDetailsModal({ isOpen: false, reqNo: null });
 
@@ -98,9 +90,9 @@ function AclApprovals() {
       // We also do not need to invalidate the query, as the activePage does not exist any more
       // And there is no need to update anything on it
       if (data?.entries.length === 1 && data?.currentPage > 1) {
-        return handleChangePage(currentPage - 1);
+        handleChangePage(currentPage - 1);
+        return;
       }
-
       // Refetch to keep Table state in sync
       queryClient.refetchQueries(["aclRequests"]);
     },
@@ -115,15 +107,7 @@ function AclApprovals() {
     variables: declineVariables,
   } = useMutation({
     mutationFn: declineAclRequest,
-    onSuccess: (responses) => {
-      const response = responses[0];
-      const responseIsAHiddenError =
-        response?.result.toLowerCase() !== "success";
-      if (responseIsAHiddenError) {
-        return setErrorMessage(
-          response.message || response.result || "Unexpected error"
-        );
-      }
+    onSuccess: () => {
       setErrorMessage("");
       setDeclineModal({ isOpen: false, reqNo: null });
 
@@ -136,7 +120,8 @@ function AclApprovals() {
       // We also do not need to invalidate the query, as the activePage does not exist any more
       // And there is no need to update anything on it
       if (data?.entries.length === 1 && data?.currentPage > 1) {
-        return handleChangePage(currentPage - 1);
+        handleChangePage(currentPage - 1);
+        return;
       }
 
       // We need to refetch all aclrequests queries to keep Table state in sync

--- a/coral/src/app/features/approvals/schemas/SchemaApprovals.test.tsx
+++ b/coral/src/app/features/approvals/schemas/SchemaApprovals.test.tsx
@@ -584,7 +584,9 @@ describe("SchemaApprovals", () => {
   describe("enables user to decline a request", () => {
     const testRequest = mockedApiResponseSchemaRequests.entries[0];
 
+    const originalConsoleError = console.error;
     beforeEach(async () => {
+      console.error = jest.fn();
       mockGetSchemaRegistryEnvironments.mockResolvedValue(
         mockedEnvironmentResponse
       );
@@ -601,6 +603,7 @@ describe("SchemaApprovals", () => {
     });
 
     afterEach(() => {
+      console.error = originalConsoleError;
       jest.clearAllMocks();
       cleanup();
     });
@@ -630,6 +633,7 @@ describe("SchemaApprovals", () => {
       await userEvent.tab();
 
       expect(confirmDeclineButton).toBeEnabled();
+      expect(console.error).not.toHaveBeenCalled();
     });
 
     it("send a decline request api call if user declines a schema request", async () => {
@@ -658,6 +662,7 @@ describe("SchemaApprovals", () => {
         reqIds: [testRequest.req_no.toString()],
         reason: "This is my message",
       });
+      expect(console.error).not.toHaveBeenCalled();
     });
 
     it("updates the the data for the table if user declined a schema request", async () => {
@@ -696,10 +701,11 @@ describe("SchemaApprovals", () => {
         2,
         defaultApiParams
       );
+      expect(console.error).not.toHaveBeenCalled();
     });
 
     it("informs user about error if declining request was not successful", async () => {
-      mockDeclineSchemaRequest.mockResolvedValue([{ result: "FAILURE" }]);
+      mockDeclineSchemaRequest.mockRejectedValue("OH NO");
       expect(mockGetSchemaRequestsForApprover).toHaveBeenNthCalledWith(
         1,
         defaultApiParams
@@ -734,13 +740,18 @@ describe("SchemaApprovals", () => {
 
       const error = screen.getByRole("alert");
       expect(error).toBeVisible();
+
+      expect(console.error).toHaveBeenCalledWith("OH NO");
     });
   });
 
   describe("enables user to approve a request", () => {
     const testRequest = mockedApiResponseSchemaRequests.entries[0];
 
+    const orignalConsoleError = console.error;
     beforeEach(async () => {
+      console.error = jest.fn();
+
       mockGetSchemaRegistryEnvironments.mockResolvedValue(
         mockedEnvironmentResponse
       );
@@ -757,6 +768,7 @@ describe("SchemaApprovals", () => {
     });
 
     afterEach(() => {
+      console.error = orignalConsoleError;
       jest.clearAllMocks();
       cleanup();
     });
@@ -773,6 +785,7 @@ describe("SchemaApprovals", () => {
       expect(mockApproveSchemaRequest).toHaveBeenCalledWith({
         reqIds: [testRequest.req_no.toString()],
       });
+      expect(console.error).not.toHaveBeenCalled();
     });
 
     it("updates the the data for the table if user approves a schema request", async () => {
@@ -796,10 +809,11 @@ describe("SchemaApprovals", () => {
         2,
         defaultApiParams
       );
+      expect(console.error).not.toHaveBeenCalled();
     });
 
     it("informs user about error if declining request was not successful", async () => {
-      mockApproveSchemaRequest.mockResolvedValue([{ result: "FAILURE" }]);
+      mockApproveSchemaRequest.mockRejectedValue("OH NO");
       expect(mockGetSchemaRequestsForApprover).toHaveBeenNthCalledWith(
         1,
         defaultApiParams
@@ -819,6 +833,8 @@ describe("SchemaApprovals", () => {
 
       const error = await screen.findByRole("alert");
       expect(error).toBeVisible();
+
+      expect(console.error).toHaveBeenCalledWith("OH NO");
     });
   });
 });

--- a/coral/src/app/features/approvals/schemas/SchemaApprovals.tsx
+++ b/coral/src/app/features/approvals/schemas/SchemaApprovals.tsx
@@ -76,23 +76,9 @@ function SchemaApprovals() {
     isLoading: declineIsLoading,
     variables: declineVariables,
   } = useMutation(declineSchemaRequest, {
-    onSuccess: (responses) => {
-      // @TODO follow up ticket #707
-      // (for all approval tables)
-      const response = responses[0];
-      const responseIsAHiddenError =
-        response?.result.toLowerCase() !== "success";
-      if (responseIsAHiddenError) {
-        return setErrorQuickActions(
-          response.message || response.result || "Unexpected error"
-        );
-      }
-
+    onSuccess: () => {
       setErrorQuickActions("");
-      setDetailsModal({ isOpen: false, reqNo: null });
-      setDeclineModal({ isOpen: false, reqNo: null });
-
-      // Refetch to update the tag number in the tabs
+      // Re-fetch to update the tag number in the tabs
       queryClient.refetchQueries(["getRequestsWaitingForApproval"]);
 
       // If declined request is last in the page, go back to previous page
@@ -104,11 +90,12 @@ function SchemaApprovals() {
         schemaRequests?.entries.length === 1 &&
         schemaRequests?.currentPage > 1
       ) {
-        return setCurrentPage(schemaRequests?.currentPage - 1);
+        // setting the current page will the api call to re-fetch the schema requests
+        setCurrentPage(schemaRequests?.currentPage - 1);
+      } else {
+        // We need to refetch the schema requests to keep Table state in sync
+        queryClient.refetchQueries(["schemaRequestsForApprover"]);
       }
-
-      // We need to refetch all aclrequests queries to keep Table state in sync
-      queryClient.refetchQueries(["schemaRequestsForApprover"]);
     },
     onError(error: Error) {
       setErrorQuickActions(parseErrorMsg(error));
@@ -123,18 +110,7 @@ function SchemaApprovals() {
     isLoading: approveIsLoading,
     variables: approveVariables,
   } = useMutation(approveSchemaRequest, {
-    onSuccess: (responses) => {
-      // @TODO follow up ticket #707
-      // (for all approval tables)
-      const response = responses[0];
-      const responseIsAHiddenError =
-        response?.result.toLowerCase() !== "success";
-      if (responseIsAHiddenError) {
-        return setErrorQuickActions(
-          response.message || response.result || "Unexpected error"
-        );
-      }
-
+    onSuccess: () => {
       setErrorQuickActions("");
       setDetailsModal({ isOpen: false, reqNo: null });
       setDeclineModal({ isOpen: false, reqNo: null });

--- a/coral/src/app/features/approvals/topics/TopicApprovals.tsx
+++ b/coral/src/app/features/approvals/topics/TopicApprovals.tsx
@@ -86,17 +86,7 @@ function TopicApprovals() {
     variables: approveVariables,
   } = useMutation({
     mutationFn: approveTopicRequest,
-    onSuccess: (responses) => {
-      // This mutation is used on a single request, so we always want the first response in the array
-      const response = responses[0];
-      const responseIsAHiddenError =
-        response?.result.toLowerCase() !== "success";
-      if (responseIsAHiddenError) {
-        return setErrorMessage(
-          response.message || response.result || "Unexpected error"
-        );
-      }
-
+    onSuccess: () => {
       setErrorMessage("");
       setDetailsModal({ isOpen: false, reqNo: null });
 
@@ -112,7 +102,8 @@ function TopicApprovals() {
         topicRequests?.entries.length === 1 &&
         topicRequests?.currentPage > 1
       ) {
-        return handleChangePage(currentPage - 1);
+        handleChangePage(currentPage - 1);
+        return;
       }
 
       // We need to refetch all aclrequests queries to keep Table state in sync
@@ -133,16 +124,7 @@ function TopicApprovals() {
     variables: declineVariables,
   } = useMutation({
     mutationFn: declineTopicRequest,
-    onSuccess: (responses) => {
-      // This mutation is used on a single request, so we always want the first response in the array
-      const response = responses[0];
-      const responseIsAHiddenError =
-        response?.result.toLowerCase() !== "success";
-      if (responseIsAHiddenError) {
-        return setErrorMessage(
-          response.message || response.result || "Unexpected error"
-        );
-      }
+    onSuccess: () => {
       setErrorMessage("");
       setDeclineModal({ isOpen: false, reqNo: null });
 
@@ -158,7 +140,8 @@ function TopicApprovals() {
         topicRequests?.entries.length === 1 &&
         topicRequests?.currentPage > 1
       ) {
-        return handleChangePage(currentPage - 1);
+        handleChangePage(currentPage - 1);
+        return;
       }
 
       // We need to refetch all aclrequests queries to keep Table state in sync

--- a/coral/src/app/features/components/layouts/TableLayout.tsx
+++ b/coral/src/app/features/components/layouts/TableLayout.tsx
@@ -13,7 +13,14 @@ type TableLayoutProps = {
 };
 
 function TableLayout(props: TableLayoutProps) {
-  const { filters, table, pagination, isLoading, isErrorLoading } = props;
+  const {
+    filters,
+    table,
+    pagination,
+    isLoading,
+    isErrorLoading,
+    errorMessage,
+  } = props;
 
   return (
     <>
@@ -43,7 +50,7 @@ function TableLayout(props: TableLayoutProps) {
       {isErrorLoading && (
         <div role={"alert"}>
           <Alert type={"error"}>
-            {parseErrorMsg(props.errorMessage)}. Please try again later!
+            {parseErrorMsg(errorMessage)}. Please try again later!
           </Alert>
         </div>
       )}

--- a/coral/src/app/features/components/layouts/TableLayout.tsx
+++ b/coral/src/app/features/components/layouts/TableLayout.tsx
@@ -15,8 +15,6 @@ type TableLayoutProps = {
 function TableLayout(props: TableLayoutProps) {
   const { filters, table, pagination, isLoading, isErrorLoading } = props;
 
-  const errorMessage = parseErrorMsg(props.errorMessage);
-
   return (
     <>
       <Box
@@ -44,7 +42,9 @@ function TableLayout(props: TableLayoutProps) {
       {isLoading && <SkeletonTable />}
       {isErrorLoading && (
         <div role={"alert"}>
-          <Alert type={"error"}>{errorMessage}. Please try again later!</Alert>
+          <Alert type={"error"}>
+            {parseErrorMsg(props.errorMessage)}. Please try again later!
+          </Alert>
         </div>
       )}
       {!isLoading && !isErrorLoading && (

--- a/coral/src/app/features/requests/acls/AclRequests.tsx
+++ b/coral/src/app/features/requests/acls/AclRequests.tsx
@@ -87,33 +87,16 @@ function AclRequests() {
 
   const { isLoading: deleteIsLoading, mutate: deleteRequest } = useMutation({
     mutationFn: deleteAclRequest,
-    onSuccess: async (responses) => {
-      const response = responses[0];
-
-      const responseIsAHiddenError =
-        response?.result.toLowerCase() !== "success";
-      if (responseIsAHiddenError) {
-        throw Error(response.message || response.result || "Unexpected error");
-      }
-
+    onSuccess: async () => {
       setErrorMessage("");
-
       // We need to refetch all aclrequests queries to keep Table state in sync
       // We await it to only close modal after refetch is done
       await queryClient.refetchQueries(["aclRequests"]);
-
-      closeModal();
     },
     onError: (error: Error) => {
-      closeModal();
-
-      // Case when error is from the server
-      if (objectHasProperty(error, "data")) {
-        return setErrorMessage(parseErrorMsg(error));
-      }
-      // Case when the error is thrown from onSuccess
-      setErrorMessage(error.message);
+      setErrorMessage(parseErrorMsg(error));
     },
+    onSettled: closeModal,
   });
 
   const handleChangePage = (page: number) => {

--- a/coral/src/app/features/requests/acls/AclRequests.tsx
+++ b/coral/src/app/features/requests/acls/AclRequests.tsx
@@ -17,7 +17,6 @@ import { AclRequestsTable } from "src/app/features/requests/acls/components/AclR
 import { DeleteRequestDialog } from "src/app/features/requests/components/DeleteRequestDialog";
 import { deleteAclRequest, getAclRequests } from "src/domain/acl/acl-api";
 import { parseErrorMsg } from "src/services/mutation-utils";
-import { objectHasProperty } from "src/services/type-utils";
 
 function AclRequests() {
   const queryClient = useQueryClient();

--- a/coral/src/app/features/requests/schemas/SchemaRequests.test.tsx
+++ b/coral/src/app/features/requests/schemas/SchemaRequests.test.tsx
@@ -769,9 +769,7 @@ describe("SchemaRequest", () => {
     });
 
     it("informs user about error if deleting request was not successful and error is hidden in success", async () => {
-      mockDeleteSchemaRequest.mockResolvedValue([
-        { result: "FAILURE", message: "OH NO" },
-      ]);
+      mockDeleteSchemaRequest.mockRejectedValue("OH NO");
       expect(mockGetSchemaRequests).toHaveBeenNthCalledWith(
         1,
         defaultApiParams
@@ -800,8 +798,7 @@ describe("SchemaRequest", () => {
       const error = screen.getByRole("alert");
       expect(error).toBeVisible();
 
-      const expectedError = new Error("OH NO");
-      expect(console.error).toHaveBeenCalledWith(expectedError);
+      expect(console.error).toHaveBeenCalledWith("OH NO");
     });
   });
 });

--- a/coral/src/app/features/requests/topics/TopicRequests.test.tsx
+++ b/coral/src/app/features/requests/topics/TopicRequests.test.tsx
@@ -581,9 +581,7 @@ describe("TopicRequests", () => {
     });
 
     it("informs user about error if deleting request was not successful and error is hidden in success", async () => {
-      mockDeleteTopicRequest.mockResolvedValue([
-        { result: "FAILURE", message: "OH NO" },
-      ]);
+      mockDeleteTopicRequest.mockRejectedValue("OH NO");
       expect(mockGetTopicRequests).toHaveBeenNthCalledWith(1, {
         pageNo: "1",
         // search: "abc",
@@ -615,8 +613,7 @@ describe("TopicRequests", () => {
       const error = screen.getByRole("alert");
       expect(error).toBeVisible();
 
-      const expectedError = new Error("OH NO");
-      expect(console.error).toHaveBeenCalledWith(expectedError);
+      expect(console.error).toHaveBeenCalledWith("OH NO");
     });
   });
 });

--- a/coral/src/app/features/requests/topics/TopicRequests.tsx
+++ b/coral/src/app/features/requests/topics/TopicRequests.tsx
@@ -15,7 +15,6 @@ import { useFiltersValues } from "src/app/features/components/filters/useFilters
 import { useState } from "react";
 import { Alert } from "@aivenio/aquarium";
 import { DeleteRequestDialog } from "src/app/features/requests/components/DeleteRequestDialog";
-import { objectHasProperty } from "src/services/type-utils";
 import { parseErrorMsg } from "src/services/mutation-utils";
 
 const defaultStatus = "ALL";
@@ -59,35 +58,15 @@ function TopicRequests() {
 
   const { mutate: deleteRequest, isLoading: deleteRequestIsLoading } =
     useMutation(deleteTopicRequest, {
-      onSuccess: (responses) => {
-        // @TODO follow up ticket #707
-        // (for all approval and request tables)
-        const response = responses[0];
-        const responseIsAHiddenError = response?.result !== "success";
-        if (responseIsAHiddenError) {
-          throw new Error(response?.message || response?.result);
-        }
+      onSuccess: async () => {
         setErrorQuickActions("");
         // We need to refetch all requests to keep Table state in sync
-        queryClient.refetchQueries(["topicRequests"]).then(() => {
-          // only close the modal when data in background is updated
-          closeModal();
-        });
+        await queryClient.refetchQueries(["topicRequests"]);
       },
       onError(error: Error) {
-        let errorMessage: string;
-        // if error comes from our api, it has a `data` property
-        // parseErrorMsg makes sure to get the right message
-        // OR set a generic error message
-        if (objectHasProperty(error, "data")) {
-          errorMessage = parseErrorMsg(error);
-        } else {
-          errorMessage = error.message;
-        }
-
-        setErrorQuickActions(errorMessage);
-        closeModal();
+        setErrorQuickActions(parseErrorMsg(error));
       },
+      onSettled: closeModal,
     });
 
   function closeModal() {

--- a/coral/src/services/api.ts
+++ b/coral/src/services/api.ts
@@ -261,6 +261,17 @@ function handleHTTPError(errorOrResponse: Error | Response): Promise<never> {
   if (errorOrResponse instanceof Response) {
     return parseResponseBody(errorOrResponse).then((body) => {
       const bodyToReturn = isArray(body) ? body[0] : body;
+      // We have api endpoints that return ApiResponse[]
+      // these endpoints are all meant for enabling "batch" processing,
+      // for example to delete multiple requests
+      // this is currently not implemented as a feature.
+      // If this endpoints contain an error, it will be contained
+      // in the first (and only) entry of the ApiResponse[]
+      // which is why we return that entry as body in case the
+      // body is an array. This enables us to show the correct
+      // error message to users.
+      // see more details: https://github.com/aiven/klaw/pull/921#issue-1641959704
+
       const httpError: HTTPError = {
         data: bodyToReturn,
         status: errorOrResponse.status,

--- a/coral/src/services/api.ts
+++ b/coral/src/services/api.ts
@@ -3,6 +3,7 @@ import isPlainObject from "lodash/isPlainObject";
 import { components } from "types/api";
 import { objectHasProperty } from "src/services/type-utils";
 import { ResolveIntersectionTypes } from "types/utils";
+import isArray from "lodash/isArray";
 
 type GenericApiResponse = components["schemas"]["ApiResponse"];
 
@@ -259,8 +260,9 @@ function parseResponseBody<T extends SomeObject>(
 function handleHTTPError(errorOrResponse: Error | Response): Promise<never> {
   if (errorOrResponse instanceof Response) {
     return parseResponseBody(errorOrResponse).then((body) => {
+      const bodyToReturn = isArray(body) ? body[0] : body;
       const httpError: HTTPError = {
-        data: body,
+        data: bodyToReturn,
         status: errorOrResponse.status,
         statusText: errorOrResponse.statusText,
         headers: errorOrResponse.headers,

--- a/coral/src/services/mutation-utils.ts
+++ b/coral/src/services/mutation-utils.ts
@@ -2,12 +2,18 @@ import isString from "lodash/isString";
 import { objectHasProperty } from "src/services/type-utils";
 
 function parseErrorMsg(error: unknown): string {
-  if (
-    objectHasProperty(error, "data") &&
-    objectHasProperty(error.data, "message")
-  ) {
-    if (isString(error.data.message)) {
+  if (objectHasProperty(error, "data")) {
+    if (
+      objectHasProperty(error.data, "message") &&
+      isString(error.data.message)
+    ) {
       return error.data.message;
+    }
+    if (
+      objectHasProperty(error.data, "result") &&
+      isString(error.data.result)
+    ) {
+      return error.data.result;
     }
   }
   return "Unexpected error";


### PR DESCRIPTION
# About this change - What it does

## Explanation 

We've endpoints that don't return `ApiResponse`, but a _list_ of `ApiResponse`:
- `/request/delete`
- `/request/decline`
- `/request/approve`

They return an array in order to (later!) enable batch operation, e.g. deleting multiple schema requests. 
In that case, they will return:
- a `200` when _all_ requests where successful
- a `500` or `405` when _no_ request was successful
- a `207` when the list contains requests that where successful and others that weren't 
    - in that case, they will also contain `data` with `req_id` so we know exactly which requests failed

In our `api.ts`, we have no handling for the `207` case and don't need it currently, since it won't happen. 

But when we get an error from Backend, the UI assumes it's always in a certain structure (and that's not an array :D), which lead to us not showing the correct error message. 

## What this PR does

### Update `api.ts`
When we get an error, this error is handled in `handleHTTPError`. 
We now checked if the response body is an array (which covers our case with multi response) and if it is, we return the first entry as `data`. That way, we return the same kind of error then in other cases and don't need a special handling in our UI. 

### Update  the components for "My team requests" and "Approve x request" ui
In this components, we had a special handling in case the response was an array without the message starting with "Success" -> because "not starting with success" is how we identify errors from BE usually. The endpoints mentioned DO return an error state, so we don't need that extra handling here 🎉   (there are update in tests that now also reflect our code better)

### Update in mutation-utils
The `parseErrorMessage` function wrongfully assumed that all errors messages will be in a `error.data.message` structure. We now also check for `error.data.result`.

### Update in `TableLayout`
Little site quest, not strictly related to the changes in `api.ts`, but I stumbled over that during debugging and testing -> the `parseErrorMsg` in `TableLayout` is executed every time, which is unnecessary. It only needs to be called when there actually is an error.

Resolves: #707



##### Screenrecordings


**BEFORE**

https://user-images.githubusercontent.com/943800/227935653-a2fc84f4-fe73-4b5e-b924-52576bf88ccc.mov



**AFTER**

https://user-images.githubusercontent.com/943800/227935689-c56f7ea8-6021-4fbe-97b2-290ab0702435.mov

