### PR TITLE
feat(coral): Paginated table All Connectors view

### DIFF
--- a/coral/src/app/features/connectors/browse/BrowseConnectors.test.tsx
+++ b/coral/src/app/features/connectors/browse/BrowseConnectors.test.tsx
@@ -1,0 +1,199 @@
+import { cleanup, screen, within } from "@testing-library/react";
+import { waitForElementToBeRemoved } from "@testing-library/react/pure";
+import userEvent from "@testing-library/user-event";
+import BrowseConnectors from "src/app/features/connectors/browse/BrowseConnectors";
+import { mockIntersectionObserver } from "src/services/test-utils/mock-intersection-observer";
+import { customRender } from "src/services/test-utils/render-with-wrappers";
+import { getConnectors } from "src/domain/connector";
+
+jest.mock("src/domain/connector/connector-api.ts");
+const mockGetConnectors = getConnectors as jest.MockedFunction<
+  typeof getConnectors
+>;
+
+const mockConnectors = [
+  {
+    sequence: 2,
+    connectorId: 1001,
+    connectorName: "test_connector_1",
+    environmentId: "4",
+    teamName: "Dev",
+    allPageNos: ["1"],
+    totalNoPages: "1",
+    currentPage: "1",
+    environmentsList: ["DEV"],
+    description: "test connect desc",
+    showEditConnector: false,
+    showDeleteConnector: false,
+    connectorDeletable: false,
+  },
+  {
+    sequence: 2,
+    connectorId: 1002,
+    connectorName: "test_connector_2",
+    environmentId: "4",
+    teamName: "Ospo",
+    allPageNos: ["1"],
+    totalNoPages: "1",
+    currentPage: "1",
+    environmentsList: ["DEV", "TST"],
+    description: "test connect desc",
+    showEditConnector: false,
+    showDeleteConnector: false,
+    connectorDeletable: false,
+  },
+  {
+    sequence: 2,
+    connectorId: 1003,
+    connectorName: "test_connector_3",
+    environmentId: "4",
+    teamName: "Infra",
+    allPageNos: ["1"],
+    totalNoPages: "1",
+    currentPage: "1",
+    environmentsList: ["TST"],
+    description: "test connect desc",
+    showEditConnector: false,
+    showDeleteConnector: false,
+    connectorDeletable: false,
+  },
+];
+
+const mockResponseDefault = {
+  totalPages: 1,
+  currentPage: 1,
+  entries: mockConnectors,
+};
+
+describe("BrowseConnectors.tsx", () => {
+  beforeAll(() => {
+    mockIntersectionObserver();
+  });
+
+  describe("handles successful response with one page", () => {
+    beforeAll(async () => {
+      mockGetConnectors.mockResolvedValue(mockResponseDefault);
+
+      customRender(<BrowseConnectors />, {
+        memoryRouter: true,
+        queryClient: true,
+      });
+
+      await waitForElementToBeRemoved(screen.getByTestId("skeleton-table"));
+    });
+
+    afterAll(() => {
+      jest.clearAllMocks();
+      cleanup();
+    });
+
+    it("renders the Connector table with information about the pages", async () => {
+      const table = screen.getByRole("table", {
+        name: "Connectors overview, page 1 of 1",
+      });
+
+      expect(table).toBeVisible();
+    });
+
+    it("shows Connector names row headers", () => {
+      const table = screen.getByRole("table", {
+        name: "Connectors overview, page 1 of 1",
+      });
+
+      const rowHeader = within(table).getByRole("cell", {
+        name: mockResponseDefault.entries[0].connectorName,
+      });
+      expect(rowHeader).toBeVisible();
+    });
+
+    it("does not render the pagination", () => {
+      const pagination = screen.queryByRole("navigation", {
+        name: /Pagination/,
+      });
+
+      expect(pagination).not.toBeInTheDocument();
+    });
+  });
+
+  describe("handles successful response with three pages", () => {
+    beforeAll(async () => {
+      mockGetConnectors.mockResolvedValue({
+        ...mockResponseDefault,
+        totalPages: 3,
+        currentPage: 2,
+      });
+
+      customRender(<BrowseConnectors />, {
+        memoryRouter: true,
+        queryClient: true,
+      });
+
+      await waitForElementToBeRemoved(screen.getByTestId("skeleton-table"));
+    });
+
+    afterAll(() => {
+      jest.clearAllMocks();
+      cleanup();
+    });
+
+    it("renders the Connector table with information about the pages", async () => {
+      const table = screen.getByRole("table", {
+        name: "Connectors overview, page 2 of 3",
+      });
+
+      expect(table).toBeVisible();
+    });
+
+    it("renders the pagination with information about the pages", () => {
+      const pagination = screen.getByRole("navigation", {
+        name: "Pagination navigation, you're on page 2 of 3",
+      });
+
+      expect(pagination).toBeVisible();
+    });
+  });
+
+  describe("handles user stepping through pagination", () => {
+    beforeEach(async () => {
+      mockGetConnectors.mockResolvedValue({
+        ...mockResponseDefault,
+        totalPages: 4,
+        currentPage: 2,
+      });
+
+      customRender(<BrowseConnectors />, {
+        memoryRouter: true,
+        queryClient: true,
+      });
+      await waitForElementToBeRemoved(screen.getByTestId("skeleton-table"));
+    });
+
+    afterEach(() => {
+      jest.clearAllMocks();
+      cleanup();
+    });
+
+    it("shows page 2 as currently active page and the total page number", () => {
+      const pagination = screen.getByRole("navigation", {
+        name: /Pagination/,
+      });
+
+      expect(pagination).toHaveAccessibleName(
+        "Pagination navigation, you're on page 2 of 4"
+      );
+    });
+
+    it("fetches new data when user clicks on next page", async () => {
+      const pageTwoButton = screen.getByRole("button", {
+        name: "Go to next page, page 3",
+      });
+
+      await userEvent.click(pageTwoButton);
+
+      expect(mockGetConnectors).toHaveBeenNthCalledWith(2, {
+        currentPage: 3,
+        environment: "ALL",
+      });
+    });
+  });
+});

