### PR TITLE
Keycloak fix for legacy version

### DIFF
--- a/core/src/main/java/io/aiven/klaw/config/CustomJwtDecoder.java
+++ b/core/src/main/java/io/aiven/klaw/config/CustomJwtDecoder.java
@@ -1,0 +1,107 @@
+package io.aiven.klaw.config;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.nimbusds.jose.Payload;
+import com.nimbusds.jwt.JWT;
+import com.nimbusds.jwt.JWTClaimsSet;
+import com.nimbusds.jwt.JWTParser;
+import com.nimbusds.jwt.SignedJWT;
+import java.text.ParseException;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.oauth2.client.registration.ClientRegistration;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.security.oauth2.jwt.JwtDecoder;
+import org.springframework.security.oauth2.jwt.JwtDecoderFactory;
+import org.springframework.security.oauth2.jwt.JwtException;
+
+/*
+Below class is only applicable for keycloak provider with legacy version (10.x)
+Known issue in keycloak https://issues.redhat.com/browse/KEYCLOAK-14309
+If token contains duplicate keys, json parser in spring framework fails. Hence custom json parser is applied here below.
+*/
+@Slf4j
+class CustomJwtDecoder implements JwtDecoder {
+
+  public static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+
+  static class CustomJwtDecoderFactory implements JwtDecoderFactory<ClientRegistration> {
+    public JwtDecoder createDecoder(ClientRegistration reg) {
+      return new CustomJwtDecoder();
+    }
+  }
+
+  @Override
+  public Jwt decode(String token) throws JwtException {
+    JWT jwt;
+    try {
+      jwt = JWTParser.parse(token);
+      return createJwt(token, jwt);
+    } catch (ParseException e) {
+      log.error("Token parsing exception : ", e);
+    }
+    return null;
+  }
+
+  private Jwt createJwt(String token, JWT parsedJwt) {
+    try {
+      Map<String, Object> headers = new LinkedHashMap<>(parsedJwt.getHeader().toJSONObject());
+      Map<String, Object> claimsMap = new HashMap<>();
+      Map<String, Object> claims;
+      if (parsedJwt instanceof SignedJWT) {
+        claims = getJWTClaimsSet(parsedJwt).getClaims();
+      } else claims = parsedJwt.getJWTClaimsSet().getClaims();
+
+      for (String key : claims.keySet()) {
+        Object value = claims.get(key);
+        if (key.equals("exp") || key.equals("iat")) {
+          value = ((Date) value).toInstant();
+        }
+        claimsMap.put(key, value);
+      }
+      return Jwt.withTokenValue(token)
+          .headers(h -> h.putAll(headers))
+          .claims(c -> c.putAll(claimsMap))
+          .build();
+    } catch (Exception ex) {
+      log.error("Exception while creating JWT : ", ex);
+      if (ex.getCause() instanceof ParseException) {
+        throw new JwtException("There is a problem parsing the JWT: " + ex.getMessage());
+      } else {
+        throw new JwtException("There is a problem decoding the JWT: " + ex.getMessage());
+      }
+    }
+  }
+
+  public JWTClaimsSet getJWTClaimsSet(JWT parsedJwt) throws ParseException {
+    Payload payload = new Payload(parsedJwt.getParsedParts()[1]);
+    log.info("Payload before : {}", payload);
+    Map<String, Object> json = toJSONObject(payload);
+    log.info("Payload after : {}", json);
+    if (json == null) {
+      log.error("Payload of JWS object is not a valid JSON object");
+      throw new ParseException("Payload of JWS object is not a valid JSON object", 0);
+    } else {
+      return JWTClaimsSet.parse(json);
+    }
+  }
+
+  public Map<String, Object> toJSONObject(Payload payload) {
+    String payloadStr = payload.toString();
+    if (payloadStr == null) {
+      return null;
+    } else {
+      try {
+        return OBJECT_MAPPER.readValue(payloadStr, new TypeReference<>() {});
+      } catch (JsonProcessingException ex) {
+        log.error("Exception while transforming payload to json object ", ex);
+        return null;
+      }
+    }
+  }
+}

