### PR TITLE
feat(coral): My Connector Requests: Add Table rendering connector requests #964

### DIFF
--- a/coral/src/app/features/requests/RequestsResourceTabs.tsx
+++ b/coral/src/app/features/requests/RequestsResourceTabs.tsx
@@ -40,10 +40,9 @@ function RequestsResourceTabs({ currentTab }: Props) {
         {currentTab === RequestsTabEnum.SCHEMAS && <Outlet />}
       </Tabs.Tab>
       <Tabs.Tab
-        title="Connectors (coming soon)"
+        title="Connectors"
         value={RequestsTabEnum.CONNECTORS}
         aria-label={"Connector requests"}
-        disabled
       >
         {currentTab === RequestsTabEnum.CONNECTORS && <Outlet />}
       </Tabs.Tab>

--- a/coral/src/app/features/requests/connectors/ConnectorRequests.test.tsx
+++ b/coral/src/app/features/requests/connectors/ConnectorRequests.test.tsx
@@ -1,0 +1,69 @@
+import { cleanup } from "@testing-library/react";
+import transformConnectorRequestApiResponse from "src/domain/connector/connector-transformer";
+import { mockIntersectionObserver } from "src/services/test-utils/mock-intersection-observer";
+import { ConnectorRequests } from "src/app/features/requests/connectors/ConnectorRequests";
+import { customRender } from "src/services/test-utils/render-with-wrappers";
+import { getEnvironments } from "src/domain/environment";
+import { mockedEnvironmentResponse } from "src/app/features/requests/schemas/utils/mocked-api-responses";
+import { getConnectorRequests } from "src/domain/connector";
+
+jest.mock("src/domain/environment/environment-api.ts");
+jest.mock("src/domain/connector/connector-api.ts");
+
+const mockGetConnectorEnvironmentRequest =
+  getEnvironments as jest.MockedFunction<typeof getEnvironments>;
+
+const mockGetConnectorRequests = getConnectorRequests as jest.MockedFunction<
+  typeof getConnectorRequests
+>;
+
+const mockGetConnectorRequestsResponse = transformConnectorRequestApiResponse([
+  {
+    connectorName: "test-connector-1",
+    environment: "1",
+    teamname: "NCC1701D",
+    remarks: "asap",
+    description: "This connector is for test",
+    environmentName: "BRG",
+    connectorId: 1000,
+    requestOperationType: "CREATE",
+    requestor: "jlpicard",
+    requesttime: "1987-09-28T13:37:00.001+00:00",
+    requesttimestring: "28-Sep-1987 13:37:00",
+    requestStatus: "CREATED",
+    totalNoPages: "1",
+    approvingTeamDetails:
+      "Team : NCC1701D, Users : jlpicard, worf, bcrusher, geordilf,",
+    teamId: 1003,
+    allPageNos: ["1"],
+    currentPage: "1",
+    editable: true,
+    deletable: true,
+    connectorConfig: "",
+  },
+]);
+
+describe("ConnectorRequests", () => {
+  beforeEach(() => {
+    mockIntersectionObserver();
+    mockGetConnectorEnvironmentRequest.mockResolvedValue(
+      mockedEnvironmentResponse
+    );
+    mockGetConnectorRequests.mockResolvedValue(
+      mockGetConnectorRequestsResponse
+    );
+  });
+
+  afterEach(() => {
+    cleanup();
+    jest.resetAllMocks();
+  });
+
+  it("makes a request to the api to get the teams connector requests", () => {
+    customRender(<ConnectorRequests />, {
+      queryClient: true,
+      memoryRouter: true,
+    });
+    expect(getConnectorRequests).toBeCalledTimes(1);
+  });
+});

--- a/coral/src/app/features/requests/connectors/ConnectorRequests.tsx
+++ b/coral/src/app/features/requests/connectors/ConnectorRequests.tsx
@@ -4,7 +4,7 @@ import { ConnectorRequestsTable } from "src/app/features/requests/connectors/com
 import { getConnectorRequests } from "src/domain/connector";
 
 function ConnectorRequests() {
-  const { data, isLoading } = useQuery({
+  const { data, isLoading, isError, error } = useQuery({
     queryKey: ["connectorRequests"],
     queryFn: () =>
       getConnectorRequests({
@@ -24,6 +24,8 @@ function ConnectorRequests() {
         />
       }
       isLoading={isLoading}
+      isErrorLoading={isError}
+      errorMessage={error}
     />
   );
 }

--- a/coral/src/app/features/requests/connectors/ConnectorRequests.tsx
+++ b/coral/src/app/features/requests/connectors/ConnectorRequests.tsx
@@ -1,0 +1,31 @@
+import { useQuery } from "@tanstack/react-query";
+import { TableLayout } from "src/app/features/components/layouts/TableLayout";
+import { ConnectorRequestsTable } from "src/app/features/requests/connectors/components/ConnectorRequestsTable";
+import { getConnectorRequests } from "src/domain/connector";
+
+function ConnectorRequests() {
+  const { data, isLoading } = useQuery({
+    queryKey: ["connectorRequests"],
+    queryFn: () =>
+      getConnectorRequests({
+        pageNo: "1",
+      }),
+  });
+
+  return (
+    <TableLayout
+      filters={[]}
+      table={
+        <ConnectorRequestsTable
+          ariaLabel="Connector requests"
+          requests={data?.entries ?? []}
+          onDetails={() => null}
+          onDelete={() => null}
+        />
+      }
+      isLoading={isLoading}
+    />
+  );
+}
+
+export { ConnectorRequests };

--- a/coral/src/app/features/requests/connectors/components/ConnectorRequestsTable.test.tsx
+++ b/coral/src/app/features/requests/connectors/components/ConnectorRequestsTable.test.tsx
@@ -1,0 +1,190 @@
+import { cleanup, render, screen, within } from "@testing-library/react";
+import { ConnectorRequest } from "src/domain/connector";
+import { mockIntersectionObserver } from "src/services/test-utils/mock-intersection-observer";
+import {
+  ConnectorRequestsTable,
+  type ConnectorRequestsTableProps,
+} from "src/app/features/requests/connectors/components/ConnectorRequestsTable";
+import userEvent from "@testing-library/user-event";
+
+const mockedRequests: ConnectorRequest[] = [
+  {
+    connectorName: "test-connector-1",
+    environment: "1",
+    teamname: "NCC1701D",
+    remarks: "asap",
+    description: "This connector is for test",
+    environmentName: "BRG",
+    connectorId: 1000,
+    connectorConfig: "",
+    requestOperationType: "CREATE",
+    requestor: "jlpicard",
+    requesttime: "1987-09-28T13:37:00.001+00:00",
+    requesttimestring: "28-Sep-1987 13:37:00",
+    requestStatus: "CREATED",
+    totalNoPages: "1",
+    approvingTeamDetails:
+      "Team : NCC1701D, Users : jlpicard, worf, bcrusher, geordilf,",
+    teamId: 1003,
+    allPageNos: ["1"],
+    currentPage: "1",
+    editable: true,
+    deletable: true,
+  },
+  {
+    connectorName: "test-connector-2",
+    environment: "1",
+    teamname: "MIRRORUNIVERSE",
+    remarks: "asap",
+    description: "This connector is for test",
+    environmentName: "SBY",
+    connectorId: 1001,
+    connectorConfig: "",
+    requestOperationType: "UPDATE",
+    requestor: "bcrusher",
+    requesttime: "1994-23-05T13:37:00.001+00:00",
+    requesttimestring: "23-May-1994 13:37:00",
+    requestStatus: "APPROVED",
+    totalNoPages: "1",
+    approvingTeamDetails:
+      "Team : NCC1701D, Users : jlpicard, worf, bcrusher, geordilf,",
+    teamId: 1003,
+    allPageNos: ["1"],
+    currentPage: "1",
+    editable: true,
+    deletable: true,
+  },
+];
+
+describe("ConnectorRequestsTable", () => {
+  function renderFromProps(props?: Partial<ConnectorRequestsTableProps>): void {
+    render(
+      <ConnectorRequestsTable
+        requests={mockedRequests}
+        onDetails={jest.fn()}
+        onDelete={jest.fn()}
+        ariaLabel={"Connector requests"}
+        {...props}
+      />
+    );
+  }
+
+  function getNthRow(nth: number): HTMLElement {
+    return screen.getAllByRole("row")[nth];
+  }
+
+  beforeEach(() => {
+    mockIntersectionObserver();
+  });
+
+  afterEach(cleanup);
+
+  it("shows a message to user in case there are no requests that match the search criteria", () => {
+    renderFromProps({ requests: [] });
+    screen.getByText("No Connector requests");
+    screen.getByText("No Connector request matched your criteria.");
+  });
+
+  it("has column to describe the connector name", () => {
+    renderFromProps();
+    expect(
+      within(getNthRow(0)).getAllByRole("columnheader")[0]
+    ).toHaveTextContent("Name");
+    expect(within(getNthRow(1)).getAllByRole("cell")[0]).toHaveTextContent(
+      "test-connector-1"
+    );
+  });
+
+  it("has column to describe the environment", () => {
+    renderFromProps();
+    expect(
+      within(getNthRow(0)).getAllByRole("columnheader")[1]
+    ).toHaveTextContent("Environment");
+    expect(within(getNthRow(1)).getAllByRole("cell")[1]).toHaveTextContent(
+      "BRG"
+    );
+  });
+
+  it("has column to describe the owner", () => {
+    renderFromProps();
+    expect(
+      within(getNthRow(0)).getAllByRole("columnheader")[2]
+    ).toHaveTextContent("Owned by");
+    expect(within(getNthRow(1)).getAllByRole("cell")[2]).toHaveTextContent(
+      "NCC1701D"
+    );
+  });
+
+  it("has column to describe the status", () => {
+    renderFromProps();
+    expect(
+      within(getNthRow(0)).getAllByRole("columnheader")[3]
+    ).toHaveTextContent("Status");
+    expect(within(getNthRow(1)).getAllByRole("cell")[3]).toHaveTextContent(
+      "Awaiting approval"
+    );
+  });
+
+  it("has column to describe the request type", () => {
+    renderFromProps();
+    expect(
+      within(getNthRow(0)).getAllByRole("columnheader")[4]
+    ).toHaveTextContent("Request type");
+    expect(within(getNthRow(1)).getAllByRole("cell")[4]).toHaveTextContent(
+      "Create"
+    );
+  });
+
+  it("has column to describe the author of the request", () => {
+    renderFromProps();
+    expect(
+      within(getNthRow(0)).getAllByRole("columnheader")[5]
+    ).toHaveTextContent("Requested by");
+    expect(within(getNthRow(1)).getAllByRole("cell")[5]).toHaveTextContent(
+      "jlpicard"
+    );
+  });
+
+  it("has column to describe the timestamp when the request was made", () => {
+    renderFromProps();
+    expect(
+      within(getNthRow(0)).getAllByRole("columnheader")[6]
+    ).toHaveTextContent("Requested on");
+    expect(within(getNthRow(1)).getAllByRole("cell")[6]).toHaveTextContent(
+      "28-Sep-1987 13:37:00 UTC"
+    );
+  });
+
+  it("has column for action to view request details", async () => {
+    const onDetails = jest.fn();
+    renderFromProps({ onDetails });
+    await userEvent.click(
+      within(within(getNthRow(1)).getAllByRole("cell")[7]).getByRole("button", {
+        name: "View connector request for test-connector-1",
+      })
+    );
+    expect(onDetails).toHaveBeenNthCalledWith(1, mockedRequests[0].connectorId);
+  });
+
+  it("has column for action to delete request", async () => {
+    const onDelete = jest.fn();
+    renderFromProps({ onDelete });
+    await userEvent.click(
+      within(within(getNthRow(1)).getAllByRole("cell")[8]).getByRole("button", {
+        name: "Delete connector request for test-connector-1",
+      })
+    );
+    expect(onDelete).toHaveBeenNthCalledWith(1, mockedRequests[0].connectorId);
+  });
+
+  it("disables the delete button for a request if the request is not deletable", () => {
+    const onDelete = jest.fn();
+    const nonDeletableRequest = { ...mockedRequests[0], deletable: false };
+    renderFromProps({ requests: [nonDeletableRequest], onDelete });
+    expect(
+      within(within(getNthRow(1)).getAllByRole("cell")[8]).getByRole("button", {
+        name: "Delete connector request for test-connector-1",
+      })
+    ).toBeDisabled();
+  });
+});

--- a/coral/src/app/features/requests/connectors/components/ConnectorRequestsTable.tsx
+++ b/coral/src/app/features/requests/connectors/components/ConnectorRequestsTable.tsx
@@ -1,0 +1,143 @@
+import { DataTable, DataTableColumn, EmptyState } from "@aivenio/aquarium";
+import {
+  requestOperationTypeChipStatusMap,
+  requestOperationTypeNameMap,
+} from "src/app/features/approvals/utils/request-operation-type-helper";
+import {
+  requestStatusChipStatusMap,
+  requestStatusNameMap,
+} from "src/app/features/approvals/utils/request-status-helper";
+import type { ConnectorRequest } from "src/domain/connector";
+import infoIcon from "@aivenio/aquarium/dist/src/icons/infoSign";
+import deleteIcon from "@aivenio/aquarium/dist/src/icons/delete";
+
+type ConnectorRequestTableRow = {
+  id: ConnectorRequest["connectorId"];
+  connectorName: ConnectorRequest["connectorName"];
+  environmentName: ConnectorRequest["environmentName"];
+  requestStatus: ConnectorRequest["requestStatus"];
+  requestOperationType: ConnectorRequest["requestOperationType"];
+  teamname: ConnectorRequest["teamname"];
+  requestor: ConnectorRequest["requestor"];
+  requesttimestring: ConnectorRequest["requesttimestring"];
+  deletable: ConnectorRequest["deletable"];
+};
+
+type Props = {
+  ariaLabel: string;
+  requests: ConnectorRequest[];
+  onDetails: (reqNo: number) => void;
+  onDelete: (reqNo: number) => void;
+};
+
+function ConnectorRequestsTable({
+  ariaLabel,
+  requests,
+  onDetails,
+  onDelete,
+}: Props) {
+  const columns: Array<DataTableColumn<ConnectorRequestTableRow>> = [
+    { type: "text", field: "connectorName", headerName: "Name" },
+    {
+      type: "status",
+      field: "environmentName",
+      headerName: "Environment",
+      status: ({ environmentName }) => ({
+        status: "neutral",
+        text: environmentName,
+      }),
+    },
+    { type: "text", field: "teamname", headerName: "Owned by" },
+    {
+      type: "status",
+      field: "requestStatus",
+      headerName: "Status",
+      status: ({ requestStatus }) => {
+        return {
+          status: requestStatusChipStatusMap[requestStatus],
+          text: requestStatusNameMap[requestStatus],
+        };
+      },
+    },
+    {
+      type: "status",
+      field: "requestOperationType",
+      headerName: "Request type",
+      status: ({ requestOperationType }) => {
+        return {
+          status: requestOperationTypeChipStatusMap[requestOperationType],
+          text: requestOperationTypeNameMap[requestOperationType],
+        };
+      },
+    },
+    { type: "text", field: "requestor", headerName: "Requested by" },
+    {
+      type: "text",
+      field: "requesttimestring",
+      headerName: "Requested on",
+      formatter: (value) => {
+        return `${value}${"\u00A0"}UTC`;
+      },
+    },
+    {
+      type: "action",
+      headerName: "Details",
+      headerInvisible: true,
+      width: 30,
+      action: ({ id, connectorName }) => ({
+        text: "View",
+        icon: infoIcon,
+        "aria-label": `View connector request for ${connectorName}`,
+        onClick: () => onDetails(id),
+      }),
+    },
+    {
+      type: "action",
+      headerName: "Delete",
+      headerInvisible: true,
+      width: 30,
+      action: ({ id, deletable, connectorName }) => ({
+        text: "Delete",
+        icon: deleteIcon,
+        onClick: () => onDelete(id),
+        "aria-label": `Delete connector request for ${connectorName}`,
+        disabled: !deletable,
+      }),
+    },
+  ];
+
+  const rows: ConnectorRequestTableRow[] = requests.map(
+    (request: ConnectorRequest) => {
+      return {
+        id: request.connectorId,
+        connectorName: request.connectorName,
+        environmentName: request.environmentName,
+        requestStatus: request.requestStatus,
+        requestOperationType: request.requestOperationType,
+        teamname: request.teamname,
+        requestor: request.requestor,
+        requesttimestring: request.requesttimestring,
+        deletable: request.deletable,
+      };
+    }
+  );
+
+  if (!rows.length) {
+    return (
+      <EmptyState title="No Connector requests">
+        No Connector request matched your criteria.
+      </EmptyState>
+    );
+  }
+
+  return (
+    <DataTable
+      ariaLabel={ariaLabel}
+      columns={columns}
+      rows={rows}
+      noWrap={false}
+    />
+  );
+}
+
+export { ConnectorRequestsTable, type Props as ConnectorRequestsTableProps };

--- a/coral/src/app/pages/requests/connectors/index.test.tsx
+++ b/coral/src/app/pages/requests/connectors/index.test.tsx
@@ -1,0 +1,62 @@
+import { customRender } from "src/services/test-utils/render-with-wrappers";
+import { cleanup, screen, within } from "@testing-library/react";
+import { waitForElementToBeRemoved } from "@testing-library/react/pure";
+import { getEnvironments } from "src/domain/environment";
+import { getConnectorRequests } from "src/domain/connector/connector-api";
+import ConnectorRequestsPage from "src/app/pages/requests/connectors/index";
+
+jest.mock("src/domain/environment/environment-api.ts");
+jest.mock("src/domain/connector/connector-api.ts");
+
+const mockGetEnvironments = getEnvironments as jest.MockedFunction<
+  typeof getEnvironments
+>;
+const mockGetConnectorRequests = getConnectorRequests as jest.MockedFunction<
+  typeof getConnectorRequests
+>;
+
+describe("ConnectorRequestsPage", () => {
+  beforeAll(async () => {
+    mockGetEnvironments.mockResolvedValue([]);
+    mockGetConnectorRequests.mockResolvedValue({
+      entries: [],
+      totalPages: 1,
+      currentPage: 1,
+    });
+
+    customRender(<ConnectorRequestsPage />, {
+      queryClient: true,
+      memoryRouter: true,
+    });
+    await waitForElementToBeRemoved(screen.getByTestId("skeleton-table"));
+  });
+
+  afterAll(cleanup);
+
+  it("shows a preview banner to inform users about the early version of the view", () => {
+    const previewBanner = screen.getByLabelText("Preview disclaimer");
+
+    expect(previewBanner).toBeVisible();
+    expect(previewBanner).toHaveTextContent(
+      "You are viewing a preview of the redesigned user interface. You are one of our early reviewers, and your feedback will help us improve the product. You can always go back to the old interface."
+    );
+  });
+
+  it("shows link back back to the original Klaw app for this view in the preview banner", () => {
+    const previewBanner = screen.getByLabelText("Preview disclaimer");
+    const link = within(previewBanner).getByRole("link", {
+      name: "old interface",
+    });
+
+    expect(link).toBeVisible();
+    expect(link).toHaveAttribute("href", "/myConnectorRequests");
+  });
+
+  it("renders the Connector request view", () => {
+    const emptyRequests = screen.getByText(
+      "No Connector request matched your criteria."
+    );
+
+    expect(emptyRequests).toBeVisible();
+  });
+});

--- a/coral/src/app/pages/requests/connectors/index.tsx
+++ b/coral/src/app/pages/requests/connectors/index.tsx
@@ -1,5 +1,13 @@
+import { ConnectorRequests } from "src/app/features/requests/connectors/ConnectorRequests";
+import PreviewBanner from "src/app/components/PreviewBanner";
+
 const ConnectorRequestsPage = () => {
-  return <></>;
+  return (
+    <>
+      <PreviewBanner linkTarget={"/myConnectorRequests"} />
+      <ConnectorRequests />
+    </>
+  );
 };
 
 export default ConnectorRequestsPage;


### PR DESCRIPTION
Enables the "Connectors" tab in My Teams requests for user and displays all connector requests from the team.

Resolves: #964

![image](https://user-images.githubusercontent.com/15416578/229770031-0ae1a9f1-917a-48b3-ba1c-0e900f7f1e38.png)
