### PR TITLE
Fix user deletion, team deletion validation

### DIFF
--- a/core/src/main/java/io/aiven/klaw/helpers/HandleDbRequests.java
+++ b/core/src/main/java/io/aiven/klaw/helpers/HandleDbRequests.java
@@ -359,4 +359,6 @@ public interface HandleDbRequests {
   int findAllComponentsCountForTeam(Integer teamId, int tenantId);
 
   int getAllTopicsCountInAllTenants();
+
+  int findAllComponentsCountForUser(String userName, int tenantId);
 }

--- a/core/src/main/java/io/aiven/klaw/helpers/db/rdbms/HandleDbRequestsJdbc.java
+++ b/core/src/main/java/io/aiven/klaw/helpers/db/rdbms/HandleDbRequestsJdbc.java
@@ -859,6 +859,11 @@ public class HandleDbRequestsJdbc implements HandleDbRequests {
   }
 
   @Override
+  public int findAllComponentsCountForUser(String userId, int tenantId) {
+    return jdbcSelectHelper.findAllComponentsCountForUser(userId, tenantId);
+  }
+
+  @Override
   public int getAllTopicsCountInAllTenants() {
     return jdbcSelectHelper.getAllTopicsCountInAllTenants();
   }

--- a/core/src/main/java/io/aiven/klaw/helpers/db/rdbms/SelectDataJdbc.java
+++ b/core/src/main/java/io/aiven/klaw/helpers/db/rdbms/SelectDataJdbc.java
@@ -1444,6 +1444,18 @@ public class SelectDataJdbc {
             .intValue();
   }
 
+  public int findAllComponentsCountForUser(String userId, int tenantId) {
+    return ((Long) schemaRequestRepo.findAllRecordsCountForUserId(userId, tenantId).get(0)[0])
+            .intValue()
+        + ((Long)
+                kafkaConnectorRequestsRepo.findAllRecordsCountForUserId(userId, tenantId).get(0)[0])
+            .intValue()
+        + ((Long) topicRequestsRepo.findAllRecordsCountForUserId(userId, tenantId).get(0)[0])
+            .intValue()
+        + ((Long) aclRequestsRepo.findAllRecordsCountForUserId(userId, tenantId).get(0)[0])
+            .intValue();
+  }
+
   public int getAllTopicsCountInAllTenants() {
     return ((Long) topicRepo.findAllTopicsCount().get(0)[0]).intValue();
   }

--- a/core/src/main/java/io/aiven/klaw/repository/AclRequestsRepo.java
+++ b/core/src/main/java/io/aiven/klaw/repository/AclRequestsRepo.java
@@ -16,18 +16,23 @@ public interface AclRequestsRepo
   List<AclRequests> findAllByTenantId(int tenantId);
 
   @Query(
-      value =
-          "select count(*) from kwaclrequests where env = :envId and tenantid = :tenantId and topicstatus='created'",
+      value = "select count(*) from kwaclrequests where env = :envId and tenantid = :tenantId",
       nativeQuery = true)
   List<Object[]> findAllAclRequestsCountForEnv(
       @Param("envId") String envId, @Param("tenantId") Integer tenantId);
 
   @Query(
-      value =
-          "select count(*) from kwaclrequests where teamid = :teamId and tenantid = :tenantId and topicstatus='created'",
+      value = "select count(*) from kwaclrequests where teamid = :teamId and tenantid = :tenantId",
       nativeQuery = true)
   List<Object[]> findAllRecordsCountForTeamId(
       @Param("teamId") Integer teamId, @Param("tenantId") Integer tenantId);
