### PR TITLE
Allow users to edit schema registry cluster with the project and service name

### DIFF
--- a/core/src/main/resources/static/js/envs.js
+++ b/core/src/main/resources/static/js/envs.js
@@ -726,7 +726,7 @@ app.controller("envsCtrl", function($scope, $http, $location, $window) {
                             }
                         }
 
-                        if($scope.kafkaFlavor === 'Aiven for Apache Kafka')
+                        if($scope.kafkaFlavor === 'Aiven for Apache Kafka' && $scope.addNewCluster.clusterType === 'kafka')
                         {
                             if($scope.addNewCluster.projectName === undefined || !$scope.addNewCluster.projectName)
                             {

--- a/core/src/main/resources/static/js/modifyEnvs.js
+++ b/core/src/main/resources/static/js/modifyEnvs.js
@@ -365,6 +365,24 @@ app.controller("modifyEnvsCtrl", function($scope, $http, $location, $window) {
                     return;
                 }
 
+
+                        if($scope.clusterDetails.kafkaFlavor === 'Aiven for Apache Kafka')
+                        {
+                            if($scope.clusterDetails.projectName === undefined || !$scope.clusterDetails.projectName)
+                            {
+                                $scope.alertnote = "Please fill in Project Name as defined in Aiven console";
+                                $scope.showAlertToast();
+                                return;
+                            }
+
+                            if($scope.clusterDetails.serviceName === undefined || !$scope.clusterDetails.serviceName)
+                            {
+                                $scope.alertnote = "Please fill in service Name as defined in Aiven console";
+                                $scope.showAlertToast();
+                                return;
+                            }
+                        }
+
                 var serviceInput = {};
                 serviceInput['clusterId'] = $scope.clusterToEdit;
                 serviceInput['clusterName'] = $scope.clusterDetails.clusterName;
@@ -372,7 +390,8 @@ app.controller("modifyEnvsCtrl", function($scope, $http, $location, $window) {
                 serviceInput['protocol'] = $scope.clusterDetails.protocol;
                 serviceInput['clusterType'] = $scope.clusterDetails.type;
                 serviceInput['kafkaFlavor'] = $scope.clusterDetails.kafkaFlavor;
-
+                serviceInput['projectName'] = $scope.clusterDetails.projectName;
+                serviceInput['serviceName'] = $scope.clusterDetails.serviceName;
                 serviceInput['otherParams'] = "default.partitions=na,max.partitions=na,replication.factor=na";
 
                 $http({

--- a/core/src/main/resources/static/js/modifyEnvs.js
+++ b/core/src/main/resources/static/js/modifyEnvs.js
@@ -366,22 +366,6 @@ app.controller("modifyEnvsCtrl", function($scope, $http, $location, $window) {
                 }
 
 
-                        if($scope.clusterDetails.kafkaFlavor === 'Aiven for Apache Kafka')
-                        {
-                            if($scope.clusterDetails.projectName === undefined || !$scope.clusterDetails.projectName)
-                            {
-                                $scope.alertnote = "Please fill in Project Name as defined in Aiven console";
-                                $scope.showAlertToast();
-                                return;
-                            }
-
-                            if($scope.clusterDetails.serviceName === undefined || !$scope.clusterDetails.serviceName)
-                            {
-                                $scope.alertnote = "Please fill in service Name as defined in Aiven console";
-                                $scope.showAlertToast();
-                                return;
-                            }
-                        }
 
                 var serviceInput = {};
                 serviceInput['clusterId'] = $scope.clusterToEdit;
@@ -390,8 +374,6 @@ app.controller("modifyEnvsCtrl", function($scope, $http, $location, $window) {
                 serviceInput['protocol'] = $scope.clusterDetails.protocol;
                 serviceInput['clusterType'] = $scope.clusterDetails.type;
                 serviceInput['kafkaFlavor'] = $scope.clusterDetails.kafkaFlavor;
-                serviceInput['projectName'] = $scope.clusterDetails.projectName;
-                serviceInput['serviceName'] = $scope.clusterDetails.serviceName;
                 serviceInput['otherParams'] = "default.partitions=na,max.partitions=na,replication.factor=na";
 
                 $http({

--- a/core/src/main/resources/templates/addCluster.html
+++ b/core/src/main/resources/templates/addCluster.html
@@ -640,7 +640,7 @@
 										</div>
 									</div>
 
-									<div class="row" ng-show="kafkaFlavor == 'Aiven for Apache Kafka'">
+									<div class="row" ng-show="kafkaFlavor == 'Aiven for Apache Kafka' && addNewCluster.clusterType == 'kafka'">
 										<div class="col-md-6">
 											<div class="form-group">
 												<label>Project Name</label>

--- a/core/src/main/resources/templates/modifyCluster.html
+++ b/core/src/main/resources/templates/modifyCluster.html
@@ -632,6 +632,24 @@
 										</div>
 										<!--/span-->
 									</div>
+									<div class="row" ng-show="clusterDetails.kafkaFlavor === 'Aiven for Apache Kafka'">
+										<div class="col-md-6">
+											<div class="form-group">
+												<label>Project Name</label>
+												<input ng-model="clusterDetails.projectName" type="text"
+													   class="form-control">
+												<small class="form-control-feedback">Project defined in Aiven console</small>
+											</div>
+										</div>
+										<div class="col-md-6">
+											<div class="form-group">
+												<label>Service Name</label>
+												<input ng-model="clusterDetails.serviceName" type="text"
+													   class="form-control">
+												<small class="form-control-feedback">Service name defined in Aiven console</small>
+											</div>
+										</div>
+									</div>
 
 									<div class="row">
 										<div class="col-md-6">

--- a/core/src/main/resources/templates/modifyCluster.html
+++ b/core/src/main/resources/templates/modifyCluster.html
@@ -632,25 +632,6 @@
 										</div>
 										<!--/span-->
 									</div>
-									<div class="row" ng-show="clusterDetails.kafkaFlavor === 'Aiven for Apache Kafka'">
-										<div class="col-md-6">
-											<div class="form-group">
-												<label>Project Name</label>
-												<input ng-model="clusterDetails.projectName" type="text"
-													   class="form-control">
-												<small class="form-control-feedback">Project defined in Aiven console</small>
-											</div>
-										</div>
-										<div class="col-md-6">
-											<div class="form-group">
-												<label>Service Name</label>
-												<input ng-model="clusterDetails.serviceName" type="text"
-													   class="form-control">
-												<small class="form-control-feedback">Service name defined in Aiven console</small>
-											</div>
-										</div>
-									</div>
-
 									<div class="row">
 										<div class="col-md-6">
 											<div class="form-group">


### PR DESCRIPTION
About this change - What it does
If the cluster is kafka only and the angularjs UI see it is an aiven kafka service it will allow the service name and project name to be altered.
Resolves: #930 
Why this way
This removes setup information that is not used for either kafkaconnect with aiven nor the schema registry with aiven.