### PR TITLE
Env hierarchy, topic creation improvements

### DIFF
--- a/cluster-api/src/main/java/io/aiven/klaw/clusterapi/controller/ClusterApiController.java
+++ b/cluster-api/src/main/java/io/aiven/klaw/clusterapi/controller/ClusterApiController.java
@@ -5,6 +5,7 @@ import io.aiven.klaw.clusterapi.models.ClusterAclRequest;
 import io.aiven.klaw.clusterapi.models.ClusterSchemaRequest;
 import io.aiven.klaw.clusterapi.models.ClusterTopicRequest;
 import io.aiven.klaw.clusterapi.models.OffsetDetails;
+import io.aiven.klaw.clusterapi.models.TopicConfig;
 import io.aiven.klaw.clusterapi.models.enums.AclType;
 import io.aiven.klaw.clusterapi.models.enums.AclsNativeType;
 import io.aiven.klaw.clusterapi.models.enums.ApiResultStatus;
@@ -92,13 +93,13 @@ public class ClusterApiController {
           "/getTopics/{bootstrapServers}/{protocol}/{clusterName}/topicsNativeType/{aclsNativeType}",
       method = RequestMethod.GET,
       produces = {MediaType.APPLICATION_JSON_VALUE})
-  public ResponseEntity<Set<Map<String, String>>> getTopics(
+  public ResponseEntity<Set<TopicConfig>> getTopics(
       @PathVariable String bootstrapServers,
       @Valid @PathVariable KafkaSupportedProtocol protocol,
       @PathVariable String clusterName,
       @PathVariable String aclsNativeType)
       throws Exception {
-    Set<Map<String, String>> topics;
+    Set<TopicConfig> topics;
     if (AclsNativeType.CONFLUENT_CLOUD.name().equals(aclsNativeType)) {
       topics = confluentCloudApiService.listTopics(bootstrapServers, protocol, clusterName);
     } else {

--- a/cluster-api/src/main/java/io/aiven/klaw/clusterapi/models/ClusterTopicRequest.java
+++ b/cluster-api/src/main/java/io/aiven/klaw/clusterapi/models/ClusterTopicRequest.java
@@ -8,9 +8,11 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 @Builder(toBuilder = true)
 @Getter
+@Setter
 @AllArgsConstructor
 @NoArgsConstructor
 public class ClusterTopicRequest {

--- a/cluster-api/src/main/java/io/aiven/klaw/clusterapi/models/TopicConfig.java
+++ b/cluster-api/src/main/java/io/aiven/klaw/clusterapi/models/TopicConfig.java
@@ -1,0 +1,12 @@
+package io.aiven.klaw.clusterapi.models;
+
+import lombok.Data;
+
+@Data
+public class TopicConfig {
+  private String topicName;
+
+  private String replicationFactor;
+
+  private String partitions;
+}

--- a/cluster-api/src/main/java/io/aiven/klaw/clusterapi/services/ConfluentCloudApiService.java
+++ b/cluster-api/src/main/java/io/aiven/klaw/clusterapi/services/ConfluentCloudApiService.java
@@ -4,6 +4,7 @@ import com.google.common.base.Strings;
 import io.aiven.klaw.clusterapi.models.ApiResponse;
 import io.aiven.klaw.clusterapi.models.ClusterAclRequest;
 import io.aiven.klaw.clusterapi.models.ClusterTopicRequest;
+import io.aiven.klaw.clusterapi.models.TopicConfig;
 import io.aiven.klaw.clusterapi.models.confluentcloud.AclObject;
 import io.aiven.klaw.clusterapi.models.confluentcloud.Config;
 import io.aiven.klaw.clusterapi.models.confluentcloud.ListAclsResponse;
@@ -61,7 +62,7 @@ public class ConfluentCloudApiService {
     this.clusterApiUtils = clusterApiUtils;
   }
 
-  public Set<Map<String, String>> listTopics(
+  public Set<TopicConfig> listTopics(
       String restApiHost, KafkaSupportedProtocol protocol, String clusterIdentification)
       throws Exception {
     RestTemplate restTemplate = getRestTemplate();
@@ -80,7 +81,7 @@ public class ConfluentCloudApiService {
           restTemplate.exchange(
               listTopicsUri, HttpMethod.GET, request, new ParameterizedTypeReference<>() {});
 
-      List<Map<String, String>> topicsListUpdated = processListTopicsResponse(responseEntity);
+      List<TopicConfig> topicsListUpdated = processListTopicsResponse(responseEntity);
 
       return new HashSet<>(topicsListUpdated);
     } catch (RestClientException e) {
@@ -478,15 +479,15 @@ public class ConfluentCloudApiService {
     return aclMap;
   }
 
-  private List<Map<String, String>> processListTopicsResponse(
+  private List<TopicConfig> processListTopicsResponse(
       ResponseEntity<ListTopicsResponse> responseEntity) {
     ListTopicsResponse topicsList = Objects.requireNonNull(responseEntity.getBody());
-    List<Map<String, String>> topicsListUpdated = new ArrayList<>();
+    List<TopicConfig> topicsListUpdated = new ArrayList<>();
     for (TopicObject topicObject : topicsList.data) {
-      Map<String, String> topicsMapUpdated = new HashMap<>();
-      topicsMapUpdated.put("topicName", topicObject.topic_name);
-      topicsMapUpdated.put("replicationFactor", "" + topicObject.replication_factor);
-      topicsMapUpdated.put("partitions", "" + topicObject.partitions_count);
+      TopicConfig topicsMapUpdated = new TopicConfig();
+      topicsMapUpdated.setTopicName(topicObject.topic_name);
+      topicsMapUpdated.setReplicationFactor("" + topicObject.replication_factor);
+      topicsMapUpdated.setPartitions("" + topicObject.partitions_count);
 
       topicsListUpdated.add(topicsMapUpdated);
     }

--- a/cluster-api/src/main/java/io/aiven/klaw/clusterapi/utils/ClusterApiUtils.java
+++ b/cluster-api/src/main/java/io/aiven/klaw/clusterapi/utils/ClusterApiUtils.java
@@ -86,7 +86,7 @@ public class ClusterApiUtils {
   //        sslKeys.forEach(adminClientsMap::remove);
   //    }
 
-  private String getHash(String envHost) {
+  public String getHash(String envHost) {
     return new String(Base64.encodeBase64(messageDigest.digest(envHost.getBytes()), false));
   }
 

--- a/cluster-api/src/test/java/io/aiven/klaw/clusterapi/ClusterApiControllerIT.java
+++ b/cluster-api/src/test/java/io/aiven/klaw/clusterapi/ClusterApiControllerIT.java
@@ -2,11 +2,11 @@ package io.aiven.klaw.clusterapi;
 
 import static io.aiven.klaw.clusterapi.models.enums.ClusterStatus.ONLINE;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.aiven.klaw.clusterapi.models.ApiResponse;
 import io.aiven.klaw.clusterapi.models.ClusterAclRequest;
@@ -160,6 +160,33 @@ public class ClusterApiControllerIT {
 
   @Test
   @Order(4)
+  public void createTopicsExistingTopicSameConfigSuccess() throws Exception {
+    String topicName = "testtopic";
+    ClusterTopicRequest clusterTopicRequest = createTopicRequest(topicName);
+    String jsonReq = OBJECT_MAPPER.writer().writeValueAsString(clusterTopicRequest);
+    String url = "/topics/createTopics";
+    MockHttpServletResponse response = executeCreateTopicRequest(jsonReq, url);
+    ApiResponse apiResponse =
+        new ObjectMapper().readValue(response.getContentAsString(), new TypeReference<>() {});
+    assertThat(apiResponse.isSuccess()).isTrue();
+  }
+
+  @Test
+  @Order(5)
+  public void createTopicsExistingTopicDifferentConfigFailure() throws Exception {
+    String topicName = "testtopic";
+    ClusterTopicRequest clusterTopicRequest = createTopicRequest(topicName);
+    clusterTopicRequest.setReplicationFactor((short) 4);
+    String jsonReq = OBJECT_MAPPER.writer().writeValueAsString(clusterTopicRequest);
+    String url = "/topics/createTopics";
+    MockHttpServletResponse response = executeCreateTopicRequest(jsonReq, url);
+    ApiResponse apiResponse =
+        new ObjectMapper().readValue(response.getContentAsString(), new TypeReference<>() {});
+    assertThat(apiResponse.getMessage()).contains("TopicExistsException");
+  }
+
+  @Test
+  @Order(6)
   public void createAclProducerIPAddress() throws Exception {
     String topicName = "testtopic";
     String ipHost = "11.12.13.14";
@@ -201,7 +228,7 @@ public class ClusterApiControllerIT {
   }
 
   @Test
-  @Order(5)
+  @Order(7)
   public void createAclConsumerIPAddress() throws Exception {
     String topicName = "testtopic";
     String ipHost = "11.12.13.14";
@@ -266,7 +293,7 @@ public class ClusterApiControllerIT {
   }
 
   @Test
-  @Order(6)
+  @Order(8)
   public void createAclProducerPrincipal() throws Exception {
     String topicName = "testtopic";
     String principle = "CN=host,OU=dept";
@@ -311,7 +338,7 @@ public class ClusterApiControllerIT {
   }
 
   @Test
-  @Order(7)
+  @Order(9)
   public void createAclConsumerPrincipal() throws Exception {
     String topicName = "testtopic";
     String principle = "CN=host,OU=dept";
@@ -382,37 +409,7 @@ public class ClusterApiControllerIT {
   }
 
   @Test
-  @Order(8)
-  public void createTopicsWhenTopicAlreadyExists() throws Exception {
-    String topicName = "testtopic";
-    ClusterTopicRequest clusterTopicRequest = createTopicRequest(topicName);
-    String jsonReq = OBJECT_MAPPER.writer().writeValueAsString(clusterTopicRequest);
-    String url = "/topics/createTopics";
-    // ensure Topic has already been created in this integration test
-    executeCreateTopicRequest(jsonReq, url);
-    // attempt to create a topic that already exists.
-    MockHttpServletResponse returnedValue = executeCreateTopicRequest(jsonReq, url);
-
-    assertTrue(returnedValue.getContentAsString().contains("TopicExistsException"));
-    // verify that the response is in the correct part of the API Response otherwise it will not be
-    // found in handling by receiving clients.
-    ApiResponse apiResponse =
-        mapper.readValue(returnedValue.getContentAsString(), ApiResponse.class);
-    assertTrue(apiResponse.getMessage().contains("TopicExistsException"));
-
-    embeddedKafkaBroker.doWithAdmin(
-        adminClient -> {
-          try {
-            Set<String> topicsSet = adminClient.listTopics().names().get();
-            assertThat(topicsSet).contains(topicName);
-          } catch (InterruptedException | ExecutionException e) {
-            log.error("Error : ", e);
-          }
-        });
-  }
-
-  @Test
-  @Order(9)
+  @Order(10)
   public void deleteTopics() throws Exception {
     // Create a topic
     String topicName = "testtopic-todelete";

--- a/cluster-api/src/test/java/io/aiven/klaw/clusterapi/UtilMethods.java
+++ b/cluster-api/src/test/java/io/aiven/klaw/clusterapi/UtilMethods.java
@@ -5,6 +5,7 @@ import io.aiven.klaw.clusterapi.models.AivenAclStruct;
 import io.aiven.klaw.clusterapi.models.ClusterAclRequest;
 import io.aiven.klaw.clusterapi.models.ClusterSchemaRequest;
 import io.aiven.klaw.clusterapi.models.ClusterTopicRequest;
+import io.aiven.klaw.clusterapi.models.TopicConfig;
 import io.aiven.klaw.clusterapi.models.confluentcloud.AclObject;
 import io.aiven.klaw.clusterapi.models.confluentcloud.ListAclsResponse;
 import io.aiven.klaw.clusterapi.models.confluentcloud.ListTopicsResponse;
@@ -59,13 +60,13 @@ public class UtilMethods {
     return aclsSet;
   }
 
-  public Set<Map<String, String>> getTopics() {
-    Set<Map<String, String>> topicsSet = new HashSet<>();
-    Map<String, String> hashMap = new HashMap<>();
-    hashMap.put("topicName", "testtopic1");
+  public Set<TopicConfig> getTopics() {
+    Set<TopicConfig> topicsSet = new HashSet<>();
+    TopicConfig hashMap = new TopicConfig();
+    hashMap.setTopicName("testtopic1");
 
-    hashMap.put("partitions", "2");
-    hashMap.put("replicationFactor", "1");
+    hashMap.setPartitions("2");
+    hashMap.setReplicationFactor("1");
     topicsSet.add(hashMap);
     return topicsSet;
   }

--- a/cluster-api/src/test/java/io/aiven/klaw/clusterapi/services/ConfluentCloudApiServiceTest.java
+++ b/cluster-api/src/test/java/io/aiven/klaw/clusterapi/services/ConfluentCloudApiServiceTest.java
@@ -11,6 +11,7 @@ import io.aiven.klaw.clusterapi.UtilMethods;
 import io.aiven.klaw.clusterapi.models.ApiResponse;
 import io.aiven.klaw.clusterapi.models.ClusterAclRequest;
 import io.aiven.klaw.clusterapi.models.ClusterTopicRequest;
+import io.aiven.klaw.clusterapi.models.TopicConfig;
 import io.aiven.klaw.clusterapi.models.confluentcloud.ListAclsResponse;
 import io.aiven.klaw.clusterapi.models.confluentcloud.ListTopicsResponse;
 import io.aiven.klaw.clusterapi.models.confluentcloud.TopicCreateRequest;
@@ -66,15 +67,14 @@ public class ConfluentCloudApiServiceTest {
             any(),
             (ParameterizedTypeReference<ListTopicsResponse>) any()))
         .thenReturn(listTopicsResponseResponseEntity);
-    Set<Map<String, String>> listTopicsSet =
+    Set<TopicConfig> listTopicsSet =
         confluentCloudApiService.listTopics(
             "localhost:443", KafkaSupportedProtocol.SSL, CLUSTER_ID);
 
     assertThat(listTopicsSet).hasSize(2); // two topics
-    assertThat(listTopicsSet.stream().toList().get(0))
-        .hasSize(3); // topicName, partitions, replication factor
-    assertThat(listTopicsSet.stream().toList().get(0))
-        .containsKeys("topicName", "partitions", "replicationFactor");
+    assertThat(listTopicsSet.stream().toList().get(0).getTopicName()).isNotNull();
+    assertThat(listTopicsSet.stream().toList().get(0).getPartitions()).isNotNull();
+    assertThat(listTopicsSet.stream().toList().get(0).getReplicationFactor()).isNotNull();
   }
 
   @Test

--- a/cluster-api/src/test/java/io/aiven/klaw/clusterapi/services/UtilComponentsServiceTest.java
+++ b/cluster-api/src/test/java/io/aiven/klaw/clusterapi/services/UtilComponentsServiceTest.java
@@ -10,12 +10,12 @@ import io.aiven.klaw.clusterapi.models.ApiResponse;
 import io.aiven.klaw.clusterapi.models.ClusterAclRequest;
 import io.aiven.klaw.clusterapi.models.ClusterSchemaRequest;
 import io.aiven.klaw.clusterapi.models.ClusterTopicRequest;
+import io.aiven.klaw.clusterapi.models.TopicConfig;
 import io.aiven.klaw.clusterapi.models.enums.AclType;
 import io.aiven.klaw.clusterapi.models.enums.ApiResultStatus;
 import io.aiven.klaw.clusterapi.models.enums.ClusterStatus;
 import io.aiven.klaw.clusterapi.models.enums.KafkaSupportedProtocol;
 import io.aiven.klaw.clusterapi.utils.ClusterApiUtils;
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
@@ -201,22 +201,21 @@ public class UtilComponentsServiceTest {
     when(describeTopicsResult.all()).thenReturn(kafkaFutureTopicdesc);
     when(kafkaFutureTopicdesc.get(anyLong(), any(TimeUnit.class))).thenReturn(getTopicDescs());
 
-    Set<Map<String, String>> result =
+    Set<TopicConfig> result =
         apacheKafkaTopicService.loadTopics("localhost", KafkaSupportedProtocol.PLAINTEXT, "");
 
-    Map<String, String> hashMap = new HashMap<>();
-    hashMap.put("partitions", "2");
-    hashMap.put("replicationFactor", "1");
-    hashMap.put("topicName", "testtopic2");
+    TopicConfig topicConfig = new TopicConfig();
+    topicConfig.setPartitions("2");
+    topicConfig.setReplicationFactor("1");
+    topicConfig.setTopicName("testtopic2");
 
-    Map<String, String> hashMap1 = new HashMap<>();
-    hashMap1.put("partitions", "2");
-    hashMap1.put("replicationFactor", "1");
-    hashMap1.put("topicName", "testtopic1");
+    TopicConfig topicConfig1 = new TopicConfig();
+    topicConfig1.setPartitions("2");
+    topicConfig1.setReplicationFactor("1");
+    topicConfig1.setTopicName("testtopic1");
 
     assertThat(result).hasSize(2);
-    assertThat(hashMap).isEqualTo(new ArrayList<>(result).get(0));
-    assertThat(hashMap1).isEqualTo(new ArrayList<>(result).get(1));
+    assertThat(result).contains(topicConfig).contains(topicConfig1);
   }
 
   @Test
@@ -230,6 +229,7 @@ public class UtilComponentsServiceTest {
             .replicationFactor(Short.parseShort("1"))
             .clusterName("")
             .build();
+    Set<String> list = new HashSet<>();
 
     when(clusterApiUtils.getAdminClient(any(), eq(KafkaSupportedProtocol.PLAINTEXT), anyString()))
         .thenReturn(adminClient);

--- a/coral/src/app/features/connectors/browse/BrowseConnectors.test.tsx
+++ b/coral/src/app/features/connectors/browse/BrowseConnectors.test.tsx
@@ -4,7 +4,7 @@ import userEvent from "@testing-library/user-event";
 import BrowseConnectors from "src/app/features/connectors/browse/BrowseConnectors";
 import { mockIntersectionObserver } from "src/services/test-utils/mock-intersection-observer";
 import { customRender } from "src/services/test-utils/render-with-wrappers";
-import { getConnectors } from "src/domain/connector";
+import { Connector, getConnectors } from "src/domain/connector";
 import { getSyncConnectorsEnvironments } from "src/domain/environment";
 import { createEnvironment } from "src/domain/environment/environment-test-helper";
 import { tabNavigateTo } from "src/services/test-utils/tabbing";
@@ -20,13 +20,14 @@ const mockGetSyncConnectorsEnvironments =
     typeof getSyncConnectorsEnvironments
   >;
 
-const mockConnectors = [
+const mockConnectors: Connector[] = [
   {
     sequence: 2,
     connectorId: 1001,
     connectorName: "test_connector_1",
     environmentId: "4",
     teamName: "Dev",
+    teamId: 1,
     allPageNos: ["1"],
     totalNoPages: "1",
     currentPage: "1",
@@ -42,6 +43,7 @@ const mockConnectors = [
     connectorName: "test_connector_2",
     environmentId: "4",
     teamName: "Ospo",
+    teamId: 2,
     allPageNos: ["1"],
     totalNoPages: "1",
     currentPage: "1",
@@ -57,6 +59,7 @@ const mockConnectors = [
     connectorName: "test_connector_3",
     environmentId: "4",
     teamName: "Infra",
+    teamId: 3,
     allPageNos: ["1"],
     totalNoPages: "1",
     currentPage: "1",

--- a/coral/src/app/features/connectors/browse/components/ConnectorTable.test.tsx
+++ b/coral/src/app/features/connectors/browse/components/ConnectorTable.test.tsx
@@ -2,14 +2,16 @@ import { cleanup, screen, render, within } from "@testing-library/react";
 import ConnectorTable from "src/app/features/connectors/browse/components/ConnectorTable";
 import { mockIntersectionObserver } from "src/services/test-utils/mock-intersection-observer";
 import { tabThroughForward } from "src/services/test-utils/tabbing";
+import { Connector } from "src/domain/connector";
 
-const mockConnectors = [
+const mockConnectors: Connector[] = [
   {
     sequence: 2,
     connectorId: 1001,
     connectorName: "test_connector_1",
     environmentId: "4",
     teamName: "Dev",
+    teamId: 1,
     allPageNos: ["1"],
     totalNoPages: "1",
     currentPage: "1",
@@ -25,6 +27,7 @@ const mockConnectors = [
     connectorName: "test_connector_2",
     environmentId: "4",
     teamName: "Ospo",
+    teamId: 2,
     allPageNos: ["1"],
     totalNoPages: "1",
     currentPage: "1",
@@ -40,6 +43,7 @@ const mockConnectors = [
     connectorName: "test_connector_3",
     environmentId: "4",
     teamName: "Infra",
+    teamId: 3,
     allPageNos: ["1"],
     totalNoPages: "1",
     currentPage: "1",
@@ -148,13 +152,16 @@ describe("ConnectorTable.tsx", () => {
           name: new RegExp(`${connector.connectorName}`, "i"),
         });
         const environmentList = within(row).getByRole("cell", {
-          name: connector.environmentsList.join(" "),
+          // environmentList could be undefined, but isn't in our usage here
+          // so this is needed to prevent type errors
+          name: (connector.environmentsList as string[]).join(" "),
         });
 
         expect(environmentList).toBeVisible();
       });
-
-      connector.environmentsList.forEach((env) => {
+      // environmentList could be undefined, but isn't in our usage here
+      // so this is needed to prevent type errors
+      (connector.environmentsList as string[]).forEach((env) => {
         it(`renders Environment ${env} for connector ${connector}`, () => {
           const table = screen.getByRole("table", {
             name: "Kafka Connectors overview, page 1 of 10",
@@ -163,7 +170,9 @@ describe("ConnectorTable.tsx", () => {
             name: new RegExp(`${connector.connectorName}`, "i"),
           });
           const environmentList = within(row).getByRole("cell", {
-            name: connector.environmentsList.join(" "),
+            // environmentList could be undefined, but isn't in our usage here
+            // so this is needed to prevent type errors
+            name: (connector.environmentsList as string[]).join(" "),
           });
 
           expect(environmentList).toBeVisible();

--- a/coral/src/domain/connector/connector-api.ts
+++ b/coral/src/domain/connector/connector-api.ts
@@ -46,7 +46,7 @@ const getConnectors = (
   const queryParams = convertQueryValuesToString({
     env: params.env,
     pageNo: params.pageNo,
-    ...(params.teamName && { teamName: params.teamName }),
+    ...(params.teamId && { teamId: params.teamId }),
     ...(params.connectornamesearch &&
       params.connectornamesearch.length > 0 && {
         connectornamesearch: params.connectornamesearch,

--- a/coral/types/api.d.ts
+++ b/coral/types/api.d.ts
@@ -637,8 +637,8 @@ export type components = {
       documentation: string;
     };
     ResetPasswordInfo: {
-      passwordSent?: string;
-      userFound?: string;
+      passwordSent: string;
+      userFound: string;
     };
     RequestVerdict: {
       reason?: string;
@@ -869,8 +869,8 @@ export type components = {
       tenantName?: string;
     };
     EnvUpdatedStatus: {
-      result?: string;
-      envstatus?: string;
+      result: string;
+      envstatus: string;
     };
     TopicsCountPerEnv: {
       status?: string;
@@ -923,7 +923,7 @@ export type components = {
       editable?: boolean;
     };
     TopicDetailsPerEnv: {
-      topicExists?: boolean;
+      topicExists: boolean;
       error?: string;
       topicId?: string;
       topicContents?: components["schemas"]["TopicInfo"];
@@ -998,6 +998,8 @@ export type components = {
       connectorName: string;
       environmentId: string;
       teamName: string;
+      /** Format: int32 */
+      teamId: number;
       showEditConnector: boolean;
       showDeleteConnector: boolean;
       connectorDeletable: boolean;
@@ -1132,7 +1134,7 @@ export type components = {
       topicSuffix?: (string)[];
     };
     DbAuthInfo: {
-      dbauth?: string;
+      dbauth: string;
     };
     DashboardStats: {
       /** Format: int32 */
@@ -3218,7 +3220,7 @@ export type operations = {
         pageNo: string;
         currentPage?: string;
         connectornamesearch?: string;
-        teamName?: string;
+        teamId?: number;
       };
     };
     responses: {

--- a/core/src/main/java/io/aiven/klaw/controller/KafkaConnectController.java
+++ b/core/src/main/java/io/aiven/klaw/controller/KafkaConnectController.java
@@ -168,11 +168,11 @@ public class KafkaConnectController {
       @RequestParam("pageNo") String pageNo,
       @RequestParam(value = "currentPage", defaultValue = "") String currentPage,
       @RequestParam(value = "connectornamesearch", required = false) String topicNameSearch,
-      @RequestParam(value = "teamName", required = false) String teamName)
+      @RequestParam(value = "teamId", required = false) Integer teamId)
       throws Exception {
     return new ResponseEntity<>(
         kafkaConnectControllerService.getConnectors(
-            envId, pageNo, currentPage, topicNameSearch, teamName),
+            envId, pageNo, currentPage, topicNameSearch, teamId),
         HttpStatus.OK);
   }
 

--- a/core/src/main/java/io/aiven/klaw/error/KlawErrorMessages.java
+++ b/core/src/main/java/io/aiven/klaw/error/KlawErrorMessages.java
@@ -144,6 +144,9 @@ public class KlawErrorMessages {
 
   public static final String ENV_CLUSTER_TNT_109 = "Our Organization";
 
+  public static final String ENV_CLUSTER_TNT_110 =
+      "Environments pointing to same cluster without a different prefix/suffix regex";
+
   // Kafka connect service
 
   public static final String KAFKA_CONNECT_ERR_101 =
@@ -270,6 +273,9 @@ public class KlawErrorMessages {
 
   public static final String SERVER_CONFIG_ERR_105 =
       "Resource %s must be created before being added to the Tenant Model";
+
+  public static final String SERVER_CONFIG_ERR_106 =
+      "Environments pointing to same kafka cluster is not allowed.";
 
   // Topic service
   public static final String TOPICS_ERR_101 = "Missing Permissions for this operation.";

--- a/core/src/main/java/io/aiven/klaw/model/response/KafkaConnectorModelResponse.java
+++ b/core/src/main/java/io/aiven/klaw/model/response/KafkaConnectorModelResponse.java
@@ -17,6 +17,8 @@ public class KafkaConnectorModelResponse {
 
   @NotNull private String teamName;
 
+  @NotNull private int teamId;
+
   @NotNull private boolean showEditConnector;
 
   @NotNull private boolean showDeleteConnector;

--- a/core/src/main/java/io/aiven/klaw/model/response/TopicConfig.java
+++ b/core/src/main/java/io/aiven/klaw/model/response/TopicConfig.java
@@ -1,0 +1,12 @@
+package io.aiven.klaw.model.response;
+
+import lombok.Data;
+
+@Data
+public class TopicConfig {
+  private String topicName;
+
+  private String replicationFactor;
+
+  private String partitions;
+}

--- a/core/src/main/java/io/aiven/klaw/service/ClusterApiService.java
+++ b/core/src/main/java/io/aiven/klaw/service/ClusterApiService.java
@@ -42,6 +42,7 @@ import io.aiven.klaw.model.enums.KafkaFlavors;
 import io.aiven.klaw.model.enums.KafkaSupportedProtocol;
 import io.aiven.klaw.model.enums.RequestOperationType;
 import io.aiven.klaw.model.response.OffsetDetails;
+import io.aiven.klaw.model.response.TopicConfig;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.SignatureAlgorithm;
 import jakarta.annotation.PostConstruct;
@@ -353,7 +354,7 @@ public class ClusterApiService {
     return aclListOriginal;
   }
 
-  public List<Map<String, String>> getAllTopics(
+  public List<TopicConfig> getAllTopics(
       String bootstrapHost,
       KafkaSupportedProtocol protocol,
       String clusterIdentification,
@@ -362,7 +363,7 @@ public class ClusterApiService {
       throws Exception {
     log.info("getAllTopics {} {}", bootstrapHost, protocol);
     getClusterApiProperties(tenantId);
-    List<Map<String, String>> topicsList;
+    List<TopicConfig> topicsList;
     String aclsNativeType = AclsNativeType.NATIVE.value;
 
     if (KafkaFlavors.CONFLUENT_CLOUD.value.equals(kafkaFlavors)) {
@@ -382,7 +383,7 @@ public class ClusterApiService {
                   aclsNativeType);
 
       HttpEntity<String> entity = getHttpEntity();
-      ResponseEntity<Set<Map<String, String>>> s =
+      ResponseEntity<Set<TopicConfig>> s =
           getRestTemplate()
               .exchange(
                   uriGetTopicsFull, HttpMethod.GET, entity, new ParameterizedTypeReference<>() {});

--- a/core/src/main/java/io/aiven/klaw/service/KafkaConnectControllerService.java
+++ b/core/src/main/java/io/aiven/klaw/service/KafkaConnectControllerService.java
@@ -232,11 +232,11 @@ public class KafkaConnectControllerService {
   }
 
   public List<List<KafkaConnectorModelResponse>> getConnectors(
-      String env, String pageNo, String currentPage, String connectorNameSearch, String teamName)
+      String env, String pageNo, String currentPage, String connectorNameSearch, Integer teamId)
       throws Exception {
     log.debug("getConnectors {}", connectorNameSearch);
     List<KafkaConnectorModelResponse> topicListUpdated =
-        getConnectorsPaginated(env, pageNo, currentPage, connectorNameSearch, teamName);
+        getConnectorsPaginated(env, pageNo, currentPage, connectorNameSearch, teamId);
 
     if (topicListUpdated != null && topicListUpdated.size() > 0) {
       updateTeamNamesForDisplay(topicListUpdated);
@@ -281,7 +281,7 @@ public class KafkaConnectControllerService {
   }
 
   private List<KafkaConnectorModelResponse> getConnectorsPaginated(
-      String env, String pageNo, String currentPage, String connectorNameSearch, String teamName) {
+      String env, String pageNo, String currentPage, String connectorNameSearch, Integer teamId) {
     if (connectorNameSearch != null) {
       connectorNameSearch = connectorNameSearch.trim();
     }
@@ -292,8 +292,7 @@ public class KafkaConnectControllerService {
     // Get Sync topics
 
     List<KwKafkaConnector> topicsFromSOT =
-        handleDbRequests.getSyncConnectors(
-            env, manageDatabase.getTeamIdFromTeamName(tenantId, teamName), tenantId);
+        handleDbRequests.getSyncConnectors(env, teamId, tenantId);
     topicsFromSOT = getFilteredConnectorsForTenant(topicsFromSOT);
     List<Env> listAllEnvs = manageDatabase.getKafkaConnectEnvList(tenantId);
     // tenant filtering
@@ -372,28 +371,30 @@ public class KafkaConnectControllerService {
     for (int i = 0; i < topicsFromSOT.size(); i++) {
       int counterInc = counterIncrement();
       if (i >= startVar && i < lastVar) {
-        KafkaConnectorModelResponse mp = new KafkaConnectorModelResponse();
-        mp.setSequence(counterInc);
+        KafkaConnectorModelResponse kafkaConnectorModelResponse = new KafkaConnectorModelResponse();
+        kafkaConnectorModelResponse.setSequence(counterInc);
         KwKafkaConnector topicSOT = topicsFromSOT.get(i);
 
         List<String> envList = topicSOT.getEnvironmentsList();
         envList.sort(Comparator.comparingInt(orderOfEnvs::indexOf));
 
-        mp.setConnectorId(topicSOT.getConnectorId());
-        mp.setEnvironmentId(topicSOT.getEnvironment());
-        mp.setEnvironmentsList(getConvertedEnvs(listAllEnvs, envList));
-        mp.setConnectorName(topicSOT.getConnectorName());
-        mp.setTeamName(manageDatabase.getTeamNameFromTeamId(tenantId, topicSOT.getTeamId()));
+        kafkaConnectorModelResponse.setConnectorId(topicSOT.getConnectorId());
+        kafkaConnectorModelResponse.setEnvironmentId(topicSOT.getEnvironment());
+        kafkaConnectorModelResponse.setEnvironmentsList(getConvertedEnvs(listAllEnvs, envList));
+        kafkaConnectorModelResponse.setConnectorName(topicSOT.getConnectorName());
+        kafkaConnectorModelResponse.setTeamName(
+            manageDatabase.getTeamNameFromTeamId(tenantId, topicSOT.getTeamId()));
+        kafkaConnectorModelResponse.setTeamId(topicSOT.getTeamId());
 
-        mp.setDescription(topicSOT.getDescription());
+        kafkaConnectorModelResponse.setDescription(topicSOT.getDescription());
 
-        mp.setTotalNoPages(totalPages + "");
-        mp.setCurrentPage(pageNo);
+        kafkaConnectorModelResponse.setTotalNoPages(totalPages + "");
+        kafkaConnectorModelResponse.setCurrentPage(pageNo);
 
-        mp.setAllPageNos(numList);
+        kafkaConnectorModelResponse.setAllPageNos(numList);
 
         if (topicsListMap != null) {
-          topicsListMap.add(mp);
+          topicsListMap.add(kafkaConnectorModelResponse);
         }
       }
     }

--- a/core/src/main/java/io/aiven/klaw/service/TopicControllerService.java
+++ b/core/src/main/java/io/aiven/klaw/service/TopicControllerService.java
@@ -46,6 +46,7 @@ import io.aiven.klaw.model.enums.PermissionType;
 import io.aiven.klaw.model.enums.RequestOperationType;
 import io.aiven.klaw.model.enums.RequestStatus;
 import io.aiven.klaw.model.requests.TopicRequestModel;
+import io.aiven.klaw.model.response.TopicConfig;
 import io.aiven.klaw.model.response.TopicDetailsPerEnv;
 import io.aiven.klaw.model.response.TopicRequestsResponseModel;
 import io.aiven.klaw.model.response.TopicTeamResponse;
@@ -1001,10 +1002,10 @@ public class TopicControllerService {
     }
   }
 
-  static class TopicNameSyncComparator implements Comparator<Map<String, String>> {
+  static class TopicNameSyncComparator implements Comparator<TopicConfig> {
     @Override
-    public int compare(Map<String, String> topic1, Map<String, String> topic2) {
-      return topic1.get("topicName").compareTo(topic2.get("topicName"));
+    public int compare(TopicConfig topic1, TopicConfig topic2) {
+      return topic1.getTopicName().compareTo(topic2.getTopicName());
     }
   }
 
@@ -1070,7 +1071,7 @@ public class TopicControllerService {
 
       // select all topics and then filter
       env = "ALL";
-      teamId = 0;
+      teamId = 1;
     }
 
     // Get Sync topics

--- a/core/src/main/java/io/aiven/klaw/service/TopicSyncControllerService.java
+++ b/core/src/main/java/io/aiven/klaw/service/TopicSyncControllerService.java
@@ -27,6 +27,7 @@ import io.aiven.klaw.model.enums.KafkaClustersType;
 import io.aiven.klaw.model.enums.PermissionType;
 import io.aiven.klaw.model.enums.RequestOperationType;
 import io.aiven.klaw.model.response.SyncTopicsList;
+import io.aiven.klaw.model.response.TopicConfig;
 import io.aiven.klaw.model.response.TopicRequestsResponseModel;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -166,8 +167,8 @@ public class TopicSyncControllerService {
       }
     }
 
-    List<Map<String, String>> topicFilteredList = getTopicsFromKafkaCluster(env, topicNameSearch);
-    List<Map<String, String>> topicsList;
+    List<TopicConfig> topicFilteredList = getTopicsFromKafkaCluster(env, topicNameSearch);
+    List<TopicConfig> topicsList;
 
     topicsList =
         topicFilteredList.stream()
@@ -200,7 +201,7 @@ public class TopicSyncControllerService {
   }
 
   private List<TopicRequestsResponseModel> getSyncTopicList(
-      List<Map<String, String>> topicsList,
+      List<TopicConfig> topicsList,
       List<TopicRequestsResponseModel> deletedTopicsFromClusterList,
       String pageNo,
       String currentPage,
@@ -278,7 +279,7 @@ public class TopicSyncControllerService {
   }
 
   private List<TopicRequestsResponseModel> getSyncTopicListRecon(
-      List<Map<String, String>> clusterTopicsList,
+      List<TopicConfig> clusterTopicsList,
       List<TopicRequestsResponseModel> deletedTopicsFromClusterList,
       String env,
       boolean isBulkOption,
@@ -331,22 +332,22 @@ public class TopicSyncControllerService {
   }
 
   private boolean createTopicRequest(
-      List<Map<String, String>> topicsList,
+      List<TopicConfig> topicsList,
       List<Topic> topicsFromSOT,
       List<String> teamList,
       int i,
       int counterInc,
       TopicRequest mp,
       int tenantId) {
-    Map<String, String> topicMap;
+    TopicConfig topicMap;
     mp.setSequence(counterInc + "");
 
     topicMap = topicsList.get(i);
-    final String tmpTopicName = topicMap.get("topicName");
+    final String tmpTopicName = topicMap.getTopicName();
 
     mp.setTopicname(tmpTopicName);
-    mp.setTopicpartitions(Integer.parseInt(topicMap.get("partitions")));
-    mp.setReplicationfactor(topicMap.get("replicationFactor"));
+    mp.setTopicpartitions(Integer.parseInt(topicMap.getPartitions()));
+    mp.setReplicationfactor(topicMap.getReplicationFactor());
 
     String teamUpdated = null;
 
@@ -381,7 +382,7 @@ public class TopicSyncControllerService {
   }
 
   private void updateClusterDeletedTopicsList(
-      List<Map<String, String>> clusterTopicsList,
+      List<TopicConfig> clusterTopicsList,
       List<TopicRequestsResponseModel> deletedTopicsFromClusterList,
       List<Topic> topicsFromSOT,
       List<String> teamList,
@@ -389,7 +390,7 @@ public class TopicSyncControllerService {
     try {
       List<String> clusterTopicStringList = new ArrayList<>();
       clusterTopicsList.forEach(
-          hashMapTopicObj -> clusterTopicStringList.add(hashMapTopicObj.get("topicName")));
+          hashMapTopicObj -> clusterTopicStringList.add(hashMapTopicObj.getTopicName()));
 
       Map<String, TopicRequestsResponseModel> sotTopics = new HashMap<>();
 
@@ -800,10 +801,10 @@ public class TopicSyncControllerService {
       }
     } else {
       try {
-        List<Map<String, String>> topicsMap =
+        List<TopicConfig> topicsMap =
             getTopicsFromKafkaCluster(
                 syncTopicsBulk.getSourceEnv(), syncTopicsBulk.getTopicSearchFilter());
-        for (Map<String, String> hashMap : topicsMap) {
+        for (TopicConfig hashMap : topicsMap) {
           invokeUpdateSyncAllTopics(syncTopicsBulk, logArray, hashMap);
         }
       } catch (Exception e) {
@@ -820,31 +821,31 @@ public class TopicSyncControllerService {
   }
 
   private void invokeUpdateSyncAllTopics(
-      SyncTopicsBulk syncTopicsBulk, List<String> logArray, Map<String, String> hashMap) {
+      SyncTopicsBulk syncTopicsBulk, List<String> logArray, TopicConfig hashMap) {
     SyncTopicUpdates syncTopicUpdates;
     List<SyncTopicUpdates> updatedSyncTopicsList = new ArrayList<>();
 
     syncTopicUpdates = new SyncTopicUpdates();
     syncTopicUpdates.setTeamSelected(syncTopicsBulk.getSelectedTeam());
-    syncTopicUpdates.setTopicName(hashMap.get("topicName"));
+    syncTopicUpdates.setTopicName(hashMap.getTopicName());
     syncTopicUpdates.setEnvSelected(syncTopicsBulk.getSourceEnv());
-    syncTopicUpdates.setPartitions(Integer.parseInt(hashMap.get("partitions")));
-    syncTopicUpdates.setReplicationFactor(hashMap.get("replicationFactor"));
+    syncTopicUpdates.setPartitions(Integer.parseInt(hashMap.getPartitions()));
+    syncTopicUpdates.setReplicationFactor(hashMap.getReplicationFactor());
 
     updatedSyncTopicsList.add(syncTopicUpdates);
     try {
       logArray.add(
           "Topic status :"
-              + hashMap.get("topicName")
+              + hashMap.getTopicName()
               + " "
               + updateSyncTopics(updatedSyncTopicsList).getMessage());
     } catch (Exception e) {
-      logArray.add(TOPICS_SYNC_ERR_102 + hashMap.get("topicName") + " " + e);
+      logArray.add(TOPICS_SYNC_ERR_102 + hashMap.getTopicName() + " " + e);
       log.error("Exception:", e);
     }
   }
 
-  private List<Map<String, String>> getTopicsFromKafkaCluster(String env, String topicNameSearch)
+  private List<TopicConfig> getTopicsFromKafkaCluster(String env, String topicNameSearch)
       throws Exception {
     if (topicNameSearch != null) {
       topicNameSearch = topicNameSearch.trim();
@@ -856,7 +857,7 @@ public class TopicSyncControllerService {
             .getClusters(KafkaClustersType.KAFKA, tenantId)
             .get(envSelected.getClusterId());
 
-    List<Map<String, String>> topicsList =
+    List<TopicConfig> topicsList =
         clusterApiService.getAllTopics(
             kwClusters.getBootstrapServers(),
             kwClusters.getProtocol(),
@@ -866,14 +867,14 @@ public class TopicSyncControllerService {
 
     topicCounter = 0;
 
-    List<Map<String, String>> topicFilteredList = topicsList;
+    List<TopicConfig> topicFilteredList = topicsList;
     // Filter topics on topic name for search
 
     if (topicNameSearch != null && topicNameSearch.length() > 0) {
       final String topicSearchFilter = topicNameSearch;
       topicFilteredList =
           topicsList.stream()
-              .filter(topic -> topic.get("topicName").contains(topicSearchFilter))
+              .filter(topic -> topic.getTopicName().contains(topicSearchFilter))
               .collect(Collectors.toList());
     }
     return topicFilteredList;

--- a/core/src/main/resources/static/index.html
+++ b/core/src/main/resources/static/index.html
@@ -448,7 +448,7 @@
                 <div class="col-lg-3 col-md-12">
                     <div class="card card-inverse bg-info">
                         <div class="card-body">
-                            <a href="browseTopics?team={{teamname}}">
+                            <a href="browseTopics?team={{teamId}}">
                                 <div class="carousel-item active flex-column">
                                     <i class="fas fa-cogs fa-2x text-white"></i>
                                     <p class="text-white">{{ teamname }}</p>
@@ -463,7 +463,7 @@
                     </div>
                     <div class="card card-inverse bg-primary">
                         <div class="card-body">
-                            <a href="browseTopics?team={{teamname}}&producer=true">
+                            <a href="browseTopics?team={{teamId}}&producer=true">
                                 <div class="carousel-item active flex-column">
                                     <i class="fas fas fa-unlock fa-2x text-white"></i>
                                     <p class="text-white">{{ teamname }}</p>
@@ -497,7 +497,7 @@
 
                     <div class="card card-inverse bg-primary">
                         <div class="card-body">
-                            <a href="browseTopics?team={{teamname}}&consumer=true">
+                            <a href="browseTopics?team={{teamId}}&consumer=true">
                                 <div class="carousel-item active flex-column">
                                     <i class="fas fa-venus-double fa-2x text-white"></i>
                                     <p class="text-white">{{ teamname }}</p>

--- a/core/src/main/resources/static/js/kafkaconnect.js
+++ b/core/src/main/resources/static/js/kafkaconnect.js
@@ -36,7 +36,7 @@ app.controller("kafkaConnectCtrl", function($scope, $http, $location, $window) {
         $scope.loadTeams = function() {
                 $http({
                     method: "GET",
-                    url: "getAllTeamsSUOnly",
+                    url: "getAllTeamsSU",
                     headers : { 'Content-Type' : 'application/json' }
                 }).success(function(output) {
                     $scope.allTeams = output;
@@ -283,7 +283,7 @@ app.controller("kafkaConnectCtrl", function($scope, $http, $location, $window) {
                 'pageNo' : pageNoSelected,
                 'currentPage' : $scope.currentPageSelected,
                  'connectornamesearch' : $scope.getConnectors.connectornamesearch,
-                 'teamName' : teamSel
+                 'teamId' : teamSel
                  }
 		}).success(function(output) {
 			$scope.resultBrowse = output;

--- a/core/src/main/resources/templates/execTopics.html
+++ b/core/src/main/resources/templates/execTopics.html
@@ -442,7 +442,7 @@
 
 			<!-- Row -->
 
-			<div class="row" ng-show="resultPages == null && alert != null && alert != ''" ng-init="">
+			<div class="row" ng-show="alert != null && alert != ''" ng-init="">
 				<div  class="col-lg-12 col-md-6 col-xlg-2 col-xs-12" >
 					<div class="ribbon-wrapper card">
 						<div ng-show="alert.indexOf('success') != -1" class="ribbon ribbon-success">Notification</div>

--- a/core/src/main/resources/templates/index.html
+++ b/core/src/main/resources/templates/index.html
@@ -448,7 +448,7 @@
                 <div class="col-lg-3 col-md-12">
                     <div class="card card-inverse bg-info">
                         <div class="card-body">
-                            <a href="browseTopics?team={{teamname}}">
+                            <a href="browseTopics?team={{teamId}}">
                                 <div class="carousel-item active flex-column">
                                     <i class="fas fa-cogs fa-2x text-white"></i>
                                     <p class="text-white">{{ teamname }}</p>
@@ -463,7 +463,7 @@
                     </div>
                     <div class="card card-inverse bg-primary">
                         <div class="card-body">
-                            <a href="browseTopics?team={{teamname}}&producer=true">
+                            <a href="browseTopics?team={{teamId}}&producer=true">
                                 <div class="carousel-item active flex-column">
                                     <i class="fas fas fa-unlock fa-2x text-white"></i>
                                     <p class="text-white">{{ teamname }}</p>
@@ -497,7 +497,7 @@
 
                     <div class="card card-inverse bg-primary">
                         <div class="card-body">
-                            <a href="browseTopics?team={{teamname}}&consumer=true">
+                            <a href="browseTopics?team={{teamId}}&consumer=true">
                                 <div class="carousel-item active flex-column">
                                     <i class="fas fa-venus-double fa-2x text-white"></i>
                                     <p class="text-white">{{ teamname }}</p>

--- a/core/src/main/resources/templates/kafkaConnectors.html
+++ b/core/src/main/resources/templates/kafkaConnectors.html
@@ -480,7 +480,7 @@
 					<div class="form-group has-success">
 						<label class="control-label">Select Team</label>
 						<select class="form-control custom-select" ng-model="getConnectors.team"
-								ng-options="team as team for team in allTeams" ng-change="getConnectors(1,'true','grid')">
+								ng-options="team.teamId as team.teamname for team in allTeams" ng-change="getConnectors(1,'true','grid')">
 						</select>
 					</div>
 				</div>

--- a/core/src/main/resources/templates/serverConfig.html
+++ b/core/src/main/resources/templates/serverConfig.html
@@ -500,6 +500,7 @@
       "requestTopicsEnvironmentsList": ["DEV", "TST"],
       "baseSyncKafkaConnectCluster" : null,
       "orderOfConnectorsPromotionEnvsList" : [],
+      "requestSchemaEnvironmentsList" : [],
       "requestConnectorsEnvironmentsList" : []
     }
 }

--- a/core/src/test/java/io/aiven/klaw/UtilMethods.java
+++ b/core/src/test/java/io/aiven/klaw/UtilMethods.java
@@ -40,6 +40,7 @@ import io.aiven.klaw.model.response.RequestsCountOverview;
 import io.aiven.klaw.model.response.RequestsOperationTypeCount;
 import io.aiven.klaw.model.response.SchemaRequestsResponseModel;
 import io.aiven.klaw.model.response.TeamModelResponse;
+import io.aiven.klaw.model.response.TopicConfig;
 import io.aiven.klaw.model.response.TopicOverview;
 import io.aiven.klaw.model.response.TopicRequestsResponseModel;
 import io.aiven.klaw.model.response.UserInfoModelResponse;
@@ -656,14 +657,14 @@ public class UtilMethods {
     return aclRequest;
   }
 
-  public List<Map<String, String>> getClusterApiTopics(String topicPrefix, int size) {
-    List<Map<String, String>> listTopics = new ArrayList<>();
-    HashMap<String, String> hashMap;
+  public List<TopicConfig> getClusterApiTopics(String topicPrefix, int size) {
+    List<TopicConfig> listTopics = new ArrayList<>();
+    TopicConfig hashMap;
     for (int i = 0; i < size; i++) {
-      hashMap = new HashMap<>();
-      hashMap.put("topicName", topicPrefix + i);
-      hashMap.put("replicationFactor", "1");
-      hashMap.put("partitions", "2");
+      hashMap = new TopicConfig();
+      hashMap.setTopicName(topicPrefix + i);
+      hashMap.setReplicationFactor("1");
+      hashMap.setPartitions("2");
       listTopics.add(hashMap);
     }
     return listTopics;

--- a/core/src/test/java/io/aiven/klaw/service/ClusterApiServiceTest.java
+++ b/core/src/test/java/io/aiven/klaw/service/ClusterApiServiceTest.java
@@ -24,6 +24,7 @@ import io.aiven.klaw.model.enums.ClusterStatus;
 import io.aiven.klaw.model.enums.KafkaClustersType;
 import io.aiven.klaw.model.enums.KafkaSupportedProtocol;
 import io.aiven.klaw.model.enums.RequestOperationType;
+import io.aiven.klaw.model.response.TopicConfig;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
@@ -180,7 +181,7 @@ public class ClusterApiServiceTest {
             (ParameterizedTypeReference<Object>) any()))
         .thenReturn(response);
 
-    List<Map<String, String>> result =
+    List<TopicConfig> result =
         clusterApiService.getAllTopics("", KafkaSupportedProtocol.PLAINTEXT, "", "", 1);
     assertThat(result).isEqualTo(new ArrayList<>(topicsList));
   }

--- a/core/src/test/java/io/aiven/klaw/service/EnvsClustersTenantsControllerServiceTest.java
+++ b/core/src/test/java/io/aiven/klaw/service/EnvsClustersTenantsControllerServiceTest.java
@@ -90,10 +90,10 @@ class EnvsClustersTenantsControllerServiceTest {
     when(handleDbRequestsJdbc.selectAllEnvs(anyInt()))
         .thenReturn(
             List.of(
-                buildEnv("4", 101, "DEV", KafkaClustersType.KAFKA),
-                buildEnv("5", 101, "TST", KafkaClustersType.SCHEMA_REGISTRY)));
+                buildEnv("4", 101, "DEV", KafkaClustersType.KAFKA, 4),
+                buildEnv("5", 101, "TST", KafkaClustersType.SCHEMA_REGISTRY, 5)));
     when(manageDatabase.getKafkaEnvList(anyInt()))
-        .thenReturn(List.of(buildEnv("4", 101, "DEV", KafkaClustersType.KAFKA)));
+        .thenReturn(List.of(buildEnv("4", 101, "DEV", KafkaClustersType.KAFKA, 4)));
     ApiResponse response = service.addNewEnv(env);
     assertThat(response.getMessage())
         .contains("Failure. Please choose a different name. This environment name already exists.");
@@ -251,13 +251,15 @@ class EnvsClustersTenantsControllerServiceTest {
     return info;
   }
 
-  private Env buildEnv(String id, int tenantId, String name, KafkaClustersType type) {
+  private Env buildEnv(
+      String id, int tenantId, String name, KafkaClustersType type, int clusterId) {
     Env mapping = new Env();
     mapping.setId(id);
     mapping.setName(name);
     mapping.setTenantId(tenantId);
     mapping.setType(type.value);
     mapping.setEnvExists("true");
+    mapping.setClusterId(clusterId);
     return mapping;
   }
 }

--- a/core/src/test/java/io/aiven/klaw/service/ServerConfigServiceTest.java
+++ b/core/src/test/java/io/aiven/klaw/service/ServerConfigServiceTest.java
@@ -1,5 +1,6 @@
 package io.aiven.klaw.service;
 
+import static io.aiven.klaw.error.KlawErrorMessages.SERVER_CONFIG_ERR_106;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
@@ -195,13 +196,12 @@ public class ServerConfigServiceTest {
             "DEV",
             "TST",
             "UAT");
-    prop =
-        addKafkaConnInformation(
-            prop,
-            Arrays.asList("DEV_CONN", "TST_CONN", "UAT_CONN"),
-            "DEV_CONN",
-            "TST_CONN",
-            "UAT_CONN");
+    addKafkaConnInformation(
+        prop,
+        Arrays.asList("DEV_CONN", "TST_CONN", "UAT_CONN"),
+        "DEV_CONN",
+        "TST_CONN",
+        "UAT_CONN");
 
     prop.setTenantName("default");
     TenantConfig config = new TenantConfig();
@@ -231,13 +231,12 @@ public class ServerConfigServiceTest {
             "TST",
             "UAT");
 
-    prop =
-        addKafkaConnInformation(
-            prop,
-            Arrays.asList("DEV_CONN", "TST_CONN", "UAT_CONN"),
-            "DEV_CONN",
-            "TST_CONN",
-            "UAT_CONN");
+    addKafkaConnInformation(
+        prop,
+        Arrays.asList("DEV_CONN", "TST_CONN", "UAT_CONN"),
+        "DEV_CONN",
+        "TST_CONN",
+        "UAT_CONN");
     prop.setTenantName("default");
     TenantConfig config = new TenantConfig();
     config.setTenantModel(prop);
@@ -356,18 +355,39 @@ public class ServerConfigServiceTest {
     assertThat(tenantConfig.getTenantModel()).isNull();
   }
 
+  @Test
+  @Order(11)
+  public void givenValidTenantModelTopicsInvalidEnvsClustersOnly_returnFailure()
+      throws KlawException, JsonProcessingException {
+    stubValidateTests();
+    // Create Test Object
+    KwTenantConfigModel prop =
+        addKafkaTopicInformation(
+            new KwTenantConfigModel(), "DEV", Arrays.asList("DEV", "TST", "UAT"), "DEV", "PRE");
+    prop.setTenantName("default");
+    TenantConfig config = new TenantConfig();
+    config.setTenantModel(prop);
+    KwPropertiesModel request =
+        createKwPropertiesModel(KLAW_TENANT_CONFIG, mapper.writeValueAsString(config));
+    // Execute
+    ApiResponse response = serverConfigService.updateKwCustomProperty(request);
+
+    // verify
+    assertThat(response.getMessage()).isEqualTo(SERVER_CONFIG_ERR_106);
+  }
+
   private Map<String, Map<String, String>> buildFullDbObject() throws JsonProcessingException {
     // This object is created using IDs from stubValidateTests()
     KwTenantConfigModel prop =
         addKafkaTopicInformation(
             new KwTenantConfigModel(), "1", Arrays.asList("1", "2", "3"), "1", "3", "2");
-    prop = addKafkaConnInformation(prop, Arrays.asList("5", "6", "4"), "6", "5", "4");
+    addKafkaConnInformation(prop, Arrays.asList("5", "6", "4"), "6", "5", "4");
 
     prop.setTenantName("default");
     TenantConfig config = new TenantConfig();
     config.setTenantModel(prop);
     Map<String, Map<String, String>> dbObject = new HashMap<>();
-    Map<String, String> map = new HashMap();
+    Map<String, String> map = new HashMap<>();
 
     map.put("kwvalue", mapper.writeValueAsString(config));
     map.put("kwkey", KLAW_TENANT_CONFIG);
@@ -399,29 +419,30 @@ public class ServerConfigServiceTest {
     when(managedb.getKafkaEnvList(anyInt()))
         .thenReturn(
             List.of(
-                createEnv("DEV", "1", KafkaClustersType.KAFKA.value),
-                createEnv("TST", "2", KafkaClustersType.KAFKA.value),
-                createEnv("UAT", "3", KafkaClustersType.KAFKA.value)));
+                createEnv("DEV", "1", KafkaClustersType.KAFKA.value, 1),
+                createEnv("TST", "2", KafkaClustersType.KAFKA.value, 2),
+                createEnv("UAT", "3", KafkaClustersType.KAFKA.value, 3),
+                createEnv("PRE", "3", KafkaClustersType.KAFKA.value, 1)));
     when(managedb.getKafkaConnectEnvList(anyInt()))
         .thenReturn(
             List.of(
-                createEnv("DEV_CONN", "4", KafkaClustersType.KAFKA_CONNECT.value),
-                createEnv("TST_CONN", "5", KafkaClustersType.KAFKA_CONNECT.value),
-                createEnv("UAT_CONN", "6", KafkaClustersType.KAFKA_CONNECT.value)));
+                createEnv("DEV_CONN", "4", KafkaClustersType.KAFKA_CONNECT.value, 4),
+                createEnv("TST_CONN", "5", KafkaClustersType.KAFKA_CONNECT.value, 5),
+                createEnv("UAT_CONN", "6", KafkaClustersType.KAFKA_CONNECT.value, 6)));
 
     when(managedb.getSchemaRegEnvList(anyInt()))
         .thenReturn(
             List.of(
-                createEnv("DEV_SCH", "7", KafkaClustersType.SCHEMA_REGISTRY.value),
-                createEnv("TST_SCH", "8", KafkaClustersType.SCHEMA_REGISTRY.value),
-                createEnv("UAT_SCH", "9", KafkaClustersType.SCHEMA_REGISTRY.value)));
+                createEnv("DEV_SCH", "7", KafkaClustersType.SCHEMA_REGISTRY.value, 7),
+                createEnv("TST_SCH", "8", KafkaClustersType.SCHEMA_REGISTRY.value, 8),
+                createEnv("UAT_SCH", "9", KafkaClustersType.SCHEMA_REGISTRY.value, 9)));
 
     when(managedb.getHandleDbRequests()).thenReturn(handleDbRequests);
     when(handleDbRequests.updateKwProperty(any(), eq(101)))
         .thenReturn(ApiResultStatus.SUCCESS.value);
   }
 
-  private Env createEnv(String envName, String envId, String envType) {
+  private Env createEnv(String envName, String envId, String envType, int clusterId) {
     Env env = new Env();
     env.setName(envName);
     env.setTenantId(101);
@@ -429,6 +450,7 @@ public class ServerConfigServiceTest {
     env.setType(envType); // kafka,schemaregistry
     env.setEnvStatus("NOT_KNOWN");
     env.setEnvExists("true");
+    env.setClusterId(clusterId);
 
     return env;
   }

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -3910,11 +3910,12 @@
             "type" : "string"
           }
         }, {
-          "name" : "teamName",
+          "name" : "teamId",
           "in" : "query",
           "required" : false,
           "schema" : {
-            "type" : "string"
+            "type" : "integer",
+            "format" : "int32"
           }
         } ],
         "responses" : {
@@ -6484,6 +6485,10 @@
           "teamName" : {
             "type" : "string"
           },
+          "teamId" : {
+            "type" : "integer",
+            "format" : "int32"
+          },
           "showEditConnector" : {
             "type" : "boolean"
           },
@@ -6533,7 +6538,7 @@
             "type" : "string"
           }
         },
-        "required" : [ "connectorDeletable", "connectorId", "connectorName", "environmentId", "showDeleteConnector", "showEditConnector", "teamName" ]
+        "required" : [ "connectorDeletable", "connectorId", "connectorName", "environmentId", "showDeleteConnector", "showEditConnector", "teamId", "teamName" ]
       },
       "EnvModelResponse" : {
         "properties" : {


### PR DESCRIPTION
About this change - What it does

- configuring tenant config in settings : Dev, Tst should not be allowed in hierarchy of kafka environments, if both pointing to same kafka cluster
- If two envs are pointing to same cluster, enforce prefix/suffix on envs, while adding new envs
- If topic already exists in kafka cluster, and it is being requested in klaw, approve shud be successful if same config is requested atleast.
- Updates getConnectors endpoint to return teamId, and takes search param teamId
- fixes couple of bugs related to teamId in browse topics

Resolves: #873 
Why this way
these first 3 improvements enable users to handle topic promotions/creations in a consistent approach