+
+  @Query(
+      value =
+          "select count(*) from kwaclrequests where (requestor = :userId or approver = :userId) and tenantid = :tenantId",
+      nativeQuery = true)
+  List<Object[]> findAllRecordsCountForUserId(
+      @Param("userId") String userId, @Param("tenantId") Integer tenantId);
 
   @Query(
       value = "select max(aclid) from kwaclrequests where tenantid = :tenantId",

--- a/core/src/main/java/io/aiven/klaw/repository/KwKafkaConnectorRequestsRepo.java
+++ b/core/src/main/java/io/aiven/klaw/repository/KwKafkaConnectorRequestsRepo.java
@@ -33,10 +33,17 @@ public interface KwKafkaConnectorRequestsRepo
 
   @Query(
       value =
-          "select count(*) from kwkafkaconnectorrequests where teamid = :teamId and tenantid = :tenantId and connectorstatus='created'",
+          "select count(*) from kwkafkaconnectorrequests where teamid = :teamId and tenantid = :tenantId",
       nativeQuery = true)
   List<Object[]> findAllRecordsCountForTeamId(
       @Param("teamId") Integer teamId, @Param("tenantId") Integer tenantId);
+
+  @Query(
+      value =
+          "select count(*) from kwkafkaconnectorrequests where (requestor = :userId or approver = :userId) and tenantid = :tenantId",
+      nativeQuery = true)
+  List<Object[]> findAllRecordsCountForUserId(
+      @Param("userId") String userId, @Param("tenantId") Integer tenantId);
 
   @Query(
       value =

--- a/core/src/main/java/io/aiven/klaw/repository/SchemaRequestRepo.java
+++ b/core/src/main/java/io/aiven/klaw/repository/SchemaRequestRepo.java
@@ -19,18 +19,24 @@ public interface SchemaRequestRepo
   Integer getNextSchemaRequestId(@Param("tenantId") Integer tenantId);
 
   @Query(
-      value =
-          "select count(*) from kwschemarequests where env = :envId and tenantid = :tenantId and topicstatus='created'",
+      value = "select count(*) from kwschemarequests where env = :envId and tenantid = :tenantId",
       nativeQuery = true)
   List<Object[]> findAllSchemaRequestsCountForEnv(
       @Param("envId") String envId, @Param("tenantId") Integer tenantId);
 
   @Query(
       value =
-          "select count(*) from kwschemarequests where teamid = :teamId and tenantid = :tenantId and topicstatus='created'",
+          "select count(*) from kwschemarequests where teamid = :teamId and tenantid = :tenantId",
       nativeQuery = true)
   List<Object[]> findAllRecordsCountForTeamId(
       @Param("teamId") Integer teamId, @Param("tenantId") Integer tenantId);
+
+  @Query(
+      value =
+          "select count(*) from kwschemarequests where (requestor = :userId or approver = :userId) and tenantid = :tenantId",
+      nativeQuery = true)
+  List<Object[]> findAllRecordsCountForUserId(
+      @Param("userId") String userId, @Param("tenantId") Integer tenantId);
 
   List<SchemaRequest> findAllByTenantId(int tenantId);
 

--- a/core/src/main/java/io/aiven/klaw/repository/TopicRequestsRepo.java
+++ b/core/src/main/java/io/aiven/klaw/repository/TopicRequestsRepo.java
@@ -19,18 +19,24 @@ public interface TopicRequestsRepo
       String topicStatus, String topicName, String envId, int tenantId);
 
   @Query(
-      value =
-          "select count(*) from kwtopicrequests where env = :envId and tenantid = :tenantId and topicstatus='created'",
+      value = "select count(*) from kwtopicrequests where env = :envId and tenantid = :tenantId",
       nativeQuery = true)
   List<Object[]> findAllTopicRequestsCountForEnv(
       @Param("envId") String envId, @Param("tenantId") Integer tenantId);
 
   @Query(
       value =
-          "select count(*) from kwtopicrequests where teamid = :teamId and tenantid = :tenantId and topicstatus='created'",
+          "select count(*) from kwtopicrequests where teamid = :teamId and tenantid = :tenantId",
       nativeQuery = true)
   List<Object[]> findAllRecordsCountForTeamId(
       @Param("teamId") Integer teamId, @Param("tenantId") Integer tenantId);
+
+  @Query(
+      value =
+          "select count(*) from kwtopicrequests where (requestor = :userId or approver = :userId) and tenantid = :tenantId",
+      nativeQuery = true)
+  List<Object[]> findAllRecordsCountForUserId(
+      @Param("userId") String userId, @Param("tenantId") Integer tenantId);
 
   @Query(
       value = "select max(topicid) from kwtopicrequests where tenantid = :tenantId",

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -10,7 +10,7 @@
       "name" : "Apache 2.0",
       "url" : "https://www.apache.org/licenses/LICENSE-2.0.html"
     },
-    "version" : "2.1.0"
+    "version" : "2.2.0"
   },
   "externalDocs" : {
     "description" : "Klaw documentation",


### PR DESCRIPTION
About this change - What it does

when a user or team is deleted, check if there are any users or requests associated to them, and prevent from deletion

Resolves: #947 
Why this way
Keeps sanity of the metadata