### PR TITLE
Schema Association defect

### DIFF
--- a/core/src/main/java/io/aiven/klaw/service/CommonUtilsService.java
+++ b/core/src/main/java/io/aiven/klaw/service/CommonUtilsService.java
@@ -527,7 +527,12 @@ public class CommonUtilsService {
         kafkaEnvsList.stream()
             .filter(env -> env.getId().equals(kafkaEnvId))
             .findFirst()
-            .ifPresent(env -> orderOfSchemaEnvs.append(env.getAssociatedEnv().getId()).append(","));
+            .ifPresent(
+                env -> {
+                  if (env.getAssociatedEnv() != null) {
+                    orderOfSchemaEnvs.append(env.getAssociatedEnv().getId()).append(",");
+                  }
+                });
       }
     }
 

--- a/core/src/main/java/io/aiven/klaw/service/EnvsClustersTenantsControllerService.java
+++ b/core/src/main/java/io/aiven/klaw/service/EnvsClustersTenantsControllerService.java
@@ -940,8 +940,8 @@ public class EnvsClustersTenantsControllerService {
       throws KlawValidationException {
     // only assignable on a schema registry
     if (KafkaClustersType.SCHEMA_REGISTRY.value.equals(envType)) {
-      //      EnvTag existingTag = getKafkaAssociation(null, id, tenantId);
-      if (envTag != null) {
+      log.info("Env Tag supplied = ", envTag);
+      if (envTag != null && !envTag.getId().isEmpty()) {
 
         associateWithKafkaEnv(envTag, envId, envName, tenantId);
         // remove existing association if it exists


### PR DESCRIPTION
About this change - What it does
This change puts in a null pointer check for when some kafka envs have schema registries attached and others do not.
It also fixes an issue where Kafka environments were not being updated when an association was removed from a schema registry to a blank registry.
Resolves: #xxxxx
Why this way
This makes sure that the behaviour is as expected when we go to request or promote a schema.
