### PR TITLE
feat(coral): Approve connector request: Add View, Approve and Reject logic

### DIFF
--- a/coral/src/app/features/approvals/connectors/ConnectorApprovals.tsx
+++ b/coral/src/app/features/approvals/connectors/ConnectorApprovals.tsx
@@ -1,18 +1,30 @@
-import { useQuery } from "@tanstack/react-query";
+import { Alert } from "@aivenio/aquarium";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { useState } from "react";
 import { useSearchParams } from "react-router-dom";
 import { Pagination } from "src/app/components/Pagination";
+import RequestDeclineModal from "src/app/features/approvals/components/RequestDeclineModal";
 import ConnectorApprovalsTable from "src/app/features/approvals/connectors/components/ConnectorApprovalsTable";
+import { ConnectorRequestDetails } from "src/app/features/components/ConnectorDetailsModalContent";
+import RequestDetailsModal from "src/app/features/components/RequestDetailsModal";
 import EnvironmentFilter from "src/app/features/components/filters/EnvironmentFilter";
 import { RequestTypeFilter } from "src/app/features/components/filters/RequestTypeFilter";
 import SearchFilter from "src/app/features/components/filters/SearchFilter";
 import StatusFilter from "src/app/features/components/filters/StatusFilter";
 import { useFiltersValues } from "src/app/features/components/filters/useFiltersValues";
 import { TableLayout } from "src/app/features/components/layouts/TableLayout";
