### PR TITLE
feat(coral): Add filter for Environment and search field.

### DIFF
--- a/coral/src/app/features/connectors/browse/BrowseConnectors.tsx
+++ b/coral/src/app/features/connectors/browse/BrowseConnectors.tsx
@@ -4,12 +4,16 @@ import ConnectorTable from "src/app/features/connectors/browse/components/Connec
 import { useQuery } from "@tanstack/react-query";
 import { getConnectors } from "src/domain/connector/connector-api";
 import { useSearchParams } from "react-router-dom";
+import EnvironmentFilter from "src/app/features/components/filters/EnvironmentFilter";
+import { useFiltersValues } from "src/app/features/components/filters/useFiltersValues";
+import SearchFilter from "src/app/features/components/filters/SearchFilter";
 
 function BrowseConnectors() {
   const [searchParams, setSearchParams] = useSearchParams();
   const currentPage = searchParams.get("page")
     ? Number(searchParams.get("page"))
     : 1;
+  const { environment, search } = useFiltersValues();
 
   const {
     data: connectors,
@@ -17,11 +21,12 @@ function BrowseConnectors() {
     isError,
     error,
   } = useQuery({
-    queryKey: ["browseConnectors", currentPage],
+    queryKey: ["browseConnectors", currentPage, environment, search],
     queryFn: () =>
       getConnectors({
-        currentPage,
-        environment: "ALL",
+        pageNo: currentPage.toString(),
+        env: environment,
+        connectornamesearch: search.length === 0 ? undefined : search,
       }),
     keepPreviousData: true,
   });
@@ -42,7 +47,13 @@ function BrowseConnectors() {
 
   return (
     <TableLayout
-      filters={[]}
+      filters={[
+        <EnvironmentFilter
+          key={"environment"}
+          environmentEndpoint={"getSyncConnectorsEnvironments"}
+        />,
+        <SearchFilter key="connector-name" />,
+      ]}
       table={
         <ConnectorTable
           connectors={connectors?.entries ?? []}

--- a/coral/src/app/features/topics/browse/BrowseTopics.test.tsx
+++ b/coral/src/app/features/topics/browse/BrowseTopics.test.tsx
@@ -79,7 +79,7 @@ describe("BrowseTopics.tsx", () => {
   const defaultApiParams = {
     pageNo: "1",
     env: "ALL",
-    topicnamesearch: "",
+    topicnamesearch: undefined,
     teamId: undefined,
   };
 

--- a/coral/src/app/features/topics/browse/BrowseTopics.tsx
+++ b/coral/src/app/features/topics/browse/BrowseTopics.tsx
@@ -30,7 +30,7 @@ function BrowseTopics() {
         pageNo: currentPage.toString(),
         env: environment,
         teamId: teamId === "ALL" ? undefined : Number(teamId),
-        topicnamesearch: topic,
+        topicnamesearch: topic.length === 0 ? undefined : topic,
       }),
     keepPreviousData: true,
   });

--- a/coral/src/domain/connector/connector-api.ts
+++ b/coral/src/domain/connector/connector-api.ts
@@ -10,6 +10,7 @@ import {
 } from "src/domain/requests/requests-types";
 import api from "src/services/api";
 import { KlawApiRequestQueryParameters, KlawApiResponse } from "types/utils";
+import { convertQueryValuesToString } from "src/services/api-helper";
 
 const filterGetConnectorRequestParams = (
   params: KlawApiRequestQueryParameters<"getConnectorRequests">
@@ -39,25 +40,19 @@ const filterGetConnectorRequestParams = (
   });
 };
 
-const getConnectors = ({
-  currentPage,
-  environment = "ALL",
-  teamName,
-  connectorName,
-}: {
-  currentPage: number;
-  environment: string;
-  teamName?: string;
-  connectorName?: string;
-}) => {
-  const queryParams: KlawApiRequestQueryParameters<"getConnectors"> = {
-    pageNo: currentPage.toString(),
-    env: environment,
-    ...(teamName && { teamName: teamName }),
-    ...(connectorName && {
-      connectornamesearch: connectorName,
-    }),
-  };
+const getConnectors = (
+  params: KlawApiRequestQueryParameters<"getConnectors">
+) => {
+  const queryParams = convertQueryValuesToString({
+    env: params.env,
+    pageNo: params.pageNo,
+    ...(params.teamName && { teamName: params.teamName }),
+    ...(params.connectornamesearch &&
+      params.connectornamesearch.length > 0 && {
+        connectornamesearch: params.connectornamesearch,
+      }),
+  });
+
   return api
     .get<KlawApiResponse<"getConnectors">>(
       `/getConnectors?${new URLSearchParams(queryParams)}`

--- a/coral/src/domain/topic/topic-api.ts
+++ b/coral/src/domain/topic/topic-api.ts
@@ -26,9 +26,12 @@ const getTopics = async (
   params: KlawApiRequestQueryParameters<"getTopics">
 ): Promise<TopicApiResponse> => {
   const queryParams = convertQueryValuesToString({
-    ...params,
+    pageNo: params.pageNo,
+    env: params.env,
     ...(params.teamId && { teamId: params.teamId }),
-    ...(params.topicnamesearch && { topicnamesearch: params.topicnamesearch }),
+    ...(params.topicnamesearch && {
+      topicnamesearch: params.topicnamesearch,
+    }),
   });
 
   return api


### PR DESCRIPTION
# About this change - What it does
- adds a select element to enables users to filter the Connectors by Environment 
- adds a search field to enable users searching by a Connectors name

#### Note
- `Filter by team` will be in a separate PRs as I'm waiting for a little Backend change for that (we want to use `teamId` here to be consistent with the other requests, it currently still uses `teamName`)
- The search is currently case-sensitive, this will be updated in the Backend

## Recordings
(note: I only have Connectors in `DEV` and can't create Connectors requests on different Envs as a service is not running at the moment, that's why it looks weird in the recording. API calls work like expected and I will test that manually later when the service is up!)


https://user-images.githubusercontent.com/943800/231199064-b0a2798a-c83c-4d46-a6e1-29cc56241ec8.mov



Resolves: #982 