--- a/coral/src/app/features/connectors/browse/BrowseConnectors.tsx
+++ b/coral/src/app/features/connectors/browse/BrowseConnectors.tsx
@@ -1,0 +1,62 @@
+import { Pagination } from "src/app/components/Pagination";
+import { TableLayout } from "src/app/features/components/layouts/TableLayout";
+import ConnectorTable from "src/app/features/connectors/browse/components/ConnectorTable";
+import { useQuery } from "@tanstack/react-query";
+import { getConnectors } from "src/domain/connector/connector-api";
+import { useSearchParams } from "react-router-dom";
+
+function BrowseConnectors() {
+  const [searchParams, setSearchParams] = useSearchParams();
+  const currentPage = searchParams.get("page")
+    ? Number(searchParams.get("page"))
+    : 1;
+
+  const {
+    data: connectors,
+    isLoading,
+    isError,
+    error,
+  } = useQuery({
+    queryKey: ["browseConnectors", currentPage],
+    queryFn: () =>
+      getConnectors({
+        currentPage,
+        environment: "ALL",
+      }),
+    keepPreviousData: true,
+  });
+
+  function handleChangePage(page: number) {
+    searchParams.set("page", page.toString());
+    setSearchParams(searchParams);
+  }
+
+  const pagination =
+    connectors && connectors.totalPages > 1 ? (
+      <Pagination
+        activePage={connectors.currentPage}
+        totalPages={connectors.totalPages}
+        setActivePage={handleChangePage}
+      />
+    ) : undefined;
+
+  return (
+    <TableLayout
+      filters={[]}
+      table={
+        <ConnectorTable
+          connectors={connectors?.entries ?? []}
+          ariaLabel={`Connectors overview, page ${
+            connectors?.currentPage ?? 0
+          } of ${connectors?.totalPages ?? 0}`}
+        />
+      }
+      pagination={pagination}
+      isLoading={isLoading}
+      isErrorLoading={isError}
+      errorMessage={error}
+    />
+  );
+}
+
+export default BrowseConnectors;