-import { getConnectorRequestsForApprover } from "src/domain/connector";
+import {
+  approveConnectorRequest,
+  declineConnectorRequest,
+  getConnectorRequestsForApprover,
+} from "src/domain/connector";
+import { parseErrorMsg } from "src/services/mutation-utils";
 
 const defaultType = "ALL";
 
 function ConnectorApprovals() {
+  const queryClient = useQueryClient();
+
   const [searchParams, setSearchParams] = useSearchParams();
   const currentPage = searchParams.get("page")
     ? Number(searchParams.get("page"))
@@ -21,6 +33,23 @@ function ConnectorApprovals() {
   const { environment, status, search, requestType } = useFiltersValues({
     defaultStatus: "CREATED",
   });
+
+  const [detailsModal, setDetailsModal] = useState<{
+    isOpen: boolean;
+    connectorId: number | null;
+  }>({
+    isOpen: false,
+    connectorId: null,
+  });
+  const [declineModal, setDeclineModal] = useState<{
+    isOpen: boolean;
+    connectorId: number | null;
+  }>({
+    isOpen: false,
+    connectorId: null,
+  });
+
+  const [errorQuickActions, setErrorQuickActions] = useState("");
 
   const {
     data: connectorRequests,
@@ -47,14 +76,118 @@ function ConnectorApprovals() {
     keepPreviousData: true,
   });
 
+  const {
+    mutate: declineRequest,
+    isLoading: declineIsLoading,
+    variables: declineVariables,
+  } = useMutation(declineConnectorRequest, {
+    onSuccess: () => {
+      setErrorQuickActions("");
+      // Re-fetch to update the tag number in the tabs
+      queryClient.refetchQueries(["connectorRequestsForApprover"]);
+
+      // If declined request is last in the page, go back to previous page
+      // This avoids staying on a non-existent page of entries, which makes the table bug hard
+      // With pagination being 0 of 0, and clicking Previous button sets active page at -1
+      // We also do not need to invalidate the query, as the activePage does not exist any more
+      // And there is no need to update anything on it
+      if (
+        connectorRequests?.entries.length === 1 &&
+        connectorRequests?.currentPage > 1
+      ) {
+        // setting the current page will the api call to re-fetch the connector requests
+        setCurrentPage(connectorRequests?.currentPage - 1);
+      } else {
+        // We need to refetch the connector requests to keep Table state in sync
+        queryClient.refetchQueries(["connectorRequestsForApprover"]);
+      }
+    },
+    onError(error: unknown) {
+      setErrorQuickActions(parseErrorMsg(error));
+    },
+    onSettled() {
+      closeModal();
+    },
+  });
+
+  const {
+    mutate: approveRequest,
+    isLoading: approveIsLoading,
+    variables: approveVariables,
+  } = useMutation(approveConnectorRequest, {
+    onSuccess: () => {
+      setErrorQuickActions("");
+      setDetailsModal({ isOpen: false, connectorId: null });
+      setDeclineModal({ isOpen: false, connectorId: null });
+
+      // Refetch to update the tag number in the tabs
+      queryClient.refetchQueries(["getRequestsWaitingForApproval"]);
+
+      // If declined request is last in the page, go back to previous page
+      // This avoids staying on a non-existent page of entries, which makes the table bug hard
+      // With pagination being 0 of 0, and clicking Previous button sets active page at -1
+      // We also do not need to invalidate the query, as the activePage does not exist any more
+      // And there is no need to update anything on it
+      if (
+        connectorRequests?.entries.length === 1 &&
+        connectorRequests?.currentPage > 1
+      ) {
+        return setCurrentPage(connectorRequests?.currentPage - 1);
+      }
+
+      // We need to refetch all aclrequests queries to keep Table state in sync
+      queryClient.refetchQueries(["connectorRequestsForApprover"]);
+    },
+    onError(error: Error) {
+      setErrorQuickActions(parseErrorMsg(error));
+    },
+    onSettled() {
+      closeModal();
+    },
+  });
+
+  function closeModal() {
+    setDetailsModal({ isOpen: false, connectorId: null });
+    setDeclineModal({ isOpen: false, connectorId: null });
+  }
+
+  function handleViewRequest(connectorId: number): void {
+    setDetailsModal({ isOpen: true, connectorId });
+  }
+
+  function handleApproveRequest(connectorId: number): void {
+    approveRequest({
+      reqIds: [String(connectorId)],
+    });
+  }
+
+  function handleDeclineRequest(connectorId: number): void {
+    setDeclineModal({ isOpen: true, connectorId });
+  }
+
+  function handleIsBeingApproved(connectorId: number): boolean {
+    return (
+      Boolean(approveVariables?.reqIds?.includes(String(connectorId))) &&
+      approveIsLoading
+    );
+  }
+
+  function handleIsBeingDeclined(connectorId: number): boolean {
+    return (
+      Boolean(declineVariables?.reqIds?.includes(String(connectorId))) &&
+      declineIsLoading
+    );
+  }
+
   const table = (
     <ConnectorApprovalsTable
       requests={connectorRequests?.entries || []}
-      onDetails={() => null}
-      onApprove={() => null}
-      onDecline={() => null}
-      isBeingDeclined={() => false}
-      isBeingApproved={() => false}
+      actionsDisabled={approveIsLoading || declineIsLoading}
+      onDetails={handleViewRequest}
+      onApprove={handleApproveRequest}
+      onDecline={handleDeclineRequest}
+      isBeingDeclined={handleIsBeingDeclined}
+      isBeingApproved={handleIsBeingApproved}
       ariaLabel={`Connector approval requests, page ${
         connectorRequests?.currentPage ?? 0
       } of ${connectorRequests?.totalPages ?? 0}`}
@@ -75,23 +208,82 @@ function ConnectorApprovals() {
       />
     ) : undefined;
 
+  console.log("connectorRequests", connectorRequests);
+
   return (
-    <TableLayout
-      filters={[
-        <EnvironmentFilter
-          key={"environment"}
-          environmentEndpoint={"getSyncConnectorsEnvironments"}
-        />,
-        <StatusFilter key={"status"} defaultStatus={"CREATED"} />,
-        <RequestTypeFilter key={"requestType"} />,
-        <SearchFilter key={"search"} />,
-      ]}
-      table={table}
-      pagination={pagination}
-      isLoading={connectorRequestsIsLoading}
-      isErrorLoading={connectorRequestsIsError}
-      errorMessage={connectorRequestsError}
-    />
+    <>
+      {detailsModal.isOpen && (
+        <RequestDetailsModal
+          onClose={closeModal}
+          actions={{
+            primary: {
+              text: "Approve",
+              onClick: () => {
+                if (detailsModal.connectorId === null) {
+                  throw Error("connectorId can't be null");
+                }
+                approveRequest({ reqIds: [String(detailsModal.connectorId)] });
+              },
+            },
+            secondary: {
+              text: "Decline",
+              onClick: () => {
+                setDetailsModal({ isOpen: false, connectorId: null });
+                setDeclineModal({
+                  isOpen: true,
+                  connectorId: detailsModal.connectorId,
+                });
+              },
+            },
+          }}
+          isLoading={declineIsLoading || approveIsLoading}
+          disabledActions={declineIsLoading || approveIsLoading}
+        >
+          <ConnectorRequestDetails
+            request={connectorRequests?.entries.find(
+              (request) => request.connectorId === detailsModal.connectorId
+            )}
+          />
+        </RequestDetailsModal>
+      )}
+      {declineModal.isOpen && (
+        <RequestDeclineModal
+          onClose={closeModal}
+          onCancel={closeModal}
+          onSubmit={(message: string) => {
+            if (declineModal.connectorId === null) {
+              throw Error("connectorId can't be null");
+            }
+            declineRequest({
+              reason: message,
+              reqIds: [String(declineModal.connectorId)],
+            });
+          }}
+          isLoading={declineIsLoading || approveIsLoading}
+        />
+      )}
+      {errorQuickActions && (
+        <div role="alert">
+          <Alert type="error">{errorQuickActions}</Alert>
+        </div>
+      )}
+      <TableLayout
+        filters={[
+          <EnvironmentFilter
+            key={"environment"}
+            environmentEndpoint={"getSyncConnectorsEnvironments"}
+          />,
+          <StatusFilter key={"status"} defaultStatus={"CREATED"} />,
+          <RequestTypeFilter key={"requestType"} />,
+          <SearchFilter key={"search"} />,
+        ]}
+        table={table}
+        pagination={pagination}
+        isLoading={connectorRequestsIsLoading}
+        isErrorLoading={connectorRequestsIsError}
+        errorMessage={connectorRequestsError}
+      />
+    </>
   );
 }
 

--- a/coral/src/app/features/components/ConnectorDetailsModalContent.test.tsx
+++ b/coral/src/app/features/components/ConnectorDetailsModalContent.test.tsx
@@ -1,0 +1,119 @@
+import { cleanup, render, screen, within } from "@testing-library/react";
+import { ConnectorRequestDetails } from "src/app/features/components/ConnectorDetailsModalContent";
+import { ConnectorRequest } from "src/domain/connector";
+
+const testRequest: ConnectorRequest = {
+  environment: "4",
+  environmentName: "DEV",
+  requestor: "aindriul",
+  teamId: 1003,
+  teamname: "Ospo",
+  requestOperationType: "DELETE",
+  requestStatus: "CREATED",
+  requesttime: "2023-04-06T08:04:39.783+00:00",
+  requesttimestring: "06-Apr-2023 08:04:39",
+  currentPage: "1",
+  totalNoPages: "1",
+  allPageNos: ["1"],
+  approvingTeamDetails:
+    "Team : Ospo, Users : muralibasani,josepprat,samulisuortti,mirjamaulbach,smustafa,amathieu,roopek,miketest,harshini,mischa,",
+  connectorName: "Mirjam-10",
+  description: "Mirjam-10",
+  connectorConfig:
+    '{\n  "name" : "Mirjam-10",\n  "topic" : "testtopic",\n  "tasks.max" : "1",\n  "topics.regex" : "*",\n  "connector.class" : "io.confluent.connect.storage.tools.ConnectorSourceConnector"\n}',
+  connectorId: 1026,
+  deletable: false,
+  editable: false,
+  remarks: "Hello there",
+};
+
+const findTerm = (term: string) => {
+  return screen
+    .getAllByRole("term")
+    .find((value) => value.textContent === term);
+};
+
+// since all our dt/dd pairs are always wrapped in a div
+// this makes sure the right pairs relate to each other.
+// this depends heavily on DOM structure, so it can be
+// brittle in case we change that. In that case, the helper
+// function has to be updated.
+const findDefinition = (term: HTMLElement | undefined) => {
+  if (!term) throw Error("term is null");
+  const termParent = term.parentElement;
+  if (!termParent) throw Error("term has no parent element");
+
+  return within(termParent).getByRole("definition");
+};
+
+describe("ConnectorRequestDetailsModalContent", () => {
+  describe("renders all necessary elements", () => {
+    beforeAll(() => {
+      render(<ConnectorRequestDetails request={testRequest} />);
+    });
+
+    afterAll(cleanup);
+
+    it("shows the Environment", () => {
+      const term = findTerm("Environment");
+      const definition = findDefinition(term);
+
+      expect(term).toBeVisible();
+      expect(definition).toHaveTextContent(testRequest.environmentName);
+    });
+
+    it("shows the Topic name", () => {
+      const term = findTerm("Connector name");
+      const definition = findDefinition(term);
+
+      expect(term).toBeVisible();
+      expect(definition).toHaveTextContent(testRequest.connectorName);
+    });
+
+    it("shows the Description", () => {
+      const term = findTerm("Description");
+      const definition = findDefinition(term);
+
+      expect(term).toBeVisible();
+      expect(definition).toHaveTextContent(testRequest.description);
+    });
+
+    it("shows the connector configuration", () => {
+      const term = findTerm("Connector configuration");
+      const definition = findDefinition(term);
+
+      expect(term).toBeVisible();
+
+      // Doing a toHaveTextContent assertion here does not work because of minute formatting issues
+      // We parse the stringified JSON to ensure integrity of data
+      const parsedDefinition = JSON.parse(definition.textContent as string);
+      const parsedConnectorConfig = JSON.parse(testRequest.connectorConfig);
+
+      expect(parsedDefinition).toEqual(parsedConnectorConfig);
+    });
+
+    it("shows a message to approver", () => {
+      const term = findTerm("Message for the approver");
+      const definition = findDefinition(term);
+
+      expect(term).toBeVisible();
+      expect(definition).toHaveTextContent(testRequest.remarks as string);
+    });
+
+    it("shows who requested the connector", () => {
+      const term = findTerm("Requested by");
+      const definition = findDefinition(term);
+
+      expect(term).toBeVisible();
+      expect(definition).toHaveTextContent(testRequest.requestor);
+    });
+
+    it("shows the time the connector request was made", () => {
+      const term = findTerm("Requested on");
+      const definition = findDefinition(term);
+
+      expect(term).toBeVisible();
+      expect(definition).toHaveTextContent(testRequest.requesttimestring);
+    });
+  });
+});

--- a/coral/src/app/features/components/ConnectorDetailsModalContent.tsx
+++ b/coral/src/app/features/components/ConnectorDetailsModalContent.tsx
@@ -38,7 +38,7 @@ function ConnectorRequestDetails(props: DetailsModalContentProps) {
           <dd>
             <MonacoEditor
               data-testid="kafka-connector"
-              height="300px"
+              height="250px"
               language="json"
               theme={"light"}
               value={request.connectorConfig}

--- a/coral/src/app/features/components/ConnectorDetailsModalContent.tsx
+++ b/coral/src/app/features/components/ConnectorDetailsModalContent.tsx
@@ -1,0 +1,80 @@
+import { Flexbox, Grid, GridItem, StatusChip } from "@aivenio/aquarium";
+import MonacoEditor from "@monaco-editor/react";
+import { ConnectorRequest } from "src/domain/connector";
+
+type DetailsModalContentProps = {
+  request?: ConnectorRequest;
+};
+
+const Label = ({ children }: { children: React.ReactNode }) => (
+  <dt className="inline-block mb-2 typography-small-strong text-grey-60">
+    {children}
+  </dt>
+);
+
+function ConnectorRequestDetails(props: DetailsModalContentProps) {
+  const { request } = props;
+  if (!request) return null;
+  return (
+    <Grid htmlTag={"dl"} cols={"2"} rowGap={"6"}>
+      <Flexbox direction={"column"}>
+        <Label>Environment</Label>
+        <dd>
+          <StatusChip text={request.environmentName} />
+        </dd>
+      </Flexbox>
+      <Flexbox direction={"column"}>
+        <Label>Connector name</Label>
+        <dd>{request.connectorName}</dd>
+      </Flexbox>
+
+      <GridItem colSpan={"span-2"}>
+        <Label>Description</Label>
+        <dd>{request.description}</dd>
+      </GridItem>
+      <GridItem colSpan={"span-2"}>
+        <Flexbox direction={"column"}>
+          <Label>Connector configuration</Label>
+          <dd>
+            <MonacoEditor
+              data-testid="kafka-connector"
+              height="300px"
+              language="json"
+              theme={"light"}
+              value={request.connectorConfig}
+              loading={"Loading preview"}
+              options={{
+                ariaLabel: "Connector configuration",
+                readOnly: true,
+                domReadOnly: true,
+                renderControlCharacters: false,
+                minimap: { enabled: false },
+                folding: false,
+                lineNumbers: "off",
+                scrollBeyondLastLine: false,
+              }}
+            />
+          </dd>
+        </Flexbox>
+      </GridItem>
+
+      <GridItem colSpan={"span-2"}>
+        <Flexbox direction={"column"}>
+          <Label>Message for the approver</Label>
+          <dd>{request.remarks || <i>No message</i>}</dd>
+        </Flexbox>
+      </GridItem>
+
+      <Flexbox direction={"column"}>
+        <Label>Requested by</Label>
+        <dd>{request.requestor}</dd>
+      </Flexbox>
+      <Flexbox direction={"column"}>
+        <Label>Requested on</Label>
+        <dd>{request.requesttimestring} UTC</dd>
+      </Flexbox>
+    </Grid>
+  );
+}
+
+export { ConnectorRequestDetails };

--- a/coral/src/app/features/components/SchemaRequestDetails.tsx
+++ b/coral/src/app/features/components/SchemaRequestDetails.tsx
@@ -37,7 +37,7 @@ function SchemaRequestDetails(props: DetailsModalContentProps) {
           <dd>
             <MonacoEditor
               data-testid="topic-schema"
-              height="300px"
+              height="250px"
               language="json"
               theme={"light"}
               value={request.schemafull}

--- a/coral/src/domain/connector/connector-api.ts
+++ b/coral/src/domain/connector/connector-api.ts
@@ -72,7 +72,7 @@ const getConnectorRequestsForApprover = (
 
   return api
     .get<KlawApiResponse<"getCreatedConnectorRequests">>(
-      `/getConnectorRequestsForApproval?${new URLSearchParams(filteredParams)}`
+      `/getConnectorRequestsForApprover?${new URLSearchParams(filteredParams)}`
     )
     .then(transformConnectorRequestApiResponse);
 };


### PR DESCRIPTION
## About this change - What it does

- Add `ConnectorDetailsModalContent` component
- Add Approve, Decline and Details modals and business logic handling their respective actions

https://user-images.githubusercontent.com/20607294/231417796-2b9b1fc2-8b72-4bb9-9323-d027cde232c5.mov

## Other changes

- fix `getConnectorRequestsForApproval` API endpoint path -> `getConnectorRequestsForApprover`
- make height of `MonacoEditor` for Connector and Schema requests a little smaller, to avoid rendering superfluous vertical scroll bars

### Before

<img width="1506" alt="Screenshot 2023-04-12 at 11 32 31" src="https://user-images.githubusercontent.com/20607294/231418361-b4962c1c-ad28-4286-bb3c-e8efb3e45510.png">

### After



<img width="756" alt="Screenshot 2023-04-12 at 11 32 12" src="https://user-images.githubusercontent.com/20607294/231418358-8867c417-9f73-4496-ae99-666050f6cd80.png">



Resolves: #1014
