### PR TITLE
feat(coral): Use `search` param to filter by topics in data tables

### DIFF
--- a/coral/src/app/features/approvals/acls/AclApprovals.test.tsx
+++ b/coral/src/app/features/approvals/acls/AclApprovals.test.tsx
@@ -403,7 +403,7 @@ describe("AclApprovals", () => {
           env: "ALL",
           pageNo: "1",
           requestStatus: "CREATED",
-          topic: "",
+          search: "",
           operationType: "CREATE",
         })
       );
@@ -467,7 +467,7 @@ describe("AclApprovals", () => {
           env: "ALL",
           pageNo: "1",
           requestStatus: "CREATED",
-          topic: "",
+          search: "",
           operationType: "DELETE",
         })
       );

--- a/coral/src/app/features/approvals/acls/AclApprovals.test.tsx
+++ b/coral/src/app/features/approvals/acls/AclApprovals.test.tsx
@@ -311,7 +311,7 @@ describe("AclApprovals", () => {
           env: "1",
           pageNo: "1",
           requestStatus: "CREATED",
-          topic: "",
+          search: "",
         });
       });
     });
@@ -335,7 +335,7 @@ describe("AclApprovals", () => {
           env: "ALL",
           pageNo: "1",
           requestStatus: "DECLINED",
-          topic: "",
+          search: "",
         })
       );
     });
@@ -359,7 +359,7 @@ describe("AclApprovals", () => {
           env: "ALL",
           pageNo: "1",
           requestStatus: "CREATED",
-          topic: "",
+          search: "",
         })
       );
     });
@@ -379,7 +379,7 @@ describe("AclApprovals", () => {
           env: "ALL",
           pageNo: "1",
           requestStatus: "CREATED",
-          topic: "topicname",
+          search: "topicname",
         })
       );
     });
@@ -429,7 +429,7 @@ describe("AclApprovals", () => {
           env: "ALL",
           pageNo: "1",
           requestStatus: "CREATED",
-          topic: "topicname",
+          search: "topicname",
         })
       );
     });

--- a/coral/src/app/features/approvals/acls/AclApprovals.test.tsx
+++ b/coral/src/app/features/approvals/acls/AclApprovals.test.tsx
@@ -290,7 +290,7 @@ describe("AclApprovals", () => {
 
       expect(search).toBeVisible();
       expect(search).toHaveAccessibleDescription(
-        'Search for an exact match for topic name. Searching starts automatically with a little delay while typing. Press "Escape" to delete all your input.'
+        'Search for an partial match for topic name. Searching starts automatically with a little delay while typing. Press "Escape" to delete all your input.'
       );
     });
 

--- a/coral/src/app/features/approvals/acls/AclApprovals.tsx
+++ b/coral/src/app/features/approvals/acls/AclApprovals.tsx
@@ -79,7 +79,7 @@ function AclApprovals() {
         env: environment,
         requestStatus: status,
         aclType,
-        topic,
+        search: topic,
         operationType: requestType !== defaultType ? requestType : undefined,
       }),
     keepPreviousData: true,

--- a/coral/src/app/features/approvals/schemas/SchemaApprovals.test.tsx
+++ b/coral/src/app/features/approvals/schemas/SchemaApprovals.test.tsx
@@ -217,7 +217,7 @@ describe("SchemaApprovals", () => {
 
       expect(search).toBeVisible();
       expect(search).toHaveAccessibleDescription(
-        'Search for an exact match for topic name. Searching starts automatically with a little delay while typing. Press "Escape" to delete all your input.'
+        'Search for an partial match for topic name. Searching starts automatically with a little delay while typing. Press "Escape" to delete all your input.'
       );
     });
 