--- a/coral/src/app/features/connectors/browse/components/ConnectorTable.test.tsx
+++ b/coral/src/app/features/connectors/browse/components/ConnectorTable.test.tsx
@@ -1,0 +1,207 @@
+import { cleanup, screen, render, within } from "@testing-library/react";
+import ConnectorTable from "src/app/features/connectors/browse/components/ConnectorTable";
+import { mockIntersectionObserver } from "src/services/test-utils/mock-intersection-observer";
+import { tabThroughForward } from "src/services/test-utils/tabbing";
+
+const mockConnectors = [
+  {
+    sequence: 2,
+    connectorId: 1001,
+    connectorName: "test_connector_1",
+    environmentId: "4",
+    teamName: "Dev",
+    allPageNos: ["1"],
+    totalNoPages: "1",
+    currentPage: "1",
+    environmentsList: ["DEV"],
+    description: "test connect desc",
+    showEditConnector: false,
+    showDeleteConnector: false,
+    connectorDeletable: false,
+  },
+  {
+    sequence: 2,
+    connectorId: 1002,
+    connectorName: "test_connector_2",
+    environmentId: "4",
+    teamName: "Ospo",
+    allPageNos: ["1"],
+    totalNoPages: "1",
+    currentPage: "1",
+    environmentsList: ["DEV", "TST"],
+    description: "test connect desc",
+    showEditConnector: false,
+    showDeleteConnector: false,
+    connectorDeletable: false,
+  },
+  {
+    sequence: 2,
+    connectorId: 1003,
+    connectorName: "test_connector_3",
+    environmentId: "4",
+    teamName: "Infra",
+    allPageNos: ["1"],
+    totalNoPages: "1",
+    currentPage: "1",
+    environmentsList: ["TST"],
+    description: "test connect desc",
+    showEditConnector: false,
+    showDeleteConnector: false,
+    connectorDeletable: false,
+  },
+];
+
+const tableRowHeader = ["Connector", "Environments", "Team"];
+
+describe("ConnectorTable.tsx", () => {
+  describe("shows empty state correctly", () => {
+    afterAll(cleanup);
+
+    it("show empty state when there is no data", () => {
+      render(
+        <ConnectorTable
+          connectors={[]}
+          ariaLabel={"Kafka Connector overview, page 0 of 0"}
+        />
+      );
+      expect(
+        screen.getByRole("heading", {
+          name: "No Kafka Connectors",
+        })
+      ).toBeVisible();
+    });
+  });
+
+  describe("shows all Kafka Connectors as a table", () => {
+    beforeAll(() => {
+      mockIntersectionObserver();
+      render(
+        <ConnectorTable
+          connectors={mockConnectors}
+          ariaLabel={"Kafka Connectors overview, page 1 of 10"}
+        />
+      );
+    });
+
+    afterAll(cleanup);
+
+    it("renders a connector table with information about pages", async () => {
+      const table = screen.getByRole("table", {
+        name: "Kafka Connectors overview, page 1 of 10",
+      });
+
+      expect(table).toBeVisible();
+    });
+
+    tableRowHeader.forEach((header) => {
+      it(`renders a column header for ${header}`, () => {
+        const table = screen.getByRole("table", {
+          name: "Kafka Connectors overview, page 1 of 10",
+        });
+        const colHeader = within(table).getByRole("columnheader", {
+          name: header,
+        });
+
+        expect(colHeader).toBeVisible();
+      });
+    });
+
+    mockConnectors.forEach((connector) => {
+      it(`renders the connector name "${connector.connectorName}" as a link to the detail view as row header`, () => {
+        const table = screen.getByRole("table", {
+          name: "Kafka Connectors overview, page 1 of 10",
+        });
+        const rowHeader = within(table).getByRole("cell", {
+          name: connector.connectorName,
+        });
+        const link = within(rowHeader).getByRole("link", {
+          name: connector.connectorName,
+        });
+
+        expect(rowHeader).toBeVisible();
+        expect(link).toBeVisible();
+        expect(link).toHaveAttribute(
+          "href",
+          `/connectorOverview?connectorName=${connector.connectorName}`
+        );
+      });
+
+      it(`renders the team for ${connector.connectorName} `, () => {
+        const table = screen.getByRole("table", {
+          name: "Kafka Connectors overview, page 1 of 10",
+        });
+        const row = within(table).getByRole("row", {
+          name: new RegExp(`${connector.connectorName}`, "i"),
+        });
+        const team = within(row).getByRole("cell", {
+          name: connector.teamName,
+        });
+
+        expect(team).toBeVisible();
+      });
+
+      it(`renders a list of Environments for connector ${connector}`, () => {
+        const table = screen.getByRole("table", {
+          name: "Kafka Connectors overview, page 1 of 10",
+        });
+        const row = within(table).getByRole("row", {
+          name: new RegExp(`${connector.connectorName}`, "i"),
+        });
+        const environmentList = within(row).getByRole("cell", {
+          name: connector.environmentsList.join(" "),
+        });
+
+        expect(environmentList).toBeVisible();
+      });
+
+      connector.environmentsList.forEach((env) => {
+        it(`renders Environment ${env} for connector ${connector}`, () => {
+          const table = screen.getByRole("table", {
+            name: "Kafka Connectors overview, page 1 of 10",
+          });
+          const row = within(table).getByRole("row", {
+            name: new RegExp(`${connector.connectorName}`, "i"),
+          });
+          const environmentList = within(row).getByRole("cell", {
+            name: connector.environmentsList.join(" "),
+          });
+
+          expect(environmentList).toBeVisible();
+        });
+      });
+    });
+  });
+
+  describe("enables user to keyboard navigate from connector name to connector name", () => {
+    beforeEach(() => {
+      mockIntersectionObserver();
+      render(
+        <ConnectorTable
+          connectors={mockConnectors}
+          ariaLabel={"Kafka Connectors overview, page 1 of 10"}
+        />
+      );
+      const table = screen.getByRole("table", {
+        name: "Kafka Connectors overview, page 1 of 10",
+      });
+      table.focus();
+    });
+
+    afterEach(cleanup);
+
+    mockConnectors.forEach((connector, index) => {
+      const numbersOfTabs = index + 1;
+      it(`sets focus on "${connector.connectorName}" when user tabs ${numbersOfTabs} times`, async () => {
+        const link = screen.getByRole("link", {
+          name: connector.connectorName,
+        });
+
+        expect(link).not.toHaveFocus();
+
+        await tabThroughForward(numbersOfTabs);
+
+        expect(link).toHaveFocus();
+      });
+    });
+  });
+});

