### PR TITLE
Add case insensitive checks

### DIFF
--- a/core/src/main/java/io/aiven/klaw/helpers/db/rdbms/SelectDataJdbc.java
+++ b/core/src/main/java/io/aiven/klaw/helpers/db/rdbms/SelectDataJdbc.java
@@ -754,7 +754,7 @@ public class SelectDataJdbc {
                 .format((row.getRequesttime()).getTime()));
       } catch (Exception ignored) {
       }
-      if (!wildcardSearch || row.getConnectorName().toLowerCase().contains(search))
+      if (!wildcardSearch || row.getConnectorName().toLowerCase().contains(search.toLowerCase()))
         topicRequestList.add(row); // no team filter
     }
 

--- a/core/src/main/java/io/aiven/klaw/service/KafkaConnectControllerService.java
+++ b/core/src/main/java/io/aiven/klaw/service/KafkaConnectControllerService.java
@@ -307,7 +307,12 @@ public class KafkaConnectControllerService {
       final String topicSearchFilter = connectorNameSearch;
       topicFilteredList =
           topicsFromSOT.stream()
-              .filter(topic -> topic.getConnectorName().contains(topicSearchFilter))
+              .filter(
+                  topic ->
+                      topic
+                          .getConnectorName()
+                          .toLowerCase()
+                          .contains(topicSearchFilter.toLowerCase()))
               .collect(Collectors.toList());
 
       // searching documentation
@@ -316,7 +321,10 @@ public class KafkaConnectControllerService {
               .filter(
                   topic ->
                       (topic.getDocumentation() != null
-                          && topic.getDocumentation().contains(topicSearchFilter)))
+                          && topic
+                              .getDocumentation()
+                              .toLowerCase()
+                              .contains(topicSearchFilter.toLowerCase())))
               .toList();
 
       topicFilteredList.addAll(searchDocList);


### PR DESCRIPTION
About this change - What it does
This change allows connectors to be searched using a case insensitive partial match.
Resolves: #xxxxx
Why this way
This makes it consistent with the other resources like topics and requests and maintains a common user experience.
