### PR TITLE
feat(coral): Approve connector request: Add `Connectors` tab content (`DataTable`, filters)

### DIFF
--- a/coral/src/app/features/approvals/components/ApprovalResourceTabs.test.tsx
+++ b/coral/src/app/features/approvals/components/ApprovalResourceTabs.test.tsx
@@ -142,13 +142,12 @@ describe("ApprovalResourceTabs", () => {
         replace: true,
       });
     });
-    // Tab is disabled because Connectors are not yet implemented in coral
-    // @TODO uncomment test when Connectors are implemented
-    // it('navigates to correct URL when "Connectors" tab is clicked', async () => {
-    //   await user.click(screen.getByRole("tab", { name: "Connectors" }));
-    //   expect(mockedNavigate).toHaveBeenCalledWith("/approvals/connectors", {
-    //     replace: true,
-    //   });
-    // });
+
+    it('navigates to correct URL when "Connectors" tab is clicked', async () => {
+      await user.click(screen.getByRole("tab", { name: "Connectors" }));
+      expect(mockedNavigate).toHaveBeenCalledWith("/approvals/connectors", {
+        replace: true,
+      });
+    });
   });
 });

--- a/coral/src/app/features/approvals/components/ApprovalResourceTabs.tsx
+++ b/coral/src/app/features/approvals/components/ApprovalResourceTabs.tsx
@@ -49,11 +49,10 @@ function ApprovalResourceTabs({ currentTab }: Props) {
         {currentTab === ApprovalsTabEnum.SCHEMAS && <Outlet />}
       </Tabs.Tab>
       <Tabs.Tab
-        title="Connectors (coming soon)"
+        title="Kafka connectors"
         value={ApprovalsTabEnum.CONNECTORS}
         badge={getBadgeValue(data?.CONNECTOR)}
         aria-label={getTabAriaLabel("Connectors", data?.CONNECTOR)}
-        disabled
       >
         {currentTab === ApprovalsTabEnum.CONNECTORS && <Outlet />}
       </Tabs.Tab>

--- a/coral/src/app/features/approvals/connectors/ConnectorApprovals.test.tsx
+++ b/coral/src/app/features/approvals/connectors/ConnectorApprovals.test.tsx
@@ -1,0 +1,381 @@
+import { cleanup, screen, within } from "@testing-library/react";
+import { waitForElementToBeRemoved } from "@testing-library/react/pure";
+import userEvent from "@testing-library/user-event";
+import ConnectorApprovals from "src/app/features/approvals/connectors/ConnectorApprovals";
+import {
+  ConnectorRequest,
+  getConnectorRequestsForApprover,
+} from "src/domain/connector";
+import { transformConnectorRequestApiResponse } from "src/domain/connector/connector-transformer";
+import { getSyncConnectorsEnvironments } from "src/domain/environment";
+import { createMockEnvironmentDTO } from "src/domain/environment/environment-test-helper";
+import { transformEnvironmentApiResponse } from "src/domain/environment/environment-transformer";
+import { mockIntersectionObserver } from "src/services/test-utils/mock-intersection-observer";
+import { customRender } from "src/services/test-utils/render-with-wrappers";
+
+jest.mock("src/domain/connector/connector-api.ts");
+jest.mock("src/domain/environment/environment-api.ts");
+
+const mockGetSyncConnectorsEnvironments =
+  getSyncConnectorsEnvironments as jest.MockedFunction<
+    typeof getSyncConnectorsEnvironments
+  >;
+
+const mockGetConnectorRequestsForApprover =
+  getConnectorRequestsForApprover as jest.MockedFunction<
+    typeof getConnectorRequestsForApprover
+  >;
+
+const mockedEnvironments = [
+  {
+    id: "4",
+    name: "DEV",
+    type: "kafkaconnect",
+  },
+  {
+    id: "4",
+    name: "TST",
+    type: "kafkaconnect",
+  },
+];
+
+const mockedEnvironmentResponse = transformEnvironmentApiResponse([
+  createMockEnvironmentDTO(mockedEnvironments[0]),
+  createMockEnvironmentDTO(mockedEnvironments[1]),
+]);
+
+const mockedConnectorRequests: ConnectorRequest[] = [
+  {
+    environment: "4",
+    environmentName: "DEV",
+    requestor: "aindriul",
+    teamId: 1003,
+    teamname: "Ospo",
+    requestOperationType: "DELETE",
+    requestStatus: "CREATED",
+    requesttime: "2023-04-06T08:04:39.783+00:00",
+    requesttimestring: "06-Apr-2023 08:04:39",
+    currentPage: "1",
+    totalNoPages: "1",
+    allPageNos: ["1"],
+    approvingTeamDetails:
+      "Team : Ospo, Users : muralibasani,josepprat,samulisuortti,mirjamaulbach,smustafa,amathieu,roopek,miketest,harshini,mischa,",
+    connectorName: "Mirjam-10",
+    description: "Mirjam-10",
+    connectorConfig:
+      '{\n  "name" : "Mirjam-10",\n  "topic" : "testtopic",\n  "tasks.max" : "1",\n  "topics.regex" : "*",\n  "connector.class" : "io.confluent.connect.storage.tools.ConnectorSourceConnector"\n}',
+    connectorId: 1026,
+    deletable: false,
+    editable: false,
+  },
+  {
+    environment: "4",
+    environmentName: "DEV",
+    requestor: "miketest",
+    teamId: 1003,
+    teamname: "Ospo",
+    requestOperationType: "CREATE",
+    requestStatus: "CREATED",
+    requesttime: "2023-04-04T13:12:32.970+00:00",
+    requesttimestring: "04-Apr-2023 13:12:32",
+    currentPage: "1",
+    totalNoPages: "1",
+    allPageNos: ["1"],
+    approvingTeamDetails:
+      "Team : Ospo, Users : muralibasani,josepprat,samulisuortti,mirjamaulbach,smustafa,amathieu,aindriul,roopek,harshini,mischa,",
+    connectorName: "Mirjam-7",
+    description: "Mirjam-7",
+    connectorConfig:
+      '{\n  "name" : "Mirjam-2",\n  "topic" : "testtopic",\n  "tasks.max" : "1",\n  "topics.regex" : "*",\n  "connector.class" : "io.confluent.connect.storage.tools.ConnectorSourceConnector"\n}',
+    connectorId: 1010,
+    deletable: false,
+    editable: false,
+  },
+];
+
+const mockedApiResponseConnectorRequests = transformConnectorRequestApiResponse(
+  mockedConnectorRequests
+);
+
+describe("ConnectorApprovals", () => {
+  const defaultApiParams = {
+    pageNo: "1",
+    requestStatus: "CREATED",
+    env: "ALL",
+    search: "",
+  };
+  beforeAll(() => {
+    mockIntersectionObserver();
+  });
+
+  //@TODO - I remove the useQuery mock because that isn't useful for a component
+  // using more then one query. While this block still covers the cases, it's
+  // more brittle due to it's dependency on the async process of the api call
+  // I'll add a helper for controlling api mocks better (get a loading state etc)
+  // after this release cycle.
+  describe("handles loading and error state when fetching the requests", () => {
+    const originalConsoleError = console.error;
+    beforeEach(() => {
+      // used to swallow a console.error that _should_ happen
+      // while making sure to not swallow other console.errors
+      console.error = jest.fn();
+
+      mockGetConnectorRequestsForApprover.mockResolvedValue({
+        entries: [],
+        totalPages: 1,
+        currentPage: 1,
+      });
+      mockGetSyncConnectorsEnvironments.mockResolvedValue([]);
+    });
+
+    afterEach(() => {
+      console.error = originalConsoleError;
+      cleanup();
+      jest.clearAllMocks();
+    });
+
+    it("shows a loading state instead of a table while schema requests are being fetched", () => {
+      customRender(<ConnectorApprovals />, {
+        queryClient: true,
+        memoryRouter: true,
+      });
+
+      const table = screen.queryByRole("table");
+      const loading = screen.getByTestId("skeleton-table");
+
+      expect(table).not.toBeInTheDocument();
+      expect(loading).toBeVisible();
+      expect(console.error).not.toHaveBeenCalled();
+    });
+
+    it("shows a error message in case of an error for fetching schema requests", async () => {
+      mockGetConnectorRequestsForApprover.mockRejectedValue("mock-error");
+
+      customRender(<ConnectorApprovals />, {
+        queryClient: true,
+        memoryRouter: true,
+      });
+
+      const table = screen.queryByRole("table");
+      const errorMessage = await screen.findByText(
+        "Unexpected error. Please try again later!"
+      );
+
+      expect(table).not.toBeInTheDocument();
+      expect(errorMessage).toBeVisible();
+      expect(console.error).toHaveBeenCalledWith("mock-error");
+    });
+  });
+
+  describe("renders all necessary elements", () => {
+    beforeAll(async () => {
+      mockGetSyncConnectorsEnvironments.mockResolvedValue(
+        mockedEnvironmentResponse
+      );
+      mockGetConnectorRequestsForApprover.mockResolvedValue(
+        mockedApiResponseConnectorRequests
+      );
+
+      customRender(<ConnectorApprovals />, {
+        queryClient: true,
+        memoryRouter: true,
+      });
+
+      await waitForElementToBeRemoved(screen.getByTestId("skeleton-table"));
+    });
+
+    afterAll(() => {
+      cleanup();
+      jest.clearAllMocks();
+    });
+
+    it("shows a select to filter by environment with default", () => {
+      const select = screen.getByLabelText("Filter by Environment");
+
+      expect(select).toBeVisible();
+      expect(select).toHaveDisplayValue("All Environments");
+    });
+
+    it("shows a select to filter by status with default value", () => {
+      const select = screen.getByRole("combobox", {
+        name: "Filter by status",
+      });
+
+      expect(select).toBeVisible();
+      expect(select).toHaveDisplayValue("Awaiting approval");
+    });
+
+    it("shows a search input to search for topic names", () => {
+      const search = screen.getByRole("search");
+
+      expect(search).toBeVisible();
+      expect(search).toHaveAccessibleDescription(
+        'Search for an partial match in name. Searching starts automatically with a little delay while typing. Press "Escape" to delete all your input.'
+      );
+    });
+
+    it("shows a table with all schema requests and a header row", () => {
+      const table = screen.getByRole("table", {
+        name: "Connector approval requests, page 1 of 1",
+      });
+      const rows = within(table).getAllByRole("row");
+
+      expect(table).toBeVisible();
+      expect(rows).toHaveLength(
+        mockedApiResponseConnectorRequests.entries.length + 1
+      );
+    });
+  });
+
+  describe("renders pagination dependent on response", () => {
+    beforeEach(() => {
+      mockGetConnectorRequestsForApprover.mockResolvedValue({
+        entries: [],
+        totalPages: 1,
+        currentPage: 1,
+      });
+      mockGetSyncConnectorsEnvironments.mockResolvedValue([]);
+    });
+
+    afterEach(() => {
+      cleanup();
+      jest.clearAllMocks();
+    });
+
+    it("fetches the right page number if a page is set in search params", async () => {
+      const routePath = `/?page=100`;
+      customRender(<ConnectorApprovals />, {
+        queryClient: true,
+        memoryRouter: true,
+        customRoutePath: routePath,
+      });
+
+      await waitForElementToBeRemoved(screen.getByTestId("skeleton-table"));
+
+      expect(mockGetConnectorRequestsForApprover).toHaveBeenCalledWith({
+        ...defaultApiParams,
+        pageNo: "100",
+      });
+    });
+
+    it("fetches the first page if no search param is defined", async () => {
+      customRender(<ConnectorApprovals />, {
+        queryClient: true,
+        memoryRouter: true,
+      });
+
+      await waitForElementToBeRemoved(screen.getByTestId("skeleton-table"));
+
+      expect(mockGetConnectorRequestsForApprover).toHaveBeenCalledWith({
+        ...defaultApiParams,
+        pageNo: "1",
+      });
+    });
+
+    it("shows no pagination for a response with only one page", async () => {
+      mockGetConnectorRequestsForApprover.mockResolvedValue({
+        ...mockedApiResponseConnectorRequests,
+        totalPages: 1,
+      });
+
+      customRender(<ConnectorApprovals />, {
+        queryClient: true,
+        memoryRouter: true,
+      });
+
+      await waitForElementToBeRemoved(screen.getByTestId("skeleton-table"));
+
+      const pagination = screen.queryByRole("navigation", {
+        name: /Pagination/,
+      });
+      expect(pagination).not.toBeInTheDocument();
+    });
+
+    it("shows a pagination when response has more then one page", async () => {
+      mockGetConnectorRequestsForApprover.mockResolvedValue({
+        totalPages: 4,
+        currentPage: 1,
+        entries: [],
+      });
+
+      customRender(<ConnectorApprovals />, {
+        queryClient: true,
+        memoryRouter: true,
+      });
+
+      await waitForElementToBeRemoved(screen.getByTestId("skeleton-table"));
+
+      const pagination = screen.getByRole("navigation", {
+        name: "Pagination navigation, you're on page 1 of 4",
+      });
+      expect(pagination).toBeVisible();
+    });
+
+    it("shows the currently active page based on api response", async () => {
+      mockGetConnectorRequestsForApprover.mockResolvedValue({
+        totalPages: 4,
+        currentPage: 2,
+        entries: [],
+      });
+
+      customRender(<ConnectorApprovals />, {
+        queryClient: true,
+        memoryRouter: true,
+      });
+
+      await waitForElementToBeRemoved(screen.getByTestId("skeleton-table"));
+
+      const pagination = screen.getByRole("navigation", {
+        name: "Pagination navigation, you're on page 2 of 4",
+      });
+      expect(pagination).toBeVisible();
+    });
+  });
+
+  describe("handles user stepping through pagination", () => {
+    beforeEach(async () => {
+      mockGetConnectorRequestsForApprover.mockResolvedValue({
+        totalPages: 3,
+        currentPage: 1,
+        entries: [],
+      });
+
+      mockGetSyncConnectorsEnvironments.mockResolvedValue([]);
+
+      customRender(<ConnectorApprovals />, {
+        queryClient: true,
+        memoryRouter: true,
+      });
+
+      await waitForElementToBeRemoved(screen.getByTestId("skeleton-table"));
+    });
+
+    afterEach(() => {
+      jest.clearAllMocks();
+      cleanup();
+    });
+
+    it("shows page 1 as currently active page and the total page number", () => {
+      const pagination = screen.getByRole("navigation", {
+        name: /Pagination/,
+      });
+
+      expect(pagination).toHaveAccessibleName(
+        "Pagination navigation, you're on page 1 of 3"
+      );
+    });
+
+    it("fetches new data when user clicks on next page", async () => {
+      const pageTwoButton = screen.getByRole("button", {
+        name: "Go to next page, page 2",
+      });
+
+      await userEvent.click(pageTwoButton);
+
+      expect(mockGetConnectorRequestsForApprover).toHaveBeenNthCalledWith(2, {
+        ...defaultApiParams,
+        pageNo: "2",
+      });
+    });
+  });
+});

--- a/coral/src/app/features/approvals/connectors/ConnectorApprovals.tsx
+++ b/coral/src/app/features/approvals/connectors/ConnectorApprovals.tsx
@@ -1,5 +1,98 @@
+import { useQuery } from "@tanstack/react-query";
+import { useSearchParams } from "react-router-dom";
+import { Pagination } from "src/app/components/Pagination";
+import ConnectorApprovalsTable from "src/app/features/approvals/connectors/components/ConnectorApprovalsTable";
+import EnvironmentFilter from "src/app/features/components/filters/EnvironmentFilter";
+import { RequestTypeFilter } from "src/app/features/components/filters/RequestTypeFilter";
+import SearchFilter from "src/app/features/components/filters/SearchFilter";
+import StatusFilter from "src/app/features/components/filters/StatusFilter";
+import { useFiltersValues } from "src/app/features/components/filters/useFiltersValues";
+import { TableLayout } from "src/app/features/components/layouts/TableLayout";
+import { getConnectorRequestsForApprover } from "src/domain/connector";
+
+const defaultType = "ALL";
+
 function ConnectorApprovals() {
-  return <p>ConnectorApprovals</p>;
+  const [searchParams, setSearchParams] = useSearchParams();
+  const currentPage = searchParams.get("page")
+    ? Number(searchParams.get("page"))
+    : 1;
+
+  const { environment, status, search, requestType } = useFiltersValues({
+    defaultStatus: "CREATED",
+  });
+
+  const {
+    data: connectorRequests,
+    isLoading: connectorRequestsIsLoading,
+    isError: connectorRequestsIsError,
+    error: connectorRequestsError,
+  } = useQuery({
+    queryKey: [
+      "connectorRequestsForApprover",
+      currentPage,
+      status,
+      environment,
+      search,
+      requestType,
+    ],
+    queryFn: () =>
+      getConnectorRequestsForApprover({
+        requestStatus: status,
+        pageNo: currentPage.toString(),
+        env: environment,
+        search: search,
+        operationType: requestType !== defaultType ? requestType : undefined,
+      }),
+    keepPreviousData: true,
+  });
+
+  const table = (
+    <ConnectorApprovalsTable
+      requests={connectorRequests?.entries || []}
+      onDetails={() => null}
+      onApprove={() => null}
+      onDecline={() => null}
+      isBeingDeclined={() => false}
+      isBeingApproved={() => false}
+      ariaLabel={`Connector approval requests, page ${
+        connectorRequests?.currentPage ?? 0
+      } of ${connectorRequests?.totalPages ?? 0}`}
+    />
+  );
+
+  const setCurrentPage = (page: number) => {
+    searchParams.set("page", page.toString());
+    setSearchParams(searchParams);
+  };
+
+  const pagination =
+    connectorRequests?.totalPages && connectorRequests.totalPages > 1 ? (
+      <Pagination
+        activePage={connectorRequests.currentPage}
+        totalPages={connectorRequests?.totalPages}
+        setActivePage={setCurrentPage}
+      />
+    ) : undefined;
+
+  return (
+    <TableLayout
+      filters={[
+        <EnvironmentFilter
+          key={"environment"}
+          environmentEndpoint={"getSyncConnectorsEnvironments"}
+        />,
+        <StatusFilter key={"status"} defaultStatus={"CREATED"} />,
+        <RequestTypeFilter key={"requestType"} />,
+        <SearchFilter key={"search"} />,
+      ]}
+      table={table}
+      pagination={pagination}
+      isLoading={connectorRequestsIsLoading}
+      isErrorLoading={connectorRequestsIsError}
+      errorMessage={connectorRequestsError}
+    />
+  );
 }
 
 export default ConnectorApprovals;

--- a/coral/src/app/features/approvals/connectors/components/ConnectorApprovalsTable.test.tsx
+++ b/coral/src/app/features/approvals/connectors/components/ConnectorApprovalsTable.test.tsx
@@ -1,0 +1,506 @@
+import { cleanup, render, screen, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import ConnectorApprovalsTable from "src/app/features/approvals/connectors/components/ConnectorApprovalsTable";
+import { requestOperationTypeNameMap } from "src/app/features/approvals/utils/request-operation-type-helper";
+import { requestStatusNameMap } from "src/app/features/approvals/utils/request-status-helper";
+import { ConnectorRequest } from "src/domain/connector";
+import {
+  RequestOperationType,
+  RequestStatus,
+} from "src/domain/requests/requests-types";
+import { mockIntersectionObserver } from "src/services/test-utils/mock-intersection-observer";
+
+const mockedConnectorRequests: ConnectorRequest[] = [
+  {
+    environment: "4",
+    environmentName: "DEV",
+    requestor: "aindriul",
+    teamId: 1003,
+    teamname: "Ospo",
+    requestOperationType: "DELETE",
+    requestStatus: "CREATED",
+    requesttime: "2023-04-06T08:04:39.783+00:00",
+    requesttimestring: "06-Apr-2023 08:04:39",
+    currentPage: "1",
+    totalNoPages: "1",
+    allPageNos: ["1"],
+    approvingTeamDetails:
+      "Team : Ospo, Users : muralibasani,josepprat,samulisuortti,mirjamaulbach,smustafa,amathieu,roopek,miketest,harshini,mischa,",
+    connectorName: "Mirjam-10",
+    description: "Mirjam-10",
+    connectorConfig:
+      '{\n  "name" : "Mirjam-10",\n  "topic" : "testtopic",\n  "tasks.max" : "1",\n  "topics.regex" : "*",\n  "connector.class" : "io.confluent.connect.storage.tools.ConnectorSourceConnector"\n}',
+    connectorId: 1026,
+    deletable: false,
+    editable: false,
+  },
+  {
+    environment: "5",
+    environmentName: "TST",
+    requestor: "miketest",
+    teamId: 1003,
+    teamname: "Ospo",
+    requestOperationType: "CREATE",
+    requestStatus: "APPROVED",
+    requesttime: "2023-04-04T13:12:32.970+00:00",
+    requesttimestring: "04-Apr-2023 13:12:32",
+    currentPage: "1",
+    totalNoPages: "1",
+    allPageNos: ["1"],
+    approvingTeamDetails:
+      "Team : Ospo, Users : muralibasani,josepprat,samulisuortti,mirjamaulbach,smustafa,amathieu,aindriul,roopek,harshini,mischa,",
+    connectorName: "Mirjam-7",
+    description: "Mirjam-7",
+    connectorConfig:
+      '{\n  "name" : "Mirjam-2",\n  "topic" : "testtopic",\n  "tasks.max" : "1",\n  "topics.regex" : "*",\n  "connector.class" : "io.confluent.connect.storage.tools.ConnectorSourceConnector"\n}',
+    connectorId: 1010,
+    deletable: false,
+    editable: false,
+  },
+];
+
+const createdRequests = mockedConnectorRequests.filter(
+  (request) => request.requestStatus === "CREATED"
+);
+
+const mockApproveRequest = jest.fn();
+
+describe("ConnectorApprovalsTable", () => {
+  beforeAll(mockIntersectionObserver);
+
+  const columnsFieldMap = [
+    { columnHeader: "Connector name", relatedField: "connectorName" },
+    { columnHeader: "Environment", relatedField: "environmentName" },
+    { columnHeader: "Status", relatedField: "requestStatus" },
+    { columnHeader: "Request type", relatedField: "requestOperationType" },
+    { columnHeader: "Requested by", relatedField: "requestor" },
+    { columnHeader: "Requested on", relatedField: "requesttimestring" },
+    { columnHeader: "Details", relatedField: null },
+    { columnHeader: "Approve", relatedField: null },
+    { columnHeader: "Decline", relatedField: null },
+  ];
+
+  it("shows a message to user in case there are no requests that match the search criteria", () => {
+    render(
+      <ConnectorApprovalsTable
+        requests={[]}
+        onDetails={jest.fn()}
+        onApprove={mockApproveRequest}
+        onDecline={jest.fn()}
+        isBeingApproved={jest.fn()}
+        isBeingDeclined={jest.fn()}
+        ariaLabel={"Connector approval requests, page 1 of 10"}
+      />
+    );
+    screen.getByText("No Kafka connector requests");
+    screen.getByText("No Kafka connector request matched your criteria.");
+  });
+
+  describe("user is able to view all the necessary Kafka connector request data and actions", () => {
+    beforeAll(() => {
+      render(
+        <ConnectorApprovalsTable
+          requests={mockedConnectorRequests}
+          onDetails={jest.fn()}
+          onApprove={jest.fn()}
+          onDecline={jest.fn()}
+          isBeingApproved={jest.fn()}
+          isBeingDeclined={jest.fn()}
+          ariaLabel={"Connector approval requests, page 1 of 10"}
+        />
+      );
+    });
+    afterAll(cleanup);
+
+    it("shows a table with all Kafka connector requests", () => {
+      const table = screen.getByRole("table", {
+        name: "Connector approval requests, page 1 of 10",
+      });
+
+      expect(table).toBeVisible();
+    });
+
+    it("shows all column headers", () => {
+      const table = screen.getByRole("table", {
+        name: "Connector approval requests, page 1 of 10",
+      });
+      const header = within(table).getAllByRole("columnheader");
+
+      expect(header).toHaveLength(columnsFieldMap.length);
+    });
+
+    it("shows a row for each given requests plus header row", () => {
+      const table = screen.getByRole("table", {
+        name: "Connector approval requests, page 1 of 10",
+      });
+      const row = within(table).getAllByRole("row");
+
+      expect(row).toHaveLength(mockedConnectorRequests.length + 1);
+    });
+
+    it("shows an detail button for every row", () => {
+      const table = screen.getByRole("table", {
+        name: "Connector approval requests, page 1 of 10",
+      });
+      const buttons = within(table).getAllByRole("button", {
+        name: /View Kafka connector request for /,
+      });
+
+      expect(buttons).toHaveLength(mockedConnectorRequests.length);
+    });
+
+    it("shows an approve button for every row", () => {
+      const table = screen.getByRole("table", {
+        name: "Connector approval requests, page 1 of 10",
+      });
+      const buttons = within(table).getAllByRole("button", {
+        name: /Approve Kafka connector request for /,
+      });
+
+      expect(buttons).toHaveLength(mockedConnectorRequests.length);
+    });
+
+    it("shows an decline button for every row", () => {
+      const table = screen.getByRole("table", {
+        name: "Connector approval requests, page 1 of 10",
+      });
+      const buttons = within(table).getAllByRole("button", {
+        name: /Decline Kafka connector request for /,
+      });
+
+      expect(buttons).toHaveLength(mockedConnectorRequests.length);
+    });
+
+    mockedConnectorRequests.forEach((request) => {
+      it(`shows a button to show the detailed Kafka connector request for topic name ${request.connectorName}`, () => {
+        const table = screen.getByRole("table", {
+          name: "Connector approval requests, page 1 of 10",
+        });
+        const button = within(table).getByRole("button", {
+          name: `View Kafka connector request for ${request.connectorName}`,
+        });
+
+        expect(button).toBeEnabled();
+      });
+    });
+
+    createdRequests.forEach((request) => {
+      it(`shows a button to approve Kafka connector request for topic name ${request.connectorName}`, () => {
+        const table = screen.getByRole("table", {
+          name: "Connector approval requests, page 1 of 10",
+        });
+        const button = within(table).getByRole("button", {
+          name: `Approve Kafka connector request for ${request.connectorName}`,
+        });
+
+        expect(button).toBeEnabled();
+      });
+
+      it(`shows a button to approve Kafka connector request for topic name ${request.connectorName}`, () => {
+        const table = screen.getByRole("table", {
+          name: "Connector approval requests, page 1 of 10",
+        });
+        const button = within(table).getByRole("button", {
+          name: `Decline Kafka connector request for ${request.connectorName}`,
+        });
+
+        expect(button).toBeEnabled();
+      });
+    });
+  });
+
+  describe("renders all content based on the column definition", () => {
+    beforeAll(() => {
+      render(
+        <ConnectorApprovalsTable
+          requests={mockedConnectorRequests}
+          onDetails={jest.fn()}
+          onApprove={jest.fn()}
+          onDecline={jest.fn()}
+          isBeingApproved={jest.fn()}
+          isBeingDeclined={jest.fn()}
+          ariaLabel={"Connector approval requests, page 1 of 10"}
+        />
+      );
+    });
+
+    afterAll(cleanup);
+
+    it(`renders the right amount of cells`, () => {
+      const table = screen.getByRole("table", {
+        name: "Connector approval requests, page 1 of 10",
+      });
+      const cells = within(table).getAllByRole("cell");
+
+      expect(cells).toHaveLength(
+        columnsFieldMap.length * mockedConnectorRequests.length
+      );
+    });
+
+    columnsFieldMap.forEach((column) => {
+      it(`shows a column header for ${column.columnHeader}`, () => {
+        const table = screen.getByRole("table", {
+          name: "Connector approval requests, page 1 of 10",
+        });
+        const header = within(table).getByRole("columnheader", {
+          name: column.columnHeader,
+        });
+
+        expect(header).toBeVisible();
+      });
+
+      if (column.relatedField) {
+        mockedConnectorRequests.forEach((request) => {
+          it(`shows field ${column.relatedField} for request number ${request.connectorId}`, () => {
+            const table = screen.getByRole("table", {
+              name: "Connector approval requests, page 1 of 10",
+            });
+
+            // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+            //@ts-ignore
+            const field = request[column.relatedField];
+
+            let text = field;
+            if (column.columnHeader === "Requested on") {
+              text = `${field}${"\u00A0"}UTC`;
+            }
+
+            if (column.columnHeader === "Status") {
+              text = requestStatusNameMap[field as RequestStatus];
+            }
+
+            if (column.columnHeader === "Request type") {
+              text = requestOperationTypeNameMap[field as RequestOperationType];
+            }
+
+            const cell = within(table).getByRole("cell", { name: text });
+
+            expect(cell).toBeVisible();
+          });
+        });
+      }
+    });
+  });
+
+  describe("triggers opening of a modal with all details if user clicks button for overview", () => {
+    const onDetails = jest.fn();
+    beforeEach(() => {
+      render(
+        <ConnectorApprovalsTable
+          requests={mockedConnectorRequests}
+          onDetails={onDetails}
+          onApprove={jest.fn()}
+          onDecline={jest.fn()}
+          isBeingApproved={jest.fn()}
+          isBeingDeclined={jest.fn()}
+          ariaLabel={"Connector approval requests, page 1 of 10"}
+        />
+      );
+    });
+    afterEach(() => {
+      cleanup(), jest.clearAllMocks();
+    });
+    it("triggers details action for the corresponding request when clicked", async () => {
+      const table = screen.getByRole("table", {
+        name: "Connector approval requests, page 1 of 10",
+      });
+      const rows = within(table).getAllByRole("row");
+      const createdRequestRow = rows[1];
+      await userEvent.click(
+        within(createdRequestRow).getByRole("button", {
+          name: "View Kafka connector request for Mirjam-10",
+        })
+      );
+      expect(onDetails).toHaveBeenCalledTimes(1);
+      expect(onDetails).toHaveBeenCalledWith(1026);
+    });
+  });
+
+  describe("user is able to approve and decline pending requests", () => {
+    const onApprove = jest.fn();
+    const onDecline = jest.fn();
+    beforeEach(() => {
+      render(
+        <ConnectorApprovalsTable
+          requests={mockedConnectorRequests}
+          onDetails={jest.fn()}
+          onApprove={onApprove}
+          onDecline={onDecline}
+          isBeingApproved={jest.fn()}
+          isBeingDeclined={jest.fn()}
+          ariaLabel={"Connector approval requests, page 1 of 10"}
+        />
+      );
+    });
+    afterEach(cleanup);
+    it("triggers approve action for the corresponding request when clicked", async () => {
+      const table = screen.getByRole("table", {
+        name: "Connector approval requests, page 1 of 10",
+      });
+      const rows = within(table).getAllByRole("row");
+      const createdRequestRow = rows[1];
+      const approve = within(createdRequestRow).getByRole("button", {
+        name: "Approve Kafka connector request for Mirjam-10",
+      });
+      await userEvent.click(approve);
+      expect(onApprove).toHaveBeenCalledTimes(1);
+      expect(onApprove).toHaveBeenCalledWith(1026);
+    });
+    it("triggers decline action for the corresponding request when clicked", async () => {
+      const table = screen.getByRole("table", {
+        name: "Connector approval requests, page 1 of 10",
+      });
+      const rows = within(table).getAllByRole("row");
+      const createdRequestRow = rows[1];
+      const decline = within(createdRequestRow).getByRole("button", {
+        name: "Decline Kafka connector request for Mirjam-10",
+      });
+      await userEvent.click(decline);
+      expect(onDecline).toHaveBeenCalledTimes(1);
+      expect(onDecline).toHaveBeenCalledWith(1026);
+    });
+  });
+
+  describe("user is unable to approve and decline non pending requests", () => {
+    beforeEach(() => {
+      render(
+        <ConnectorApprovalsTable
+          requests={mockedConnectorRequests}
+          onDetails={jest.fn()}
+          onApprove={jest.fn()}
+          onDecline={jest.fn()}
+          isBeingApproved={jest.fn()}
+          isBeingDeclined={jest.fn()}
+          ariaLabel={"Connector approval requests, page 1 of 10"}
+        />
+      );
+    });
+    afterEach(cleanup);
+    it("disables approve action if request is not in created state", async () => {
+      const table = screen.getByRole("table", {
+        name: "Connector approval requests, page 1 of 10",
+      });
+      const rows = within(table).getAllByRole("row");
+      const approvedRequestRow = rows[2];
+      const approve = within(approvedRequestRow).getByRole("button", {
+        name: "Approve Kafka connector request for Mirjam-7",
+      });
+      expect(approve).toBeDisabled();
+    });
+    it("disables decline action if request is not in created state", async () => {
+      const table = screen.getByRole("table", {
+        name: "Connector approval requests, page 1 of 10",
+      });
+      const rows = within(table).getAllByRole("row");
+      const approvedRequestRow = rows[2];
+      const decline = within(approvedRequestRow).getByRole("button", {
+        name: "Decline Kafka connector request for Mirjam-7",
+      });
+      expect(decline).toBeDisabled();
+    });
+  });
+
+  describe("user is unable to approve a request if the action is already in progress", () => {
+    const isBeingApproved = jest.fn(() => true);
+    const isBeingDeclined = jest.fn(() => true);
+    beforeEach(() => {
+      render(
+        <ConnectorApprovalsTable
+          requests={mockedConnectorRequests}
+          onDetails={jest.fn()}
+          onApprove={jest.fn()}
+          onDecline={jest.fn()}
+          isBeingApproved={isBeingApproved}
+          isBeingDeclined={isBeingDeclined}
+          ariaLabel={"Connector approval requests, page 1 of 10"}
+        />
+      );
+    });
+    afterEach(cleanup);
+    it("disables approve action if request is already in progress", async () => {
+      const table = screen.getByRole("table", {
+        name: "Connector approval requests, page 1 of 10",
+      });
+      const rows = within(table).getAllByRole("row");
+      const createdRequestRow = rows[1];
+      const approve = within(createdRequestRow).getByRole("button", {
+        name: "Approve Kafka connector request for Mirjam-10",
+      });
+      expect(approve).toBeDisabled();
+    });
+    it("disables decline action if request is already in progress", async () => {
+      const table = screen.getByRole("table", {
+        name: "Connector approval requests, page 1 of 10",
+      });
+      const rows = within(table).getAllByRole("row");
+      const createdRequestRow = rows[1];
+      const decline = within(createdRequestRow).getByRole("button", {
+        name: "Decline Kafka connector request for Mirjam-10",
+      });
+      expect(decline).toBeDisabled();
+    });
+  });
+
+  describe("user is unable to approve or decline a request if table has actions disabled", () => {
+    const requestsWithStatusCreated = [
+      mockedConnectorRequests[0],
+      {
+        ...mockedConnectorRequests[0],
+        connectorName: "Additional-topic",
+        req_no: 1234,
+      },
+    ];
+
+    beforeAll(() => {
+      render(
+        <ConnectorApprovalsTable
+          requests={requestsWithStatusCreated}
+          actionsDisabled={true}
+          onDetails={jest.fn()}
+          onApprove={mockApproveRequest}
+          onDecline={jest.fn()}
+          isBeingApproved={jest.fn()}
+          isBeingDeclined={jest.fn()}
+          ariaLabel={"Connector approval requests, page 1 of 10"}
+        />
+      );
+    });
+
+    afterAll(cleanup);
+
+    requestsWithStatusCreated.forEach((request) => {
+      it(`disables button to approve Kafka connector request for topic name ${request.connectorName}`, () => {
+        const table = screen.getByRole("table", {
+          name: "Connector approval requests, page 1 of 10",
+        });
+        const button = within(table).getByRole("button", {
+          name: `Approve Kafka connector request for ${request.connectorName}`,
+        });
+
+        expect(button).toBeDisabled();
+      });
+
+      it(`disables button to decline Kafka connector request for topic name ${request.connectorName}`, () => {
+        const table = screen.getByRole("table", {
+          name: "Connector approval requests, page 1 of 10",
+        });
+        const button = within(table).getByRole("button", {
+          name: `Decline Kafka connector request for ${request.connectorName}`,
+        });
+
+        expect(button).toBeDisabled();
+      });
+
+      it(`does not disable details for Kafka connector request for topic name ${request.connectorName}`, () => {
+        const table = screen.getByRole("table", {
+          name: "Connector approval requests, page 1 of 10",
+        });
+        const detailsButton = within(table).getByRole("button", {
+          name: `View Kafka connector request for ${request.connectorName}`,
+        });
+
+        expect(detailsButton).toBeEnabled();
+      });
+    });
+  });
+});

--- a/coral/src/app/features/approvals/connectors/components/ConnectorApprovalsTable.tsx
+++ b/coral/src/app/features/approvals/connectors/components/ConnectorApprovalsTable.tsx
@@ -1,0 +1,188 @@
+import { DataTable, DataTableColumn, EmptyState } from "@aivenio/aquarium";
+import infoSign from "@aivenio/aquarium/icons/infoSign";
+import tickCircle from "@aivenio/aquarium/icons/tickCircle";
+import deleteIcon from "@aivenio/aquarium/icons/delete";
+import {
+  requestStatusChipStatusMap,
+  requestStatusNameMap,
+} from "src/app/features/approvals/utils/request-status-helper";
+import loadingIcon from "@aivenio/aquarium/icons/loading";
+import {
+  requestOperationTypeChipStatusMap,
+  requestOperationTypeNameMap,
+} from "src/app/features/approvals/utils/request-operation-type-helper";
+import { ConnectorRequest } from "src/domain/connector";
+
+interface ConnectorRequestTableData {
+  id: ConnectorRequest["connectorId"];
+  connectorName: ConnectorRequest["connectorName"];
+  environmentName: ConnectorRequest["environmentName"];
+  requestor: ConnectorRequest["requestor"];
+  requesttimestring: ConnectorRequest["requesttimestring"];
+  requestStatus: ConnectorRequest["requestStatus"];
+  requestOperationType: ConnectorRequest["requestOperationType"];
+}
+
+type ConnectorApprovalsTableProps = {
+  requests: ConnectorRequest[];
+  ariaLabel: string;
+  actionsDisabled?: boolean;
+  onDetails: (req_no: number) => void;
+  onApprove: (req_no: number) => void;
+  onDecline: (req_no: number) => void;
+  isBeingApproved: (req_no: number) => boolean;
+  isBeingDeclined: (req_no: number) => boolean;
+};
+
+function ConnectorApprovalsTable({
+  requests,
+  ariaLabel,
+  actionsDisabled = false,
+  onDetails,
+  onApprove,
+  onDecline,
+  isBeingApproved,
+  isBeingDeclined,
+}: ConnectorApprovalsTableProps) {
+  const columns: Array<DataTableColumn<ConnectorRequestTableData>> = [
+    { type: "text", field: "connectorName", headerName: "Connector name" },
+    {
+      type: "status",
+      field: "environmentName",
+      headerName: "Environment",
+      status: ({ environmentName }) => {
+        return {
+          status: "neutral",
+          text: environmentName,
+        };
+      },
+    },
+    {
+      type: "status",
+      field: "requestStatus",
+      headerName: "Status",
+      status: ({ requestStatus }) => {
+        return {
+          status: requestStatusChipStatusMap[requestStatus],
+          text: requestStatusNameMap[requestStatus],
+        };
+      },
+    },
+    {
+      type: "status",
+      field: "requestOperationType",
+      headerName: "Request type",
+      status: ({ requestOperationType }) => {
+        return {
+          status: requestOperationTypeChipStatusMap[requestOperationType],
+          text: requestOperationTypeNameMap[requestOperationType],
+        };
+      },
+    },
+    { type: "text", field: "requestor", headerName: "Requested by" },
+    {
+      type: "text",
+      field: "requesttimestring",
+      headerName: "Requested on",
+      formatter: (value) => {
+        return `${value}${"\u00A0"}UTC`;
+      },
+    },
+    {
+      type: "action",
+      headerName: "Details",
+      headerInvisible: true,
+      width: 30,
+      action: (request) => ({
+        onClick: () => onDetails(request.id),
+        icon: infoSign,
+        text: "View",
+        "aria-label": `View Kafka connector request for ${request.connectorName}`,
+      }),
+    },
+    {
+      type: "action",
+      headerName: "Approve",
+      headerInvisible: true,
+      width: 30,
+      action: (request) => {
+        const approveInProgress = isBeingApproved(request.id);
+        const declineInProgress = isBeingDeclined(request.id);
+        return {
+          onClick: () => onApprove(request.id),
+          text: "Approve",
+          "aria-label": `Approve Kafka connector request for ${request.connectorName}`,
+          disabled:
+            approveInProgress ||
+            declineInProgress ||
+            actionsDisabled ||
+            request.requestStatus !== "CREATED",
+          icon: approveInProgress ? loadingIcon : tickCircle,
+          loading: approveInProgress,
+        };
+      },
+    },
+    {
+      type: "action",
+      headerName: "Decline",
+      headerInvisible: true,
+      width: 30,
+      action: (request) => {
+        const approveInProgress = isBeingApproved(request.id);
+        const declineInProgress = isBeingDeclined(request.id);
+        return {
+          onClick: () => onDecline(request.id),
+          text: "Decline",
+          "aria-label": `Decline Kafka connector request for ${request.connectorName}`,
+          disabled:
+            approveInProgress ||
+            declineInProgress ||
+            actionsDisabled ||
+            request.requestStatus !== "CREATED",
+          icon: declineInProgress ? loadingIcon : deleteIcon,
+          loading: declineInProgress,
+        };
+      },
+    },
+  ];
+  const rows: ConnectorRequestTableData[] = requests.map(
+    ({
+      connectorId,
+      connectorName,
+      environmentName,
+      requestor,
+      requesttimestring,
+      requestStatus,
+      requestOperationType,
+    }: ConnectorRequest) => {
+      return {
+        id: connectorId,
+        connectorName,
+        environmentName,
+        requestor,
+        requesttimestring,
+        requestStatus,
+        requestOperationType,
+      };
+    }
+  );
+
+  if (!rows.length) {
+    return (
+      <EmptyState title="No Kafka connector requests">
+        No Kafka connector request matched your criteria.
+      </EmptyState>
+    );
+  }
+
+  return (
+    <DataTable
+      ariaLabel={ariaLabel}
+      columns={columns}
+      rows={rows}
+      noWrap={false}
+    />
+  );
+}
+
+export default ConnectorApprovalsTable;


### PR DESCRIPTION
## About this change - What it does

- enable the connectors tab in Approval page
- Add connectors table
- Add filters


https://user-images.githubusercontent.com/20607294/231186604-71d12efd-ec9f-4a46-afb9-d6477c334f34.mov


## Followup

The View, Approve and Reject buttons are nonfunctional, feature to be added in issue 
#1014 

Resolves: #1013
