### PR TITLE
[blocked] feat(coral): Add Connector domain

### DIFF
--- a/coral/src/domain/connector/connector-api.ts
+++ b/coral/src/domain/connector/connector-api.ts
@@ -1,0 +1,103 @@
+import omitBy from "lodash/omitBy";
+import transformConnectorRequestApiResponse from "src/domain/connector/connector-transformer";
+import {
+  RequestVerdictApproval,
+  RequestVerdictDecline,
+  RequestVerdictDelete,
+} from "src/domain/requests/requests-types";
+import api from "src/services/api";
+import { KlawApiRequestQueryParameters, KlawApiResponse } from "types/utils";
+
+const filterGetConnectorRequestParams = (
+  params: KlawApiRequestQueryParameters<"getConnectorRequests">
+) => {
+  const isMyRequest = "true";
+  // @TODO: update when this issue is resolved https://github.com/aiven/klaw/issues/974
+  // const isMyRequest = String(Boolean(params.isMyRequest));
+
+  return omitBy({ ...params, isMyRequest }, (value, property) => {
+    const omitEnv = property === "env" && value === "ALL";
+    const omitConnectorType = property === "aclType" && value === "ALL";
+    const omitTopic = property === "topic" && value === "";
+    const omitIsMyRequest = property === "isMyRequest" && value !== "true";
+    const omitOperationType =
+      property === "operationType" && value === undefined;
+    const omitSearch =
+      property === "search" && (value === "" || value === undefined);
+
+    return (
+      omitEnv ||
+      omitConnectorType ||
+      omitTopic ||
+      omitOperationType ||
+      omitIsMyRequest ||
+      omitSearch
+    );
+  });
+};
+
+const getConnectorRequestsForApprover = (
+  params: KlawApiRequestQueryParameters<"getCreatedConnectorRequests">
+) => {
+  const filteredParams = filterGetConnectorRequestParams(params);
+
+  return api
+    .get<KlawApiResponse<"getCreatedConnectorRequests">>(
+      `/getConnectorRequestsForApproval?${new URLSearchParams(filteredParams)}`
+    )
+    .then(transformConnectorRequestApiResponse);
+};
+
+const getConnectorRequests = (
+  params: KlawApiRequestQueryParameters<"getConnectorRequests">
+) => {
+  const filteredParams = filterGetConnectorRequestParams(params);
+
+  return api
+    .get<KlawApiResponse<"getConnectorRequests">>(
+      `/getConnectorRequests?${new URLSearchParams(filteredParams)}`
+    )
+    .then(transformConnectorRequestApiResponse);
+};
+
+type ApproveConnectorRequestPayload = RequestVerdictApproval<"CONNECTOR">;
+type ApproveRequestParams = {
+  reqIds: ApproveConnectorRequestPayload["reqIds"];
+};
+const approveConnectorRequest = ({ reqIds }: ApproveRequestParams) => {
+  return api.post<
+    KlawApiResponse<"approveRequest">,
+    ApproveConnectorRequestPayload
+  >(`/request/approve`, { requestEntityType: "CONNECTOR", reqIds });
+};
+
+type DeclineConnectorRequestPayload = RequestVerdictDecline<"CONNECTOR">;
+type DeclineRequestParams = {
+  reqIds: DeclineConnectorRequestPayload["reqIds"];
+  reason: DeclineConnectorRequestPayload["reason"];
+};
+const declineConnectorRequest = ({ reqIds, reason }: DeclineRequestParams) => {
+  return api.post<
+    KlawApiResponse<"declineRequest">,
+    DeclineConnectorRequestPayload
+  >(`/request/decline`, { requestEntityType: "CONNECTOR", reqIds, reason });
+};
+
+type DeleteConnectorRequestPayload = RequestVerdictDelete<"CONNECTOR">;
+type DeleteRequestParams = {
+  reqIds: DeleteConnectorRequestPayload["reqIds"];
+};
+const deleteConnectorRequest = ({ reqIds }: DeleteRequestParams) => {
+  return api.post<
+    KlawApiResponse<"deleteRequest">,
+    DeleteConnectorRequestPayload
+  >(`/request/delete`, { requestEntityType: "CONNECTOR", reqIds });
+};
+
+export {
+  getConnectorRequestsForApprover,
+  getConnectorRequests,
+  approveConnectorRequest,
+  declineConnectorRequest,
+  deleteConnectorRequest,
+};

--- a/coral/src/domain/connector/connector-transformer.ts
+++ b/coral/src/domain/connector/connector-transformer.ts
@@ -1,0 +1,21 @@
+import { ConnectorRequestsForApprover } from "src/domain/connector/connector-types";
+import { KlawApiResponse } from "types/utils";
+
+const transformConnectorRequestApiResponse = (
+  data: KlawApiResponse<"getCreatedConnectorRequests">
+): ConnectorRequestsForApprover => {
+  if (data.length === 0) {
+    return {
+      totalPages: 0,
+      currentPage: 0,
+      entries: [],
+    };
+  }
+  return {
+    totalPages: Number(data[0].totalNoPages),
+    currentPage: Number(data[0].currentPage),
+    entries: data,
+  };
+};
+
+export default transformConnectorRequestApiResponse;

--- a/coral/src/domain/connector/connector-types.ts
+++ b/coral/src/domain/connector/connector-types.ts
@@ -1,0 +1,9 @@
+import { KlawApiModel, Paginated, ResolveIntersectionTypes } from "types/utils";
+
+type ConnectorRequest = KlawApiModel<"KafkaConnectorRequestsResponseModel">;
+
+type ConnectorRequestsForApprover = ResolveIntersectionTypes<
+  Paginated<ConnectorRequest[]>
+>;
+
+export type { ConnectorRequest, ConnectorRequestsForApprover };

--- a/coral/src/domain/connector/index.ts
+++ b/coral/src/domain/connector/index.ts
@@ -1,0 +1,20 @@
+import {
+  approveConnectorRequest,
+  declineConnectorRequest,
+  getConnectorRequests,
+  getConnectorRequestsForApprover,
+  deleteConnectorRequest,
+} from "src/domain/connector/connector-api";
+import {
+  ConnectorRequest,
+  ConnectorRequestsForApprover,
+} from "src/domain/connector/connector-types";
+
+export type { ConnectorRequestsForApprover, ConnectorRequest };
+export {
+  getConnectorRequestsForApprover,
+  getConnectorRequests,
+  approveConnectorRequest,
+  declineConnectorRequest,
+  deleteConnectorRequest,
+};


### PR DESCRIPTION
## About this change - What it does

- Add `connector` folder in `domain`
- Add API endpoints handlers:
  - `getConnectorRequests`
  - `getConnectorRequestsForApprover`
  - `approveConnectorRequest`
  - `declineConnectorRequest`
  - `deleteConnectorRequest`
- Add necessary types and transformers

## Blocked

Depends on https://github.com/aiven/klaw/issues/974 for updating the naming and adding actual support for `isMyRequest` param.

