### PR TITLE
Exportdata

### DIFF
--- a/core/src/main/java/io/aiven/klaw/UiapiApplication.java
+++ b/core/src/main/java/io/aiven/klaw/UiapiApplication.java
@@ -5,7 +5,9 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration;
 import org.springframework.boot.autoconfigure.jdbc.DataSourceTransactionManagerAutoConfiguration;
 import org.springframework.boot.autoconfigure.orm.jpa.HibernateJpaAutoConfiguration;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
+@EnableScheduling
 @SpringBootApplication(
     exclude = {
       DataSourceAutoConfiguration.class,

--- a/core/src/main/java/io/aiven/klaw/config/MetadataConfig.java
+++ b/core/src/main/java/io/aiven/klaw/config/MetadataConfig.java
@@ -1,0 +1,19 @@
+package io.aiven.klaw.config;
+
+import java.util.concurrent.Executor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableAsync;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+
+@EnableAsync
+@Configuration
+public class MetadataConfig {
+
+  @Bean(name = "metadataExportTaskExecutor")
+  public Executor threadPoolTaskExecutor() {
+    ThreadPoolTaskExecutor threadPoolTaskExecutor = new ThreadPoolTaskExecutor();
+    threadPoolTaskExecutor.setCorePoolSize(4);
+    return threadPoolTaskExecutor;
+  }
+}

--- a/core/src/main/java/io/aiven/klaw/dao/metadata/KwAdminConfig.java
+++ b/core/src/main/java/io/aiven/klaw/dao/metadata/KwAdminConfig.java
@@ -1,0 +1,28 @@
+package io.aiven.klaw.dao.metadata;
+
+import io.aiven.klaw.dao.Env;
+import io.aiven.klaw.dao.KwClusters;
+import io.aiven.klaw.dao.KwProperties;
+import io.aiven.klaw.dao.KwRolesPermissions;
+import io.aiven.klaw.dao.KwTenants;
+import io.aiven.klaw.dao.ProductDetails;
+import io.aiven.klaw.dao.Team;
+import io.aiven.klaw.dao.UserInfo;
+import java.util.List;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+
+@Builder
+@Getter
+@Setter
+public class KwAdminConfig {
+  List<KwTenants> tenants;
+  List<KwClusters> clusters;
+  List<Env> environments;
+  List<KwRolesPermissions> rolesPermissions;
+  List<Team> teams;
+  List<UserInfo> users;
+  List<KwProperties> properties;
+  ProductDetails productDetails;
+}

--- a/core/src/main/java/io/aiven/klaw/dao/metadata/KwData.java
+++ b/core/src/main/java/io/aiven/klaw/dao/metadata/KwData.java
@@ -1,0 +1,20 @@
+package io.aiven.klaw.dao.metadata;
+
+import io.aiven.klaw.dao.Acl;
+import io.aiven.klaw.dao.KwKafkaConnector;
+import io.aiven.klaw.dao.MessageSchema;
+import io.aiven.klaw.dao.Topic;
+import java.util.List;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+
+@Builder
+@Getter
+@Setter
+public class KwData {
+  List<Topic> topics;
+  List<Acl> subscriptions;
+  List<MessageSchema> schemas;
+  List<KwKafkaConnector> kafkaConnectors;
+}

--- a/core/src/main/java/io/aiven/klaw/dao/metadata/KwMetadata.java
+++ b/core/src/main/java/io/aiven/klaw/dao/metadata/KwMetadata.java
@@ -1,0 +1,14 @@
+package io.aiven.klaw.dao.metadata;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@Builder
+public class KwMetadata {
+  KwAdminConfig kwAdminConfig;
+  KwData kwData;
+  KwRequests KwRequests;
+}

--- a/core/src/main/java/io/aiven/klaw/dao/metadata/KwRequests.java
+++ b/core/src/main/java/io/aiven/klaw/dao/metadata/KwRequests.java
@@ -1,0 +1,24 @@
+package io.aiven.klaw.dao.metadata;
+
+import io.aiven.klaw.dao.AclRequests;
+import io.aiven.klaw.dao.ActivityLog;
+import io.aiven.klaw.dao.KafkaConnectorRequest;
+import io.aiven.klaw.dao.RegisterUserInfo;
+import io.aiven.klaw.dao.SchemaRequest;
+import io.aiven.klaw.dao.TopicRequest;
+import java.util.List;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+
+@Builder
+@Getter
+@Setter
+public class KwRequests {
+  List<TopicRequest> topicRequests;
+  List<AclRequests> subscriptionRequests;
+  List<SchemaRequest> schemaRequests;
+  List<KafkaConnectorRequest> connectorRequests;
+  List<RegisterUserInfo> userRequests;
+  List<ActivityLog> activityLogs;
+}

--- a/core/src/main/java/io/aiven/klaw/helpers/HandleDbRequests.java
+++ b/core/src/main/java/io/aiven/klaw/helpers/HandleDbRequests.java
@@ -363,4 +363,32 @@ public interface HandleDbRequests {
   int getAllTopicsCountInAllTenants();
 
   int findAllComponentsCountForUser(String userName, int tenantId);
+
+  List<Topic> getAllTopics();
+
+  List<TopicRequest> getAllTopicRequests();
+
+  List<KafkaConnectorRequest> getAllConnectorRequests();
+
+  List<KwKafkaConnector> getAllConnectors();
+
+  List<Acl> getAllSubscriptions();
+
+  List<AclRequests> getAllAclRequests();
+
+  List<SchemaRequest> getAllSchemaRequests();
+
+  List<MessageSchema> selectAllSchemas();
+
+  List<Team> selectTeams();
+
+  List<RegisterUserInfo> getAllRegisterUsersInfo();
+
+  List<Env> selectEnvs();
+
+  List<ActivityLog> getAllActivityLog();
+
+  List<KwProperties> selectKwProperties();
+
+  List<KwClusters> getClusters();
 }

--- a/core/src/main/java/io/aiven/klaw/helpers/db/rdbms/HandleDbRequestsJdbc.java
+++ b/core/src/main/java/io/aiven/klaw/helpers/db/rdbms/HandleDbRequestsJdbc.java
@@ -869,4 +869,74 @@ public class HandleDbRequestsJdbc implements HandleDbRequests {
   public int getAllTopicsCountInAllTenants() {
     return jdbcSelectHelper.getAllTopicsCountInAllTenants();
   }
+
+  @Override
+  public List<TopicRequest> getAllTopicRequests() {
+    return jdbcSelectHelper.getAllTopicRequests();
+  }
+
+  @Override
+  public List<KafkaConnectorRequest> getAllConnectorRequests() {
+    return jdbcSelectHelper.getAllConnectorRequests();
+  }
+
+  @Override
+  public List<KwKafkaConnector> getAllConnectors() {
+    return jdbcSelectHelper.getAllConnectors();
+  }
+
+  @Override
+  public List<Topic> getAllTopics() {
+    return jdbcSelectHelper.getAllTopics();
+  }
+
+  @Override
+  public List<Acl> getAllSubscriptions() {
+    return jdbcSelectHelper.getAllSubscriptions();
+  }
+
+  @Override
+  public List<AclRequests> getAllAclRequests() {
+    return jdbcSelectHelper.getAllAclRequests();
+  }
+
+  @Override
+  public List<SchemaRequest> getAllSchemaRequests() {
+    return jdbcSelectHelper.getAllSchemaRequests();
+  }
+
+  @Override
+  public List<MessageSchema> selectAllSchemas() {
+    return jdbcSelectHelper.selectAllSchemas();
+  }
+
+  @Override
+  public List<Team> selectTeams() {
+    return jdbcSelectHelper.selectTeams();
+  }
+
+  @Override
+  public List<RegisterUserInfo> getAllRegisterUsersInfo() {
+    return jdbcSelectHelper.getAllRegisterUsersInfo();
+  }
+
+  @Override
+  public List<Env> selectEnvs() {
+    return jdbcSelectHelper.selectEnvs();
+  }
+
+  @Override
+  public List<ActivityLog> getAllActivityLog() {
+    return jdbcSelectHelper.getAllActivityLog();
+  }
+
+  @Override
+  public List<KwProperties> selectKwProperties() {
+    return jdbcSelectHelper.selectKwProperties();
+  }
+
+  @Override
+  public List<KwClusters> getClusters() {
+    return jdbcSelectHelper.getClusters();
+  }
 }

--- a/core/src/main/java/io/aiven/klaw/helpers/db/rdbms/SelectDataJdbc.java
+++ b/core/src/main/java/io/aiven/klaw/helpers/db/rdbms/SelectDataJdbc.java
@@ -1395,7 +1395,14 @@ public class SelectDataJdbc {
   }
 
   public List<UserInfo> selectAllUsersAllTenants() {
-    return Lists.newArrayList(userInfoRepo.findAll());
+    List<UserInfo> userList = Lists.newArrayList(userInfoRepo.findAll());
+
+    userList =
+        userList.stream()
+            .filter(user -> user.getUsername().equals("superadmin"))
+            .collect(Collectors.toList());
+    userList.forEach(user -> user.setPwd(""));
+    return userList;
   }
 
   public Optional<ProductDetails> selectProductDetails(String name) {
@@ -1645,5 +1652,61 @@ public class SelectDataJdbc {
 
   private static void updateMap(Map<String, Long> countsMap, List<Object[]> requestObjList) {
     requestObjList.forEach(reqObj -> countsMap.put((String) reqObj[0], (Long) reqObj[1]));
+  }
+
+  public List<KwClusters> getClusters() {
+    return Lists.newArrayList(kwClusterRepo.findAll());
+  }
+
+  public List<Env> selectEnvs() {
+    return Lists.newArrayList(envRepo.findAll());
+  }
+
+  public List<Team> selectTeams() {
+    return Lists.newArrayList(teamRepo.findAll());
+  }
+
+  public List<KwProperties> selectKwProperties() {
+    return Lists.newArrayList(kwPropertiesRepo.findAll());
+  }
+
+  public List<Topic> getAllTopics() {
+    return Lists.newArrayList(topicRepo.findAll());
+  }
+
+  public List<Acl> getAllSubscriptions() {
+    return Lists.newArrayList(aclRepo.findAll());
+  }
+
+  public List<MessageSchema> selectAllSchemas() {
+    return Lists.newArrayList(messageSchemaRepo.findAll());
+  }
+
+  public List<KwKafkaConnector> getAllConnectors() {
+    return Lists.newArrayList(kafkaConnectorRepo.findAll());
+  }
+
+  public List<ActivityLog> getAllActivityLog() {
+    return Lists.newArrayList(activityLogRepo.findAll());
+  }
+
+  public List<TopicRequest> getAllTopicRequests() {
+    return Lists.newArrayList(topicRequestsRepo.findAll());
+  }
+
+  public List<AclRequests> getAllAclRequests() {
+    return Lists.newArrayList(aclRequestsRepo.findAll());
+  }
+
+  public List<SchemaRequest> getAllSchemaRequests() {
+    return Lists.newArrayList(schemaRequestRepo.findAll());
+  }
+
+  public List<KafkaConnectorRequest> getAllConnectorRequests() {
+    return Lists.newArrayList(kafkaConnectorRequestsRepo.findAll());
+  }
+
+  public List<RegisterUserInfo> getAllRegisterUsersInfo() {
+    return Lists.newArrayList(registerInfoRepo.findAll());
   }
 }

--- a/core/src/main/java/io/aiven/klaw/service/ExportImportDataService.java
+++ b/core/src/main/java/io/aiven/klaw/service/ExportImportDataService.java
@@ -1,0 +1,158 @@
+package io.aiven.klaw.service;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.aiven.klaw.config.ManageDatabase;
+import io.aiven.klaw.dao.ProductDetails;
+import io.aiven.klaw.dao.UserInfo;
+import io.aiven.klaw.dao.metadata.KwAdminConfig;
+import io.aiven.klaw.dao.metadata.KwData;
+import io.aiven.klaw.dao.metadata.KwRequests;
+import io.aiven.klaw.helpers.HandleDbRequests;
+import jakarta.annotation.PostConstruct;
+import java.io.File;
+import java.io.IOException;
+import java.text.SimpleDateFormat;
+import java.util.Date;
+import java.util.List;
+import lombok.extern.slf4j.Slf4j;
+import org.jasypt.util.text.BasicTextEncryptor;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+
+/*
+Export Klaw metadata (Admin config, Core data, Requests data) to json files
+ */
+@Slf4j
+@Service
+public class ExportImportDataService {
+
+  public static final String PWD_ALL_USERS = "WelcomeToKlaw!!";
+
+  @Value("${klaw.jasypt.encryptor.secretkey}")
+  private String encryptorSecretKey;
+
+  private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+  private static final String FILE_EXT = ".json";
+  private static final String FILE_PREFIX = "kwmetadata";
+  private static final String ADMIN_CONFIG_PREFIX = "admin_config";
+  private static final String KW_DATA_PREFIX = "kwdata";
+  private static final String KW_REQUEST_DATA_PREFIX = "kwrequests_data";
+  @Autowired ManageDatabase manageDatabase;
+
+  @Value("${klaw.export.file.path:/target}")
+  private String klawExportFilePath;
+
+  @Value("${klaw.export.scheduler.enable:false}")
+  private boolean exportMetadata;
+
+  @Async("metadataExportTaskExecutor")
+  @Scheduled(cron = "${klaw.export.cron.expression:0 0 0 * * ?}")
+  void exportKwMetadataScheduler() {
+    if (!exportMetadata) {
+      return;
+    }
+    exportKwMetadata();
+  }
+
+  // select data from database, write to files in json format
+  private void exportKwMetadata() {
+    HandleDbRequests handleDbRequests = manageDatabase.getHandleDbRequests();
+    KwAdminConfig adminConfig = getAdminConfig(handleDbRequests);
+    KwData kwData = getKwData(handleDbRequests);
+    KwRequests kwRequestData = getRequestsData(handleDbRequests);
+
+    // write to files
+    try {
+      String timeStamp = getTimeStamp();
+      OBJECT_MAPPER
+          .writerWithDefaultPrettyPrinter()
+          .writeValue(getFile(ADMIN_CONFIG_PREFIX, timeStamp), adminConfig);
+      OBJECT_MAPPER
+          .writerWithDefaultPrettyPrinter()
+          .writeValue(getFile(KW_DATA_PREFIX, timeStamp), kwData);
+      OBJECT_MAPPER
+          .writerWithDefaultPrettyPrinter()
+          .writeValue(getFile(KW_REQUEST_DATA_PREFIX, timeStamp), kwRequestData);
+      log.info("Klaw metadata exported !!");
+    } catch (IOException e) {
+      log.error("Error during parsing/writing to files : ", e);
+    }
+  }
+
+  // tenants, clusters, environments, roles, permissions, teams, users, properties
+  private KwAdminConfig getAdminConfig(HandleDbRequests handleDbRequests) {
+    log.info(
+        "Selecting Kw Admin Config (tenants, clusters, environments, roles, permissions, teams, users, properties) --- STARTED");
+    List<UserInfo> userList = getUpdatedUserList(handleDbRequests.selectAllUsersAllTenants());
+
+    KwAdminConfig kwMetadata =
+        KwAdminConfig.builder()
+            .tenants(handleDbRequests.getTenants())
+            .clusters(handleDbRequests.getClusters())
+            .environments(handleDbRequests.selectEnvs())
+            .rolesPermissions(handleDbRequests.getRolesPermissions())
+            .teams(handleDbRequests.selectTeams())
+            .users(userList)
+            .properties(handleDbRequests.selectKwProperties())
+            .productDetails(
+                handleDbRequests.selectProductDetails("Klaw").orElse(new ProductDetails()))
+            .build();
+    log.info("Selecting Kw Admin Config --- ENDED");
+    return kwMetadata;
+  }
+
+  private List<UserInfo> getUpdatedUserList(List<UserInfo> userList) {
+    log.info("Users password exported as : {}", PWD_ALL_USERS);
+    BasicTextEncryptor textEncryptor = new BasicTextEncryptor();
+    textEncryptor.setPasswordCharArray(encryptorSecretKey.toCharArray());
+    userList.forEach(user -> user.setPwd(textEncryptor.encrypt(PWD_ALL_USERS)));
+
+    return userList;
+  }
+
+  // Get core configuration of topics, acls, schemas, connectors
+  private KwData getKwData(HandleDbRequests handleDbRequests) {
+    log.info("Selecting Kw Data (topics, acls, schemas, connectors) --- STARTED");
+    KwData kwMetadata =
+        KwData.builder()
+            .topics(handleDbRequests.getAllTopics())
+            .subscriptions(handleDbRequests.getAllSubscriptions())
+            .schemas(handleDbRequests.selectAllSchemas())
+            .kafkaConnectors(handleDbRequests.getAllConnectors())
+            .build();
+    log.info("Selecting Kw Data --- STARTED");
+    return kwMetadata;
+  }
+
+  // Get requests data and activity log
+  private KwRequests getRequestsData(HandleDbRequests handleDbRequests) {
+    log.info(
+        "Selecting Kw Requests Data (topic, subscription, schema and connector requests, activity log)--- STARTED");
+    KwRequests kwMetadata =
+        KwRequests.builder()
+            .topicRequests(handleDbRequests.getAllTopicRequests())
+            .subscriptionRequests(handleDbRequests.getAllAclRequests())
+            .schemaRequests(handleDbRequests.getAllSchemaRequests())
+            .connectorRequests(handleDbRequests.getAllConnectorRequests())
+            .activityLogs(handleDbRequests.getAllActivityLog())
+            .build();
+    log.info("Selecting Kw Requests Data --- ENDED");
+    return kwMetadata;
+  }
+
+  private File getFile(String fileName, String timeStamp) {
+    File file =
+        new File(klawExportFilePath + FILE_PREFIX + "-" + fileName + "-" + timeStamp + FILE_EXT);
+    log.info("File : {}", file);
+    return file;
+  }
+
+  private String getTimeStamp() {
+    String dataPattern = "yyyy-MM-ddHH-mm-ssSSS";
+    SimpleDateFormat simpleDateFormat = new SimpleDateFormat(dataPattern);
+    return simpleDateFormat.format(new Date());
+  }
+}

--- a/core/src/main/java/io/aiven/klaw/service/ExportImportDataService.java
+++ b/core/src/main/java/io/aiven/klaw/service/ExportImportDataService.java
@@ -8,7 +8,6 @@ import io.aiven.klaw.dao.metadata.KwAdminConfig;
 import io.aiven.klaw.dao.metadata.KwData;
 import io.aiven.klaw.dao.metadata.KwRequests;
 import io.aiven.klaw.helpers.HandleDbRequests;
-import jakarta.annotation.PostConstruct;
 import java.io.File;
 import java.io.IOException;
 import java.text.SimpleDateFormat;
@@ -83,7 +82,7 @@ public class ExportImportDataService {
   }
 
   // tenants, clusters, environments, roles, permissions, teams, users, properties
-  private KwAdminConfig getAdminConfig(HandleDbRequests handleDbRequests) {
+  public KwAdminConfig getAdminConfig(HandleDbRequests handleDbRequests) {
     log.info(
         "Selecting Kw Admin Config (tenants, clusters, environments, roles, permissions, teams, users, properties) --- STARTED");
     List<UserInfo> userList = getUpdatedUserList(handleDbRequests.selectAllUsersAllTenants());
@@ -114,7 +113,7 @@ public class ExportImportDataService {
   }
 
   // Get core configuration of topics, acls, schemas, connectors
-  private KwData getKwData(HandleDbRequests handleDbRequests) {
+  public KwData getKwData(HandleDbRequests handleDbRequests) {
     log.info("Selecting Kw Data (topics, acls, schemas, connectors) --- STARTED");
     KwData kwMetadata =
         KwData.builder()
@@ -128,7 +127,7 @@ public class ExportImportDataService {
   }
 
   // Get requests data and activity log
-  private KwRequests getRequestsData(HandleDbRequests handleDbRequests) {
+  public KwRequests getRequestsData(HandleDbRequests handleDbRequests) {
     log.info(
         "Selecting Kw Requests Data (topic, subscription, schema and connector requests, activity log)--- STARTED");
     KwRequests kwMetadata =

--- a/core/src/main/resources/application.properties
+++ b/core/src/main/resources/application.properties
@@ -205,6 +205,12 @@ management.endpoint.shutdown.enabled=false
 # global settings on api responses
 spring.jackson.default-property-inclusion=non_null
 
+# Klaw Export Import metadata config
+klaw.export.scheduler.enable=false
+klaw.export.file.path=./target/
+# cron expression, default 12 am everyday
+klaw.export.cron.expression=0 0 0 * * ?
+
 # log file settings
 logging.level.root=info
 logging.level.org.hibernate.SQL=off

--- a/core/src/test/java/io/aiven/klaw/UtilMethods.java
+++ b/core/src/test/java/io/aiven/klaw/UtilMethods.java
@@ -163,6 +163,27 @@ public class UtilMethods {
     return allTopicReqs;
   }
 
+  public List<Topic> getMultipleTopics(String topicPrefix, int size) {
+    List<Topic> listTopics = new ArrayList<>();
+    Topic t;
+
+    for (int i = 0; i < size; i++) {
+      t = new Topic();
+
+      if (i % 2 == 0) t.setTeamId(1);
+      else t.setTeamId(2);
+
+      t.setTopicname(topicPrefix + i);
+      t.setTopicid(i);
+      t.setEnvironment("1");
+      t.setTeamId(101);
+      t.setEnvironmentsList(new ArrayList<>());
+
+      listTopics.add(t);
+    }
+    return listTopics;
+  }
+
   public List<Acl> getAcls() {
     List<Acl> allTopicReqs = new ArrayList<>();
     Acl topicRequest = new Acl();

--- a/core/src/test/java/io/aiven/klaw/service/ExportImportDataServiceTest.java
+++ b/core/src/test/java/io/aiven/klaw/service/ExportImportDataServiceTest.java
@@ -1,0 +1,72 @@
+package io.aiven.klaw.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+import io.aiven.klaw.UtilMethods;
+import io.aiven.klaw.config.ManageDatabase;
+import io.aiven.klaw.dao.KwKafkaConnector;
+import io.aiven.klaw.dao.metadata.KwAdminConfig;
+import io.aiven.klaw.dao.metadata.KwData;
+import io.aiven.klaw.dao.metadata.KwRequests;
+import io.aiven.klaw.helpers.db.rdbms.HandleDbRequestsJdbc;
+import java.util.Collections;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+@ExtendWith(SpringExtension.class)
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+public class ExportImportDataServiceTest {
+
+  @Mock private ManageDatabase manageDatabase;
+
+  private UtilMethods utilMethods;
+
+  @Mock private HandleDbRequestsJdbc handleDbRequests;
+  private ExportImportDataService exportImportDataService;
+
+  @BeforeEach
+  public void setUp() throws Exception {
+    exportImportDataService = new ExportImportDataService();
+    utilMethods = new UtilMethods();
+    ReflectionTestUtils.setField(exportImportDataService, "manageDatabase", manageDatabase);
+    ReflectionTestUtils.setField(exportImportDataService, "encryptorSecretKey", "testkey");
+    when(manageDatabase.getHandleDbRequests()).thenReturn(handleDbRequests);
+  }
+
+  @Test
+  public void getAdminConfig() {
+    when(handleDbRequests.selectAllUsersAllTenants())
+        .thenReturn(utilMethods.getUserInfoList("", ""));
+    when(handleDbRequests.getClusters())
+        .thenReturn(Collections.singletonList(utilMethods.getKwClusters()));
+    KwAdminConfig kwAdminConfig = exportImportDataService.getAdminConfig(handleDbRequests);
+    assertThat(kwAdminConfig.getUsers().size()).isEqualTo(1);
+    assertThat(kwAdminConfig.getClusters().size()).isEqualTo(1);
+  }
+
+  @Test
+  public void getKwData() {
+    when(handleDbRequests.getAllTopics()).thenReturn(utilMethods.getMultipleTopics("test", 10));
+    when(handleDbRequests.getAllConnectors())
+        .thenReturn(Collections.singletonList(new KwKafkaConnector()));
+    KwData kwData = exportImportDataService.getKwData(handleDbRequests);
+    assertThat(kwData.getTopics().size()).isEqualTo(10);
+    assertThat(kwData.getKafkaConnectors().size()).isEqualTo(1);
+  }
+
+  @Test
+  public void getRequestsData() {
+    when(handleDbRequests.getAllTopicRequests()).thenReturn(utilMethods.getTopicRequests());
+    when(handleDbRequests.getAllAclRequests()).thenReturn(utilMethods.getAclRequests());
+    KwRequests kwRequests = exportImportDataService.getRequestsData(handleDbRequests);
+    assertThat(kwRequests.getTopicRequests().size()).isEqualTo(1);
+    assertThat(kwRequests.getSubscriptionRequests().size()).isEqualTo(1);
+  }
+}

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -10,7 +10,7 @@
       "name" : "Apache 2.0",
       "url" : "https://www.apache.org/licenses/LICENSE-2.0.html"
     },
-    "version" : "2.2.0"
+    "version" : "2.1.0"
   },
   "externalDocs" : {
     "description" : "Klaw documentation",


### PR DESCRIPTION
About this change - What it does

- With a scheduler configuration, exports klaw data into 3 json files
  - Admin data
  - Requests data
  - Core data

Resolves: #437 
Why this way
Apart from database backups, these backups are easy to manage, and should be easy to import to another klaw instance.
