### PR TITLE
feat(coral): Topic approvals, Schema approvals : Add operation type filter approvals

### DIFF
--- a/coral/src/app/features/approvals/acls/AclApprovals.tsx
+++ b/coral/src/app/features/approvals/acls/AclApprovals.tsx
@@ -6,13 +6,14 @@ import { Pagination } from "src/app/components/Pagination";
 import AclApprovalsTable from "src/app/features/approvals/acls/components/AclApprovalsTable";
 import RequestDeclineModal from "src/app/features/approvals/components/RequestDeclineModal";
 import AclDetailsModalContent from "src/app/features/components/AclDetailsModalContent";
-import { TableLayout } from "src/app/features/components/layouts/TableLayout";
 import RequestDetailsModal from "src/app/features/components/RequestDetailsModal";
 import AclTypeFilter from "src/app/features/components/filters/AclTypeFilter";
 import EnvironmentFilter from "src/app/features/components/filters/EnvironmentFilter";
+import { RequestTypeFilter } from "src/app/features/components/filters/RequestTypeFilter";
 import StatusFilter from "src/app/features/components/filters/StatusFilter";
 import TopicFilter from "src/app/features/components/filters/TopicFilter";
 import { useFiltersValues } from "src/app/features/components/filters/useFiltersValues";
+import { TableLayout } from "src/app/features/components/layouts/TableLayout";
 import {
   approveAclRequest,
   declineAclRequest,
@@ -20,7 +21,6 @@ import {
 } from "src/domain/acl/acl-api";
 import { AclRequestsForApprover } from "src/domain/acl/acl-types";
 import { parseErrorMsg } from "src/services/mutation-utils";
-import { RequestTypeFilter } from "src/app/features/components/filters/RequestTypeFilter";
 
 const defaultType = "ALL";
 

--- a/coral/src/app/features/approvals/schemas/SchemaApprovals.test.tsx
+++ b/coral/src/app/features/approvals/schemas/SchemaApprovals.test.tsx
@@ -544,6 +544,27 @@ describe("SchemaApprovals", () => {
       });
     });
 
