### PR TITLE
Description field valition, gettopics search for env fix

### DIFF
--- a/core/src/main/java/io/aiven/klaw/helpers/db/rdbms/SelectDataJdbc.java
+++ b/core/src/main/java/io/aiven/klaw/helpers/db/rdbms/SelectDataJdbc.java
@@ -372,13 +372,15 @@ public class SelectDataJdbc {
       if (env == null || env.equals("ALL")) {
         return topicRepo.findAllByTenantId(tenantId);
       } else {
-        return topicRepo.findAllByEnvironmentAndTenantId(env, tenantId);
+        List<String> topics = topicRepo.findAllTopicNamesForEnv(env, tenantId);
+        return topicRepo.findAllByTenantIdAndTopicnameIn(tenantId, topics);
       }
     } else {
       if ("ALL".equals(env)) {
         return topicRepo.findAllByTeamIdAndTenantId(teamId, tenantId);
       } else {
-        return topicRepo.findAllByEnvironmentAndTeamIdAndTenantId(env, teamId, tenantId);
+        List<String> topics = topicRepo.findAllTopicNamesForEnvAndTeam(env, teamId, tenantId);
+        return topicRepo.findAllByTenantIdAndTopicnameIn(tenantId, topics);
       }
     }
   }

--- a/core/src/main/java/io/aiven/klaw/model/requests/TopicRequestModel.java
+++ b/core/src/main/java/io/aiven/klaw/model/requests/TopicRequestModel.java
@@ -27,9 +27,7 @@ public class TopicRequestModel extends BaseRequestModel implements Serializable 
   @Min(value = 1, message = "Replication factor must be greater than zero")
   private String replicationfactor;
 
-  @NotNull
-  @Pattern(message = "Invalid description", regexp = "^[a-zA-Z 0-9_.,-]{3,}$")
-  private String description;
+  @NotNull private String description;
 
   private List<TopicConfigEntry> advancedTopicConfigEntries;
 

--- a/core/src/main/java/io/aiven/klaw/repository/TopicRepo.java
+++ b/core/src/main/java/io/aiven/klaw/repository/TopicRepo.java
@@ -13,11 +13,11 @@ public interface TopicRepo extends CrudRepository<Topic, TopicID> {
 
   List<Topic> findAllByTenantId(int tenantId);
 
+  List<Topic> findAllByTenantIdAndTopicnameIn(int tenantId, List<String> topicsNamesList);
+
   List<Topic> findAllByEnvironmentAndTenantId(String env, int tenantId);
 
   List<Topic> findAllByTeamIdAndTenantId(Integer teamId, int tenantId);
-
-  List<Topic> findAllByEnvironmentAndTeamIdAndTenantId(String env, Integer teamId, int tenantId);
 
   List<Topic> findAllByTopicnameAndTenantId(String topicName, int tenantId);
 
@@ -87,4 +87,19 @@ public interface TopicRepo extends CrudRepository<Topic, TopicID> {
 
   @Query(value = "select max(topicid) from kwtopics where tenantid = :tenantId", nativeQuery = true)
   Integer getNextTopicRequestId(@Param("tenantId") Integer tenantId);
+
+  @Query(
+      value = "select topicname from kwtopics where env = :envId and tenantid = :tenantId",
+      nativeQuery = true)
+  List<String> findAllTopicNamesForEnv(
+      @Param("envId") String envId, @Param("tenantId") Integer tenantId);
+
+  @Query(
+      value =
+          "select topicname from kwtopics where env = :envId and teamid = :teamId and tenantid = :tenantId",
+      nativeQuery = true)
+  List<String> findAllTopicNamesForEnvAndTeam(
+      @Param("envId") String envId,
+      @Param("teamId") Integer teamId,
+      @Param("tenantId") Integer tenantId);
 }

--- a/core/src/test/java/io/aiven/klaw/helpers/db/rdbms/SelectDataJdbcTest.java
+++ b/core/src/test/java/io/aiven/klaw/helpers/db/rdbms/SelectDataJdbcTest.java
@@ -30,6 +30,7 @@ import io.aiven.klaw.repository.TopicRepo;
 import io.aiven.klaw.repository.TopicRequestsRepo;
 import io.aiven.klaw.repository.UserInfoRepo;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -183,7 +184,11 @@ public class SelectDataJdbcTest {
   @Test
   public void selectSyncTopics() {
     String env = "DEV";
-    when(topicRepo.findAllByEnvironmentAndTenantId(env, 1)).thenReturn(utilMethods.getTopics());
+    List<String> stringList =
+        Collections.singletonList(utilMethods.getTopics().get(0).getTopicname());
+    when(topicRepo.findAllTopicNamesForEnv(env, 1)).thenReturn(stringList);
+    when(topicRepo.findAllByTenantIdAndTopicnameIn(1, stringList))
+        .thenReturn(utilMethods.getTopics());
     List<Topic> topicList = selectData.selectSyncTopics(env, null, 1);
     assertThat(topicList).hasSize(1);
   }

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -5128,8 +5128,7 @@
             "type" : "string"
           },
           "description" : {
-            "type" : "string",
-            "pattern" : "^[a-zA-Z 0-9_.,-]{3,}$"
+            "type" : "string"
           },
           "advancedTopicConfigEntries" : {
             "type" : "array",
@@ -5678,8 +5677,7 @@
             "type" : "string"
           },
           "description" : {
-            "type" : "string",
-            "pattern" : "^[a-zA-Z 0-9_.,-]{3,}$"
+            "type" : "string"
           },
           "advancedTopicConfigEntries" : {
             "type" : "array",


### PR DESCRIPTION
About this change - What it does

- validation on 'description' field in requests is now removed. 
- seraching topics based on one env used to return only one env, instead of topics if also exists in other envs. its fixed in this pr

Resolves: #xxxxx
Why this way
For good experience :)
