### PR TITLE
Mask ACL data that is not owned by the team.

### DIFF
--- a/core/src/main/java/io/aiven/klaw/service/BaseOverviewService.java
+++ b/core/src/main/java/io/aiven/klaw/service/BaseOverviewService.java
@@ -35,7 +35,7 @@ public abstract class BaseOverviewService {
       OBJECT_MAPPER.writerWithDefaultPrettyPrinter();
   public static final TypeReference<ArrayList<TopicHistory>> VALUE_TYPE_REF =
       new TypeReference<>() {};
-  public static final String MASKED_FOR_SECURITY = "Available to Owning Team Only";
+  public static final String MASKED_FOR_SECURITY = "Not Authorized to see this.";
   @Autowired protected ManageDatabase manageDatabase;
   @Autowired protected ClusterApiService clusterApiService;
   @Autowired protected CommonUtilsService commonUtilsService;

--- a/core/src/main/java/io/aiven/klaw/service/BaseOverviewService.java
+++ b/core/src/main/java/io/aiven/klaw/service/BaseOverviewService.java
@@ -35,7 +35,7 @@ public abstract class BaseOverviewService {
       OBJECT_MAPPER.writerWithDefaultPrettyPrinter();
   public static final TypeReference<ArrayList<TopicHistory>> VALUE_TYPE_REF =
       new TypeReference<>() {};
-  public static final String MASKED_FOR_SECURITY = "Not Authorized to see this.";
+  private static final String MASKED_FOR_SECURITY = "Not Authorized to see this.";
   @Autowired protected ManageDatabase manageDatabase;
   @Autowired protected ClusterApiService clusterApiService;
   @Autowired protected CommonUtilsService commonUtilsService;

--- a/core/src/main/java/io/aiven/klaw/service/BaseOverviewService.java
+++ b/core/src/main/java/io/aiven/klaw/service/BaseOverviewService.java
@@ -35,6 +35,7 @@ public abstract class BaseOverviewService {
       OBJECT_MAPPER.writerWithDefaultPrettyPrinter();
   public static final TypeReference<ArrayList<TopicHistory>> VALUE_TYPE_REF =
       new TypeReference<>() {};
+  public static final String MASKED_FOR_SECURITY = "Available to Owning Team Only";
   @Autowired protected ManageDatabase manageDatabase;
   @Autowired protected ClusterApiService clusterApiService;
   @Autowired protected CommonUtilsService commonUtilsService;
@@ -85,29 +86,37 @@ public abstract class BaseOverviewService {
     AclInfo mp;
 
     for (Acl aclSotItem : aclsFromSOT) {
-      mp = new AclInfo();
-      mp.setEnvironment(aclSotItem.getEnvironment());
-      Env envDetails = getEnvDetails(aclSotItem.getEnvironment(), tenantId);
-      mp.setEnvironmentName(envDetails.getName());
-      mp.setTopicname(aclSotItem.getTopicname());
-      mp.setAcl_ip(aclSotItem.getAclip());
-      mp.setAcl_ssl(aclSotItem.getAclssl());
-      mp.setTransactionalId(aclSotItem.getTransactionalId());
-      mp.setTeamname(manageDatabase.getTeamNameFromTeamId(tenantId, aclSotItem.getTeamId()));
-      mp.setConsumergroup(aclSotItem.getConsumergroup());
-      mp.setTopictype(aclSotItem.getAclType());
-      mp.setAclPatternType(aclSotItem.getAclPatternType());
-      mp.setReq_no(aclSotItem.getReq_no() + "");
-      mp.setKafkaFlavorType(
-          KafkaFlavors.of(
-              manageDatabase
-                  .getClusters(KafkaClustersType.KAFKA, tenantId)
-                  .get(envDetails.getClusterId())
-                  .getKafkaFlavor()));
-      if (aclSotItem.getTeamId() != null && aclSotItem.getTeamId().equals(loggedInUserTeam))
-        mp.setShowDeleteAcl(true);
+      if (aclSotItem.getAclip() != null || aclSotItem.getAclssl() != null) {
+        mp = new AclInfo();
+        mp.setEnvironment(aclSotItem.getEnvironment());
+        Env envDetails = getEnvDetails(aclSotItem.getEnvironment(), tenantId);
+        mp.setEnvironmentName(envDetails.getName());
+        mp.setTopicname(aclSotItem.getTopicname());
 
-      if (aclSotItem.getAclip() != null || aclSotItem.getAclssl() != null) aclList.add(mp);
+        mp.setTransactionalId(aclSotItem.getTransactionalId());
+        mp.setTeamname(manageDatabase.getTeamNameFromTeamId(tenantId, aclSotItem.getTeamId()));
+        mp.setConsumergroup(aclSotItem.getConsumergroup());
+        mp.setTopictype(aclSotItem.getAclType());
+        mp.setAclPatternType(aclSotItem.getAclPatternType());
+        mp.setReq_no(aclSotItem.getReq_no() + "");
+        mp.setKafkaFlavorType(
+            KafkaFlavors.of(
+                manageDatabase
+                    .getClusters(KafkaClustersType.KAFKA, tenantId)
+                    .get(envDetails.getClusterId())
+                    .getKafkaFlavor()));
+        if (aclSotItem.getTeamId() != null && aclSotItem.getTeamId().equals(loggedInUserTeam)) {
+          mp.setShowDeleteAcl(true);
+          // Only add ACL info if it is the owning team that is requesting it
+          mp.setAcl_ip(aclSotItem.getAclip());
+          mp.setAcl_ssl(aclSotItem.getAclssl());
+        } else {
+          mp.setAcl_ip(MASKED_FOR_SECURITY);
+          mp.setAcl_ssl(MASKED_FOR_SECURITY);
+        }
+
+        aclList.add(mp);
+      }
     }
     return aclList;
   }

--- a/core/src/main/java/io/aiven/klaw/service/TopicOverviewService.java
+++ b/core/src/main/java/io/aiven/klaw/service/TopicOverviewService.java
@@ -133,6 +133,7 @@ public class TopicOverviewService extends BaseOverviewService {
     List<Acl> allPrefixedAcls;
     List<AclInfo> tmpAclPrefixed;
     List<AclInfo> tmpAcl;
+    boolean ownsTopic = topicOwnerTeamId == loggedInUserTeam;
     for (TopicInfo topicInfo : topicInfoList) {
       aclsFromSOT.addAll(getAclsFromSOT(topicInfo.getEnvId(), topicNameSearch, false, tenantId));
 

--- a/core/src/main/java/io/aiven/klaw/service/TopicOverviewService.java
+++ b/core/src/main/java/io/aiven/klaw/service/TopicOverviewService.java
@@ -133,7 +133,7 @@ public class TopicOverviewService extends BaseOverviewService {
     List<Acl> allPrefixedAcls;
     List<AclInfo> tmpAclPrefixed;
     List<AclInfo> tmpAcl;
-    boolean ownsTopic = topicOwnerTeamId == loggedInUserTeam;
+
     for (TopicInfo topicInfo : topicInfoList) {
       aclsFromSOT.addAll(getAclsFromSOT(topicInfo.getEnvId(), topicNameSearch, false, tenantId));
 

--- a/core/src/main/resources/templates/browseAcls.html
+++ b/core/src/main/resources/templates/browseAcls.html
@@ -670,13 +670,15 @@
 																<h6 class="text-primary">Consumer Group</h6><b>{{ aclRequest.consumergroup }}</b>
 															</div>
 															<div ng-show="aclRequest.acl_ip != null" class="p-2 border-right" style="width:15%">
-																<h6 class="text-primary">IP Address</h6><b>{{ aclRequest.acl_ip }}</b>
+																<h6 class="text-primary">IP Address</h6><b ><i ng-show="aclRequest.showDeleteAcl == false" class="fa fa-lock"></i> {{ aclRequest.acl_ip }}</b>
 															</div>
 															<div ng-show="aclRequest.acl_ip == null" class="p-2 border-right" style="width:15%">
-																<h6 class="text-primary">IP Address</h6><b>*</b>
+																<h6 class="text-primary">IP Address</h6><b ><i ng-show="aclRequest.showDeleteAcl == false" class="fa fa-lock"></i> *</b>
 															</div>
-															<div ng-show="aclRequest.acl_ssl != null" class="p-2 border-right" style="width:30%">
-																<h6 class="text-primary">Principal / Username</h6><b>{{ aclRequest.acl_ssl }}</b>
+															<div ng-show="aclRequest.acl_ssl != null" class="p-2 border-right" style="width:30%" >
+
+																<h6 class="text-primary">Principal / Username</h6><b><i ng-show="aclRequest.showDeleteAcl == false" class="fa fa-lock"></i> {{ aclRequest.acl_ssl }}</b>
+
 															</div>
 
 															<div class="p-2" style="width:15%">

--- a/core/src/test/java/io/aiven/klaw/service/TopicOverviewServiceTest.java
+++ b/core/src/test/java/io/aiven/klaw/service/TopicOverviewServiceTest.java
@@ -259,8 +259,8 @@ public class TopicOverviewServiceTest {
     assertThat(aclList.get(0).getTopicname()).isEqualTo(TESTTOPIC);
     assertThat(aclList.get(0).getConsumergroup()).isEqualTo("mygrp1");
     // MASKED DATA
-    assertThat(aclList.get(0).getAcl_ip()).isEqualTo("Available to Owning Team Only");
-    assertThat(aclList.get(0).getAcl_ssl()).isEqualTo("Available to Owning Team Only");
+    assertThat(aclList.get(0).getAcl_ip()).isEqualTo("Not Authorized to see this.");
+    assertThat(aclList.get(0).getAcl_ssl()).isEqualTo("Not Authorized to see this.");
   }
 
   private Topic createTopic(String topicName) {

--- a/core/src/test/java/io/aiven/klaw/service/TopicOverviewServiceTest.java
+++ b/core/src/test/java/io/aiven/klaw/service/TopicOverviewServiceTest.java
@@ -222,6 +222,47 @@ public class TopicOverviewServiceTest {
     assertThat(returnedValue.isTopicExists()).isFalse();
   }
 
+  @Test
+  @Order(6)
+  public void getAclsSyncFalseMaskedData() throws KlawException {
+    String env1 = "1";
+    when(handleDbRequests.getUsersInfo(anyString())).thenReturn(userInfo);
+    when(userInfo.getTeamId()).thenReturn(110);
+    when(mailService.getUserName(any())).thenReturn(TEAM_ID);
+    when(commonUtilsService.getTeamId(eq(TEAM_ID))).thenReturn(110);
+    when(commonUtilsService.getEnvsFromUserId(anyString()))
+        .thenReturn(new HashSet<>(Collections.singletonList("1")));
+    when(manageDatabase.getKwPropertyValue(anyString(), anyInt())).thenReturn("true");
+    when(manageDatabase.getKafkaEnvList(anyInt())).thenReturn(utilMethods.getEnvLists());
+    when(handleDbRequests.selectAllTeamsOfUsers(anyString(), anyInt()))
+        .thenReturn(utilMethods.getTeams());
+    when(handleDbRequests.getTopics(anyString(), anyInt()))
+        .thenReturn(utilMethods.getTopics(TESTTOPIC));
+    when(handleDbRequests.getSyncAcls(anyString(), anyString(), anyInt()))
+        .thenReturn(getAclsSOT(TESTTOPIC));
+    when(handleDbRequests.getTopicTeam(anyString(), anyInt()))
+        .thenReturn(utilMethods.getTopics(TESTTOPIC));
+    when(commonUtilsService.getFilteredTopicsForTenant(any()))
+        .thenReturn(utilMethods.getTopics(TESTTOPIC));
+    when(manageDatabase.getClusters(any(KafkaClustersType.class), anyInt()))
+        .thenReturn(kwClustersHashMap);
+    when(kwClustersHashMap.get(anyInt())).thenReturn(kwClusters);
+
+    when(manageDatabase.getAllEnvList(anyInt()))
+        .thenReturn(createListOfEnvs(KafkaClustersType.SCHEMA_REGISTRY, 5));
+    when(commonUtilsService.getEnvProperty(eq(101), eq("REQUEST_TOPICS_OF_ENVS"))).thenReturn("1");
+    mockTenantConfig();
+    List<AclInfo> aclList = topicOverviewService.getTopicOverview(TESTTOPIC).getAclInfoList();
+
+    assertThat(aclList).hasSize(1);
+
+    assertThat(aclList.get(0).getTopicname()).isEqualTo(TESTTOPIC);
+    assertThat(aclList.get(0).getConsumergroup()).isEqualTo("mygrp1");
+    // MASKED DATA
+    assertThat(aclList.get(0).getAcl_ip()).isEqualTo("Available to Owning Team Only");
+    assertThat(aclList.get(0).getAcl_ssl()).isEqualTo("Available to Owning Team Only");
+  }
+
   private Topic createTopic(String topicName) {
     Topic t = new Topic();
     t.setTopicname(topicName);
@@ -346,6 +387,7 @@ public class TopicOverviewServiceTest {
     aclReq.setEnvironment("1");
     aclReq.setConsumergroup("mygrp1");
     aclReq.setAclType(AclType.CONSUMER.value);
+    aclReq.setTeamId(10);
 
     aclList.add(aclReq);
     return aclList;


### PR DESCRIPTION
About this change - What it does
This change removes the ability to see sensitive ACL data that has been supplied by another team.

Resolves: #696 
Why this way
This will contribute to a better more secure experience.
As no data is sent over via https request unless it has been validated already in the backend.