+    it("enables user to filter by 'request type'", async () => {
+      const select = screen.getByLabelText("Filter by request type");
+
+      const option = within(select).getByRole("option", {
+        name: "Create",
+      });
+
+      expect(option).toBeEnabled();
+
+      await userEvent.selectOptions(select, option);
+
+      expect(select).toHaveDisplayValue("Create");
+
+      await waitFor(() =>
+        expect(mockGetSchemaRequestsForApprover).toHaveBeenCalledWith({
+          ...defaultApiParams,
+          operationType: "CREATE",
+        })
+      );
+    });
+
     it("enables user to filter by 'environment'", async () => {
       expect(mockGetSchemaRequestsForApprover).toHaveBeenNthCalledWith(
         1,

--- a/coral/src/app/features/approvals/schemas/SchemaApprovals.tsx
+++ b/coral/src/app/features/approvals/schemas/SchemaApprovals.tsx
@@ -18,6 +18,9 @@ import {
   getSchemaRequestsForApprover,
 } from "src/domain/schema-request";
 import { parseErrorMsg } from "src/services/mutation-utils";
+import { RequestTypeFilter } from "src/app/features/components/filters/RequestTypeFilter";
+
+const defaultType = "ALL";
 
 function SchemaApprovals() {
   const queryClient = useQueryClient();
@@ -27,7 +30,7 @@ function SchemaApprovals() {
     ? Number(searchParams.get("page"))
     : 1;
 
-  const { environment, status, topic } = useFiltersValues({
+  const { environment, status, topic, requestType } = useFiltersValues({
     defaultStatus: "CREATED",
   });
 
@@ -60,6 +63,7 @@ function SchemaApprovals() {
       status,
       environment,
       topic,
+      requestType,
     ],
     queryFn: () =>
       getSchemaRequestsForApprover({
@@ -67,6 +71,7 @@ function SchemaApprovals() {
         pageNo: currentPage.toString(),
         env: environment,
         search: topic,
+        operationType: requestType !== defaultType ? requestType : undefined,
       }),
     keepPreviousData: true,
   });
@@ -266,6 +271,7 @@ function SchemaApprovals() {
             isSchemaRegistryEnvironments
           />,
           <StatusFilter key={"status"} defaultStatus={"CREATED"} />,
+          <RequestTypeFilter key={"requestType"} />,
           <TopicFilter key={"topic"} />,
         ]}
         table={table}

--- a/coral/src/app/features/approvals/topics/TopicApprovals.test.tsx
+++ b/coral/src/app/features/approvals/topics/TopicApprovals.test.tsx
@@ -583,6 +583,31 @@ describe("TopicApprovals", () => {
       );
     });
 
+    it("filters by Request type", async () => {
+      const select = screen.getByLabelText("Filter by request type");
+
+      const option = within(select).getByRole("option", {
+        name: "Create",
+      });
+
+      expect(option).toBeEnabled();
+
+      await userEvent.selectOptions(select, option);
+
+      expect(select).toHaveDisplayValue("Create");
+
+      await waitFor(() =>
+        expect(mockGetTopicRequestsForApprover).toHaveBeenCalledWith({
+          env: "ALL",
+          pageNo: "1",
+          requestStatus: "CREATED",
+          search: "",
+          teamId: undefined,
+          operationType: "CREATE",
+        })
+      );
+    });
+
     it("filters by ACL type", async () => {
       const select = screen.getByLabelText("Filter by team");
 

--- a/coral/src/app/features/approvals/topics/TopicApprovals.tsx
+++ b/coral/src/app/features/approvals/topics/TopicApprovals.tsx
@@ -4,21 +4,24 @@ import { useState } from "react";
 import { useSearchParams } from "react-router-dom";
 import { Pagination } from "src/app/components/Pagination";
 import RequestDeclineModal from "src/app/features/approvals/components/RequestDeclineModal";
-import TopicDetailsModalContent from "src/app/features/components/TopicDetailsModalContent";
 import { TopicApprovalsTable } from "src/app/features/approvals/topics/components/TopicApprovalsTable";
-import { TableLayout } from "src/app/features/components/layouts/TableLayout";
 import RequestDetailsModal from "src/app/features/components/RequestDetailsModal";
+import TopicDetailsModalContent from "src/app/features/components/TopicDetailsModalContent";
 import EnvironmentFilter from "src/app/features/components/filters/EnvironmentFilter";
+import { RequestTypeFilter } from "src/app/features/components/filters/RequestTypeFilter";
 import StatusFilter from "src/app/features/components/filters/StatusFilter";
 import TeamFilter from "src/app/features/components/filters/TeamFilter";
 import TopicFilter from "src/app/features/components/filters/TopicFilter";
 import { useFiltersValues } from "src/app/features/components/filters/useFiltersValues";
+import { TableLayout } from "src/app/features/components/layouts/TableLayout";
 import {
   approveTopicRequest,
   declineTopicRequest,
   getTopicRequestsForApprover,
 } from "src/domain/topic/topic-api";
 import { HTTPError } from "src/services/api";
+
+const defaultType = "ALL";
 
 function TopicApprovals() {
   const queryClient = useQueryClient();
@@ -29,7 +32,7 @@ function TopicApprovals() {
     ? Number(searchParams.get("page"))
     : 1;
 
-  const { environment, status, topic, team } = useFiltersValues({
+  const { environment, status, topic, team, requestType } = useFiltersValues({
     defaultStatus: "CREATED",
   });
 
@@ -68,6 +71,7 @@ function TopicApprovals() {
       status,
       team,
       topic,
+      requestType,
     ],
     queryFn: () =>
       getTopicRequestsForApprover({
@@ -76,6 +80,7 @@ function TopicApprovals() {
         requestStatus: status,
         teamId: team === "ALL" ? undefined : Number(team),
         search: topic,
+        operationType: requestType !== defaultType ? requestType : undefined,
       }),
     keepPreviousData: true,
   });
@@ -280,6 +285,7 @@ function TopicApprovals() {
         filters={[
           <EnvironmentFilter key={"environment"} />,
           <StatusFilter key={"status"} defaultStatus={"CREATED"} />,
+          <RequestTypeFilter key={"requestType"} />,
           <TeamFilter key={"team"} />,
           <TopicFilter key={"topic"} />,
         ]}

--- a/coral/src/domain/schema-request/schema-request-api.ts
+++ b/coral/src/domain/schema-request/schema-request-api.ts
@@ -47,7 +47,7 @@ type GetSchemaRequestsForApproverQueryParams = ResolveIntersectionTypes<
   > &
     Pick<
       KlawApiRequestQueryParameters<"getSchemaRequestsForApprover">,
-      "pageNo" | "env" | "search"
+      "pageNo" | "env" | "search" | "operationType"
     >
 >;
 

--- a/coral/src/domain/schema-request/schema-request-api.ts
+++ b/coral/src/domain/schema-request/schema-request-api.ts
@@ -59,13 +59,14 @@ const getSchemaRequestsForApprover = (
     requestStatus: args.requestStatus,
     ...(args.search && args.search !== "" && { search: args.search }),
     ...(args.env && args.env !== "ALL" && { env: args.env }),
+    ...(args.operationType !== undefined && {
+      operationType: args.operationType,
+    }),
   };
 
   return api
     .get<KlawApiResponse<"getSchemaRequestsForApprover">>(
-      `/getSchemaRequestsForApprover?${new URLSearchParams(
-        queryObject
-      ).toString()}`
+      `/getSchemaRequestsForApprover?${new URLSearchParams(queryObject)}`
     )
     .then(transformGetSchemaRequests);
 };

--- a/coral/src/domain/topic/topic-api.ts
+++ b/coral/src/domain/topic/topic-api.ts
@@ -117,8 +117,10 @@ const getTopicRequestsForApprover = (
       const omitSearch = property === "search" && value === "";
       const omitEnv =
         property === "env" && (value === "ALL" || value === undefined);
+      const omitOperationType =
+        property === "operationType" && value === undefined;
 
-      return omitTeamId || omitSearch || omitEnv;
+      return omitTeamId || omitSearch || omitEnv || omitOperationType;
     }
   );
 


### PR DESCRIPTION
## About this change - What it does

Add support for filtering by request type for Topic approvals and Schema approvals


https://user-images.githubusercontent.com/20607294/229511244-91be6274-b749-48a3-a6cc-3d6e8bf98720.mov