--- a/core/src/main/java/io/aiven/klaw/config/CustomJwtDecoder.java
+++ b/core/src/main/java/io/aiven/klaw/config/CustomJwtDecoder.java
@@ -55,11 +55,13 @@ class CustomJwtDecoder implements JwtDecoder {
       Map<String, Object> claims;
       if (parsedJwt instanceof SignedJWT) {
         claims = getJWTClaimsSet(parsedJwt).getClaims();
-      } else claims = parsedJwt.getJWTClaimsSet().getClaims();
+      } else {
+        claims = parsedJwt.getJWTClaimsSet().getClaims();
+      }
 
       for (String key : claims.keySet()) {
         Object value = claims.get(key);
-        if (key.equals("exp") || key.equals("iat")) {
+        if ((key.equals("exp") || key.equals("iat")) && (value instanceof Date)) {
           value = ((Date) value).toInstant();
         }
         claimsMap.put(key, value);
@@ -80,9 +82,7 @@ class CustomJwtDecoder implements JwtDecoder {
 
   public JWTClaimsSet getJWTClaimsSet(JWT parsedJwt) throws ParseException {
     Payload payload = new Payload(parsedJwt.getParsedParts()[1]);
-    log.info("Payload before : {}", payload);
     Map<String, Object> json = toJSONObject(payload);
-    log.info("Payload after : {}", json);
     if (json == null) {
       log.error("Payload of JWS object is not a valid JSON object");
       throw new ParseException("Payload of JWS object is not a valid JSON object", 0);

--- a/core/src/main/java/io/aiven/klaw/config/SecurityConfigSSO.java
+++ b/core/src/main/java/io/aiven/klaw/config/SecurityConfigSSO.java
@@ -36,9 +36,6 @@ public class SecurityConfigSSO {
   @Value("${klaw.coral.enabled:false}")
   private boolean coralEnabled;
 
-  @Value("${klaw.sso.provider.keycloak.legacy:false}")
-  private boolean keycloakLegacy;
-
   @Autowired KwAuthenticationSuccessHandler kwAuthenticationSuccessHandler;
 
   @Autowired KwAuthenticationFailureHandler kwAuthenticationFailureHandler;

--- a/core/src/main/java/io/aiven/klaw/config/SecurityConfigSSO.java
+++ b/core/src/main/java/io/aiven/klaw/config/SecurityConfigSSO.java
@@ -1,11 +1,25 @@
 package io.aiven.klaw.config;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.nimbusds.jose.Payload;
+import com.nimbusds.jwt.JWT;
+import com.nimbusds.jwt.JWTClaimsSet;
+import com.nimbusds.jwt.JWTParser;
+import com.nimbusds.jwt.SignedJWT;
 import io.aiven.klaw.auth.KwAuthenticationFailureHandler;
 import io.aiven.klaw.auth.KwAuthenticationSuccessHandler;
+import java.text.ParseException;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.Map;
 import java.util.Properties;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -14,12 +28,17 @@ import org.springframework.security.config.annotation.web.configuration.EnableWe
 import org.springframework.security.oauth2.client.endpoint.DefaultAuthorizationCodeTokenResponseClient;
 import org.springframework.security.oauth2.client.endpoint.OAuth2AccessTokenResponseClient;
 import org.springframework.security.oauth2.client.endpoint.OAuth2AuthorizationCodeGrantRequest;
+import org.springframework.security.oauth2.client.registration.ClientRegistration;
 import org.springframework.security.oauth2.client.registration.ClientRegistrationRepository;
 import org.springframework.security.oauth2.client.web.AuthorizationRequestRepository;
 import org.springframework.security.oauth2.client.web.HttpSessionOAuth2AuthorizationRequestRepository;
 import org.springframework.security.oauth2.client.web.OAuth2AuthorizedClientRepository;
 import org.springframework.security.oauth2.client.web.reactive.function.client.ServletOAuth2AuthorizedClientExchangeFilterFunction;
 import org.springframework.security.oauth2.core.endpoint.OAuth2AuthorizationRequest;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.security.oauth2.jwt.JwtDecoder;
+import org.springframework.security.oauth2.jwt.JwtDecoderFactory;
+import org.springframework.security.oauth2.jwt.JwtException;
 import org.springframework.security.provisioning.InMemoryUserDetailsManager;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.web.reactive.function.client.WebClient;
@@ -32,6 +51,9 @@ public class SecurityConfigSSO {
 
   @Value("${klaw.coral.enabled:false}")
   private boolean coralEnabled;
+
+  @Value("${klaw.sso.provider.keycloak.legacy:false}")
+  private boolean keycloakLegacy;
 
   @Autowired KwAuthenticationSuccessHandler kwAuthenticationSuccessHandler;
 
@@ -75,5 +97,98 @@ public class SecurityConfigSSO {
   public InMemoryUserDetailsManager inMemoryUserDetailsManager() {
     final Properties globalUsers = new Properties();
     return new InMemoryUserDetailsManager(globalUsers);
+  }
+
+  /*
+  Below code and class is only applicable for keycloak provider with legacy version (10.x)
+  Known issue in keycloak https://issues.redhat.com/browse/KEYCLOAK-14309
+  If token contains duplicate keys, json parser in spring framework fails. Hence custom json parser is applied here below.
+  */
+
+  @Bean
+  @ConditionalOnExpression("${klaw.sso.provider.keycloak.legacy:false}")
+  public JwtDecoderFactory<ClientRegistration> customJwtDecoderFactory() {
+    return new CustomJwtDecoderFactory();
+  }
+
+  static class CustomJwtDecoderFactory implements JwtDecoderFactory<ClientRegistration> {
+    public JwtDecoder createDecoder(ClientRegistration reg) {
+      return new CustomJwtDecoder();
+    }
+  }
+}
+
+@Slf4j
+class CustomJwtDecoder implements JwtDecoder {
+
+  public static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+
+  @Override
+  public Jwt decode(String token) throws JwtException {
+    JWT jwt;
+    try {
+      jwt = JWTParser.parse(token);
+      return createJwt(token, jwt);
+    } catch (ParseException e) {
+      log.error("Token parsing exception : ", e);
+    }
+    return null;
+  }
+
+  private Jwt createJwt(String token, JWT parsedJwt) {
+    try {
+      Map<String, Object> headers = new LinkedHashMap<>(parsedJwt.getHeader().toJSONObject());
+      Map<String, Object> claimsMap = new HashMap<>();
+      Map<String, Object> claims;
+      if (parsedJwt instanceof SignedJWT) {
+        claims = getJWTClaimsSet(parsedJwt).getClaims();
+      } else claims = parsedJwt.getJWTClaimsSet().getClaims();
+
+      for (String key : claims.keySet()) {
+        Object value = claims.get(key);
+        if (key.equals("exp") || key.equals("iat")) {
+          value = ((Date) value).toInstant();
+        }
+        claimsMap.put(key, value);
+      }
+      return Jwt.withTokenValue(token)
+          .headers(h -> h.putAll(headers))
+          .claims(c -> c.putAll(claimsMap))
+          .build();
+    } catch (Exception ex) {
+      log.error("Exception while creating JWT : ", ex);
+      if (ex.getCause() instanceof ParseException) {
+        throw new JwtException("There is a problem parsing the JWT: " + ex.getMessage());
+      } else {
+        throw new JwtException("There is a problem decoding the JWT: " + ex.getMessage());
+      }
+    }
+  }
+
+  public JWTClaimsSet getJWTClaimsSet(JWT parsedJwt) throws ParseException {
+    Payload payload = new Payload(parsedJwt.getParsedParts()[1]);
+    log.info("Payload before : {}", payload);
+    Map<String, Object> json = toJSONObject(payload);
+    log.info("Payload after : {}", json);
+    if (json == null) {
+      log.error("Payload of JWS object is not a valid JSON object");
+      throw new ParseException("Payload of JWS object is not a valid JSON object", 0);
+    } else {
+      return JWTClaimsSet.parse(json);
+    }
+  }
+
+  public Map<String, Object> toJSONObject(Payload payload) {
+    String payloadStr = payload.toString();
+    if (payloadStr == null) {
+      return null;
+    } else {
+      try {
+        return OBJECT_MAPPER.readValue(payloadStr, new TypeReference<>() {});
+      } catch (JsonProcessingException ex) {
+        log.error("Exception while transforming payload to json object ", ex);
+        return null;
+      }
+    }
   }
 }

--- a/core/src/main/java/io/aiven/klaw/service/UtilControllerService.java
+++ b/core/src/main/java/io/aiven/klaw/service/UtilControllerService.java
@@ -642,7 +642,8 @@ public class UtilControllerService {
         .forEach(
             k -> {
               String providerName = k.substring(0, k.indexOf("."));
-              ssoProviders.put(providerName, registration.get(providerName + IMAGE_URI));
+              String imageUri = registration.get(providerName + IMAGE_URI);
+              ssoProviders.put(providerName, imageUri == null ? "" : imageUri);
             });
 
     return ssoProviders;

--- a/core/src/main/resources/application.properties
+++ b/core/src/main/resources/application.properties
@@ -193,6 +193,8 @@ spring.thymeleaf.cache=false
 # Klaw Settings for Schema validation
 klaw.schema.validate.compatibility.onSave=true
 
+# SSO provider Keycloak if legacy version (10.x), has different json parser for tokens.
+klaw.sso.provider.keycloak.legacy=false
 
 # application shutdown and health properties
 management.endpoints.web.exposure.include=health,info,metrics

--- a/core/src/test/java/io/aiven/klaw/config/CustomJwtDecoderTest.java
+++ b/core/src/test/java/io/aiven/klaw/config/CustomJwtDecoderTest.java
@@ -1,0 +1,76 @@
+package io.aiven.klaw.config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.nimbusds.jose.Payload;
+import io.jsonwebtoken.Jwts;
+import java.time.temporal.ChronoUnit;
+import java.util.Date;
+import java.util.Map;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+@ExtendWith(SpringExtension.class)
+public class CustomJwtDecoderTest {
+
+  CustomJwtDecoder customJwtDecoder;
+
+  @BeforeEach
+  public void setUp() throws Exception {
+    customJwtDecoder = new CustomJwtDecoder();
+  }
+
+  @Test
+  public void decode() {
+    Jwt jwt = customJwtDecoder.decode(getSampleToken());
+    assertThat(jwt.getClaims()).hasSize(6);
+    assertThat(jwt.getClaims()).containsKeys("name", "email", "sub", "jti", "iat", "exp");
+    assertThat(jwt.getClaims()).containsEntry("name", "Jane Doe");
+  }
+
+  @Test
+  public void toJSONObject() {
+    Payload payload = new Payload(getPayLoad());
+    Map<String, Object> jsonMap = customJwtDecoder.toJSONObject(payload);
+    assertThat(jsonMap.size()).isEqualTo(13); // ignores duplicates
+  }
+
+  private String getSampleToken() {
+    return Jwts.builder()
+        .claim("name", "Jane Doe")
+        .claim("email", "jane@example.com")
+        .setSubject("jane")
+        .setId(UUID.randomUUID().toString())
+        .setIssuedAt(new Date())
+        .setExpiration(Date.from(new Date().toInstant().plus(5, ChronoUnit.DAYS)))
+        .compact();
+  }
+
+  // number of keys 14, with duplicate key (sub)
+  private String getPayLoad() {
+    return """
+            {
+              "exp": 1675788223,
+              "iat": 1675787923,
+              "auth_time": 1675787563,
+              "jti": "c07d2db2f",
+              "iss": "https://login.test.com/auth/realms/appid-123",
+              "aud": "dbb-dev",
+              "sub": "abcdefgh:test@test.com",
+              "typ": "ID",
+              "azp": "dbb-dev",
+              "nonce": "fgdjkshfs",
+              "session_state": "fds567534g78346",
+              "acr": "0",
+              "sub": "test@test.com",
+              "groups": [
+                "GRP-AuthUser",
+                "GRP-admin"
+              ]
+            }""";
+  }
+}


### PR DESCRIPTION
About this change - What it does

there is a know issue in keycloak 10.x https://issues.redhat.com/browse/KEYCLOAK-14309
With this implementaion with a different jsson parser in spring, duplicate keys will be ignored.

Resolves: #xxxxx
Why this way
Applicable to only old keycloak version 10.x
