### PR TITLE
feat(coral): add ariaLabel prop to tables, pass a better label

### DIFF
--- a/coral/src/app/features/approvals/acls/AclApprovals.tsx
+++ b/coral/src/app/features/approvals/acls/AclApprovals.tsx
@@ -234,14 +234,15 @@ function AclApprovals() {
         table={
           <AclApprovalsTable
             aclRequests={data?.entries ?? []}
-            activePage={data?.currentPage ?? 1}
-            totalPages={data?.totalPages ?? 1}
             actionsDisabled={approveIsLoading || declineIsLoading}
             onDetails={handleViewRequest}
             onApprove={handleApproveRequest}
             onDecline={handleDeclineRequest}
             isBeingDeclined={handleIsBeingDeclined}
             isBeingApproved={handleIsBeingApproved}
+            ariaLabel={`ACL approval requests, page ${
+              data?.currentPage ?? 0
+            } of ${data?.totalPages ?? 0}`}
           />
         }
         pagination={pagination}

--- a/coral/src/app/features/approvals/acls/components/AclApprovalsTable.test.tsx
+++ b/coral/src/app/features/approvals/acls/components/AclApprovalsTable.test.tsx
@@ -80,8 +80,7 @@ describe("AclApprovalsTable", () => {
     render(
       <AclApprovalsTable
         aclRequests={aclRequests}
-        activePage={1}
-        totalPages={10}
+        ariaLabel={"ACL approval requests, page 1 of 10"}
         isBeingApproved={jest.fn()}
         isBeingDeclined={jest.fn()}
         onApprove={jest.fn()}
@@ -110,7 +109,7 @@ describe("AclApprovalsTable", () => {
 
   it("describes the table content and pagination for screen readers", () => {
     renderFromProps();
-    screen.getByLabelText(`Acl requests, page 1 of 10`);
+    screen.getByLabelText(`ACL approval requests, page 1 of 10`);
   });
 
   it("has column to describe the topic", () => {
@@ -323,7 +322,9 @@ describe("AclApprovalsTable", () => {
     });
     afterEach(cleanup);
     it("disables approve action if request is not in created state", async () => {
-      const table = screen.getByRole("table", { name: /Acl requests/ });
+      const table = screen.getByRole("table", {
+        name: /ACL approval requests/,
+      });
       const rows = within(table).getAllByRole("row");
       const approvedRequestRow = rows[2];
       const approve = within(approvedRequestRow).getByRole("button", {
@@ -332,7 +333,9 @@ describe("AclApprovalsTable", () => {
       expect(approve).toBeDisabled();
     });
     it("disables decline action if request is not in created state", async () => {
-      const table = screen.getByRole("table", { name: /Acl requests/ });
+      const table = screen.getByRole("table", {
+        name: /ACL approval requests/,
+      });
       const rows = within(table).getAllByRole("row");
       const approvedRequestRow = rows[2];
       const decline = within(approvedRequestRow).getByRole("button", {
@@ -350,7 +353,9 @@ describe("AclApprovalsTable", () => {
     });
     afterEach(cleanup);
     it("disables approve action if request is already in progress", async () => {
-      const table = screen.getByRole("table", { name: /Acl requests/ });
+      const table = screen.getByRole("table", {
+        name: /ACL approval requests/,
+      });
       const rows = within(table).getAllByRole("row");
       const createdRequestRow = rows[1];
       const approve = within(createdRequestRow).getByRole("button", {
@@ -359,7 +364,9 @@ describe("AclApprovalsTable", () => {
       expect(approve).toBeDisabled();
     });
     it("disables decline action if request is already in progress", async () => {
-      const table = screen.getByRole("table", { name: /Acl requests/ });
+      const table = screen.getByRole("table", {
+        name: /ACL approval requests/,
+      });
       const rows = within(table).getAllByRole("row");
       const createdRequestRow = rows[1];
       const decline = within(createdRequestRow).getByRole("button", {
@@ -376,7 +383,9 @@ describe("AclApprovalsTable", () => {
     });
     afterAll(cleanup);
     it("triggers details action for the corresponding request when clicked", async () => {
-      const table = screen.getByRole("table", { name: /Acl requests/ });
+      const table = screen.getByRole("table", {
+        name: /ACL approval requests/,
+      });
       const rows = within(table).getAllByRole("row");
       const createdRequestRow = rows[1];
       await userEvent.click(

--- a/coral/src/app/features/approvals/acls/components/AclApprovalsTable.tsx
+++ b/coral/src/app/features/approvals/acls/components/AclApprovalsTable.tsx
@@ -40,14 +40,13 @@ interface AclRequestTableRow {
 
 export default function AclApprovalsTable({
   aclRequests,
-  activePage,
-  totalPages,
   actionsDisabled = false,
   onDetails,
   onApprove,
   onDecline,
   isBeingApproved,
   isBeingDeclined,
+  ariaLabel,
 }: Props) {
   const getRows = (entries: AclRequest[]): AclRequestTableRow[] => {
     if (entries === undefined) {
@@ -270,7 +269,7 @@ export default function AclApprovalsTable({
 
   return (
     <DataTable
-      ariaLabel={`Acl requests, page ${activePage} of ${totalPages}`}
+      ariaLabel={ariaLabel}
       columns={columns}
       rows={rows}
       noWrap={false}
@@ -280,12 +279,11 @@ export default function AclApprovalsTable({
 
 export type Props = {
   aclRequests: AclRequest[];
-  activePage: number;
-  totalPages: number;
   actionsDisabled?: boolean;
   onDetails: (reqNo: number) => void;
   onApprove: (reqNo: number) => void;
   onDecline: (reqNo: number) => void;
   isBeingApproved: (reqNo: number) => boolean;
   isBeingDeclined: (reqNo: number) => boolean;
+  ariaLabel: string;
 };

--- a/coral/src/app/features/approvals/schemas/SchemaApprovals.test.tsx
+++ b/coral/src/app/features/approvals/schemas/SchemaApprovals.test.tsx
@@ -222,7 +222,9 @@ describe("SchemaApprovals", () => {
     });
 
     it("shows a table with all schema requests and a header row", () => {
-      const table = screen.getByRole("table", { name: "Schema requests" });
+      const table = screen.getByRole("table", {
+        name: "Schema approval requests, page 1 of 4",
+      });
       const rows = within(table).getAllByRole("row");
 
       expect(table).toBeVisible();

--- a/coral/src/app/features/approvals/schemas/SchemaApprovals.tsx
+++ b/coral/src/app/features/approvals/schemas/SchemaApprovals.tsx
@@ -188,6 +188,9 @@ function SchemaApprovals() {
       onDecline={handleDeclineRequest}
       isBeingDeclined={handleIsBeingDeclined}
       isBeingApproved={handleIsBeingApproved}
+      ariaLabel={`Schema approval requests, page ${
+        schemaRequests?.currentPage ?? 0
+      } of ${schemaRequests?.totalPages ?? 0}`}
     />
   );
   const pagination =

--- a/coral/src/app/features/approvals/schemas/components/SchemaApprovalsTable.test.tsx
+++ b/coral/src/app/features/approvals/schemas/components/SchemaApprovalsTable.test.tsx
@@ -95,6 +95,7 @@ describe("SchemaApprovalsTable", () => {
         onDecline={jest.fn()}
         isBeingApproved={jest.fn()}
         isBeingDeclined={jest.fn()}
+        ariaLabel={"Schema approval requests, page 1 of 10"}
       />
     );
     screen.getByText("No Schema requests");
@@ -111,33 +112,42 @@ describe("SchemaApprovalsTable", () => {
           onDecline={jest.fn()}
           isBeingApproved={jest.fn()}
           isBeingDeclined={jest.fn()}
+          ariaLabel={"Schema approval requests, page 1 of 10"}
         />
       );
     });
     afterAll(cleanup);
 
     it("shows a table with all schema requests", () => {
-      const table = screen.getByRole("table", { name: "Schema requests" });
+      const table = screen.getByRole("table", {
+        name: "Schema approval requests, page 1 of 10",
+      });
 
       expect(table).toBeVisible();
     });
 
     it("shows all column headers", () => {
-      const table = screen.getByRole("table", { name: "Schema requests" });
+      const table = screen.getByRole("table", {
+        name: "Schema approval requests, page 1 of 10",
+      });
       const header = within(table).getAllByRole("columnheader");
 
       expect(header).toHaveLength(columnsFieldMap.length);
     });
 
     it("shows a row for each given requests plus header row", () => {
-      const table = screen.getByRole("table", { name: "Schema requests" });
+      const table = screen.getByRole("table", {
+        name: "Schema approval requests, page 1 of 10",
+      });
       const row = within(table).getAllByRole("row");
 
       expect(row).toHaveLength(mockedRequests.length + 1);
     });
 
     it("shows an detail button for every row", () => {
-      const table = screen.getByRole("table", { name: "Schema requests" });
+      const table = screen.getByRole("table", {
+        name: "Schema approval requests, page 1 of 10",
+      });
       const buttons = within(table).getAllByRole("button", {
         name: /View schema request for /,
       });
@@ -146,7 +156,9 @@ describe("SchemaApprovalsTable", () => {
     });
 
     it("shows an approve button for every row", () => {
-      const table = screen.getByRole("table", { name: "Schema requests" });
+      const table = screen.getByRole("table", {
+        name: "Schema approval requests, page 1 of 10",
+      });
       const buttons = within(table).getAllByRole("button", {
         name: /Approve schema request for /,
       });
@@ -155,7 +167,9 @@ describe("SchemaApprovalsTable", () => {
     });
 
     it("shows an decline button for every row", () => {
-      const table = screen.getByRole("table", { name: "Schema requests" });
+      const table = screen.getByRole("table", {
+        name: "Schema approval requests, page 1 of 10",
+      });
       const buttons = within(table).getAllByRole("button", {
         name: /Decline schema request for /,
       });
@@ -165,7 +179,9 @@ describe("SchemaApprovalsTable", () => {
 
     mockedRequests.forEach((request) => {
       it(`shows a button to show the detailed schema request for topic name ${request.topicname}`, () => {
-        const table = screen.getByRole("table", { name: "Schema requests" });
+        const table = screen.getByRole("table", {
+          name: "Schema approval requests, page 1 of 10",
+        });
         const button = within(table).getByRole("button", {
           name: `View schema request for ${request.topicname}`,
         });
@@ -176,7 +192,9 @@ describe("SchemaApprovalsTable", () => {
 
     createdRequests.forEach((request) => {
       it(`shows a button to approve schema request for topic name ${request.topicname}`, () => {
-        const table = screen.getByRole("table", { name: "Schema requests" });
+        const table = screen.getByRole("table", {
+          name: "Schema approval requests, page 1 of 10",
+        });
         const button = within(table).getByRole("button", {
           name: `Approve schema request for ${request.topicname}`,
         });
@@ -185,7 +203,9 @@ describe("SchemaApprovalsTable", () => {
       });
 
       it(`shows a button to approve schema request for topic name ${request.topicname}`, () => {
-        const table = screen.getByRole("table", { name: "Schema requests" });
+        const table = screen.getByRole("table", {
+          name: "Schema approval requests, page 1 of 10",
+        });
         const button = within(table).getByRole("button", {
           name: `Decline schema request for ${request.topicname}`,
         });
@@ -205,6 +225,7 @@ describe("SchemaApprovalsTable", () => {
           onDecline={jest.fn()}
           isBeingApproved={jest.fn()}
           isBeingDeclined={jest.fn()}
+          ariaLabel={"Schema approval requests, page 1 of 10"}
         />
       );
     });
@@ -213,7 +234,7 @@ describe("SchemaApprovalsTable", () => {
 
     it(`renders the right amount of cells`, () => {
       const table = screen.getByRole("table", {
-        name: "Schema requests",
+        name: "Schema approval requests, page 1 of 10",
       });
       const cells = within(table).getAllByRole("cell");
 
@@ -225,7 +246,7 @@ describe("SchemaApprovalsTable", () => {
     columnsFieldMap.forEach((column) => {
       it(`shows a column header for ${column.columnHeader}`, () => {
         const table = screen.getByRole("table", {
-          name: "Schema requests",
+          name: "Schema approval requests, page 1 of 10",
         });
         const header = within(table).getByRole("columnheader", {
           name: column.columnHeader,
@@ -238,7 +259,7 @@ describe("SchemaApprovalsTable", () => {
         mockedRequests.forEach((request) => {
           it(`shows field ${column.relatedField} for request number ${request.req_no}`, () => {
             const table = screen.getByRole("table", {
-              name: "Schema requests",
+              name: "Schema approval requests, page 1 of 10",
             });
 
             // eslint-disable-next-line @typescript-eslint/ban-ts-comment
@@ -278,6 +299,7 @@ describe("SchemaApprovalsTable", () => {
           onDecline={jest.fn()}
           isBeingApproved={jest.fn()}
           isBeingDeclined={jest.fn()}
+          ariaLabel={"Schema approval requests, page 1 of 10"}
         />
       );
     });
@@ -285,7 +307,9 @@ describe("SchemaApprovalsTable", () => {
       cleanup(), jest.clearAllMocks();
     });
     it("triggers details action for the corresponding request when clicked", async () => {
-      const table = screen.getByRole("table", { name: "Schema requests" });
+      const table = screen.getByRole("table", {
+        name: "Schema approval requests, page 1 of 10",
+      });
       const rows = within(table).getAllByRole("row");
       const createdRequestRow = rows[1];
       await userEvent.click(
@@ -310,12 +334,15 @@ describe("SchemaApprovalsTable", () => {
           onDecline={onDecline}
           isBeingApproved={jest.fn()}
           isBeingDeclined={jest.fn()}
+          ariaLabel={"Schema approval requests, page 1 of 10"}
         />
       );
     });
     afterEach(cleanup);
     it("triggers approve action for the corresponding request when clicked", async () => {
-      const table = screen.getByRole("table", { name: "Schema requests" });
+      const table = screen.getByRole("table", {
+        name: "Schema approval requests, page 1 of 10",
+      });
       const rows = within(table).getAllByRole("row");
       const createdRequestRow = rows[1];
       const approve = within(createdRequestRow).getByRole("button", {
@@ -326,7 +353,9 @@ describe("SchemaApprovalsTable", () => {
       expect(onApprove).toHaveBeenCalledWith(1014);
     });
     it("triggers decline action for the corresponding request when clicked", async () => {
-      const table = screen.getByRole("table", { name: "Schema requests" });
+      const table = screen.getByRole("table", {
+        name: "Schema approval requests, page 1 of 10",
+      });
       const rows = within(table).getAllByRole("row");
       const createdRequestRow = rows[1];
       const decline = within(createdRequestRow).getByRole("button", {
@@ -348,12 +377,15 @@ describe("SchemaApprovalsTable", () => {
           onDecline={jest.fn()}
           isBeingApproved={jest.fn()}
           isBeingDeclined={jest.fn()}
+          ariaLabel={"Schema approval requests, page 1 of 10"}
         />
       );
     });
     afterEach(cleanup);
     it("disables approve action if request is not in created state", async () => {
-      const table = screen.getByRole("table", { name: "Schema requests" });
+      const table = screen.getByRole("table", {
+        name: "Schema approval requests, page 1 of 10",
+      });
       const rows = within(table).getAllByRole("row");
       const approvedRequestRow = rows[2];
       const approve = within(approvedRequestRow).getByRole("button", {
@@ -362,7 +394,9 @@ describe("SchemaApprovalsTable", () => {
       expect(approve).toBeDisabled();
     });
     it("disables decline action if request is not in created state", async () => {
-      const table = screen.getByRole("table", { name: "Schema requests" });
+      const table = screen.getByRole("table", {
+        name: "Schema approval requests, page 1 of 10",
+      });
       const rows = within(table).getAllByRole("row");
       const approvedRequestRow = rows[2];
       const decline = within(approvedRequestRow).getByRole("button", {
@@ -384,12 +418,15 @@ describe("SchemaApprovalsTable", () => {
           onDecline={jest.fn()}
           isBeingApproved={isBeingApproved}
           isBeingDeclined={isBeingDeclined}
+          ariaLabel={"Schema approval requests, page 1 of 10"}
         />
       );
     });
     afterEach(cleanup);
     it("disables approve action if request is already in progress", async () => {
-      const table = screen.getByRole("table", { name: "Schema requests" });
+      const table = screen.getByRole("table", {
+        name: "Schema approval requests, page 1 of 10",
+      });
       const rows = within(table).getAllByRole("row");
       const createdRequestRow = rows[1];
       const approve = within(createdRequestRow).getByRole("button", {
@@ -398,7 +435,9 @@ describe("SchemaApprovalsTable", () => {
       expect(approve).toBeDisabled();
     });
     it("disables decline action if request is already in progress", async () => {
-      const table = screen.getByRole("table", { name: "Schema requests" });
+      const table = screen.getByRole("table", {
+        name: "Schema approval requests, page 1 of 10",
+      });
       const rows = within(table).getAllByRole("row");
       const createdRequestRow = rows[1];
       const decline = within(createdRequestRow).getByRole("button", {
@@ -424,6 +463,7 @@ describe("SchemaApprovalsTable", () => {
           onDecline={jest.fn()}
           isBeingApproved={jest.fn()}
           isBeingDeclined={jest.fn()}
+          ariaLabel={"Schema approval requests, page 1 of 10"}
         />
       );
     });
@@ -432,7 +472,9 @@ describe("SchemaApprovalsTable", () => {
 
     requestsWithStatusCreated.forEach((request) => {
       it(`disables button to approve schema request for topic name ${request.topicname}`, () => {
-        const table = screen.getByRole("table", { name: "Schema requests" });
+        const table = screen.getByRole("table", {
+          name: "Schema approval requests, page 1 of 10",
+        });
         const button = within(table).getByRole("button", {
           name: `Approve schema request for ${request.topicname}`,
         });
@@ -441,7 +483,9 @@ describe("SchemaApprovalsTable", () => {
       });
 
       it(`disables button to decline schema request for topic name ${request.topicname}`, () => {
-        const table = screen.getByRole("table", { name: "Schema requests" });
+        const table = screen.getByRole("table", {
+          name: "Schema approval requests, page 1 of 10",
+        });
         const button = within(table).getByRole("button", {
           name: `Decline schema request for ${request.topicname}`,
         });
@@ -450,7 +494,9 @@ describe("SchemaApprovalsTable", () => {
       });
 
       it(`does not disable details for schema request for topic name ${request.topicname}`, () => {
-        const table = screen.getByRole("table", { name: "Schema requests" });
+        const table = screen.getByRole("table", {
+          name: "Schema approval requests, page 1 of 10",
+        });
         const detailsButton = within(table).getByRole("button", {
           name: `View schema request for ${request.topicname}`,
         });

--- a/coral/src/app/features/approvals/schemas/components/SchemaApprovalsTable.tsx
+++ b/coral/src/app/features/approvals/schemas/components/SchemaApprovalsTable.tsx
@@ -25,6 +25,7 @@ interface SchemaRequestTableData {
 
 type SchemaApprovalsTableProps = {
   requests: SchemaRequest[];
+  ariaLabel: string;
   actionsDisabled?: boolean;
   onDetails: (req_no: number) => void;
   onApprove: (req_no: number) => void;
@@ -35,6 +36,7 @@ type SchemaApprovalsTableProps = {
 
 function SchemaApprovalsTable({
   requests,
+  ariaLabel,
   actionsDisabled = false,
   onDetails,
   onApprove,
@@ -167,7 +169,7 @@ function SchemaApprovalsTable({
 
   return (
     <DataTable
-      ariaLabel={"Schema requests"}
+      ariaLabel={ariaLabel}
       columns={columns}
       rows={rows}
       noWrap={false}

--- a/coral/src/app/features/approvals/topics/TopicApprovals.test.tsx
+++ b/coral/src/app/features/approvals/topics/TopicApprovals.test.tsx
@@ -245,7 +245,9 @@ describe("TopicApprovals", () => {
     });
 
     it("shows a table with all topic requests and a header row", () => {
-      const table = screen.getByRole("table", { name: "Topic requests" });
+      const table = screen.getByRole("table", {
+        name: "Topic approval requests, page 1 of 1",
+      });
       const rows = within(table).getAllByRole("row");
 
       expect(table).toBeVisible();

--- a/coral/src/app/features/approvals/topics/TopicApprovals.tsx
+++ b/coral/src/app/features/approvals/topics/TopicApprovals.tsx
@@ -198,6 +198,9 @@ function TopicApprovals() {
       onDecline={handleDeclineRequest}
       isBeingDeclined={handleIsBeingDeclined}
       isBeingApproved={handleIsBeingApproved}
+      ariaLabel={`Topic approval requests, page ${
+        topicRequests?.currentPage ?? 0
+      } of ${topicRequests?.totalPages ?? 0}`}
     />
   );
   const pagination =

--- a/coral/src/app/features/approvals/topics/components/TopicApprovalsTable.test.tsx
+++ b/coral/src/app/features/approvals/topics/components/TopicApprovalsTable.test.tsx
@@ -108,6 +108,7 @@ describe("TopicApprovalsTable", () => {
           onDecline={jest.fn()}
           isBeingApproved={jest.fn()}
           isBeingDeclined={jest.fn()}
+          ariaLabel={"Topic approval requests, page 1 of 10"}
         />
       );
       screen.getByText("No Topic requests");
@@ -126,33 +127,42 @@ describe("TopicApprovalsTable", () => {
           onDecline={jest.fn()}
           isBeingApproved={jest.fn()}
           isBeingDeclined={jest.fn()}
+          ariaLabel={"Topic approval requests, page 1 of 10"}
         />
       );
     });
     afterAll(cleanup);
 
     it("shows a table with all topic requests", () => {
-      const table = screen.getByRole("table", { name: "Topic requests" });
+      const table = screen.getByRole("table", {
+        name: "Topic approval requests, page 1 of 10",
+      });
 
       expect(table).toBeVisible();
     });
 
     it("shows all column headers", () => {
-      const table = screen.getByRole("table", { name: "Topic requests" });
+      const table = screen.getByRole("table", {
+        name: "Topic approval requests, page 1 of 10",
+      });
       const header = within(table).getAllByRole("columnheader");
 
       expect(header).toHaveLength(columnsFieldMap.length);
     });
 
     it("shows a row for each given requests plus header row", () => {
-      const table = screen.getByRole("table", { name: "Topic requests" });
+      const table = screen.getByRole("table", {
+        name: "Topic approval requests, page 1 of 10",
+      });
       const row = within(table).getAllByRole("row");
 
       expect(row).toHaveLength(mockedRequests.length + 1);
     });
 
     it("shows an detail button for every row", () => {
-      const table = screen.getByRole("table", { name: "Topic requests" });
+      const table = screen.getByRole("table", {
+        name: "Topic approval requests, page 1 of 10",
+      });
       const buttons = within(table).getAllByRole("button", {
         name: /View topic request for /,
       });
@@ -161,7 +171,9 @@ describe("TopicApprovalsTable", () => {
     });
 
     it("shows an approve button for every row", () => {
-      const table = screen.getByRole("table", { name: "Topic requests" });
+      const table = screen.getByRole("table", {
+        name: "Topic approval requests, page 1 of 10",
+      });
       const buttons = within(table).getAllByRole("button", {
         name: /Approve topic request for /,
       });
@@ -170,7 +182,9 @@ describe("TopicApprovalsTable", () => {
     });
 
     it("shows an decline button for every row", () => {
-      const table = screen.getByRole("table", { name: "Topic requests" });
+      const table = screen.getByRole("table", {
+        name: "Topic approval requests, page 1 of 10",
+      });
       const buttons = within(table).getAllByRole("button", {
         name: /Decline topic request for /,
       });
@@ -190,6 +204,7 @@ describe("TopicApprovalsTable", () => {
           onDecline={jest.fn()}
           isBeingApproved={jest.fn()}
           isBeingDeclined={jest.fn()}
+          ariaLabel={"Topic approval requests, page 1 of 10"}
         />
       );
     });
@@ -198,7 +213,7 @@ describe("TopicApprovalsTable", () => {
 
     it(`renders the right amount of cells`, () => {
       const table = screen.getByRole("table", {
-        name: "Topic requests",
+        name: "Topic approval requests, page 1 of 10",
       });
       const cells = within(table).getAllByRole("cell");
 
@@ -213,7 +228,7 @@ describe("TopicApprovalsTable", () => {
           return;
         }
         const table = screen.getByRole("table", {
-          name: "Topic requests",
+          name: "Topic approval requests, page 1 of 10",
         });
         const header = within(table).getByRole("columnheader", {
           name: column.columnHeader,
@@ -226,7 +241,7 @@ describe("TopicApprovalsTable", () => {
         mockedRequests.forEach((request) => {
           it(`shows field ${column.relatedField} for topic id ${request.topicid}`, () => {
             const table = screen.getByRole("table", {
-              name: "Topic requests",
+              name: "Topic approval requests, page 1 of 10",
             });
 
             // eslint-disable-next-line @typescript-eslint/ban-ts-comment
@@ -265,6 +280,7 @@ describe("TopicApprovalsTable", () => {
           onDecline={jest.fn()}
           isBeingApproved={jest.fn()}
           isBeingDeclined={jest.fn()}
+          ariaLabel={"Topic approval requests, page 1 of 10"}
         />
       );
     });
@@ -298,6 +314,7 @@ describe("TopicApprovalsTable", () => {
           onDecline={jest.fn()}
           isBeingApproved={jest.fn()}
           isBeingDeclined={jest.fn()}
+          ariaLabel={"Topic approval requests, page 1 of 10"}
         />
       );
     });
@@ -305,7 +322,9 @@ describe("TopicApprovalsTable", () => {
 
     requestsWithStatusCreated.forEach((request) => {
       it(`disables button to approve topic request for topic name ${request.topicname}`, () => {
-        const table = screen.getByRole("table", { name: "Topic requests" });
+        const table = screen.getByRole("table", {
+          name: "Topic approval requests, page 1 of 10",
+        });
         const button = within(table).getByRole("button", {
           name: `Approve topic request for ${request.topicname}`,
         });
@@ -314,7 +333,9 @@ describe("TopicApprovalsTable", () => {
       });
 
       it(`disables  button to decline topic request for topic name ${request.topicname}`, () => {
-        const table = screen.getByRole("table", { name: "Topic requests" });
+        const table = screen.getByRole("table", {
+          name: "Topic approval requests, page 1 of 10",
+        });
         const button = within(table).getByRole("button", {
           name: `Decline topic request for ${request.topicname}`,
         });
@@ -323,7 +344,9 @@ describe("TopicApprovalsTable", () => {
       });
 
       it(`does not disables details for topic request for topic name ${request.topicname}`, () => {
-        const table = screen.getByRole("table", { name: "Topic requests" });
+        const table = screen.getByRole("table", {
+          name: "Topic approval requests, page 1 of 10",
+        });
         const detailsButton = within(table).getByRole("button", {
           name: `View topic request for ${request.topicname}`,
         });
@@ -343,12 +366,15 @@ describe("TopicApprovalsTable", () => {
           onDecline={jest.fn()}
           isBeingApproved={jest.fn()}
           isBeingDeclined={jest.fn()}
+          ariaLabel={"Topic approval requests, page 1 of 10"}
         />
       );
     });
     afterEach(cleanup);
     it("disables approve action if request is not in created state", async () => {
-      const table = screen.getByRole("table", { name: "Topic requests" });
+      const table = screen.getByRole("table", {
+        name: "Topic approval requests, page 1 of 10",
+      });
       const rows = within(table).getAllByRole("row");
       const approvedRequestRow = rows[2];
       const approve = within(approvedRequestRow).getByRole("button", {
@@ -357,7 +383,9 @@ describe("TopicApprovalsTable", () => {
       expect(approve).toBeDisabled();
     });
     it("disables decline action if request is not in created state", async () => {
-      const table = screen.getByRole("table", { name: "Topic requests" });
+      const table = screen.getByRole("table", {
+        name: "Topic approval requests, page 1 of 10",
+      });
       const rows = within(table).getAllByRole("row");
       const approvedRequestRow = rows[2];
       const decline = within(approvedRequestRow).getByRole("button", {
@@ -379,12 +407,15 @@ describe("TopicApprovalsTable", () => {
           onDecline={jest.fn()}
           isBeingApproved={isBeingApproved}
           isBeingDeclined={isBeingDeclined}
+          ariaLabel={"Topic approval requests, page 1 of 10"}
         />
       );
     });
     afterEach(cleanup);
     it("disables approve action if request is already in progress", async () => {
-      const table = screen.getByRole("table", { name: "Topic requests" });
+      const table = screen.getByRole("table", {
+        name: "Topic approval requests, page 1 of 10",
+      });
       const rows = within(table).getAllByRole("row");
       const createdRequestRow = rows[1];
       const approve = within(createdRequestRow).getByRole("button", {
@@ -393,7 +424,9 @@ describe("TopicApprovalsTable", () => {
       expect(approve).toBeDisabled();
     });
     it("disables decline action if request is already in progress", async () => {
-      const table = screen.getByRole("table", { name: "Topic requests" });
+      const table = screen.getByRole("table", {
+        name: "Topic approval requests, page 1 of 10",
+      });
       const rows = within(table).getAllByRole("row");
       const createdRequestRow = rows[1];
       const decline = within(createdRequestRow).getByRole("button", {
@@ -414,12 +447,15 @@ describe("TopicApprovalsTable", () => {
           onDecline={jest.fn()}
           isBeingApproved={jest.fn()}
           isBeingDeclined={jest.fn()}
+          ariaLabel={"Topic approval requests, page 1 of 10"}
         />
       );
     });
     afterAll(cleanup);
     it("triggers details action for the corresponding request when clicked", async () => {
-      const table = screen.getByRole("table", { name: "Topic requests" });
+      const table = screen.getByRole("table", {
+        name: "Topic approval requests, page 1 of 10",
+      });
       const rows = within(table).getAllByRole("row");
       const createdRequestRow = rows[1];
       await userEvent.click(

--- a/coral/src/app/features/approvals/topics/components/TopicApprovalsTable.tsx
+++ b/coral/src/app/features/approvals/topics/components/TopicApprovalsTable.tsx
@@ -26,6 +26,7 @@ interface TopicRequestTableRow {
 
 type TopicApprovalsTableProp = {
   requests: TopicRequest[];
+  ariaLabel: string;
   actionsDisabled?: boolean;
   onDetails: (req_no: number) => void;
   onApprove: (req_no: number) => void;
@@ -35,6 +36,7 @@ type TopicApprovalsTableProp = {
 };
 function TopicApprovalsTable({
   requests,
+  ariaLabel,
   actionsDisabled = false,
   onDetails,
   onApprove,
@@ -166,7 +168,7 @@ function TopicApprovalsTable({
 
   return (
     <DataTable
-      ariaLabel={"Topic requests"}
+      ariaLabel={ariaLabel}
       columns={columns}
       rows={rows}
       noWrap={false}

--- a/coral/src/app/features/requests/acls/AclRequests.tsx
+++ b/coral/src/app/features/requests/acls/AclRequests.tsx
@@ -181,6 +181,9 @@ function AclRequests() {
             requests={data?.entries ?? []}
             onDetails={openDetailsModal}
             onDelete={openDeleteModal}
+            ariaLabel={`ACL requests, page ${data?.currentPage ?? 0} of ${
+              data?.totalPages ?? 0
+            }`}
           />
         }
         pagination={pagination}

--- a/coral/src/app/features/requests/acls/components/AclRequestsTable.test.tsx
+++ b/coral/src/app/features/requests/acls/components/AclRequestsTable.test.tsx
@@ -88,6 +88,7 @@ describe("AclRequestsTable", () => {
         requests={mockedRequests}
         onDetails={jest.fn()}
         onDelete={jest.fn()}
+        ariaLabel={"ACL requests, page 1 of 22"}
         {...props}
       />
     );

--- a/coral/src/app/features/requests/acls/components/AclRequestsTable.tsx
+++ b/coral/src/app/features/requests/acls/components/AclRequestsTable.tsx
@@ -39,12 +39,14 @@ type AclRequestsTableProps = {
   requests: AclRequest[];
   onDetails: (req_no: number) => void;
   onDelete: (req_no: number) => void;
+  ariaLabel: string;
 };
 
 function AclRequestsTable({
   requests,
   onDetails,
   onDelete,
+  ariaLabel,
 }: AclRequestsTableProps) {
   const columns: Array<DataTableColumn<AclRequestTableRow>> = [
     { type: "text", field: "topicname", headerName: "Topic" },
@@ -193,7 +195,7 @@ function AclRequestsTable({
 
   return (
     <DataTable
-      ariaLabel={"ACL requests"}
+      ariaLabel={ariaLabel}
       columns={columns}
       rows={rows}
       noWrap={false}

--- a/coral/src/app/features/requests/schemas/SchemaRequests.test.tsx
+++ b/coral/src/app/features/requests/schemas/SchemaRequests.test.tsx
@@ -172,7 +172,9 @@ describe("SchemaRequest", () => {
     });
 
     it("shows a table with all schema requests", () => {
-      const table = screen.getByRole("table", { name: "Schema requests" });
+      const table = screen.getByRole("table", {
+        name: "Schema requests, page 1 of 4",
+      });
       const rows = within(table).getAllByRole("row");
       const headerRow = 1;
 

--- a/coral/src/app/features/requests/schemas/SchemaRequests.tsx
+++ b/coral/src/app/features/requests/schemas/SchemaRequests.tsx
@@ -178,6 +178,9 @@ function SchemaRequests() {
             requests={schemaRequests?.entries || []}
             showDetails={openDetailsModal}
             showDeleteDialog={openDeleteModal}
+            ariaLabel={`Schema requests, page ${
+              schemaRequests?.currentPage ?? 0
+            } of ${schemaRequests?.totalPages ?? 0}`}
           />
         }
         pagination={pagination}

--- a/coral/src/app/features/requests/schemas/components/SchemaRequestTable.test.tsx
+++ b/coral/src/app/features/requests/schemas/components/SchemaRequestTable.test.tsx
@@ -37,6 +37,7 @@ describe("SchemaRequestTable", () => {
           requests={[]}
           showDetails={showDetailsMock}
           showDeleteDialog={showDeleteDialogMock}
+          ariaLabel={"Schema requests, page 1 of 10"}
         />
       );
     });
@@ -57,6 +58,7 @@ describe("SchemaRequestTable", () => {
           requests={schemaRequests}
           showDetails={showDetailsMock}
           showDeleteDialog={showDeleteDialogMock}
+          ariaLabel={"Schema requests, page 1 of 10"}
         />
       );
     });
@@ -64,27 +66,35 @@ describe("SchemaRequestTable", () => {
     afterAll(cleanup);
 
     it("shows a table with all schema requests", () => {
-      const table = screen.getByRole("table", { name: "Schema requests" });
+      const table = screen.getByRole("table", {
+        name: "Schema requests, page 1 of 10",
+      });
 
       expect(table).toBeVisible();
     });
 
     it("shows all column headers", () => {
-      const table = screen.getByRole("table", { name: "Schema requests" });
+      const table = screen.getByRole("table", {
+        name: "Schema requests, page 1 of 10",
+      });
       const header = within(table).getAllByRole("columnheader");
 
       expect(header).toHaveLength(columnsFieldMap.length);
     });
 
     it("shows a row for each given requests plus header row", () => {
-      const table = screen.getByRole("table", { name: "Schema requests" });
+      const table = screen.getByRole("table", {
+        name: "Schema requests, page 1 of 10",
+      });
       const row = within(table).getAllByRole("row");
 
       expect(row).toHaveLength(schemaRequests.length + 1);
     });
 
     it("shows a button to view details for every row", () => {
-      const table = screen.getByRole("table", { name: "Schema requests" });
+      const table = screen.getByRole("table", {
+        name: "Schema requests, page 1 of 10",
+      });
       const buttons = within(table).getAllByRole("button", {
         name: /View schema request for/,
       });
@@ -93,7 +103,9 @@ describe("SchemaRequestTable", () => {
     });
 
     it("shows an enabled button for every row where request is 'deletable'", () => {
-      const table = screen.getByRole("table", { name: "Schema requests" });
+      const table = screen.getByRole("table", {
+        name: "Schema requests, page 1 of 10",
+      });
       const buttons = within(table).getAllByRole("button", {
         name: /Delete schema request for/,
       });
@@ -114,7 +126,9 @@ describe("SchemaRequestTable", () => {
       //@TODO buttons don't have discernible names right now
       // should be fixed for accessibility
       it(`shows a button to show the detailed schema request for topic name ${request.topicname}`, () => {
-        const table = screen.getByRole("table", { name: "Schema requests" });
+        const table = screen.getByRole("table", {
+          name: "Schema requests, page 1 of 10",
+        });
         const button = within(table).getByRole("button", {
           name: `View schema request for ${request.topicname}`,
         });
@@ -127,7 +141,9 @@ describe("SchemaRequestTable", () => {
       //@TODO buttons don't have discernible names right now
       // should be fixed for accessibility
       it(`shows a button to delete schema request for topic name ${request.topicname}`, () => {
-        const table = screen.getByRole("table", { name: "Schema requests" });
+        const table = screen.getByRole("table", {
+          name: "Schema requests, page 1 of 10",
+        });
         const button = within(table).getByRole("button", {
           name: `Delete schema request for ${request.topicname}`,
         });
@@ -144,6 +160,7 @@ describe("SchemaRequestTable", () => {
           requests={schemaRequests}
           showDetails={showDetailsMock}
           showDeleteDialog={showDeleteDialogMock}
+          ariaLabel={"Schema requests, page 1 of 10"}
         />
       );
     });
@@ -152,7 +169,7 @@ describe("SchemaRequestTable", () => {
 
     it(`renders the right amount of cells`, () => {
       const table = screen.getByRole("table", {
-        name: "Schema requests",
+        name: "Schema requests, page 1 of 10",
       });
       const cells = within(table).getAllByRole("cell");
 
@@ -164,7 +181,7 @@ describe("SchemaRequestTable", () => {
     columnsFieldMap.forEach((column) => {
       it(`shows a column header for ${column.columnHeader}`, () => {
         const table = screen.getByRole("table", {
-          name: "Schema requests",
+          name: "Schema requests, page 1 of 10",
         });
         const header = within(table).getByRole("columnheader", {
           name: column.columnHeader,
@@ -177,7 +194,7 @@ describe("SchemaRequestTable", () => {
         schemaRequests.forEach((request) => {
           it(`shows field ${column.relatedField} for request number ${request.req_no}`, () => {
             const table = screen.getByRole("table", {
-              name: "Schema requests",
+              name: "Schema requests, page 1 of 10",
             });
 
             // eslint-disable-next-line @typescript-eslint/ban-ts-comment
@@ -212,6 +229,7 @@ describe("SchemaRequestTable", () => {
           requests={schemaRequests}
           showDetails={showDetailsMock}
           showDeleteDialog={showDeleteDialogMock}
+          ariaLabel={"Schema requests, page 1 of 10"}
         />
       );
     });
@@ -252,6 +270,7 @@ describe("SchemaRequestTable", () => {
           requests={schemaRequests}
           showDetails={showDetailsMock}
           showDeleteDialog={showDeleteDialogMock}
+          ariaLabel={"Schema requests, page 1 of 10"}
         />
       );
     });

--- a/coral/src/app/features/requests/schemas/components/SchemaRequestTable.tsx
+++ b/coral/src/app/features/requests/schemas/components/SchemaRequestTable.tsx
@@ -27,12 +27,14 @@ type SchemaRequestTableProps = {
   requests: SchemaRequest[];
   showDetails: (req_no: number) => void;
   showDeleteDialog: (req_no: number) => void;
+  ariaLabel: string;
 };
 
 function SchemaRequestTable({
   requests,
   showDetails,
   showDeleteDialog,
+  ariaLabel,
 }: SchemaRequestTableProps) {
   const columns: Array<DataTableColumn<SchemaRequestTableRow>> = [
     { type: "text", field: "topic", headerName: "Topic" },
@@ -129,7 +131,7 @@ function SchemaRequestTable({
 
   return (
     <DataTable
-      ariaLabel={"Schema requests"}
+      ariaLabel={ariaLabel}
       columns={columns}
       rows={rows}
       noWrap={false}

--- a/coral/src/app/features/requests/topics/TopicRequests.tsx
+++ b/coral/src/app/features/requests/topics/TopicRequests.tsx
@@ -166,6 +166,9 @@ function TopicRequests() {
             requests={data?.entries ?? []}
             onDetails={handleDetails}
             onDelete={handleDeleteRequest}
+            ariaLabel={`Topic requests, page ${data?.currentPage ?? 0} of ${
+              data?.totalPages ?? 0
+            }`}
           />
         }
         pagination={pagination}

--- a/coral/src/app/features/requests/topics/components/TopicRequestsTable.test.tsx
+++ b/coral/src/app/features/requests/topics/components/TopicRequestsTable.test.tsx
@@ -80,6 +80,7 @@ describe("TopicRequestsTable", () => {
         requests={mockedRequests}
         onDetails={jest.fn()}
         onDelete={jest.fn()}
+        ariaLabel={"Topic requests, page 1 of 10"}
         {...props}
       />
     );

--- a/coral/src/app/features/requests/topics/components/TopicRequestsTable.tsx
+++ b/coral/src/app/features/requests/topics/components/TopicRequestsTable.tsx
@@ -27,12 +27,14 @@ type TopicRequestsTableProps = {
   requests: TopicRequest[];
   onDetails: (topicId: number) => void;
   onDelete: (topicId: number) => void;
+  ariaLabel: string;
 };
 
 function TopicRequestsTable({
   requests,
   onDetails,
   onDelete,
+  ariaLabel,
 }: TopicRequestsTableProps) {
   const columns: Array<DataTableColumn<TopicRequestTableRow>> = [
     { type: "text", field: "topicname", headerName: "Topic" },
@@ -128,7 +130,7 @@ function TopicRequestsTable({
 
   return (
     <DataTable
-      ariaLabel={"Topic requests"}
+      ariaLabel={ariaLabel}
       columns={columns}
       rows={rows}
       noWrap={false}

--- a/coral/src/app/features/topics/browse/BrowseTopics.test.tsx
+++ b/coral/src/app/features/topics/browse/BrowseTopics.test.tsx
@@ -82,7 +82,7 @@ describe("BrowseTopics.tsx", () => {
 
     it("renders the topic table with information about the pages", async () => {
       const table = screen.getByRole("table", {
-        name: `Topics overview`,
+        name: "Topics overview, page 1 of 1",
       });
 
       expect(table).toBeVisible();
@@ -90,7 +90,7 @@ describe("BrowseTopics.tsx", () => {
 
     it("shows topic names row headers", () => {
       const table = screen.getByRole("table", {
-        name: "Topics overview",
+        name: "Topics overview, page 1 of 1",
       });
 
       const rowHeader = within(table).getByRole("cell", {

--- a/coral/src/app/features/topics/browse/BrowseTopics.tsx
+++ b/coral/src/app/features/topics/browse/BrowseTopics.tsx
@@ -55,7 +55,14 @@ function BrowseTopics() {
         <EnvironmentFilter key="environment" />,
         <TopicFilter key="search" />,
       ]}
-      table={<TopicTable topics={topics?.entries ?? []} />}
+      table={
+        <TopicTable
+          topics={topics?.entries ?? []}
+          ariaLabel={`Topics overview, page ${topics?.currentPage ?? 0} of ${
+            topics?.totalPages ?? 0
+          }`}
+        />
+      }
       pagination={pagination}
       isLoading={isLoading}
       isErrorLoading={isError}

--- a/coral/src/app/features/topics/browse/components/TopicTable.test.tsx
+++ b/coral/src/app/features/topics/browse/components/TopicTable.test.tsx
@@ -16,7 +16,9 @@ describe("TopicTable.tsx", () => {
     afterAll(cleanup);
 
     it("show empty state when there is no data", () => {
-      render(<TopicTable topics={[]} />);
+      render(
+        <TopicTable topics={[]} ariaLabel={"Topics overview, page 0 of 0"} />
+      );
       expect(screen.getByRole("heading", { name: "No Topics" })).toBeVisible();
     });
   });
@@ -24,14 +26,19 @@ describe("TopicTable.tsx", () => {
   describe("shows all topics as a table", () => {
     beforeAll(() => {
       mockIntersectionObserver();
-      render(<TopicTable topics={mockedTopics} />);
+      render(
+        <TopicTable
+          topics={mockedTopics}
+          ariaLabel={"Topics overview, page 1 of 10"}
+        />
+      );
     });
 
     afterAll(cleanup);
 
     it("renders a topic table with information about pages", async () => {
       const table = screen.getByRole("table", {
-        name: "Topics overview",
+        name: "Topics overview, page 1 of 10",
       });
 
       expect(table).toBeVisible();
@@ -40,7 +47,7 @@ describe("TopicTable.tsx", () => {
     tableRowHeader.forEach((header) => {
       it(`renders a column header for ${header}`, () => {
         const table = screen.getByRole("table", {
-          name: "Topics overview",
+          name: "Topics overview, page 1 of 10",
         });
         const colHeader = within(table).getByRole("columnheader", {
           name: header,
@@ -53,7 +60,7 @@ describe("TopicTable.tsx", () => {
     mockedTopics.forEach((topic) => {
       it(`renders the topic name "${topic.topicName}" as a link to the detail view as row header`, () => {
         const table = screen.getByRole("table", {
-          name: "Topics overview",
+          name: "Topics overview, page 1 of 10",
         });
         const rowHeader = within(table).getByRole("cell", {
           name: topic.topicName,
@@ -72,7 +79,7 @@ describe("TopicTable.tsx", () => {
 
       it(`renders the team for ${topic.topicName} `, () => {
         const table = screen.getByRole("table", {
-          name: "Topics overview",
+          name: "Topics overview, page 1 of 10",
         });
         const row = within(table).getByRole("row", {
           name: new RegExp(`${topic.topicName}`, "i"),
@@ -84,7 +91,7 @@ describe("TopicTable.tsx", () => {
 
       it(`renders a list of Environments for topic ${topic}`, () => {
         const table = screen.getByRole("table", {
-          name: "Topics overview",
+          name: "Topics overview, page 1 of 10",
         });
         const row = within(table).getByRole("row", {
           name: new RegExp(`${topic.topicName}`, "i"),
@@ -99,7 +106,7 @@ describe("TopicTable.tsx", () => {
       topic.environmentsList.forEach((env) => {
         it(`renders Environment ${env} for topic ${topic}`, () => {
           const table = screen.getByRole("table", {
-            name: "Topics overview",
+            name: "Topics overview, page 1 of 10",
           });
           const row = within(table).getByRole("row", {
             name: new RegExp(`${topic.topicName}`, "i"),
@@ -117,9 +124,14 @@ describe("TopicTable.tsx", () => {
   describe("enables user to keyboard navigate from topic name to topic name", () => {
     beforeEach(() => {
       mockIntersectionObserver();
-      render(<TopicTable topics={mockedTopics} />);
+      render(
+        <TopicTable
+          topics={mockedTopics}
+          ariaLabel={"Topics overview, page 1 of 10"}
+        />
+      );
       const table = screen.getByRole("table", {
-        name: "Topics overview",
+        name: "Topics overview, page 1 of 10",
       });
       table.focus();
     });

--- a/coral/src/app/features/topics/browse/components/TopicTable.tsx
+++ b/coral/src/app/features/topics/browse/components/TopicTable.tsx
@@ -10,6 +10,7 @@ import { Topic } from "src/domain/topic";
 
 type TopicListProps = {
   topics: Topic[];
+  ariaLabel: string;
 };
 
 interface TopicsTableRow {
@@ -20,7 +21,7 @@ interface TopicsTableRow {
 }
 
 function TopicTable(props: TopicListProps) {
-  const { topics } = props;
+  const { topics, ariaLabel } = props;
 
   const columns: Array<DataTableColumn<TopicsTableRow>> = [
     {
@@ -79,7 +80,7 @@ function TopicTable(props: TopicListProps) {
 
   return (
     <DataTable
-      ariaLabel={"Topics overview"}
+      ariaLabel={ariaLabel}
       columns={columns}
       rows={rows}
       noWrap={false}


### PR DESCRIPTION
## About this change - What it does

- add an `ariaLabel` prop to all our `XXTable` components 
- pass it an informative aria label with the page context
- forward this `ariaLabel` value to `DataTable`'s `ariaLabel` prop

Resolves: #925