--- a/coral/src/app/features/approvals/schemas/SchemaApprovals.test.tsx
+++ b/coral/src/app/features/approvals/schemas/SchemaApprovals.test.tsx
@@ -109,7 +109,7 @@ describe("SchemaApprovals", () => {
     pageNo: "1",
     requestStatus: "CREATED",
     env: "ALL",
-    topic: "",
+    search: "",
   };
   beforeAll(() => {
     mockIntersectionObserver();
@@ -577,7 +577,7 @@ describe("SchemaApprovals", () => {
       await waitFor(() => {
         expect(mockGetSchemaRequestsForApprover).toHaveBeenNthCalledWith(2, {
           ...defaultApiParams,
-          topic: "myTopic",
+          search: "myTopic",
         });
       });
     });

--- a/coral/src/app/features/approvals/schemas/SchemaApprovals.tsx
+++ b/coral/src/app/features/approvals/schemas/SchemaApprovals.tsx
@@ -66,7 +66,7 @@ function SchemaApprovals() {
         requestStatus: status,
         pageNo: currentPage.toString(),
         env: environment,
-        topic,
+        search: topic,
       }),
     keepPreviousData: true,
   });

--- a/coral/src/app/features/approvals/topics/TopicApprovals.test.tsx
+++ b/coral/src/app/features/approvals/topics/TopicApprovals.test.tsx
@@ -240,7 +240,7 @@ describe("TopicApprovals", () => {
 
       expect(search).toBeVisible();
       expect(search).toHaveAccessibleDescription(
-        'Search for an exact match for topic name. Searching starts automatically with a little delay while typing. Press "Escape" to delete all your input.'
+        'Search for an partial match for topic name. Searching starts automatically with a little delay while typing. Press "Escape" to delete all your input.'
       );
     });
 

--- a/coral/src/app/features/components/filters/TopicFilter.tsx
+++ b/coral/src/app/features/components/filters/TopicFilter.tsx
@@ -19,9 +19,9 @@ function TopicFilter() {
         }, 500)}
       />
       <div id={"search-field-description"} className={"visually-hidden"}>
-        Search for an exact match for topic name. Searching starts automatically
-        with a little delay while typing. Press &quot;Escape&quot; to delete all
-        your input.
+        Search for an partial match for topic name. Searching starts
+        automatically with a little delay while typing. Press &quot;Escape&quot;
+        to delete all your input.
       </div>
     </div>
   );