--- a/coral/src/app/features/connectors/browse/components/ConnectorTable.tsx
+++ b/coral/src/app/features/connectors/browse/components/ConnectorTable.tsx
@@ -1,0 +1,91 @@
+import {
+  DataTable,
+  DataTableColumn,
+  EmptyState,
+  Flexbox,
+  StatusChip,
+} from "@aivenio/aquarium";
+import { Connector } from "src/domain/connector";
+
+type ConnectorTableProps = {
+  connectors: Connector[];
+  ariaLabel: string;
+};
+
+interface ConnectorTableRow {
+  id: number;
+  connectorName: Connector["connectorName"];
+  environmentsList: Connector["environmentsList"];
+  teamName: Connector["teamName"];
+}
+
+function ConnectorTable(props: ConnectorTableProps) {
+  const { connectors, ariaLabel } = props;
+
+  const columns: Array<DataTableColumn<ConnectorTableRow>> = [
+    {
+      type: "custom",
+      field: "connectorName",
+      headerName: "Connector",
+      UNSAFE_render: ({ connectorName }: ConnectorTableRow) => (
+        <a href={`/connectorOverview?connectorName=${connectorName}`}>
+          {connectorName}
+        </a>
+      ),
+    },
+    {
+      type: "custom",
+      field: "environmentsList",
+      headerName: "Environments",
+      UNSAFE_render: ({ environmentsList }: ConnectorTableRow) => {
+        return (
+          <Flexbox wrap={"wrap"} gap={"2"}>
+            {environmentsList?.map((env, index) => (
+              <StatusChip
+                dense
+                status="neutral"
+                key={`${env}-${index}`}
+                // We need to add a space after text value
+                // Otherwise a list of values would be rendered as value1value2value3 for screen readers
+                // Instead of value1 value2 value3
+                text={`${env} `}
+              />
+            ))}
+          </Flexbox>
+        );
+      },
+    },
+    {
+      type: "text",
+      field: "teamName",
+      headerName: "Team",
+    },
+  ];
+
+  const rows: ConnectorTableRow[] = connectors.map((connectors: Connector) => {
+    return {
+      id: Number(connectors.connectorId),
+      connectorName: connectors.connectorName,
+      teamName: connectors.teamName,
+      environmentsList: connectors?.environmentsList ?? [],
+    };
+  });
+
+  if (rows.length === 0) {
+    return (
+      <EmptyState title="No Kafka Connectors">
+        No Kafka Connectors matched your criteria.
+      </EmptyState>
+    );
+  }
+
+  return (
+    <DataTable
+      ariaLabel={ariaLabel}
+      columns={columns}
+      rows={rows}
+      noWrap={false}
+    />
+  );
+}
+export default ConnectorTable;

