### PR TITLE
feat(coral): Routing and skeleton page All Connectors view

### DIFF
--- a/coral/src/app/layout/main-navigation/MainNavigation.test.tsx
+++ b/coral/src/app/layout/main-navigation/MainNavigation.test.tsx
@@ -21,7 +21,7 @@ const navLinks = [
   },
   {
     name: "Kafka Connectors",
-    linkTo: "/kafkaConnectors",
+    linkTo: "/connectors",
   },
   { name: "Approve requests", linkTo: "/approvals" },
   { name: "My team's requests", linkTo: "/requests" },

--- a/coral/src/app/layout/main-navigation/MainNavigation.tsx
+++ b/coral/src/app/layout/main-navigation/MainNavigation.tsx
@@ -72,8 +72,9 @@ function MainNavigation() {
         <li>
           <MainNavigationLink
             icon={layoutGroupBy}
-            to={`/kafkaConnectors`}
+            to={Routes.CONNECTORS}
             linkText={"Kafka Connectors"}
+            active={pathname.startsWith(Routes.CONNECTORS)}
           />
         </li>
         <li>

--- a/coral/src/app/pages/connectors/index.tsx
+++ b/coral/src/app/pages/connectors/index.tsx
@@ -1,0 +1,26 @@
+import { PageHeader } from "@aivenio/aquarium";
+import add from "@aivenio/aquarium/dist/src/icons/add";
+import AuthenticationRequiredBoundary from "src/app/components/AuthenticationRequiredBoundary";
+import PreviewBanner from "src/app/components/PreviewBanner";
+import Layout from "src/app/layout/Layout";
+
+const ConnectorsPage = () => {
+  return (
+    <AuthenticationRequiredBoundary>
+      <Layout>
+        <PreviewBanner linkTarget={"/browseTopics"} />
+        <PageHeader
+          title={"All Kafka Connectors"}
+          primaryAction={{
+            text: "Request new Connector",
+            onClick: () => (window.location.href = "/requestConnector"),
+            icon: add,
+          }}
+        />
+        <div>👋Kafka Connectors here </div>
+      </Layout>
+    </AuthenticationRequiredBoundary>
+  );
+};
+
+export default ConnectorsPage;

--- a/coral/src/app/router.tsx
+++ b/coral/src/app/router.tsx
@@ -15,6 +15,7 @@ import ConnectorApprovalsPage from "src/app/pages/approvals/connectors";
 import { getRouterBasename } from "src/config";
 import RequestTopic from "src/app/pages/topics/request";
 import SchemaRequest from "src/app/pages/topics/schema-request";
+import ConnectorsPage from "src/app/pages/connectors";
 import {
   APPROVALS_TAB_ID_INTO_PATH,
   ApprovalsTabEnum,
@@ -32,6 +33,10 @@ const routes: Array<RouteObject> = [
   {
     path: Routes.TOPICS,
     element: <Topics />,
+  },
+  {
+    path: Routes.CONNECTORS,
+    element: <ConnectorsPage />,
   },
   {
     path: Routes.TOPIC_REQUEST,

--- a/coral/src/app/router_utils.ts
+++ b/coral/src/app/router_utils.ts
@@ -2,6 +2,7 @@ import isString from "lodash/isString";
 
 enum Routes {
   TOPICS = "/topics",
+  CONNECTORS = "/connectors",
   TOPIC_REQUEST = "/topics/request",
   TOPIC_ACL_REQUEST = "/topic/:topicName/subscribe",
   TOPIC_SCHEMA_REQUEST = "/topic/:topicName/request-schema",


### PR DESCRIPTION
# About this change - What it does

- adds a skeleton page for the new All Kafka Connectors view
- adds routing
- adds correct navigation

Resolves: #980

## Implementation
(note: I noticed that the button text is wrong and renamed it to "Request new Connector", didn't update the recording bc it's not necessary for demostrating)

https://user-images.githubusercontent.com/943800/229723381-8a1d1fdc-84e3-4af4-96af-f9d0826a76f7.mov