--- a/coral/src/app/features/requests/acls/AclRequests.test.tsx
+++ b/coral/src/app/features/requests/acls/AclRequests.test.tsx
@@ -321,7 +321,7 @@ describe("AclRequests", () => {
       const search = screen.getByRole("search");
       expect(search).toBeEnabled();
       expect(search).toHaveAccessibleDescription(
-        'Search for an exact match for topic name. Searching starts automatically with a little delay while typing. Press "Escape" to delete all your input.'
+        'Search for an partial match for topic name. Searching starts automatically with a little delay while typing. Press "Escape" to delete all your input.'
       );
       await userEvent.type(search, "abc");
       await waitFor(() => {

--- a/coral/src/app/features/requests/acls/AclRequests.test.tsx
+++ b/coral/src/app/features/requests/acls/AclRequests.test.tsx
@@ -152,7 +152,7 @@ describe("AclRequests", () => {
 
       expect(mockGetAclRequests).toHaveBeenCalledWith({
         pageNo: "100",
-        topic: "",
+        search: "",
         env: "ALL",
         aclType: "ALL",
         requestStatus: "ALL",
@@ -171,7 +171,7 @@ describe("AclRequests", () => {
 
       expect(mockGetAclRequests).toHaveBeenCalledWith({
         pageNo: "1",
-        topic: "",
+        search: "",
         env: "ALL",
         aclType: "ALL",
         requestStatus: "ALL",
@@ -280,7 +280,7 @@ describe("AclRequests", () => {
 
       expect(mockGetAclRequests).toHaveBeenNthCalledWith(2, {
         pageNo: "2",
-        topic: "",
+        search: "",
         env: "ALL",
         aclType: "ALL",
         requestStatus: "ALL",
@@ -304,7 +304,7 @@ describe("AclRequests", () => {
       });
       expect(getAclRequests).toHaveBeenNthCalledWith(1, {
         pageNo: "1",
-        topic: "abc",
+        search: "abc",
         env: "ALL",
         aclType: "ALL",
         requestStatus: "ALL",
@@ -327,7 +327,7 @@ describe("AclRequests", () => {
       await waitFor(() => {
         expect(getAclRequests).toHaveBeenLastCalledWith({
           pageNo: "1",
-          topic: "abc",
+          search: "abc",
           env: "ALL",
           aclType: "ALL",
           requestStatus: "ALL",
@@ -362,7 +362,7 @@ describe("AclRequests", () => {
 
       expect(getAclRequests).toHaveBeenNthCalledWith(1, {
         pageNo: "1",
-        topic: "",
+        search: "",
         env: "1",
         aclType: "ALL",
         requestStatus: "ALL",
@@ -390,7 +390,7 @@ describe("AclRequests", () => {
       await waitFor(() => {
         expect(getAclRequests).toHaveBeenLastCalledWith({
           pageNo: "1",
-          topic: "",
+          search: "",
           env: "1",
           aclType: "ALL",
           requestStatus: "ALL",
@@ -421,7 +421,7 @@ describe("AclRequests", () => {
 
       expect(getAclRequests).toHaveBeenNthCalledWith(1, {
         pageNo: "1",
-        topic: "",
+        search: "",
         env: "ALL",
         aclType: "CONSUMER",
         requestStatus: "ALL",
@@ -445,7 +445,7 @@ describe("AclRequests", () => {
       await waitFor(() => {
         expect(getAclRequests).toHaveBeenLastCalledWith({
           pageNo: "1",
-          topic: "",
+          search: "",
           env: "ALL",
           aclType: "CONSUMER",
           requestStatus: "ALL",
@@ -476,7 +476,7 @@ describe("AclRequests", () => {
 
       expect(getAclRequests).toHaveBeenNthCalledWith(1, {
         pageNo: "1",
-        topic: "",
+        search: "",
         env: "ALL",
         aclType: "ALL",
         requestStatus: "APPROVED",
@@ -501,7 +501,7 @@ describe("AclRequests", () => {
       await waitFor(() => {
         expect(getAclRequests).toHaveBeenLastCalledWith({
           pageNo: "1",
-          topic: "",
+          search: "",
           env: "ALL",
           aclType: "ALL",
           requestStatus: "APPROVED",
@@ -532,7 +532,7 @@ describe("AclRequests", () => {
 
       expect(getAclRequests).toHaveBeenNthCalledWith(1, {
         pageNo: "1",
-        topic: "",
+        search: "",
         env: "ALL",
         aclType: "ALL",
         requestStatus: "ALL",
@@ -560,7 +560,7 @@ describe("AclRequests", () => {
       await waitFor(() => {
         expect(getAclRequests).toHaveBeenLastCalledWith({
           pageNo: "1",
-          topic: "",
+          search: "",
           env: "ALL",
           aclType: "ALL",
           requestStatus: "ALL",
@@ -591,7 +591,7 @@ describe("AclRequests", () => {
 
       expect(getAclRequests).toHaveBeenNthCalledWith(1, {
         pageNo: "1",
-        topic: "",
+        search: "",
         env: "ALL",
         aclType: "ALL",
         requestStatus: "ALL",
@@ -617,7 +617,7 @@ describe("AclRequests", () => {
       await waitFor(() => {
         expect(getAclRequests).toHaveBeenLastCalledWith({
           pageNo: "1",
-          topic: "",
+          search: "",
           env: "ALL",
           aclType: "ALL",
           requestStatus: "ALL",

--- a/coral/src/app/features/requests/acls/AclRequests.tsx
+++ b/coral/src/app/features/requests/acls/AclRequests.tsx
@@ -72,7 +72,7 @@ function AclRequests() {
     queryFn: () =>
       getAclRequests({
         pageNo: String(currentPage),
-        topic,
+        search: topic,
         env: environment,
         aclType,
         requestStatus: status,

--- a/coral/src/app/features/requests/schemas/SchemaRequests.test.tsx
+++ b/coral/src/app/features/requests/schemas/SchemaRequests.test.tsx
@@ -159,7 +159,7 @@ describe("SchemaRequest", () => {
 
       expect(search).toBeVisible();
       expect(search).toHaveAccessibleDescription(
-        'Search for an exact match for topic name. Searching starts automatically with a little delay while typing. Press "Escape" to delete all your input.'
+        'Search for an partial match for topic name. Searching starts automatically with a little delay while typing. Press "Escape" to delete all your input.'
       );
     });
 

--- a/coral/src/app/features/requests/schemas/SchemaRequests.test.tsx
+++ b/coral/src/app/features/requests/schemas/SchemaRequests.test.tsx
@@ -43,7 +43,7 @@ describe("SchemaRequest", () => {
     pageNo: "1",
     operationType: undefined,
     requestStatus: undefined,
-    topic: "",
+    search: "",
     isMyRequest: false,
   };
 
@@ -503,7 +503,7 @@ describe("SchemaRequest", () => {
     it("populates the filter from the url search parameters", () => {
       expect(mockGetSchemaRequests).toHaveBeenNthCalledWith(1, {
         ...defaultApiParams,
-        topic: "TEST_SEARCH_VALUE",
+        search: "TEST_SEARCH_VALUE",
       });
     });
 
@@ -518,7 +518,7 @@ describe("SchemaRequest", () => {
       await waitFor(() => {
         expect(mockGetSchemaRequests).toHaveBeenNthCalledWith(2, {
           ...defaultApiParams,
-          topic: "myNiceTopic",
+          search: "myNiceTopic",
         });
       });
     });

--- a/coral/src/app/features/requests/schemas/SchemaRequests.tsx
+++ b/coral/src/app/features/requests/schemas/SchemaRequests.tsx
@@ -62,7 +62,7 @@ function SchemaRequests() {
         pageNo: String(currentPage),
         env: environment,
         requestStatus: status !== defaultStatus ? status : undefined,
-        topic,
+        search: topic,
         isMyRequest: showOnlyMyRequests,
         operationType: requestType !== defaultType ? requestType : undefined,
       }),

--- a/coral/src/app/features/requests/topics/TopicRequests.test.tsx
+++ b/coral/src/app/features/requests/topics/TopicRequests.test.tsx
@@ -119,7 +119,7 @@ describe("TopicRequests", () => {
       const search = screen.getByRole("search");
       expect(search).toBeVisible();
       expect(search).toHaveAccessibleDescription(
-        'Search for an exact match for topic name. Searching starts automatically with a little delay while typing. Press "Escape" to delete all your input.'
+        'Search for an partial match for topic name. Searching starts automatically with a little delay while typing. Press "Escape" to delete all your input.'
       );
       await userEvent.type(search, "abc");
       await waitFor(() => {

--- a/coral/src/app/features/requests/topics/TopicRequests.test.tsx
+++ b/coral/src/app/features/requests/topics/TopicRequests.test.tsx
@@ -100,11 +100,11 @@ describe("TopicRequests", () => {
       customRender(<TopicRequests />, {
         queryClient: true,
         memoryRouter: true,
-        customRoutePath: "/?topic=abc",
+        customRoutePath: "/?topic=",
       });
       expect(getTopicRequests).toHaveBeenNthCalledWith(1, {
         pageNo: "1",
-        // search: "abc",
+        search: "",
         isMyRequest: false,
         requestStatus: "ALL",
         env: "ALL",
@@ -125,7 +125,7 @@ describe("TopicRequests", () => {
       await waitFor(() => {
         expect(getTopicRequests).toHaveBeenLastCalledWith({
           pageNo: "1",
-          // search: "abc",
+          search: "abc",
           isMyRequest: false,
           requestStatus: "ALL",
           env: "ALL",
@@ -149,7 +149,7 @@ describe("TopicRequests", () => {
       expect(getTopicRequests).toHaveBeenNthCalledWith(1, {
         pageNo: "1",
         isMyRequest: true,
-        search: undefined,
+        search: "",
         requestStatus: "ALL",
         env: "ALL",
       });
@@ -168,7 +168,7 @@ describe("TopicRequests", () => {
         expect(getTopicRequests).toHaveBeenLastCalledWith({
           pageNo: "1",
           isMyRequest: true,
-          search: undefined,
+          search: "",
           requestStatus: "ALL",
           env: "ALL",
         });
@@ -189,7 +189,7 @@ describe("TopicRequests", () => {
         expect(getTopicRequests).toHaveBeenLastCalledWith({
           pageNo: "1",
           isMyRequest: false,
-          search: undefined,
+          search: "",
           requestStatus: "ALL",
           env: "ALL",
         });
@@ -225,7 +225,7 @@ describe("TopicRequests", () => {
 
       expect(mockGetTopicRequests).toHaveBeenCalledWith({
         pageNo: "100",
-        search: undefined,
+        search: "",
         isMyRequest: false,
         requestStatus: "ALL",
         env: "ALL",
@@ -242,7 +242,7 @@ describe("TopicRequests", () => {
 
       expect(mockGetTopicRequests).toHaveBeenCalledWith({
         pageNo: "1",
-        search: undefined,
+        search: "",
         isMyRequest: false,
         requestStatus: "ALL",
         env: "ALL",
@@ -352,7 +352,7 @@ describe("TopicRequests", () => {
 
       expect(mockGetTopicRequests).toHaveBeenNthCalledWith(2, {
         pageNo: "2",
-        search: undefined,
+        search: "",
         isMyRequest: false,
         requestStatus: "ALL",
         env: "ALL",
@@ -383,7 +383,7 @@ describe("TopicRequests", () => {
     it("populates the filter from the url search parameters", () => {
       expect(mockGetTopicRequests).toHaveBeenNthCalledWith(1, {
         pageNo: "1",
-        search: undefined,
+        search: "",
         isMyRequest: false,
         requestStatus: "ALL",
         env: "TEST_ENV_THAT_CANNOT_BE_PART_OF_ANY_API_MOCK",
@@ -402,7 +402,7 @@ describe("TopicRequests", () => {
 
       expect(mockGetTopicRequests).toHaveBeenNthCalledWith(2, {
         pageNo: "1",
-        search: undefined,
+        search: "",
         isMyRequest: false,
         requestStatus: "ALL",
         env: mockedEnvironmentResponse[0].id,
@@ -435,7 +435,7 @@ describe("TopicRequests", () => {
     it("populates the filter from the url search parameters", () => {
       expect(mockGetTopicRequests).toHaveBeenNthCalledWith(1, {
         pageNo: "1",
-        search: undefined,
+        search: "",
         isMyRequest: false,
         requestStatus: "TEST_STATUS_THAT_CANNOT_BE_PART_OF_ANY_API_MOCK",
         env: "ALL",
@@ -455,7 +455,7 @@ describe("TopicRequests", () => {
 
       expect(mockGetTopicRequests).toHaveBeenNthCalledWith(2, {
         pageNo: "1",
-        search: undefined,
+        search: "",
         isMyRequest: false,
         requestStatus: newStatus,
         env: "ALL",
@@ -597,7 +597,7 @@ describe("TopicRequests", () => {
       mockDeleteTopicRequest.mockResolvedValue([{ result: "success" }]);
       expect(mockGetTopicRequests).toHaveBeenNthCalledWith(1, {
         pageNo: "1",
-        // search: "abc",
+        search: "",
         isMyRequest: false,
         requestStatus: "ALL",
         env: "ALL",
@@ -623,7 +623,7 @@ describe("TopicRequests", () => {
       await waitForElementToBeRemoved(modal);
       expect(mockGetTopicRequests).toHaveBeenNthCalledWith(2, {
         pageNo: "1",
-        // search: "abc",
+        search: "",
         isMyRequest: false,
         requestStatus: "ALL",
         env: "ALL",
@@ -635,7 +635,7 @@ describe("TopicRequests", () => {
       mockDeleteTopicRequest.mockRejectedValue({ message: "OH NO" });
       expect(mockGetTopicRequests).toHaveBeenNthCalledWith(1, {
         pageNo: "1",
-        // search: "abc",
+        search: "",
         isMyRequest: false,
         requestStatus: "ALL",
         env: "ALL",
@@ -670,7 +670,7 @@ describe("TopicRequests", () => {
       mockDeleteTopicRequest.mockRejectedValue("OH NO");
       expect(mockGetTopicRequests).toHaveBeenNthCalledWith(1, {
         pageNo: "1",
-        // search: "abc",
+        search: "",
         isMyRequest: false,
         requestStatus: "ALL",
         env: "ALL",
@@ -733,6 +733,7 @@ describe("TopicRequests", () => {
         operationType: "DELETE",
         requestStatus: "ALL",
         env: "ALL",
+        search: "",
       });
     });
 
@@ -753,6 +754,7 @@ describe("TopicRequests", () => {
         requestStatus: "ALL",
         operationType: newType,
         env: "ALL",
+        search: "",
       });
     });
   });

--- a/coral/src/app/features/requests/topics/TopicRequests.tsx
+++ b/coral/src/app/features/requests/topics/TopicRequests.tsx
@@ -52,8 +52,7 @@ function TopicRequests() {
     queryFn: () =>
       getTopicRequests({
         pageNo: String(currentPage),
-        // search is not yet implemented as a param to getTopicRequests
-        // search: topic,
+        search: topic,
         env: environment,
         requestStatus: status,
         isMyRequest: showOnlyMyRequests,

--- a/coral/src/domain/acl/acl-api.ts
+++ b/coral/src/domain/acl/acl-api.ts
@@ -35,13 +35,16 @@ const filterGetAclRequestParams = (params: GetCreatedAclRequestParameters) => {
       const omitIsMyRequest = property === "isMyRequest" && value !== "true";
       const omitOperationType =
         property === "operationType" && value === undefined;
+      const omitSearch =
+        property === "search" && (value === "" || value === undefined);
 
       return (
         omitEnv ||
         omitAclType ||
         omitTopic ||
         omitOperationType ||
-        omitIsMyRequest
+        omitIsMyRequest ||
+        omitSearch
       );
     }
   );

--- a/coral/src/domain/schema-request/schema-request-api.ts
+++ b/coral/src/domain/schema-request/schema-request-api.ts
@@ -47,7 +47,7 @@ type GetSchemaRequestsForApproverQueryParams = ResolveIntersectionTypes<
   > &
     Pick<
       KlawApiRequestQueryParameters<"getSchemaRequestsForApprover">,
-      "pageNo" | "env" | "topic"
+      "pageNo" | "env" | "search"
     >
 >;
 
@@ -57,7 +57,7 @@ const getSchemaRequestsForApprover = (
   const queryObject: GetSchemaRequestsForApproverQueryParams = {
     pageNo: args.pageNo,
     requestStatus: args.requestStatus,
-    ...(args.topic && { topic: args.topic }),
+    ...(args.search && args.search !== "" && { search: args.search }),
     ...(args.env && args.env !== "ALL" && { env: args.env }),
   };
 
@@ -75,7 +75,7 @@ type GetSchemaRequestsQueryParams = ResolveIntersectionTypes<
     KlawApiRequestQueryParameters<"getSchemaRequests">,
     | "pageNo"
     | "requestStatus"
-    | "topic"
+    | "search"
     | "env"
     | "isMyRequest"
     | "operationType"
@@ -91,7 +91,7 @@ const getSchemaRequests = (
     pageNo: args.pageNo,
     ...(args.operationType && { operationType: args.operationType }),
     ...(args.requestStatus && { requestStatus: args.requestStatus }),
-    ...(args.topic && { topic: args.topic }),
+    ...(args.search && args.search !== "" && { search: args.search }),
     ...(args.env && args.env !== "ALL" && { env: args.env }),
     ...(args.operationType !== undefined && { env: args.operationType }),
     ...(args.isMyRequest && { isMyRequest: String(Boolean(args.isMyRequest)) }),

--- a/coral/src/domain/topic/topic-api.ts
+++ b/coral/src/domain/topic/topic-api.ts
@@ -136,7 +136,8 @@ const getTopicRequests = (
     { ...params, isMyRequest: String(Boolean(params.isMyRequest)) },
     (value, property) => {
       const omitIsMyRequest = property === "isMyRequest" && value !== "true"; // Omit if anything else than true
-      const omitSearch = property === "search" && !value;
+      const omitSearch =
+        property === "search" && (value === "" || value === undefined);
       const omitEnv =
         property === "env" && (value === "ALL" || value === undefined);
       const omitRequestOperationType =

--- a/coral/types/api.d.ts
+++ b/coral/types/api.d.ts
@@ -3510,6 +3510,7 @@ export type operations = {
         requestStatus?: "CREATED" | "DELETED" | "DECLINED" | "APPROVED" | "ALL";
         topic?: string;
         env?: string;
+        search?: string;
         aclType?: "PRODUCER" | "CONSUMER";
         operationType?: "CREATE" | "UPDATE" | "PROMOTE" | "CLAIM" | "DELETE";
         order?: "ASC_REQUESTED_TIME" | "DESC_REQUESTED_TIME";

--- a/core/src/main/java/io/aiven/klaw/controller/AclController.java
+++ b/core/src/main/java/io/aiven/klaw/controller/AclController.java
@@ -97,6 +97,7 @@ public class AclController {
    * @param requestStatus What type of requests are you looking for e.g. 'CREATED' or 'DELETED'
    * @param topic The name of the topic you would like returned
    * @param env The name of the environment you would like returned e.g. '1' or '4'
+   * @param search is a wildcard search that will patial match against the topic name
    * @param aclType The Type of acl Consumer/Producer
    * @param order allows the requestor to specify what order the pagination should be returned in
    *     OLDEST_FIRST/NEWEST_FIRST
@@ -117,6 +118,7 @@ public class AclController {
       @RequestParam(value = "requestStatus", defaultValue = "CREATED") RequestStatus requestStatus,
       @RequestParam(value = "topic", required = false) String topic,
       @RequestParam(value = "env", required = false) String env,
+      @RequestParam(value = "search", required = false) String search,
       @RequestParam(value = "aclType", required = false) AclType aclType,
       @RequestParam(value = "operationType", required = false)
           RequestOperationType requestOperationType,
@@ -130,6 +132,7 @@ public class AclController {
             topic,
             env,
             requestOperationType,
+            search,
             aclType,
             order),
         HttpStatus.OK);

--- a/core/src/main/java/io/aiven/klaw/helpers/HandleDbRequests.java
+++ b/core/src/main/java/io/aiven/klaw/helpers/HandleDbRequests.java
@@ -147,6 +147,7 @@ public interface HandleDbRequests {
       RequestOperationType requestOperationType,
       String topic,
       String environment,
+      String wildcardSearch,
       AclType aclType,
       int tenantId);
 

--- a/core/src/main/java/io/aiven/klaw/helpers/db/rdbms/HandleDbRequestsJdbc.java
+++ b/core/src/main/java/io/aiven/klaw/helpers/db/rdbms/HandleDbRequestsJdbc.java
@@ -327,6 +327,7 @@ public class HandleDbRequestsJdbc implements HandleDbRequests {
       RequestOperationType requestOperationType,
       String topic,
       String environment,
+      String wildcardSearch,
       AclType aclType,
       int tenantId) {
     return jdbcSelectHelper.selectFilteredAclRequests(
@@ -338,7 +339,7 @@ public class HandleDbRequestsJdbc implements HandleDbRequests {
         showRequestsOfAllTeams,
         topic,
         environment,
-        null,
+        wildcardSearch,
         aclType,
         false,
         tenantId);

--- a/core/src/main/java/io/aiven/klaw/service/AclControllerService.java
+++ b/core/src/main/java/io/aiven/klaw/service/AclControllerService.java
@@ -477,6 +477,7 @@ public class AclControllerService {
       String topic,
       String environment,
       RequestOperationType requestOperationType,
+      String search,
       AclType aclType,
       Order order) {
     log.debug("getCreatedAclRequests {} {}", pageNo, requestStatus);
@@ -497,6 +498,7 @@ public class AclControllerService {
                   requestOperationType,
                   topic,
                   environment,
+                  search,
                   aclType,
                   tenantId);
     } else {
@@ -510,6 +512,7 @@ public class AclControllerService {
                   requestOperationType,
                   topic,
                   environment,
+                  search,
                   aclType,
                   tenantId);
     }

--- a/core/src/main/resources/application.properties
+++ b/core/src/main/resources/application.properties
@@ -98,7 +98,7 @@ klaw.uiapi.servers=https://localhost:9097
 # Make sure node, pnpm are installed.
 # If the above are already installed, mvn install will build and copy the coral assets for you.
 # Alternatively you can go through https://github.com/aiven/klaw/blob/main/coral/README.md
-klaw.coral.enabled=false
+klaw.coral.enabled=true
 
 # Email notification properties
 klaw.admin.mailid=superuser@maild
@@ -138,7 +138,7 @@ spring.liquibase.enabled=true
 spring.liquibase.change-log=classpath:db/changelog/changelog.yaml
 
 #kw prize list
-klaw.prizelist.pertenant=<to be removed> 
+klaw.prizelist.pertenant=<to be removed>
 
 # Enable response compression
 server.compression.enabled=true

--- a/core/src/main/resources/application.properties
+++ b/core/src/main/resources/application.properties
@@ -98,7 +98,7 @@ klaw.uiapi.servers=https://localhost:9097
 # Make sure node, pnpm are installed.
 # If the above are already installed, mvn install will build and copy the coral assets for you.
 # Alternatively you can go through https://github.com/aiven/klaw/blob/main/coral/README.md
-klaw.coral.enabled=true
+klaw.coral.enabled=false
 
 # Email notification properties
 klaw.admin.mailid=superuser@maild
@@ -138,7 +138,7 @@ spring.liquibase.enabled=true
 spring.liquibase.change-log=classpath:db/changelog/changelog.yaml
 
 #kw prize list
-klaw.prizelist.pertenant=<to be removed>
+klaw.prizelist.pertenant=<to be removed> 
 
 # Enable response compression
 server.compression.enabled=true

--- a/core/src/test/java/io/aiven/klaw/controller/AclControllerTest.java
+++ b/core/src/test/java/io/aiven/klaw/controller/AclControllerTest.java
@@ -141,6 +141,7 @@ public class AclControllerTest {
             null,
             RequestOperationType.CREATE,
             null,
+            null,
             io.aiven.klaw.model.enums.Order.ASC_REQUESTED_TIME))
         .thenReturn(aclRequests);
 

--- a/core/src/test/java/io/aiven/klaw/service/AclControllerServiceTest.java
+++ b/core/src/test/java/io/aiven/klaw/service/AclControllerServiceTest.java
@@ -372,6 +372,7 @@ public class AclControllerServiceTest {
             any(),
             any(),
             any(),
+            any(),
             anyInt()))
         .thenReturn(getAclRequests("testtopic", 16));
     when(commonUtilsService.getEnvsFromUserId(anyString()))
@@ -389,6 +390,7 @@ public class AclControllerServiceTest {
             null,
             RequestOperationType.CREATE,
             null,
+            null,
             io.aiven.klaw.model.enums.Order.ASC_REQUESTED_TIME);
     assertThat(listReqs.size()).isEqualTo(10);
   }
@@ -404,6 +406,7 @@ public class AclControllerServiceTest {
             anyString(),
             anyBoolean(),
             eq(RequestOperationType.CREATE),
+            any(),
             any(),
             any(),
             any(),
@@ -424,6 +427,7 @@ public class AclControllerServiceTest {
             null,
             null,
             RequestOperationType.CREATE,
+            null,
             null,
             io.aiven.klaw.model.enums.Order.ASC_REQUESTED_TIME);
     assertThat(listReqs.size()).isEqualTo(10);
@@ -971,6 +975,7 @@ public class AclControllerServiceTest {
             eq(null),
             eq(null),
             eq(null),
+            eq(null),
             anyInt()))
         .thenReturn(getAclRequests("testtopic", 16));
     when(commonUtilsService.getEnvsFromUserId(anyString()))
@@ -988,6 +993,7 @@ public class AclControllerServiceTest {
             null,
             operationType,
             null,
+            null,
             io.aiven.klaw.model.enums.Order.ASC_REQUESTED_TIME);
     assertThat(listReqs.size()).isEqualTo(10);
     verify(handleDbRequests, times(1))
@@ -996,6 +1002,7 @@ public class AclControllerServiceTest {
             eq(""),
             eq(true),
             eq(operationType),
+            eq(null),
             eq(null),
             eq(null),
             eq(null),

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -4898,6 +4898,13 @@
             "type" : "string"
           }
         }, {
+          "name" : "search",
+          "in" : "query",
+          "required" : false,
+          "schema" : {
+            "type" : "string"
+          }
+        }, {
           "name" : "aclType",
           "in" : "query",
           "required" : false,


### PR DESCRIPTION
## About this change - What it does

Use `search` param for the API calls in My Requests and Approval tables, to allow partial match.


https://user-images.githubusercontent.com/20607294/228792839-27188cf2-95cd-4406-b8be-7b43b1dbd6ef.mov



## Additional changes

As visible in the video, the `getAclRequestsForApprover` endpoint did not currently support the `search` param. Changes to the API have been made to make it possible, but it is missing specific testing. It works though :o

 https://user-images.githubusercontent.com/20607294/229109052-f58aba8a-554c-4229-9535-80160cb2305d.mov



Resolves: #939
