### PR TITLE
teamId as filter param in getTopics

### DIFF
--- a/coral/types/api.d.ts
+++ b/coral/types/api.d.ts
@@ -621,6 +621,8 @@ export type components = {
       description: string;
       noOfReplicas: string;
       teamname: string;
+      /** Format: int32 */
+      teamId: number;
       envId: string;
       environmentsList: (string)[];
       showEditTopic: boolean;
@@ -2424,7 +2426,7 @@ export type operations = {
         pageNo: string;
         currentPage?: string;
         topicnamesearch?: string;
-        teamName?: string;
+        teamId?: number;
         topicType?: string;
       };
     };
@@ -2444,7 +2446,7 @@ export type operations = {
         pageNo: string;
         currentPage?: string;
         topicnamesearch?: string;
-        teamName?: string;
+        teamId?: number;
         topicType?: string;
       };
     };

--- a/core/src/main/java/io/aiven/klaw/controller/TopicController.java
+++ b/core/src/main/java/io/aiven/klaw/controller/TopicController.java
@@ -210,12 +210,12 @@ public class TopicController {
       @RequestParam("pageNo") String pageNo,
       @RequestParam(value = "currentPage", defaultValue = "") String currentPage,
       @RequestParam(value = "topicnamesearch", required = false) String topicNameSearch,
-      @RequestParam(value = "teamName", required = false) String teamName,
+      @RequestParam(value = "teamId", required = false) Integer teamId,
       @RequestParam(value = "topicType", required = false) String topicType) {
 
     return new ResponseEntity<>(
         topicControllerService.getTopics(
-            envId, pageNo, currentPage, topicNameSearch, teamName, topicType),
+            envId, pageNo, currentPage, topicNameSearch, teamId, topicType),
         HttpStatus.OK);
   }
 

--- a/core/src/main/java/io/aiven/klaw/controller/TopicSyncController.java
+++ b/core/src/main/java/io/aiven/klaw/controller/TopicSyncController.java
@@ -50,11 +50,11 @@ public class TopicSyncController {
       @RequestParam("pageNo") String pageNo,
       @RequestParam(value = "currentPage", defaultValue = "") String currentPage,
       @RequestParam(value = "topicnamesearch", required = false) String topicNameSearch,
-      @RequestParam(value = "teamName", required = false) String teamName,
+      @RequestParam(value = "teamId", required = false) Integer teamId,
       @RequestParam(value = "topicType", required = false) String topicType) {
     return new ResponseEntity<>(
         topicSyncControllerService.getTopicsRowView(
-            envId, pageNo, currentPage, topicNameSearch, teamName, topicType),
+            envId, pageNo, currentPage, topicNameSearch, teamId, topicType),
         HttpStatus.OK);
   }
 