--- a/coral/src/app/features/requests/connectors/ConnectorRequests.test.tsx
+++ b/coral/src/app/features/requests/connectors/ConnectorRequests.test.tsx
@@ -3,7 +3,7 @@ import {
   screen,
   waitForElementToBeRemoved,
 } from "@testing-library/react";
-import transformConnectorRequestApiResponse from "src/domain/connector/connector-transformer";
+import { transformConnectorRequestApiResponse } from "src/domain/connector/connector-transformer";
 import { mockIntersectionObserver } from "src/services/test-utils/mock-intersection-observer";
 import { ConnectorRequests } from "src/app/features/requests/connectors/ConnectorRequests";
 import { customRender } from "src/services/test-utils/render-with-wrappers";

--- a/coral/src/app/pages/connectors/index.tsx
+++ b/coral/src/app/pages/connectors/index.tsx
@@ -3,6 +3,7 @@ import add from "@aivenio/aquarium/dist/src/icons/add";
 import AuthenticationRequiredBoundary from "src/app/components/AuthenticationRequiredBoundary";
 import PreviewBanner from "src/app/components/PreviewBanner";
 import Layout from "src/app/layout/Layout";
+import BrowseConnectors from "src/app/features/connectors/browse/BrowseConnectors";
 
 const ConnectorsPage = () => {
   return (
@@ -17,7 +18,7 @@ const ConnectorsPage = () => {
             icon: add,
           }}
         />
-        <div>👋Kafka Connectors here </div>
+        <BrowseConnectors />
       </Layout>
     </AuthenticationRequiredBoundary>
   );

--- a/coral/src/domain/connector/connector-api.ts
+++ b/coral/src/domain/connector/connector-api.ts
@@ -1,5 +1,8 @@
 import omitBy from "lodash/omitBy";
-import transformConnectorRequestApiResponse from "src/domain/connector/connector-transformer";
+import {
+  transformConnectorRequestApiResponse,
+  transformConnectorApiResponse,
+} from "src/domain/connector/connector-transformer";
 import {
   RequestVerdictApproval,
   RequestVerdictDecline,
@@ -34,6 +37,32 @@ const filterGetConnectorRequestParams = (
       omitSearch
     );
   });
