### PR TITLE
Minor Klaw version release.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-version = 2.1.0
+version = 2.2.0
 
 # Sets a custom hook path in the local git config.
 # Currently there's only a pre-commit hook related

--- a/README.md
+++ b/README.md
@@ -25,14 +25,17 @@ For the versions available, see the [tags on this repository](https://github.com
 - Topics (approval): Create, Update, Delete, Promote
   - React UI - New look and feel for Browse topics, Create topic Request
   - React UI - New look and feel for Approving topics, ACLs, Schemas
+  - React UI - New look and feel for viewing 'My Teams Requests' for topics, ACLs and Schemas 
   
 - Acls (approval):  Create,Delete
   - React UI - Create Acl Request 
+  - Service accounts created for ACLs are assigned to the creating team
 - Connectors (approval): Create
   - Any connector can be created as long as the required plugin libraries are installed on the server.  
 - Avro Schemas (approval): Create
   - View all available versions of the subjects per topic
   - React UI - Create Schema Request
+  - Pre validation of Schemas compatibility on Schema request creation
 - Topic Overview :
   - Topic Config
   - Promote
@@ -58,6 +61,7 @@ For the versions available, see the [tags on this repository](https://github.com
 - Configure Clusters and Environments
   - Clusters can be created connecting to Apache Kafka clusters. (Cluster Management Api should be configured)
   - Environments are wrappers over clusters, enforcing flexible configs like prefix, suffix etc
+  - Kafka Rest Proxy can be added to the cluster to store the rest proxy url information.
 
 - Users, Teams & Authorizations
   - Configurable users, teams
@@ -165,4 +169,4 @@ Klaw (formerly Kafkawize) is maintained by, [Aiven](https://aiven.io/) open sour
 Recent contributors are listed on the GitHub project page,
 https://github.com/aiven/klaw/graphs/contributors
 
-Copyright (c) 2022 Aiven Oy and klaw project contributors.
+Copyright (c) 2023 Aiven Oy and klaw project contributors.

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ For the versions available, see the [tags on this repository](https://github.com
 - Topics (approval): Create, Update, Delete, Promote
   - React UI - New look and feel for Browse topics, Create topic Request
   - React UI - New look and feel for Approving topics, ACLs, Schemas
-  - React UI - New look and feel for viewing 'My Teams Requests' for topics, ACLs and Schemas 
+  - React UI - New look and feel for viewing 'My Team's Requests' for topics, ACLs and Schemas 
   
 - Acls (approval):  Create,Delete
   - React UI - Create Acl Request 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ For the versions available, see the [tags on this repository](https://github.com
 - Topics (approval): Create, Update, Delete, Promote
   - React UI - New look and feel for Browse topics, Create topic Request
   - React UI - New look and feel for Approving topics, ACLs, Schemas
-  - React UI - New look and feel for viewing 'My Team's Requests' for topics, ACLs and Schemas 
+  - React UI - New look and feel for viewing 'My team's Requests' for topics, ACLs and Schemas 
   
 - Acls (approval):  Create,Delete
   - React UI - Create Acl Request 

--- a/cluster-api/pom.xml
+++ b/cluster-api/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>io.aiven</groupId>
         <artifactId>klaw-project</artifactId>
-        <version>2.1.0</version>
+        <version>2.2.0</version>
     </parent>
 
     <artifactId>cluster-api</artifactId>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>io.aiven</groupId>
         <artifactId>klaw-project</artifactId>
-        <version>2.1.0</version>
+        <version>2.2.0</version>
     </parent>
 
     <artifactId>klaw</artifactId>

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -10,7 +10,7 @@
       "name" : "Apache 2.0",
       "url" : "https://www.apache.org/licenses/LICENSE-2.0.html"
     },
-    "version" : "2.1.0"
+    "version" : "2.2.0"
   },
   "externalDocs" : {
     "description" : "Klaw documentation",
@@ -5784,13 +5784,15 @@
           "acl_ip" : {
             "type" : "array",
             "items" : {
-              "type" : "string"
+              "type" : "string",
+              "pattern" : "^$|^(([0-9]|[1-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])(\\.(?!$)|$)){4}$"
             }
           },
           "acl_ssl" : {
             "type" : "array",
             "items" : {
-              "type" : "string"
+              "type" : "string",
+              "pattern" : "^$|^[a-zA-Z 0-9_.,=-]{3,}$"
             }
           },
           "aclPatternType" : {

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>io.aiven</groupId>
     <artifactId>klaw-project</artifactId>
-    <version>2.1.0</version>
+    <version>2.2.0</version>
     <packaging>pom</packaging>
     <name>Klaw Project</name>
     <description>Aiven Klaw - Selfservice, Governance for Kafka</description>


### PR DESCRIPTION
About this change - What it does
Update version numbers from 2.1.0 to 2.2.0 for Klaw.

Resolves: #xxxxx
Why this way
This is part of the Klaw release process.