--- a/core/src/main/java/io/aiven/klaw/model/TopicInfo.java
+++ b/core/src/main/java/io/aiven/klaw/model/TopicInfo.java
@@ -20,6 +20,8 @@ public class TopicInfo {
 
   @NotNull private String teamname;
 
+  @NotNull private int teamId;
+
   @NotNull private String envId;
 
   @NotNull private List<String> environmentsList;

--- a/core/src/main/java/io/aiven/klaw/perf/CreateBulkTests.java
+++ b/core/src/main/java/io/aiven/klaw/perf/CreateBulkTests.java
@@ -35,7 +35,7 @@ public class CreateBulkTests {
 
     private void getTopics() {
       try {
-        List<List<TopicInfo>> s = topicControllerService.getTopics("1", "1", "", null, null, null);
+        List<List<TopicInfo>> s = topicControllerService.getTopics("1", "1", "", null, 0, null);
         // System.out.println(k+"--"+s.size());
       } catch (Exception e) {
         log.error("Exception:", e);

--- a/core/src/main/java/io/aiven/klaw/service/TopicControllerService.java
+++ b/core/src/main/java/io/aiven/klaw/service/TopicControllerService.java
@@ -1012,7 +1012,7 @@ public class TopicControllerService {
       String pageNo,
       String currentPage,
       String topicNameSearch,
-      String teamName,
+      Integer teamId,
       String topicType) {
     log.debug("getTopics {}", topicNameSearch);
     String userName = getUserName();
@@ -1022,7 +1022,7 @@ public class TopicControllerService {
             pageNo,
             currentPage,
             topicNameSearch,
-            teamName,
+            teamId,
             topicType,
             commonUtilsService.getTenantId(userName));
 
@@ -1047,7 +1047,7 @@ public class TopicControllerService {
       String pageNo,
       String currentPage,
       String topicNameSearch,
-      String teamName,
+      Integer teamId,
       String topicType,
       int tenantId) {
     if (topicNameSearch != null) {
@@ -1059,10 +1059,9 @@ public class TopicControllerService {
     // To get Producer or Consumer topics, first get all topics based on acls and then filter
     List<Topic> producerConsumerTopics = new ArrayList<>();
     if ((AclType.PRODUCER.value.equals(topicType) || AclType.CONSUMER.value.equals(topicType))
-        && teamName != null) {
+        && teamId != 0) {
       producerConsumerTopics =
-          handleDbRequests.selectAllTopicsByTopictypeAndTeamname(
-              topicType, manageDatabase.getTeamIdFromTeamName(tenantId, teamName), tenantId);
+          handleDbRequests.selectAllTopicsByTopictypeAndTeamname(topicType, teamId, tenantId);
 
       // tenant filtering, not really necessary though, as based on team is searched.
       producerConsumerTopics =
@@ -1070,13 +1069,11 @@ public class TopicControllerService {
 
       // select all topics and then filter
       env = "ALL";
-      teamName = null;
+      teamId = 0;
     }
 
     // Get Sync topics
-    List<Topic> topicsFromSOT =
-        handleDbRequests.getSyncTopics(
-            env, manageDatabase.getTeamIdFromTeamName(tenantId, teamName), tenantId);
+    List<Topic> topicsFromSOT = handleDbRequests.getSyncTopics(env, teamId, tenantId);
     topicsFromSOT = commonUtilsService.getFilteredTopicsForTenant(topicsFromSOT);
 
     // tenant filtering
@@ -1253,6 +1250,7 @@ public class TopicControllerService {
         mp.setEnvId(topicSOT.getEnvironment());
         mp.setEnvironmentsList(getConvertedEnvs(listAllEnvs, envList));
         mp.setTopicName(topicSOT.getTopicname());
+        mp.setTeamId(topicSOT.getTeamId());
         mp.setTeamname(manageDatabase.getTeamNameFromTeamId(tenantId, topicSOT.getTeamId()));
 
         mp.setNoOfReplicas(topicSOT.getNoOfReplicas());

--- a/core/src/main/java/io/aiven/klaw/service/TopicSyncControllerService.java
+++ b/core/src/main/java/io/aiven/klaw/service/TopicSyncControllerService.java
@@ -585,13 +585,12 @@ public class TopicSyncControllerService {
       String pageNo,
       String currentPage,
       String topicNameSearch,
-      String teamName,
+      Integer teamId,
       String topicType) {
     log.info("getTopicsRowView {}", topicNameSearch);
     int tenantId = commonUtilsService.getTenantId(getUserName());
     List<TopicInfo> topicListUpdated =
-        getTopicsPaginated(
-            env, pageNo, currentPage, topicNameSearch, teamName, topicType, tenantId);
+        getTopicsPaginated(env, pageNo, currentPage, topicNameSearch, teamId, topicType, tenantId);
 
     if (topicListUpdated != null && topicListUpdated.size() > 0) {
       return topicListUpdated;
@@ -605,7 +604,7 @@ public class TopicSyncControllerService {
       String pageNo,
       String currentPage,
       String topicNameSearch,
-      String teamName,
+      Integer teamId,
       String topicType,
       int tenantId) {
     if (topicNameSearch != null) topicNameSearch = topicNameSearch.trim();
@@ -615,10 +614,9 @@ public class TopicSyncControllerService {
     // To get Producer or Consumer topics, first get all topics based on acls and then filter
     List<Topic> producerConsumerTopics = new ArrayList<>();
     if ((AclType.PRODUCER.value.equals(topicType) || AclType.CONSUMER.value.equals(topicType))
-        && teamName != null) {
+        && teamId != 0) {
       producerConsumerTopics =
-          handleDbRequests.selectAllTopicsByTopictypeAndTeamname(
-              topicType, manageDatabase.getTeamIdFromTeamName(tenantId, teamName), tenantId);
+          handleDbRequests.selectAllTopicsByTopictypeAndTeamname(topicType, teamId, tenantId);
 
       // tenant filtering, not really necessary though, as based on team is searched.
       producerConsumerTopics =
@@ -626,13 +624,11 @@ public class TopicSyncControllerService {
 
       // select all topics and then filter
       env = "ALL";
-      teamName = null;
+      teamId = 0;
     }
 
     // Get Sync topics
-    List<Topic> topicsFromSOT =
-        handleDbRequests.getSyncTopics(
-            env, manageDatabase.getTeamIdFromTeamName(tenantId, teamName), tenantId);
+    List<Topic> topicsFromSOT = handleDbRequests.getSyncTopics(env, teamId, tenantId);
     topicsFromSOT = commonUtilsService.getFilteredTopicsForTenant(topicsFromSOT);
 
     // tenant filtering

--- a/core/src/main/java/io/aiven/klaw/service/UsersTeamsControllerService.java
+++ b/core/src/main/java/io/aiven/klaw/service/UsersTeamsControllerService.java
@@ -350,8 +350,9 @@ public class UsersTeamsControllerService {
 
   public List<TeamModelResponse> getAllTeamsSU() {
     int tenantId = commonUtilsService.getTenantId(getUserName());
+
     List<TeamModelResponse> teamModels =
-        getTeamModels(manageDatabase.getHandleDbRequests().selectAllTeams(tenantId));
+        getTeamModels(manageDatabase.getTeamObjForTenant(tenantId));
 
     if (!commonUtilsService.isNotAuthorizedUser(
         getUserName(), PermissionType.ADD_EDIT_DELETE_TEAMS)) {

--- a/core/src/main/resources/static/js/browseTopics.js
+++ b/core/src/main/resources/static/js/browseTopics.js
@@ -36,7 +36,7 @@ app.controller("browseTopicsCtrl", function($scope, $http, $location, $window) {
         $scope.loadTeams = function() {
                 $http({
                     method: "GET",
-                    url: "getAllTeamsSUOnly",
+                    url: "getAllTeamsSU",
                     headers : { 'Content-Type' : 'application/json' }
                 }).success(function(output) {
                     $scope.allTeams = output;
@@ -292,7 +292,7 @@ app.controller("browseTopicsCtrl", function($scope, $http, $location, $window) {
                 'pageNo' : pageNoSelected,
                 'currentPage' : $scope.currentPageSelected,
                  'topicnamesearch' : $scope.getTopics.topicnamesearch,
-                 'teamName' : teamSel,
+                 'teamId' : teamSel,
                  'topicType' : topicType
                  }
 		}).success(function(output) {

--- a/core/src/main/resources/static/js/syncBackTopics.js
+++ b/core/src/main/resources/static/js/syncBackTopics.js
@@ -62,7 +62,7 @@ app.controller("syncBackTopicsCtrl", function($scope, $http, $location, $window)
         $scope.loadTeams = function() {
                 $http({
                     method: "GET",
-                    url: "getAllTeamsSUOnly",
+                    url: "getAllTeamsSU",
                     headers : { 'Content-Type' : 'application/json' }
                 }).success(function(output) {
                     $scope.allTeams = output;
@@ -307,7 +307,7 @@ app.controller("syncBackTopicsCtrl", function($scope, $http, $location, $window)
                 'pageNo' : pageNoSelected,
                 'currentPage' : $scope.currentPageSelected,
                  'topicnamesearch' : $scope.getTopics.topicnamesearch,
-                 'teamName' : teamSel,
+                 'teamId' : teamSel,
                  'topicType' : topicType
                  }
 		}).success(function(output) {

--- a/core/src/main/resources/templates/browseTopics.html
+++ b/core/src/main/resources/templates/browseTopics.html
@@ -487,7 +487,7 @@
 					<div class="form-group has-success">
 						<label class="control-label">Select Team</label>
 						<select class="form-control custom-select" ng-model="getTopics.team"
-								ng-options="team as team for team in allTeams" ng-change="getTopics(1,'true','grid')">
+								ng-options="team.teamId as team.teamname for team in allTeams" ng-change="getTopics(1,'true','grid')">
 						</select>
 					</div>
 				</div>

--- a/core/src/main/resources/templates/syncBackTopics.html
+++ b/core/src/main/resources/templates/syncBackTopics.html
@@ -493,7 +493,7 @@
 					<div class="form-group has-success">
 						<label class="control-label">Select Team</label>
 						<select class="form-control custom-select" ng-model="getTopics.team"
-								ng-options="team as team for team in allTeams" ng-change="getTopics(1,'true','tabular')">
+								ng-options="team.teamId as team.teamname for team in allTeams" ng-change="getTopics(1,'true','tabular')">
 						</select>
 					</div>
 				</div>

--- a/core/src/test/java/io/aiven/klaw/controller/TopicControllerTest.java
+++ b/core/src/test/java/io/aiven/klaw/controller/TopicControllerTest.java
@@ -5,6 +5,7 @@ import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
@@ -237,7 +238,7 @@ public class TopicControllerTest {
     List<List<TopicInfo>> topicList = utilMethods.getTopicInfoList();
 
     when(topicControllerService.getTopics(
-            anyString(), anyString(), anyString(), anyString(), anyString(), any()))
+            anyString(), anyString(), anyString(), anyString(), anyInt(), any()))
         .thenReturn(topicList);
 
     mvc.perform(
@@ -245,7 +246,7 @@ public class TopicControllerTest {
                 .param("env", "1")
                 .param("pageNo", "1")
                 .param("topicnamesearch", "testtopic")
-                .param("teamName", "Team1")
+                .param("teamId", "1001")
                 .param("topicType", "")
                 .contentType(MediaType.APPLICATION_JSON)
                 .accept(MediaType.APPLICATION_JSON))

--- a/core/src/test/java/io/aiven/klaw/service/TopicControllerServiceTest.java
+++ b/core/src/test/java/io/aiven/klaw/service/TopicControllerServiceTest.java
@@ -931,7 +931,7 @@ public class TopicControllerServiceTest {
     when(commonUtilsService.groupTopicsByEnv(any())).thenReturn(getSyncTopics("topic", 4));
 
     List<List<TopicInfo>> topicsList =
-        topicControllerService.getTopics(envSel, pageNo, "", topicNameSearch, null, null);
+        topicControllerService.getTopics(envSel, pageNo, "", topicNameSearch, 0, null);
 
     assertThat(topicsList).hasSize(2);
   }
@@ -962,7 +962,7 @@ public class TopicControllerServiceTest {
 
     List<List<TopicInfo>> topicsList =
         topicControllerService.getTopics(
-            envSel, pageNo, "", topicNameSearch, KwConstants.INFRATEAM, AclType.PRODUCER.value);
+            envSel, pageNo, "", topicNameSearch, 1001, AclType.PRODUCER.value);
 
     assertThat(topicsList).isNull(); // for this filter criteria, there are no topics.
   }
@@ -998,7 +998,7 @@ public class TopicControllerServiceTest {
 
     List<List<TopicInfo>> topicsList =
         topicControllerService.getTopics(
-            envSel, pageNo, "", topicNameSearch, KwConstants.INFRATEAM, AclType.PRODUCER.value);
+            envSel, pageNo, "", topicNameSearch, 1001, AclType.PRODUCER.value);
 
     assertThat(topicsList).isNull(); // for this filter criteria, there are no topics.
   }
@@ -1015,7 +1015,7 @@ public class TopicControllerServiceTest {
     when(handleDbRequests.getSyncTopics(envSel, null, 1)).thenReturn(getSyncTopics("topic", 4));
 
     List<List<TopicInfo>> topicsList =
-        topicControllerService.getTopics(envSel, pageNo, "", topicNameSearch, null, null);
+        topicControllerService.getTopics(envSel, pageNo, "", topicNameSearch, 0, null);
 
     assertThat(topicsList).isNull();
   }

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -2257,11 +2257,12 @@
             "type" : "string"
           }
         }, {
-          "name" : "teamName",
+          "name" : "teamId",
           "in" : "query",
           "required" : false,
           "schema" : {
-            "type" : "string"
+            "type" : "integer",
+            "format" : "int32"
           }
         }, {
           "name" : "topicType",
@@ -2325,11 +2326,12 @@
             "type" : "string"
           }
         }, {
-          "name" : "teamName",
+          "name" : "teamId",
           "in" : "query",
           "required" : false,
           "schema" : {
-            "type" : "string"
+            "type" : "integer",
+            "format" : "int32"
           }
         }, {
           "name" : "topicType",
@@ -5436,6 +5438,10 @@
           "teamname" : {
             "type" : "string"
           },
+          "teamId" : {
+            "type" : "integer",
+            "format" : "int32"
+          },
           "envId" : {
             "type" : "string"
           },
@@ -5473,7 +5479,7 @@
             "type" : "string"
           }
         },
-        "required" : [ "allPageNos", "currentPage", "description", "envId", "environmentsList", "noOfPartitions", "noOfReplicas", "sequence", "showDeleteTopic", "showEditTopic", "teamname", "topicDeletable", "topicName", "topicid", "totalNoPages" ]
+        "required" : [ "allPageNos", "currentPage", "description", "envId", "environmentsList", "noOfPartitions", "noOfReplicas", "sequence", "showDeleteTopic", "showEditTopic", "teamId", "teamname", "topicDeletable", "topicName", "topicid", "totalNoPages" ]
       },
       "KafkaConnectorModel" : {
         "properties" : {


### PR DESCRIPTION
About this change - What it does

- Currently getTopics endpoint takes teamname string as filter param, is now changed to teamId
- To get teams in topics page, getAllTeamsSUOnly is changed to getAllTeamsSU

Resolves: #928 
Why this way

teamId is better than team name strings for filtering data
