### PR TITLE
refactor(coral): Update concept of Environment in coral 

### DIFF
--- a/coral/src/domain/environment/environment-api.msw.ts
+++ b/coral/src/domain/environment/environment-api.msw.ts
@@ -4,7 +4,6 @@ import { createMockEnvironmentDTO } from "src/domain/environment/environment-tes
 import { getHTTPBaseAPIUrl } from "src/config";
 import { KlawApiResponse } from "types/utils";
 import { operations } from "types/api";
-import { ClusterInfo } from "src/domain/environment/environment-types";
 
 type MockApi<T extends keyof operations> = {
   mswInstance: MswInstance;
@@ -60,7 +59,7 @@ function mockGetClusterInfoFromEnv({
 
 const getMockedResponseGetClusterInfoFromEnv = (
   isAivenCluster: boolean
-): ClusterInfo => ({
+): KlawApiResponse<"getClusterInfoFromEnv"> => ({
   aivenCluster: isAivenCluster,
 });
 

--- a/coral/src/domain/environment/environment-api.ts
+++ b/coral/src/domain/environment/environment-api.ts
@@ -1,8 +1,5 @@
 import { transformEnvironmentApiResponse } from "src/domain/environment/environment-transformer";
-import {
-  ClusterInfo,
-  Environment,
-} from "src/domain/environment/environment-types";
+import { Environment } from "src/domain/environment/environment-types";
 import api from "src/services/api";
 import { KlawApiResponse } from "types/utils";
 
@@ -31,7 +28,7 @@ const getClusterInfo = async ({
 }: {
   envSelected: string;
   envType: Environment["type"];
-}): Promise<ClusterInfo> => {
+}): Promise<KlawApiResponse<"getClusterInfoFromEnv">> => {
   const params = new URLSearchParams({ envSelected, envType });
   return api.get<KlawApiResponse<"getClusterInfoFromEnv">>(
     `/getClusterInfoFromEnv?${params}`

--- a/coral/src/domain/environment/environment-types.ts
+++ b/coral/src/domain/environment/environment-types.ts
@@ -1,18 +1,26 @@
 import { KlawApiModel, KlawApiResponse } from "types/utils";
 
-//@TODO this seems to be specifically modified to fit
-// for creating a TopicRequest, we should check this
-// with backend and align API and our types/needs
+// KlawApiModel<"EnvModel">
+// is only relevant when creating a new Environment and reserved to that usage
+// we're not using that right now, that's why it's commented out
+// type CreateEnvironment = KlawApiModel<"EnvModel">
+
+// KlawApiModel<"EnvModelResponse">
+// This represents the Environment in the Backend and is what we're using
+// when talking about "Environment"
+// we're redefining property types here to fit our need in app better
+// transformEnvironmentApiResponse() is taking care of transforming
+// the properties and makes sure the types are matching between BE and FE
 type Environment = {
-  name: KlawApiModel<"EnvModel">["name"];
-  id: KlawApiModel<"EnvModel">["id"];
+  name: KlawApiModel<"EnvModelResponse">["name"];
+  id: KlawApiModel<"EnvModelResponse">["id"];
   defaultPartitions: number | undefined;
   defaultReplicationFactor: number | undefined;
   maxPartitions: number | undefined;
   maxReplicationFactor: number | undefined;
   topicNamePrefix: string | undefined;
   topicNameSuffix: string | undefined;
-  type: KlawApiModel<"EnvModel">["type"];
+  type: KlawApiModel<"EnvModelResponse">["type"];
 };
 
 type ClusterInfo = KlawApiResponse<"getClusterInfoFromEnv">;

--- a/coral/src/domain/environment/environment-types.ts
+++ b/coral/src/domain/environment/environment-types.ts
@@ -1,4 +1,4 @@
-import { KlawApiModel, KlawApiResponse } from "types/utils";
+import { KlawApiModel } from "types/utils";
 
 // KlawApiModel<"EnvModel">
 // is only relevant when creating a new Environment and reserved to that usage
@@ -23,10 +23,8 @@ type Environment = {
   type: KlawApiModel<"EnvModelResponse">["type"];
 };
 
-type ClusterInfo = KlawApiResponse<"getClusterInfoFromEnv">;
-
 const ALL_ENVIRONMENTS_VALUE = "ALL";
 const ENVIRONMENT_NOT_INITIALIZED = "d3a914ff-cff6-42d4-988e-b0425128e770";
 
-export type { Environment, ClusterInfo };
+export type { Environment };
 export { ALL_ENVIRONMENTS_VALUE, ENVIRONMENT_NOT_INITIALIZED };

--- a/coral/src/domain/environment/index.ts
+++ b/coral/src/domain/environment/index.ts
@@ -5,7 +5,6 @@ import {
 import { mockGetEnvironments } from "src/domain/environment/environment-api.msw";
 import {
   ALL_ENVIRONMENTS_VALUE,
-  ClusterInfo,
   Environment,
 } from "src/domain/environment/environment-types";
 
@@ -15,4 +14,4 @@ export {
   ALL_ENVIRONMENTS_VALUE,
   getSchemaRegistryEnvironments,
 };
-export type { Environment, ClusterInfo };
+export type { Environment };


### PR DESCRIPTION
# About this change - What it does

- update types in `domain/environment` to make concept more explicit (see description in #993)
- removes ClusterInfo as type

this is needed as prep for adding envs from a new endpoint to the browse connectors view, but felt like it should be in it's own scope

Resolves: #993