+};
+
+const getConnectors = ({
+  currentPage,
+  environment = "ALL",
+  teamName,
+  connectorName,
+}: {
+  currentPage: number;
+  environment: string;
+  teamName?: string;
+  connectorName?: string;
+}) => {
+  const queryParams: KlawApiRequestQueryParameters<"getConnectors"> = {
+    pageNo: currentPage.toString(),
+    env: environment,
+    ...(teamName && { teamName: teamName }),
+    ...(connectorName && {
+      connectornamesearch: connectorName,
+    }),
+  };
+  return api
+    .get<KlawApiResponse<"getConnectors">>(
+      `/getConnectors?${new URLSearchParams(queryParams)}`
+    )
+    .then(transformConnectorApiResponse);
 };
 
 const getConnectorRequestsForApprover = (
@@ -100,4 +129,5 @@ export {
   approveConnectorRequest,
   declineConnectorRequest,
   deleteConnectorRequest,
+  getConnectors,
 };

--- a/coral/src/domain/connector/connector-transformer.ts
+++ b/coral/src/domain/connector/connector-transformer.ts
@@ -1,5 +1,25 @@
-import { ConnectorRequestsForApprover } from "src/domain/connector/connector-types";
+import {
+  ConnectorApiResponse,
+  ConnectorRequestsForApprover,
+} from "src/domain/connector/connector-types";
 import { KlawApiResponse } from "types/utils";
+
+const transformConnectorApiResponse = (
+  data: KlawApiResponse<"getConnectors">
+): ConnectorApiResponse => {
+  if (data.length === 0) {
+    return {
+      totalPages: 0,
+      currentPage: 0,
+      entries: [],
+    };
+  }
+  return {
+    totalPages: Number(data[0][0].totalNoPages),
+    currentPage: Number(data[0][0].currentPage),
+    entries: data.flat(),
+  };
+};
 
 const transformConnectorRequestApiResponse = (
   data: KlawApiResponse<"getCreatedConnectorRequests">
@@ -18,4 +38,4 @@ const transformConnectorRequestApiResponse = (
   };
 };
 
-export default transformConnectorRequestApiResponse;
+export { transformConnectorApiResponse, transformConnectorRequestApiResponse };

--- a/coral/src/domain/connector/connector-types.ts
+++ b/coral/src/domain/connector/connector-types.ts
@@ -1,9 +1,17 @@
 import { KlawApiModel, Paginated, ResolveIntersectionTypes } from "types/utils";
 
+type Connector = KlawApiModel<"KafkaConnectorModel">;
+type ConnectorApiResponse = ResolveIntersectionTypes<Paginated<Connector[]>>;
+
 type ConnectorRequest = KlawApiModel<"KafkaConnectorRequestsResponseModel">;
 
 type ConnectorRequestsForApprover = ResolveIntersectionTypes<
   Paginated<ConnectorRequest[]>
 >;
 
-export type { ConnectorRequest, ConnectorRequestsForApprover };
+export type {
+  Connector,
+  ConnectorApiResponse,
+  ConnectorRequest,
+  ConnectorRequestsForApprover,
+};

--- a/coral/src/domain/connector/index.ts
+++ b/coral/src/domain/connector/index.ts
@@ -4,16 +4,19 @@ import {
   getConnectorRequests,
   getConnectorRequestsForApprover,
   deleteConnectorRequest,
+  getConnectors,
 } from "src/domain/connector/connector-api";
 import {
   ConnectorRequest,
   ConnectorRequestsForApprover,
+  Connector,
 } from "src/domain/connector/connector-types";
 
-export type { ConnectorRequestsForApprover, ConnectorRequest };
+export type { Connector, ConnectorRequestsForApprover, ConnectorRequest };
 export {
   getConnectorRequestsForApprover,
   getConnectorRequests,
+  getConnectors,
   approveConnectorRequest,
   declineConnectorRequest,
   deleteConnectorRequest,


### PR DESCRIPTION
# About this change - What it does

- adds missing endpoint `getConnectors` as well as related type and transformer
- add the browse-connector view with 
    -  table with connectors
    - pagination element for multi page responses

Resolves: #981 


#### Recording


https://user-images.githubusercontent.com/943800/229812391-7c9a89bd-90ec-4198-b0d4-a88eda76255d.mov


