### PR TITLE
refactor(coral) Update EnvironmentFilter to handle multiple endpoints.

### DIFF
--- a/coral/src/app/features/approvals/acls/AclApprovals.tsx
+++ b/coral/src/app/features/approvals/acls/AclApprovals.tsx
@@ -240,7 +240,10 @@ function AclApprovals() {
 
       <TableLayout
         filters={[
-          <EnvironmentFilter key={"environment"} />,
+          <EnvironmentFilter
+            key={"environment"}
+            environmentEndpoint={"getEnvironments"}
+          />,
           <StatusFilter key={"status"} defaultStatus={"CREATED"} />,
           <RequestTypeFilter key={"requestType"} />,
           <AclTypeFilter key={"aclType"} />,

--- a/coral/src/app/features/approvals/schemas/SchemaApprovals.tsx
+++ b/coral/src/app/features/approvals/schemas/SchemaApprovals.tsx
@@ -268,7 +268,7 @@ function SchemaApprovals() {
         filters={[
           <EnvironmentFilter
             key={"environment"}
-            isSchemaRegistryEnvironments
+            environmentEndpoint={"getSchemaRegistryEnvironments"}
           />,
           <StatusFilter key={"status"} defaultStatus={"CREATED"} />,
           <RequestTypeFilter key={"requestType"} />,

--- a/coral/src/app/features/approvals/topics/TopicApprovals.tsx
+++ b/coral/src/app/features/approvals/topics/TopicApprovals.tsx
@@ -283,7 +283,10 @@ function TopicApprovals() {
       )}
       <TableLayout
         filters={[
-          <EnvironmentFilter key={"environment"} />,
+          <EnvironmentFilter
+            key={"environment"}
+            environmentEndpoint={"getEnvironments"}
+          />,
           <StatusFilter key={"status"} defaultStatus={"CREATED"} />,
           <RequestTypeFilter key={"requestType"} />,
           <TeamFilter key={"team"} />,

--- a/coral/src/app/features/components/filters/EnvironmentFilter.tsx
+++ b/coral/src/app/features/components/filters/EnvironmentFilter.tsx
@@ -5,24 +5,34 @@ import {
   Environment,
   getEnvironments,
   getSchemaRegistryEnvironments,
+  getSyncConnectorsEnvironments,
 } from "src/domain/environment";
 import { HTTPError } from "src/services/api";
 
+type EnvironmentEndpoint =
+  | "getEnvironments"
+  | "getSchemaRegistryEnvironments"
+  | "getSyncConnectorsEnvironments";
 interface EnvironmentFilterProps {
   isSchemaRegistryEnvironments?: boolean;
+  environmentEndpoint: EnvironmentEndpoint;
 }
 
-function EnvironmentFilter({
-  isSchemaRegistryEnvironments = false,
-}: EnvironmentFilterProps) {
+const environmentEndpointMap: {
+  [key in EnvironmentEndpoint]: () => Promise<Environment[]>;
+} = {
+  getEnvironments: getEnvironments,
+  getSchemaRegistryEnvironments: getSchemaRegistryEnvironments,
+  getSyncConnectorsEnvironments: getSyncConnectorsEnvironments,
+};
+
+function EnvironmentFilter({ environmentEndpoint }: EnvironmentFilterProps) {
   const { environment, setFilterValue } = useFiltersValues();
 
   const { data: environments } = useQuery<Environment[], HTTPError>(
     ["topic-environments"],
     {
-      queryFn: isSchemaRegistryEnvironments
-        ? getSchemaRegistryEnvironments
-        : getEnvironments,
+      queryFn: environmentEndpointMap[environmentEndpoint],
     }
   );
 

--- a/coral/src/app/features/requests/acls/AclRequests.tsx
+++ b/coral/src/app/features/requests/acls/AclRequests.tsx
@@ -169,7 +169,10 @@ function AclRequests() {
       )}
       <TableLayout
         filters={[
-          <EnvironmentFilter key="environment" />,
+          <EnvironmentFilter
+            key="environment"
+            environmentEndpoint={"getEnvironments"}
+          />,
           <AclTypeFilter key="aclType" />,
           <StatusFilter key="status" defaultStatus="ALL" />,
           <RequestTypeFilter key="operationType" />,

--- a/coral/src/app/features/requests/schemas/SchemaRequests.tsx
+++ b/coral/src/app/features/requests/schemas/SchemaRequests.tsx
@@ -166,7 +166,7 @@ function SchemaRequests() {
         filters={[
           <EnvironmentFilter
             key={"environments"}
-            isSchemaRegistryEnvironments
+            environmentEndpoint={"getSchemaRegistryEnvironments"}
           />,
           <StatusFilter key={"request-status"} defaultStatus={defaultStatus} />,
           <RequestTypeFilter key={"request-type"} />,

--- a/coral/src/app/features/requests/topics/TopicRequests.tsx
+++ b/coral/src/app/features/requests/topics/TopicRequests.tsx
@@ -154,7 +154,10 @@ function TopicRequests() {
       )}
       <TableLayout
         filters={[
-          <EnvironmentFilter key="environments" />,
+          <EnvironmentFilter
+            key="environments"
+            environmentEndpoint={"getEnvironments"}
+          />,
           <StatusFilter key="request-status" defaultStatus={defaultStatus} />,
           <RequestTypeFilter key={"request-type"} />,
           <TopicFilter key={"topic"} />,

--- a/coral/src/app/features/topics/browse/BrowseTopics.tsx
+++ b/coral/src/app/features/topics/browse/BrowseTopics.tsx
@@ -52,7 +52,10 @@ function BrowseTopics() {
     <TableLayout
       filters={[
         <TeamFilter key="team" />,
-        <EnvironmentFilter key="environment" />,
+        <EnvironmentFilter
+          key="environment"
+          environmentEndpoint={"getEnvironments"}
+        />,
         <TopicFilter key="search" />,
       ]}
       table={

--- a/coral/src/domain/environment/environment-api.ts
+++ b/coral/src/domain/environment/environment-api.ts
@@ -22,6 +22,12 @@ const getSchemaRegistryEnvironments = (): Promise<Environment[]> => {
     .then(transformEnvironmentApiResponse);
 };
 
+const getSyncConnectorsEnvironments = (): Promise<Environment[]> => {
+  return api
+    .get<KlawApiResponse<"getSyncConnectorsEnv">>("/getSyncConnectorsEnv")
+    .then(transformEnvironmentApiResponse);
+};
+
 const getClusterInfo = async ({
   envSelected,
   envType,
@@ -40,4 +46,5 @@ export {
   getClusterInfo,
   getEnvironmentsForTeam,
   getSchemaRegistryEnvironments,
+  getSyncConnectorsEnvironments,
 };

--- a/coral/src/domain/environment/environment-test-helper.test.ts
+++ b/coral/src/domain/environment/environment-test-helper.test.ts
@@ -24,6 +24,8 @@ describe("environment-test-helper.ts", () => {
         topicsuffix: undefined,
         totalNoPages: "1",
         type: "kafka",
+        associatedEnv: undefined,
+        clusterType: "ALL",
       };
 
       expect(createMockEnvironmentDTO({ name: nameToTest })).toEqual(result);

--- a/coral/src/domain/environment/environment-test-helper.ts
+++ b/coral/src/domain/environment/environment-test-helper.ts
@@ -6,21 +6,23 @@ const defaultEnvironmentDTO: KlawApiModel<"EnvModelResponse"> = {
   name: "DEV",
   type: "kafka",
   tenantId: 101,
-  topicprefix: undefined,
-  topicsuffix: undefined,
   clusterId: 1,
   tenantName: "default",
   clusterName: "DEV",
   envStatus: "ONLINE",
   otherParams:
     "default.partitions=2,max.partitions=2,default.replication.factor=1,max.replication.factor=1,topic.prefix=,topic.suffix=",
+  showDeleteEnv: false,
+  totalNoPages: "1",
+  allPageNos: ["1"],
+  associatedEnv: undefined,
+  topicprefix: undefined,
+  topicsuffix: undefined,
   defaultPartitions: undefined,
   maxPartitions: undefined,
   defaultReplicationFactor: undefined,
   maxReplicationFactor: undefined,
-  showDeleteEnv: false,
-  totalNoPages: "1",
-  allPageNos: ["1"],
+  clusterType: "ALL",
 };
 
 function createMockEnvironmentDTO(

--- a/coral/src/domain/environment/environment-transformer.ts
+++ b/coral/src/domain/environment/environment-transformer.ts
@@ -1,13 +1,13 @@
 import isString from "lodash/isString";
 import { Environment } from "src/domain/environment/environment-types";
-import { KlawApiResponse } from "types/utils";
+import { KlawApiModel } from "types/utils";
 
 function parseNumberOrUndefined(value: string | undefined): number | undefined {
   return isString(value) ? parseInt(value, 10) : undefined;
 }
 
 function transformEnvironmentApiResponse(
-  apiResponse: KlawApiResponse<"getEnvs"> | KlawApiResponse<"getSchemaRegEnvs">
+  apiResponse: KlawApiModel<"EnvModelResponse">[]
 ): Environment[] {
   return apiResponse.map((environment) => {
     const rv: Environment = {

--- a/coral/src/domain/environment/index.ts
+++ b/coral/src/domain/environment/index.ts
@@ -1,6 +1,7 @@
 import {
   getEnvironments,
   getSchemaRegistryEnvironments,
+  getSyncConnectorsEnvironments,
 } from "src/domain/environment/environment-api";
 import { mockGetEnvironments } from "src/domain/environment/environment-api.msw";
 import {
@@ -13,5 +14,6 @@ export {
   mockGetEnvironments,
   ALL_ENVIRONMENTS_VALUE,
   getSchemaRegistryEnvironments,
+  getSyncConnectorsEnvironments,
 };
 export type { Environment };


### PR DESCRIPTION
# About this change - What it does

We're getting `Environment`s user can use to e.g. filter requests by through different endpoints. This PR updates the `EnvironmentFilter` component to define which endpoints it gets the Environments from so we can reuse it in different cases. 

It also updates the transformer / helper to reflect the `Environment` concept better (the Backend has the concept of an `EnvModel` but this is only used when creating a new Environment)

