### PR TITLE
feat(coral): Streamline naming and order for "My team's requests" views

### DIFF
--- a/coral/src/app/features/approvals/utils/request-operation-type-helper.ts
+++ b/coral/src/app/features/approvals/utils/request-operation-type-helper.ts
@@ -5,7 +5,7 @@ import { ChipStatus } from "@aivenio/aquarium";
 // have a more typesafe / exhaustive list
 // here TS won't complain if a possible
 // value is missing from the array.
-const operationTypeList: RequestOperationType[] = [
+const requestOperationTypeList: RequestOperationType[] = [
   "CLAIM",
   "CREATE",
   "DELETE",
@@ -34,7 +34,7 @@ const requestOperationTypeNameMap: {
 };
 
 export {
-  operationTypeList,
+  requestOperationTypeList,
   requestOperationTypeChipStatusMap,
   requestOperationTypeNameMap,
 };

--- a/coral/src/app/features/components/filters/RequestTypeFilter.test.tsx
+++ b/coral/src/app/features/components/filters/RequestTypeFilter.test.tsx
@@ -1,25 +1,25 @@
 import { cleanup, screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import {
-  operationTypeList,
+  requestOperationTypeList,
   requestOperationTypeNameMap,
 } from "src/app/features/approvals/utils/request-operation-type-helper";
-import { OperationTypeFilter } from "src/app/features/components/filters/OperationTypeFilter";
+import { RequestTypeFilter } from "src/app/features/components/filters/RequestTypeFilter";
 import { customRender } from "src/services/test-utils/render-with-wrappers";
 
-const filterLabel = "Filter by operation type";
+const filterLabel = "Filter by request type";
 
-describe("OperationTypeFilter.tsx", () => {
+describe("RequestTypeFilter.tsx", () => {
   describe("renders all necessary elements", () => {
     beforeAll(async () => {
-      customRender(<OperationTypeFilter />, {
+      customRender(<RequestTypeFilter />, {
         memoryRouter: true,
       });
     });
 
     afterAll(cleanup);
 
-    it("shows a select element for operation type", () => {
+    it("shows a select element for request type", () => {
       const select = screen.getByRole("combobox", {
         name: filterLabel,
       });
@@ -27,13 +27,13 @@ describe("OperationTypeFilter.tsx", () => {
       expect(select).toBeEnabled();
     });
 
-    it("renders a list of options for operation types", () => {
+    it("renders a list of options for request types", () => {
       const allOption = screen.getByRole("option", {
-        name: "All operation types",
+        name: "All request types",
       });
       expect(allOption).toBeEnabled();
 
-      operationTypeList.forEach((type) => {
+      requestOperationTypeList.forEach((type) => {
         const option = screen.getByRole("option", {
           name: requestOperationTypeNameMap[type],
         });
@@ -43,14 +43,14 @@ describe("OperationTypeFilter.tsx", () => {
     });
   });
 
-  describe("sets the active operation type based on a query param", () => {
-    const deleteOperation = "DELETE";
-    const deleteName = requestOperationTypeNameMap[deleteOperation];
+  describe("sets the active request type based on a query param", () => {
+    const requestTypeDelete = "DELETE";
+    const deleteName = requestOperationTypeNameMap[requestTypeDelete];
 
     beforeEach(async () => {
-      const routePath = `/?operationType=${deleteOperation}`;
+      const routePath = `/?requestType=${requestTypeDelete}`;
 
-      customRender(<OperationTypeFilter />, {
+      customRender(<RequestTypeFilter />, {
         memoryRouter: true,
         queryClient: true,
         customRoutePath: routePath,
@@ -68,18 +68,18 @@ describe("OperationTypeFilter.tsx", () => {
         selected: true,
       });
 
-      expect(select).toHaveValue(deleteOperation);
+      expect(select).toHaveValue(requestTypeDelete);
       expect(option).toBeVisible();
-      expect(option).toHaveValue(deleteOperation);
+      expect(option).toHaveValue(requestTypeDelete);
     });
   });
 
-  describe("handles user selecting an operation type", () => {
-    const createOperation = "CREATE";
-    const approvedName = requestOperationTypeNameMap[createOperation];
+  describe("handles user selecting an request type", () => {
+    const requestTypeCreate = "CREATE";
+    const approvedName = requestOperationTypeNameMap[requestTypeCreate];
 
     beforeEach(async () => {
-      customRender(<OperationTypeFilter />, {
+      customRender(<RequestTypeFilter />, {
         queryClient: true,
         memoryRouter: true,
       });
@@ -89,7 +89,7 @@ describe("OperationTypeFilter.tsx", () => {
       cleanup();
     });
 
-    it("sets the operation type the user choose as active option", async () => {
+    it("sets the request type the user choose as active option", async () => {
       const select = screen.getByRole("combobox", {
         name: filterLabel,
       });
@@ -102,16 +102,16 @@ describe("OperationTypeFilter.tsx", () => {
 
       await userEvent.selectOptions(select, option);
 
-      expect(select).toHaveValue(createOperation);
+      expect(select).toHaveValue(requestTypeCreate);
     });
   });
 
-  describe("updates the search param to preserve operation type in url", () => {
-    const defaultOperationType = "DELETE";
-    const deleteName = requestOperationTypeNameMap[defaultOperationType];
+  describe("updates the search param to preserve request type in url", () => {
+    const defaultRequestType = "DELETE";
+    const deleteName = requestOperationTypeNameMap[defaultRequestType];
 
     beforeEach(async () => {
-      customRender(<OperationTypeFilter />, {
+      customRender(<RequestTypeFilter />, {
         queryClient: true,
         browserRouter: true,
       });
@@ -127,7 +127,7 @@ describe("OperationTypeFilter.tsx", () => {
       expect(window.location.search).toEqual("");
     });
 
-    it(`sets "?operationType=${defaultOperationType}&page=1" as search param when user selected it`, async () => {
+    it(`sets "?requestType=${defaultRequestType}&page=1" as search param when user selected it`, async () => {
       const select = screen.getByRole("combobox", {
         name: filterLabel,
       });
@@ -140,18 +140,18 @@ describe("OperationTypeFilter.tsx", () => {
 
       await waitFor(() => {
         expect(window.location.search).toEqual(
-          `?operationType=${defaultOperationType}&page=1`
+          `?requestType=${defaultRequestType}&page=1`
         );
       });
     });
 
-    it(`unsets "?operationType" as search param when user selects All operation types`, async () => {
+    it(`unsets "?requestType" as search param when user selects All request types`, async () => {
       const select = screen.getByRole("combobox", {
         name: filterLabel,
       });
 
       const allOption = screen.getByRole("option", {
-        name: "All operation types",
+        name: "All request types",
       });
 
       await userEvent.selectOptions(select, allOption);

--- a/coral/src/app/features/components/filters/RequestTypeFilter.tsx
+++ b/coral/src/app/features/components/filters/RequestTypeFilter.tsx
@@ -1,7 +1,7 @@
 import { NativeSelect } from "@aivenio/aquarium";
 import { ChangeEvent } from "react";
 import {
-  operationTypeList,
+  requestOperationTypeList,
   requestOperationTypeNameMap,
 } from "src/app/features/approvals/utils/request-operation-type-helper";
 import { useFiltersValues } from "src/app/features/components/filters/useFiltersValues";
@@ -12,26 +12,26 @@ type RequestOperationTypeOptions = ResolveIntersectionTypes<
   RequestOperationType | "ALL"
 >;
 
-function OperationTypeFilter() {
-  const { operationType, setFilterValue } = useFiltersValues();
+function RequestTypeFilter() {
+  const { requestType, setFilterValue } = useFiltersValues();
 
-  const handleChangeOperationType = (e: ChangeEvent<HTMLSelectElement>) => {
+  const handleChangeRequestType = (e: ChangeEvent<HTMLSelectElement>) => {
     const nextOperationType = e.target.value as RequestOperationTypeOptions;
 
-    setFilterValue({ name: "operationType", value: nextOperationType });
+    setFilterValue({ name: "requestType", value: nextOperationType });
   };
 
   return (
     <NativeSelect
-      labelText={"Filter by operation type"}
-      key={"filter-operationType"}
-      defaultValue={operationType}
-      onChange={handleChangeOperationType}
+      labelText={"Filter by request type"}
+      key={"filter-request-type"}
+      defaultValue={requestType}
+      onChange={handleChangeRequestType}
     >
       <option key={"ALL"} value={"ALL"}>
-        All operation types
+        All request types
       </option>
-      {operationTypeList.map((operationType) => {
+      {requestOperationTypeList.map((operationType) => {
         return (
           <option key={operationType} value={operationType}>
             {requestOperationTypeNameMap[operationType]}
@@ -42,4 +42,4 @@ function OperationTypeFilter() {
   );
 }
 
-export { OperationTypeFilter };
+export { RequestTypeFilter };

--- a/coral/src/app/features/components/filters/useFiltersValues.test.tsx
+++ b/coral/src/app/features/components/filters/useFiltersValues.test.tsx
@@ -88,13 +88,13 @@ describe("useFiltersValues.tsx", () => {
         result: { current },
       } = renderHook(() => useFiltersValues(), {
         wrapper: ({ children }) => (
-          <MemoryRouter initialEntries={["/?operationType=CLAIM"]}>
+          <MemoryRouter initialEntries={["/?requestType=CLAIM"]}>
             {children}
           </MemoryRouter>
         ),
       });
 
-      expect(current.operationType).toBe("CLAIM");
+      expect(current.requestType).toBe("CLAIM");
     });
 
     describe("should get correct filter values when default value is passed", () => {
@@ -165,13 +165,13 @@ describe("useFiltersValues.tsx", () => {
         const {
           result: { current },
         } = renderHook(
-          () => useFiltersValues({ defaultOperationType: "CREATE" }),
+          () => useFiltersValues({ defaultRequestType: "CREATE" }),
           {
             wrapper: ({ children }) => <MemoryRouter>{children}</MemoryRouter>,
           }
         );
 
-        expect(current.operationType).toBe("CREATE");
+        expect(current.requestType).toBe("CREATE");
       });
     });
   });
@@ -272,11 +272,11 @@ describe("useFiltersValues.tsx", () => {
       });
 
       current.setFilterValue({
-        name: "operationType",
+        name: "requestType",
         value: "CREATE",
       });
 
-      expect(window.location.search).toBe("?operationType=CREATE&page=1");
+      expect(window.location.search).toBe("?requestType=CREATE&page=1");
     });
   });
 });

--- a/coral/src/app/features/components/filters/useFiltersValues.tsx
+++ b/coral/src/app/features/components/filters/useFiltersValues.tsx
@@ -12,7 +12,7 @@ type SetFiltersParams =
   | { name: "status"; value: RequestStatus }
   | { name: "team"; value: string }
   | { name: "showOnlyMyRequests"; value: boolean }
-  | { name: "operationType"; value: RequestOperationType | "ALL" };
+  | { name: "requestType"; value: RequestOperationType | "ALL" };
 
 type UseFiltersValuesParams =
   | {
@@ -21,7 +21,7 @@ type UseFiltersValuesParams =
       defaultAclType?: AclType | "ALL";
       defaultStatus?: RequestStatus;
       defaultTeam?: string;
-      defaultOperationType?: RequestOperationType | "ALL";
+      defaultRequestType?: RequestOperationType | "ALL";
       defaultShowOnlyMyRequests?: boolean;
     }
   | undefined;
@@ -34,7 +34,7 @@ const useFiltersValues = (defaultValues: UseFiltersValuesParams = {}) => {
     defaultAclType = "ALL",
     defaultStatus = "ALL",
     defaultTeam = "ALL",
-    defaultOperationType = "ALL",
+    defaultRequestType = "ALL",
     defaultShowOnlyMyRequests = false,
   } = defaultValues;
 
@@ -48,9 +48,9 @@ const useFiltersValues = (defaultValues: UseFiltersValuesParams = {}) => {
     searchParams.get("showOnlyMyRequests") === "true"
       ? true
       : defaultShowOnlyMyRequests;
-  const operationType =
-    (searchParams.get("operationType") as RequestOperationType | "ALL") ??
-    defaultOperationType;
+  const requestType =
+    (searchParams.get("requestType") as RequestOperationType | "ALL") ??
+    defaultRequestType;
 
   const setFilterValue = ({ name, value }: SetFiltersParams) => {
     if (
@@ -76,7 +76,7 @@ const useFiltersValues = (defaultValues: UseFiltersValuesParams = {}) => {
     status,
     team,
     showOnlyMyRequests,
-    operationType,
+    requestType,
     setFilterValue,
   };
 };

--- a/coral/src/app/features/requests/acls/AclRequests.test.tsx
+++ b/coral/src/app/features/requests/acls/AclRequests.test.tsx
@@ -571,7 +571,7 @@ describe("AclRequests", () => {
     });
   });
 
-  describe("user can filter ACL requests by request operation type ", () => {
+  describe("user can filter ACL requests by request type ", () => {
     afterEach(() => {
       cleanup();
     });
@@ -580,11 +580,11 @@ describe("AclRequests", () => {
       customRender(<AclRequests />, {
         queryClient: true,
         memoryRouter: true,
-        customRoutePath: "/?operationType=DELETE",
+        customRoutePath: "/?requestType=DELETE",
       });
 
       const envFilter = screen.getByRole("combobox", {
-        name: "Filter by operation type",
+        name: "Filter by request type",
       });
 
       expect(envFilter).toHaveDisplayValue("Delete");
@@ -600,19 +600,19 @@ describe("AclRequests", () => {
       });
     });
 
-    it("enables user to filter ACL requests by request operation type", async () => {
+    it("enables user to filter ACL requests by request type", async () => {
       customRender(<AclRequests />, {
         queryClient: true,
         memoryRouter: true,
       });
 
-      const operationTypeFilter = screen.getByRole("combobox", {
-        name: "Filter by operation type",
+      const requestTypeFilter = screen.getByRole("combobox", {
+        name: "Filter by request type",
       });
 
-      expect(operationTypeFilter).toBeEnabled();
+      expect(requestTypeFilter).toBeEnabled();
 
-      await userEvent.selectOptions(operationTypeFilter, "CREATE");
+      await userEvent.selectOptions(requestTypeFilter, "CREATE");
 
       await waitFor(() => {
         expect(getAclRequests).toHaveBeenLastCalledWith({

--- a/coral/src/app/features/requests/acls/AclRequests.tsx
+++ b/coral/src/app/features/requests/acls/AclRequests.tsx
@@ -9,7 +9,7 @@ import RequestDetailsModal from "src/app/features/components/RequestDetailsModal
 import AclTypeFilter from "src/app/features/components/filters/AclTypeFilter";
 import EnvironmentFilter from "src/app/features/components/filters/EnvironmentFilter";
 import { MyRequestsFilter } from "src/app/features/components/filters/MyRequestsFilter";
-import { OperationTypeFilter } from "src/app/features/components/filters/OperationTypeFilter";
+import { RequestTypeFilter } from "src/app/features/components/filters/RequestTypeFilter";
 import StatusFilter from "src/app/features/components/filters/StatusFilter";
 import TopicFilter from "src/app/features/components/filters/TopicFilter";
 import { useFiltersValues } from "src/app/features/components/filters/useFiltersValues";
@@ -33,7 +33,7 @@ function AclRequests() {
     aclType,
     status,
     showOnlyMyRequests,
-    operationType,
+    requestType,
   } = useFiltersValues();
 
   const [modals, setModals] = useState<{
@@ -67,7 +67,7 @@ function AclRequests() {
       environment,
       aclType,
       status,
-      operationType,
+      requestType,
       showOnlyMyRequests,
     ],
     queryFn: () =>
@@ -77,7 +77,7 @@ function AclRequests() {
         env: environment,
         aclType,
         requestStatus: status,
-        operationType: operationType === "ALL" ? undefined : operationType,
+        operationType: requestType === "ALL" ? undefined : requestType,
         isMyRequest: showOnlyMyRequests,
       }),
     keepPreviousData: true,
@@ -189,7 +189,7 @@ function AclRequests() {
         filters={[
           <EnvironmentFilter key="environment" />,
           <StatusFilter key="status" defaultStatus="ALL" />,
-          <OperationTypeFilter key="operationType" />,
+          <RequestTypeFilter key="operationType" />,
           <AclTypeFilter key="aclType" />,
           <TopicFilter key="search" />,
           <MyRequestsFilter key="myRequests" />,

--- a/coral/src/app/features/requests/acls/AclRequests.tsx
+++ b/coral/src/app/features/requests/acls/AclRequests.tsx
@@ -188,9 +188,9 @@ function AclRequests() {
       <TableLayout
         filters={[
           <EnvironmentFilter key="environment" />,
+          <AclTypeFilter key="aclType" />,
           <StatusFilter key="status" defaultStatus="ALL" />,
           <RequestTypeFilter key="operationType" />,
-          <AclTypeFilter key="aclType" />,
           <TopicFilter key="search" />,
           <MyRequestsFilter key="myRequests" />,
         ]}

--- a/coral/src/app/features/requests/acls/components/AclRequestsTable.test.tsx
+++ b/coral/src/app/features/requests/acls/components/AclRequestsTable.test.tsx
@@ -129,32 +129,12 @@ describe("AclRequestsTable", () => {
     );
   });
 
-  it("has column to decsribe the status", () => {
-    renderFromProps();
-    expect(
-      within(getNthRow(0)).getAllByRole("columnheader")[2]
-    ).toHaveTextContent("Status");
-    expect(within(getNthRow(1)).getAllByRole("cell")[2]).toHaveTextContent(
-      "Awaiting approval"
-    );
-  });
-
-  it("has column to decsribe the request type", () => {
-    renderFromProps();
-    expect(
-      within(getNthRow(0)).getAllByRole("columnheader")[3]
-    ).toHaveTextContent("Request type");
-    expect(within(getNthRow(1)).getAllByRole("cell")[3]).toHaveTextContent(
-      "Create"
-    );
-  });
-
   it("has column to describe the Principals/Usernames", () => {
     renderFromProps();
     expect(
-      within(getNthRow(0)).getAllByRole("columnheader")[4]
+      within(getNthRow(0)).getAllByRole("columnheader")[2]
     ).toHaveTextContent("Principals/Usernames");
-    expect(within(getNthRow(1)).getAllByRole("cell")[4]).toHaveTextContent(
+    expect(within(getNthRow(1)).getAllByRole("cell")[2]).toHaveTextContent(
       "josepprat"
     );
   });
@@ -162,9 +142,9 @@ describe("AclRequestsTable", () => {
   it("has column to describe the IP addresses", () => {
     renderFromProps();
     expect(
-      within(getNthRow(0)).getAllByRole("columnheader")[5]
+      within(getNthRow(0)).getAllByRole("columnheader")[3]
     ).toHaveTextContent("IP addresses");
-    expect(within(getNthRow(2)).getAllByRole("cell")[5]).toHaveTextContent(
+    expect(within(getNthRow(2)).getAllByRole("cell")[3]).toHaveTextContent(
       "1.1.1.1 2.2.2.2"
     );
   });
@@ -172,20 +152,30 @@ describe("AclRequestsTable", () => {
   it("has column to describe the ACL type", () => {
     renderFromProps();
     expect(
-      within(getNthRow(0)).getAllByRole("columnheader")[6]
+      within(getNthRow(0)).getAllByRole("columnheader")[4]
     ).toHaveTextContent("ACL type");
-    expect(within(getNthRow(1)).getAllByRole("cell")[6]).toHaveTextContent(
+    expect(within(getNthRow(1)).getAllByRole("cell")[4]).toHaveTextContent(
       "PRODUCER"
     );
   });
 
-  it("has column to describe the ACL Type", () => {
+  it("has column to describe the status", () => {
     renderFromProps();
     expect(
-      within(getNthRow(0)).getAllByRole("columnheader")[7]
-    ).toHaveTextContent("Requested on");
-    expect(within(getNthRow(1)).getAllByRole("cell")[7]).toHaveTextContent(
-      "10-Mar-2023 12:08:46 UTC"
+      within(getNthRow(0)).getAllByRole("columnheader")[5]
+    ).toHaveTextContent("Status");
+    expect(within(getNthRow(1)).getAllByRole("cell")[5]).toHaveTextContent(
+      "Awaiting approval"
+    );
+  });
+
+  it("has column to describe the request type", () => {
+    renderFromProps();
+    expect(
+      within(getNthRow(0)).getAllByRole("columnheader")[6]
+    ).toHaveTextContent("Request type");
+    expect(within(getNthRow(1)).getAllByRole("cell")[6]).toHaveTextContent(
+      "Create"
     );
   });
 

--- a/coral/src/app/features/requests/acls/components/AclRequestsTable.tsx
+++ b/coral/src/app/features/requests/acls/components/AclRequestsTable.tsx
@@ -58,28 +58,6 @@ function AclRequestsTable({
       }),
     },
     {
-      type: "status",
-      field: "requestStatus",
-      headerName: "Status",
-      status: ({ requestStatus }) => {
-        return {
-          status: requestStatusChipStatusMap[requestStatus],
-          text: requestStatusNameMap[requestStatus],
-        };
-      },
-    },
-    {
-      type: "status",
-      field: "requestOperationType",
-      headerName: "Request type",
-      status: ({ requestOperationType }) => {
-        return {
-          status: requestOperationTypeChipStatusMap[requestOperationType],
-          text: requestOperationTypeNameMap[requestOperationType],
-        };
-      },
-    },
-    {
       type: "custom",
       field: "acl_ssl",
       headerName: "Principals/Usernames",
@@ -131,6 +109,28 @@ function AclRequestsTable({
         status: aclType === "CONSUMER" ? "success" : "info",
         text: aclType,
       }),
+    },
+    {
+      type: "status",
+      field: "requestStatus",
+      headerName: "Status",
+      status: ({ requestStatus }) => {
+        return {
+          status: requestStatusChipStatusMap[requestStatus],
+          text: requestStatusNameMap[requestStatus],
+        };
+      },
+    },
+    {
+      type: "status",
+      field: "requestOperationType",
+      headerName: "Request type",
+      status: ({ requestOperationType }) => {
+        return {
+          status: requestOperationTypeChipStatusMap[requestOperationType],
+          text: requestOperationTypeNameMap[requestOperationType],
+        };
+      },
     },
     {
       type: "text",

--- a/coral/src/app/features/requests/schemas/SchemaRequests.test.tsx
+++ b/coral/src/app/features/requests/schemas/SchemaRequests.test.tsx
@@ -140,11 +140,11 @@ describe("SchemaRequest", () => {
 
     it("shows a select to filter by request type with default", () => {
       const select = screen.getByRole("combobox", {
-        name: "Filter by operation type",
+        name: "Filter by request type",
       });
 
       expect(select).toBeVisible();
-      expect(select).toHaveDisplayValue("All operation types");
+      expect(select).toHaveDisplayValue("All request types");
     });
 
     it("shows a select to filter by request status with default", () => {
@@ -394,7 +394,7 @@ describe("SchemaRequest", () => {
         queryClient: true,
         memoryRouter: true,
         customRoutePath:
-          "/?operationType=TEST_TYPE_THAT_CANNOT_BE_PART_OF_ANY_API_MOCK",
+          "/?requestType=TEST_TYPE_THAT_CANNOT_BE_PART_OF_ANY_API_MOCK",
       });
 
       await waitForElementToBeRemoved(screen.getByTestId("skeleton-table"));
@@ -416,7 +416,7 @@ describe("SchemaRequest", () => {
       const newType = "PROMOTE";
 
       const statusFilter = screen.getByRole("combobox", {
-        name: "Filter by operation type",
+        name: "Filter by request type",
       });
       const statusOption = screen.getByRole("option", {
         name: requestOperationTypeNameMap[newType],

--- a/coral/src/app/features/requests/schemas/SchemaRequests.tsx
+++ b/coral/src/app/features/requests/schemas/SchemaRequests.tsx
@@ -190,8 +190,8 @@ function SchemaRequests() {
             key={"environments"}
             isSchemaRegistryEnvironments
           />,
-          <RequestTypeFilter key={"request-type"} />,
           <StatusFilter key={"request-status"} defaultStatus={defaultStatus} />,
+          <RequestTypeFilter key={"request-type"} />,
           <TopicFilter key={"topic"} />,
           <MyRequestsFilter key={"show-only-my-requests"} />,
         ]}

--- a/coral/src/app/features/requests/schemas/SchemaRequests.tsx
+++ b/coral/src/app/features/requests/schemas/SchemaRequests.tsx
@@ -8,7 +8,7 @@ import RequestDetailsModal from "src/app/features/components/RequestDetailsModal
 import { SchemaRequestDetails } from "src/app/features/components/SchemaRequestDetails";
 import EnvironmentFilter from "src/app/features/components/filters/EnvironmentFilter";
 import { MyRequestsFilter } from "src/app/features/components/filters/MyRequestsFilter";
-import { OperationTypeFilter } from "src/app/features/components/filters/OperationTypeFilter";
+import { RequestTypeFilter } from "src/app/features/components/filters/RequestTypeFilter";
 import StatusFilter from "src/app/features/components/filters/StatusFilter";
 import TopicFilter from "src/app/features/components/filters/TopicFilter";
 import { useFiltersValues } from "src/app/features/components/filters/useFiltersValues";
@@ -32,7 +32,7 @@ function SchemaRequests() {
     ? Number(searchParams.get("page"))
     : 1;
 
-  const { topic, environment, status, showOnlyMyRequests, operationType } =
+  const { topic, environment, status, showOnlyMyRequests, requestType } =
     useFiltersValues();
 
   const [modals, setModals] = useState<{
@@ -56,7 +56,7 @@ function SchemaRequests() {
       status,
       topic,
       showOnlyMyRequests,
-      operationType,
+      requestType,
     ],
     queryFn: () =>
       getSchemaRequests({
@@ -65,8 +65,7 @@ function SchemaRequests() {
         requestStatus: status !== defaultStatus ? status : undefined,
         topic,
         isMyRequest: showOnlyMyRequests,
-        operationType:
-          operationType !== defaultType ? operationType : undefined,
+        operationType: requestType !== defaultType ? requestType : undefined,
       }),
     keepPreviousData: true,
   });
@@ -191,7 +190,7 @@ function SchemaRequests() {
             key={"environments"}
             isSchemaRegistryEnvironments
           />,
-          <OperationTypeFilter key={"request-type"} />,
+          <RequestTypeFilter key={"request-type"} />,
           <StatusFilter key={"request-status"} defaultStatus={defaultStatus} />,
           <TopicFilter key={"topic"} />,
           <MyRequestsFilter key={"show-only-my-requests"} />,

--- a/coral/src/app/features/requests/schemas/components/SchemaRequestTable.tsx
+++ b/coral/src/app/features/requests/schemas/components/SchemaRequestTable.tsx
@@ -47,23 +47,23 @@ function SchemaRequestTable({
     },
     {
       type: "status",
-      field: "requestType",
-      headerName: "Request type",
-      status: ({ requestType }) => {
-        return {
-          status: requestOperationTypeChipStatusMap[requestType],
-          text: requestOperationTypeNameMap[requestType],
-        };
-      },
-    },
-    {
-      type: "status",
       field: "requestStatus",
       headerName: "Status",
       status: ({ requestStatus }) => {
         return {
           status: requestStatusChipStatusMap[requestStatus],
           text: requestStatusNameMap[requestStatus],
+        };
+      },
+    },
+    {
+      type: "status",
+      field: "requestType",
+      headerName: "Request type",
+      status: ({ requestType }) => {
+        return {
+          status: requestOperationTypeChipStatusMap[requestType],
+          text: requestOperationTypeNameMap[requestType],
         };
       },
     },

--- a/coral/src/app/features/requests/topics/TopicRequests.test.tsx
+++ b/coral/src/app/features/requests/topics/TopicRequests.test.tsx
@@ -717,7 +717,7 @@ describe("TopicRequests", () => {
       customRender(<TopicRequests />, {
         queryClient: true,
         memoryRouter: true,
-        customRoutePath: "/?operationType=123",
+        customRoutePath: "/?requestType=DELETE",
       });
 
       await waitForElementToBeRemoved(screen.getByTestId("skeleton-table"));
@@ -733,7 +733,7 @@ describe("TopicRequests", () => {
       expect(mockGetTopicRequests).toHaveBeenNthCalledWith(1, {
         pageNo: "1",
         isMyRequest: false,
-        operationType: "123",
+        operationType: "DELETE",
         requestStatus: "ALL",
         env: "ALL",
       });
@@ -743,7 +743,7 @@ describe("TopicRequests", () => {
       const newType = "PROMOTE";
 
       const statusFilter = screen.getByRole("combobox", {
-        name: "Filter by operation type",
+        name: "Filter by request type",
       });
       const statusOption = screen.getByRole("option", {
         name: requestOperationTypeNameMap[newType],

--- a/coral/src/app/features/requests/topics/TopicRequests.tsx
+++ b/coral/src/app/features/requests/topics/TopicRequests.tsx
@@ -177,8 +177,8 @@ function TopicRequests() {
       <TableLayout
         filters={[
           <EnvironmentFilter key="environments" />,
-          <RequestTypeFilter key={"request-type"} />,
           <StatusFilter key="request-status" defaultStatus={defaultStatus} />,
+          <RequestTypeFilter key={"request-type"} />,
           <TopicFilter key={"topic"} />,
           <MyRequestsFilter key={"isMyRequest"} />,
         ]}

--- a/coral/src/app/features/requests/topics/TopicRequests.tsx
+++ b/coral/src/app/features/requests/topics/TopicRequests.tsx
@@ -19,7 +19,7 @@ import { useFiltersValues } from "src/app/features/components/filters/useFilters
 import { MyRequestsFilter } from "src/app/features/components/filters/MyRequestsFilter";
 import EnvironmentFilter from "src/app/features/components/filters/EnvironmentFilter";
 import StatusFilter from "src/app/features/components/filters/StatusFilter";
-import { OperationTypeFilter } from "src/app/features/components/filters/OperationTypeFilter";
+import { RequestTypeFilter } from "src/app/features/components/filters/RequestTypeFilter";
 
 const defaultStatus = "ALL";
 const defaultType = "ALL";
@@ -31,7 +31,7 @@ function TopicRequests() {
     ? Number(searchParams.get("page"))
     : 1;
 
-  const { topic, environment, status, showOnlyMyRequests, operationType } =
+  const { topic, environment, status, showOnlyMyRequests, requestType } =
     useFiltersValues();
 
   const [modals, setModals] = useState<{
@@ -48,7 +48,7 @@ function TopicRequests() {
       status,
       topic,
       showOnlyMyRequests,
-      operationType,
+      requestType,
     ],
     queryFn: () =>
       getTopicRequests({
@@ -58,8 +58,7 @@ function TopicRequests() {
         env: environment,
         requestStatus: status,
         isMyRequest: showOnlyMyRequests,
-        operationType:
-          operationType !== defaultType ? operationType : undefined,
+        operationType: requestType !== defaultType ? requestType : undefined,
       }),
     keepPreviousData: true,
   });
@@ -178,7 +177,7 @@ function TopicRequests() {
       <TableLayout
         filters={[
           <EnvironmentFilter key="environments" />,
-          <OperationTypeFilter key={"request-type"} />,
+          <RequestTypeFilter key={"request-type"} />,
           <StatusFilter key="request-status" defaultStatus={defaultStatus} />,
           <TopicFilter key={"topic"} />,
           <MyRequestsFilter key={"isMyRequest"} />,

--- a/coral/src/app/features/requests/topics/components/TopicRequestsTable.test.tsx
+++ b/coral/src/app/features/requests/topics/components/TopicRequestsTable.test.tsx
@@ -131,11 +131,11 @@ describe("TopicRequestsTable", () => {
     );
   });
 
-  it("has column to decsribe the request type", () => {
+  it("has column to describe the request type", () => {
     renderFromProps();
     expect(
       within(getNthRow(0)).getAllByRole("columnheader")[3]
-    ).toHaveTextContent("Type");
+    ).toHaveTextContent("Request type");
     expect(within(getNthRow(1)).getAllByRole("cell")[3]).toHaveTextContent(
       "Create"
     );

--- a/coral/src/app/features/requests/topics/components/TopicRequestsTable.test.tsx
+++ b/coral/src/app/features/requests/topics/components/TopicRequestsTable.test.tsx
@@ -121,12 +121,22 @@ describe("TopicRequestsTable", () => {
     );
   });
 
-  it("has column to decsribe the status", () => {
+  it("has column to describe the owner", () => {
     renderFromProps();
     expect(
       within(getNthRow(0)).getAllByRole("columnheader")[2]
-    ).toHaveTextContent("Status");
+    ).toHaveTextContent("Owned by");
     expect(within(getNthRow(1)).getAllByRole("cell")[2]).toHaveTextContent(
+      "NCC1701D"
+    );
+  });
+
+  it("has column to describe the status", () => {
+    renderFromProps();
+    expect(
+      within(getNthRow(0)).getAllByRole("columnheader")[3]
+    ).toHaveTextContent("Status");
+    expect(within(getNthRow(1)).getAllByRole("cell")[3]).toHaveTextContent(
       "Awaiting approval"
     );
   });
@@ -134,24 +144,14 @@ describe("TopicRequestsTable", () => {
   it("has column to describe the request type", () => {
     renderFromProps();
     expect(
-      within(getNthRow(0)).getAllByRole("columnheader")[3]
+      within(getNthRow(0)).getAllByRole("columnheader")[4]
     ).toHaveTextContent("Request type");
-    expect(within(getNthRow(1)).getAllByRole("cell")[3]).toHaveTextContent(
+    expect(within(getNthRow(1)).getAllByRole("cell")[4]).toHaveTextContent(
       "Create"
     );
   });
 
-  it("has column to describe the owner", () => {
-    renderFromProps();
-    expect(
-      within(getNthRow(0)).getAllByRole("columnheader")[4]
-    ).toHaveTextContent("Owned by");
-    expect(within(getNthRow(1)).getAllByRole("cell")[4]).toHaveTextContent(
-      "NCC1701D"
-    );
-  });
-
-  it("has column to decsribe the author of the request", () => {
+  it("has column to describe the author of the request", () => {
     renderFromProps();
     expect(
       within(getNthRow(0)).getAllByRole("columnheader")[5]
@@ -161,7 +161,7 @@ describe("TopicRequestsTable", () => {
     );
   });
 
-  it("has column to decsribe the timestamp when the request was made", () => {
+  it("has column to describe the timestamp when the request was made", () => {
     renderFromProps();
     expect(
       within(getNthRow(0)).getAllByRole("columnheader")[6]

--- a/coral/src/app/features/requests/topics/components/TopicRequestsTable.tsx
+++ b/coral/src/app/features/requests/topics/components/TopicRequestsTable.tsx
@@ -45,6 +45,7 @@ function TopicRequestsTable({
         text: environmentName,
       }),
     },
+    { type: "text", field: "teamname", headerName: "Owned by" },
     {
       type: "status",
       field: "requestStatus",
@@ -67,7 +68,6 @@ function TopicRequestsTable({
         };
       },
     },
-    { type: "text", field: "teamname", headerName: "Owned by" },
     { type: "text", field: "requestor", headerName: "Requested by" },
     {
       type: "text",

--- a/coral/src/app/features/requests/topics/components/TopicRequestsTable.tsx
+++ b/coral/src/app/features/requests/topics/components/TopicRequestsTable.tsx
@@ -59,7 +59,7 @@ function TopicRequestsTable({
     {
       type: "status",
       field: "requestOperationType",
-      headerName: "Type",
+      headerName: "Request type",
       status: ({ requestOperationType }) => {
         return {
           status: requestOperationTypeChipStatusMap[requestOperationType],

--- a/coral/src/domain/schema-request/schema-request-api.ts
+++ b/coral/src/domain/schema-request/schema-request-api.ts
@@ -93,8 +93,7 @@ const getSchemaRequests = (
     ...(args.requestStatus && { requestStatus: args.requestStatus }),
     ...(args.topic && { topic: args.topic }),
     ...(args.env && args.env !== "ALL" && { env: args.env }),
-    ...(args.operationType &&
-      args.operationType !== undefined && { env: args.operationType }),
+    ...(args.operationType !== undefined && { env: args.operationType }),
     ...(args.isMyRequest && { isMyRequest: String(Boolean(args.isMyRequest)) }),
   };
 


### PR DESCRIPTION
# About this change - What it does
- the naming for (request)operation-type is made consistent to be "Request type" in all user-facing elements
- order of filters and columns in approvals table is aligned and updated
- change CONSUMER and PRODUCER to Consumer and Producer for ACL types (UI only)


### Comparison current Figma layout and UI for filter / columns

#### Topics
<img width="929" alt="Screenshot 2023-03-28 at 12 13 28" src="https://user-images.githubusercontent.com/943800/228204601-dc204392-d6e4-47f6-b7cb-f9c4264b8c62.png">

<img width="1405" alt="Screenshot 2023-03-28 at 12 04 18" src="https://user-images.githubusercontent.com/943800/228204646-85840349-5779-4929-b683-3d371bfa366c.png">


#### ACLs

<img width="928" alt="Screenshot 2023-03-28 at 12 13 14" src="https://user-images.githubusercontent.com/943800/228204710-954f7df6-15ca-4c8f-9139-a8680b1ab1ed.png">

<img width="1410" alt="Screenshot 2023-03-28 at 12 09 35" src="https://user-images.githubusercontent.com/943800/228204737-673cd5ed-1c7f-45cb-a058-78ea105b3bc4.png">

#### Schemas

<img width="928" alt="Screenshot 2023-03-28 at 12 13 07" src="https://user-images.githubusercontent.com/943800/228204791-45027f17-5f89-4654-965f-11054f5e0040.png">

<img width="1412" alt="Screenshot 2023-03-28 at 12 11 03" src="https://user-images.githubusercontent.com/943800/228204830-632e7a09-3038-46d0-b62b-94b5e3ee2b0c.png">


### ACL types

<img width="879" alt="approve-tables" src="https://user-images.githubusercontent.com/943800/228287423-6bca0153-2bbf-44fd-bbee-f4d8c409b87d.png">
<img width="638" alt="my-team-request-table" src="https://user-images.githubusercontent.com/943800/228287432-47dfd6b7-fd51-43d5-b769-0f1b49fe5408.png">



Resolves: #896

