### PR TITLE
Reverting change to -D param for pom

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -266,7 +266,7 @@
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-maven-plugin</artifactId>
                 <configuration>
-                    <jvmArguments>-Dspringdoc.writer-with-default-pretty-printer=true -Dserver.port=8097</jvmArguments>
+                    <jvmArguments>-Dspringdoc.writer-with-default-pretty-printer=true </jvmArguments>
                 </configuration>
                 <executions>
                     <execution>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -286,7 +286,7 @@
                 <artifactId>springdoc-openapi-maven-plugin</artifactId>
                 <version>${springdoc-openapi-maven-plugin.version}</version>
                 <configuration>
-                    <apiDocsUrl>http://localhost:8097/v3/api-docs</apiDocsUrl>
+                    <apiDocsUrl>http://localhost:9097/v3/api-docs</apiDocsUrl>
                     <outputFileName>openapi.yaml</outputFileName>
                     <outputDir>${project.parent.basedir}</outputDir>
                     <skip>false</skip>

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -17,7 +17,7 @@
     "url" : "https://www.klaw-project.io/docs"
   },
   "servers" : [ {
-    "url" : "http://localhost:8097",
+    "url" : "http://localhost:9097",
     "description" : "Generated server url"
   } ],
   "paths" : {


### PR DESCRIPTION
About this change - What it does
Revrts a change to add a -D param into the core/pom.xml
The change had been added to allow the openapi.yaml to be work off port 8097 however this is also the port now used when using mvn spring boot run.

Resolves: #xxxxx
Why this way
it reverts a breaking change of changing the port.