### PR TITLE
refactor(coral): Update main navigation based on current design.

### DIFF
--- a/coral/src/app/layout/main-navigation/MainNavigation.test.tsx
+++ b/coral/src/app/layout/main-navigation/MainNavigation.test.tsx
@@ -16,8 +16,12 @@ const navLinks = [
     linkTo: "/index",
   },
   {
-    name: "All Topics",
+    name: "Topics",
     linkTo: "/topics",
+  },
+  {
+    name: "Kafka Connectors",
+    linkTo: "/kafkaConnectors",
   },
   { name: "Approve requests", linkTo: "/approvals" },
   { name: "My team's requests", linkTo: "/requests" },
@@ -26,14 +30,13 @@ const navLinks = [
 ];
 
 const submenuItems = [
-  { name: "Kafka Connectors", links: ["All Connectors", "Connector requests"] },
   { name: "Users and teams", links: ["Users", "Teams", "User requests"] },
 ];
 
 const navOrderFirstLevel = [
   { name: "Dashboard", isSubmenu: false },
-  { name: "All Topics", isSubmenu: false },
-  { name: "Kafka Connectors", isSubmenu: true },
+  { name: "Topics", isSubmenu: false },
+  { name: "Kafka Connectors", isSubmenu: false },
   { name: "Users and teams", isSubmenu: true },
   { name: "Approve requests", isSubmenu: false },
   { name: "My team's requests", isSubmenu: false },

--- a/coral/src/app/layout/main-navigation/MainNavigation.tsx
+++ b/coral/src/app/layout/main-navigation/MainNavigation.tsx
@@ -61,7 +61,7 @@ function MainNavigation() {
         <li>
           <MainNavigationLink
             icon={codeBlock}
-            linkText={"All Topics"}
+            linkText={"Topics"}
             to={Routes.TOPICS}
             active={
               pathname.startsWith(Routes.TOPICS) ||
@@ -70,19 +70,11 @@ function MainNavigation() {
           />
         </li>
         <li>
-          <MainNavigationSubmenuList
+          <MainNavigationLink
             icon={layoutGroupBy}
-            text={"Kafka Connectors"}
-          >
-            <MainNavigationLink
-              to={`/kafkaConnectors`}
-              linkText={"All Connectors"}
-            />
-            <MainNavigationLink
-              to={`/execConnectors`}
-              linkText={"Connector requests"}
-            />
-          </MainNavigationSubmenuList>
+            to={`/kafkaConnectors`}
+            linkText={"Kafka Connectors"}
+          />
         </li>
         <li>
           <MainNavigationSubmenuList icon={people} text={"Users and teams"}>


### PR DESCRIPTION
# About this change - What it does

Matches navigation in sidebar to the current design in Figma  (see issue #976) 

<img width="695" alt="Screenshot 2023-04-04 at 08 12 25" src="https://user-images.githubusercontent.com/943800/229703586-b8fc5bfc-fa82-4d0a-ba66-f7c8bd72d187.png">


## Note about differences
- It's called "Dashboard" because that's the established name for Klaw users in the Angular app
- there's no "User and Teams" page in Angular app, that's why we have a submenu list with relevant links
- We don't have pages in Angular app to link to in "Settings"  that's why it's currently only one list item without sub menu


Resolves: #976
Why this way
