### PR TITLE
Users and topics set in memory to reduce db calls

### DIFF
--- a/cluster-api/src/main/java/io/aiven/klaw/clusterapi/controller/ClusterApiController.java
+++ b/cluster-api/src/main/java/io/aiven/klaw/clusterapi/controller/ClusterApiController.java
@@ -5,6 +5,7 @@ import io.aiven.klaw.clusterapi.models.ClusterAclRequest;
 import io.aiven.klaw.clusterapi.models.ClusterSchemaRequest;
 import io.aiven.klaw.clusterapi.models.ClusterTopicRequest;
 import io.aiven.klaw.clusterapi.models.OffsetDetails;
+import io.aiven.klaw.clusterapi.models.ServiceAccountDetails;
 import io.aiven.klaw.clusterapi.models.TopicConfig;
 import io.aiven.klaw.clusterapi.models.enums.AclType;
 import io.aiven.klaw.clusterapi.models.enums.AclsNativeType;
@@ -139,25 +140,13 @@ public class ClusterApiController {
       value = "/serviceAccountDetails/project/{projectName}/service/{serviceName}/user/{userName}",
       method = RequestMethod.GET,
       produces = {MediaType.APPLICATION_JSON_VALUE})
-  public ResponseEntity<ApiResponse> getServiceAccountCredentials(
+  public ResponseEntity<ServiceAccountDetails> getServiceAccountCredentials(
       @PathVariable String projectName,
       @PathVariable String serviceName,
       @PathVariable String userName) {
-    Map<String, String> serviceDetailsMap =
-        aivenApiService.getServiceAccountDetails(projectName, serviceName, userName);
-    ApiResponse apiResponse;
-    if (serviceDetailsMap.isEmpty()) {
-      apiResponse =
-          ApiResponse.builder().success(false).message(ApiResultStatus.FAILURE.value).build();
-    } else {
-      apiResponse =
-          ApiResponse.builder()
-              .data(aivenApiService.getServiceAccountDetails(projectName, serviceName, userName))
-              .message(ApiResultStatus.SUCCESS.value)
-              .success(true)
-              .build();
-    }
-    return new ResponseEntity<>(apiResponse, HttpStatus.OK);
+    return new ResponseEntity<>(
+        aivenApiService.getServiceAccountDetails(projectName, serviceName, userName),
+        HttpStatus.OK);
   }
 
   /*

--- a/cluster-api/src/main/java/io/aiven/klaw/clusterapi/models/ClusterTopicRequest.java
+++ b/cluster-api/src/main/java/io/aiven/klaw/clusterapi/models/ClusterTopicRequest.java
@@ -9,12 +9,14 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
+import lombok.ToString;
 
 @Builder(toBuilder = true)
 @Getter
 @Setter
 @AllArgsConstructor
 @NoArgsConstructor
+@ToString
 public class ClusterTopicRequest {
   @JsonProperty private String env;
 

--- a/cluster-api/src/main/java/io/aiven/klaw/clusterapi/models/ServiceAccountDetails.java
+++ b/cluster-api/src/main/java/io/aiven/klaw/clusterapi/models/ServiceAccountDetails.java
@@ -1,0 +1,12 @@
+package io.aiven.klaw.clusterapi.models;
+
+import lombok.Data;
+
+@Data
+public class ServiceAccountDetails {
+  private String username;
+
+  private String password;
+
+  private boolean accountFound;
+}

--- a/cluster-api/src/main/java/io/aiven/klaw/clusterapi/services/AivenApiService.java
+++ b/cluster-api/src/main/java/io/aiven/klaw/clusterapi/services/AivenApiService.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import io.aiven.klaw.clusterapi.models.AivenAclResponse;
 import io.aiven.klaw.clusterapi.models.AivenAclStruct;
 import io.aiven.klaw.clusterapi.models.ClusterAclRequest;
+import io.aiven.klaw.clusterapi.models.ServiceAccountDetails;
 import io.aiven.klaw.clusterapi.models.enums.AclAttributes;
 import io.aiven.klaw.clusterapi.models.enums.ApiResultStatus;
 import java.util.ArrayList;
@@ -115,8 +116,8 @@ public class AivenApiService {
           projectName,
           serviceName,
           clusterAclRequest.getTopicName());
-      if (getServiceAccountDetails(projectName, serviceName, clusterAclRequest.getUsername())
-          .isEmpty()) {
+      if (!getServiceAccountDetails(projectName, serviceName, clusterAclRequest.getUsername())
+          .isAccountFound()) {
         createServiceAccount(clusterAclRequest, resultMap);
       } else {
         resultMap.put("result", ApiResultStatus.SUCCESS.value);
@@ -160,7 +161,7 @@ public class AivenApiService {
   }
 
   // Get Aiven service account details
-  public Map<String, String> getServiceAccountDetails(
+  public ServiceAccountDetails getServiceAccountDetails(
       String projectName, String serviceName, String userName) {
     log.debug(
         "Service account for project :{} service : {} user : {}",
@@ -174,6 +175,8 @@ public class AivenApiService {
             .replace(SERVICE_NAME, serviceName)
             .replace("userName", userName);
     HttpEntity<Map<String, String>> request = new HttpEntity<>(headers);
+    ServiceAccountDetails serviceAccountDetails = new ServiceAccountDetails();
+    serviceAccountDetails.setAccountFound(false);
     try {
       ResponseEntity<Map<String, Map<String, String>>> response =
           getRestTemplate()
@@ -186,17 +189,18 @@ public class AivenApiService {
           // Not sending the full service account details.
           // Response enriched only with username and password. Certificates are removed from the
           // response.
-          Map<String, String> responseInnerMap = new HashMap<>();
+
           Map<String, String> resultMap = responseMap.get("user");
-          responseInnerMap.put("password", resultMap.get("password"));
-          responseInnerMap.put(USERNAME, resultMap.get(USERNAME));
-          return responseInnerMap;
+          serviceAccountDetails.setPassword(resultMap.get("password"));
+          serviceAccountDetails.setUsername(resultMap.get(USERNAME));
+          serviceAccountDetails.setAccountFound(true);
+          return serviceAccountDetails;
         }
       }
     } catch (Exception e) {
       log.error("Exception:", e);
     }
-    return new HashMap<>();
+    return serviceAccountDetails;
   }
 
   // Get Aiven service accounts

--- a/cluster-api/src/main/java/io/aiven/klaw/clusterapi/services/ApacheKafkaTopicService.java
+++ b/cluster-api/src/main/java/io/aiven/klaw/clusterapi/services/ApacheKafkaTopicService.java
@@ -96,7 +96,7 @@ public class ApacheKafkaTopicService {
 
   public synchronized ApiResponse createTopic(ClusterTopicRequest clusterTopicRequest)
       throws Exception {
-    log.info("createTopic {}", clusterTopicRequest);
+    log.info("createTopic {}", clusterTopicRequest.toString());
     AdminClient client =
         clusterApiUtils.getAdminClient(
             clusterTopicRequest.getEnv(),

--- a/cluster-api/src/main/java/io/aiven/klaw/clusterapi/services/ApacheKafkaTopicService.java
+++ b/cluster-api/src/main/java/io/aiven/klaw/clusterapi/services/ApacheKafkaTopicService.java
@@ -96,7 +96,7 @@ public class ApacheKafkaTopicService {
 
   public synchronized ApiResponse createTopic(ClusterTopicRequest clusterTopicRequest)
       throws Exception {
-    log.info("createTopic {}", clusterTopicRequest.toString());
+    log.info("createTopic {}", clusterTopicRequest);
     AdminClient client =
         clusterApiUtils.getAdminClient(
             clusterTopicRequest.getEnv(),

--- a/core/src/main/java/io/aiven/klaw/controller/AclController.java
+++ b/core/src/main/java/io/aiven/klaw/controller/AclController.java
@@ -9,11 +9,13 @@ import io.aiven.klaw.model.enums.RequestStatus;
 import io.aiven.klaw.model.requests.AclRequestsModel;
 import io.aiven.klaw.model.response.AclRequestsResponseModel;
 import io.aiven.klaw.model.response.OffsetDetails;
+import io.aiven.klaw.model.response.ServiceAccountDetails;
 import io.aiven.klaw.model.response.TopicOverview;
 import io.aiven.klaw.service.AclControllerService;
 import io.aiven.klaw.service.TopicOverviewService;
 import jakarta.validation.Valid;
 import java.util.List;
+import java.util.Set;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
@@ -197,7 +199,7 @@ public class AclController {
       value = "/getAivenServiceAccount",
       method = RequestMethod.GET,
       produces = {MediaType.APPLICATION_JSON_VALUE})
-  public ResponseEntity<ApiResponse> getAivenServiceAccountDetails(
+  public ResponseEntity<ServiceAccountDetails> getAivenServiceAccountDetails(
       @RequestParam("env") String envId,
       @RequestParam("topicName") String topicName,
       @RequestParam(value = "userName") String userName,
@@ -212,7 +214,7 @@ public class AclController {
       value = "/getAivenServiceAccounts",
       method = RequestMethod.GET,
       produces = {MediaType.APPLICATION_JSON_VALUE})
-  public ResponseEntity<ApiResponse> getAivenServiceAccounts(@RequestParam("env") String envId) {
+  public ResponseEntity<Set<String>> getAivenServiceAccounts(@RequestParam("env") String envId) {
     return new ResponseEntity<>(aclControllerService.getAivenServiceAccounts(envId), HttpStatus.OK);
   }
 }

--- a/core/src/main/java/io/aiven/klaw/helpers/db/rdbms/SelectDataJdbc.java
+++ b/core/src/main/java/io/aiven/klaw/helpers/db/rdbms/SelectDataJdbc.java
@@ -377,7 +377,7 @@ public class SelectDataJdbc {
         return topicRepo.findAllByTenantIdAndTopicnameIn(tenantId, topics);
       }
     } else {
-      if ("ALL".equals(env)) {
+      if (env == null || "ALL".equals(env)) {
         return topicRepo.findAllByTeamIdAndTenantId(teamId, tenantId);
       } else {
         List<String> topics = topicRepo.findAllTopicNamesForEnvAndTeam(env, teamId, tenantId);
@@ -1402,7 +1402,7 @@ public class SelectDataJdbc {
         return kafkaConnectorRepo.findAllByEnvironmentAndTenantId(env, tenantId);
       }
     } else {
-      if ("ALL".equals(env)) {
+      if (env == null || "ALL".equals(env)) {
         return kafkaConnectorRepo.findAllByTeamIdAndTenantId(teamId, tenantId);
       }
       return kafkaConnectorRepo.findAllByEnvironmentAndTeamIdAndTenantId(env, teamId, tenantId);

--- a/core/src/main/java/io/aiven/klaw/model/enums/EntityType.java
+++ b/core/src/main/java/io/aiven/klaw/model/enums/EntityType.java
@@ -5,12 +5,14 @@ import org.checkerframework.checker.nullness.qual.Nullable;
 
 @Slf4j
 public enum EntityType {
+  USERS,
   TEAM,
   ENVIRONMENT,
   CLUSTER,
   TENANT,
   ROLES_PERMISSIONS,
-  PROPERTIES;
+  PROPERTIES,
+  TOPICS;
 
   @Nullable
   public static EntityType of(@Nullable String value) {

--- a/core/src/main/java/io/aiven/klaw/model/response/ServiceAccountDetails.java
+++ b/core/src/main/java/io/aiven/klaw/model/response/ServiceAccountDetails.java
@@ -1,0 +1,12 @@
+package io.aiven.klaw.model.response;
+
+import lombok.Data;
+
+@Data
+public class ServiceAccountDetails {
+  private String username;
+
+  private String password;
+
+  private boolean accountFound;
+}

--- a/core/src/main/java/io/aiven/klaw/service/ClusterApiService.java
+++ b/core/src/main/java/io/aiven/klaw/service/ClusterApiService.java
@@ -42,6 +42,7 @@ import io.aiven.klaw.model.enums.KafkaFlavors;
 import io.aiven.klaw.model.enums.KafkaSupportedProtocol;
 import io.aiven.klaw.model.enums.RequestOperationType;
 import io.aiven.klaw.model.response.OffsetDetails;
+import io.aiven.klaw.model.response.ServiceAccountDetails;
 import io.aiven.klaw.model.response.TopicConfig;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.SignatureAlgorithm;
@@ -640,7 +641,7 @@ public class ClusterApiService {
     }
   }
 
-  public ApiResponse getAivenServiceAccountDetails(
+  public ServiceAccountDetails getAivenServiceAccountDetails(
       String projectName, String serviceName, String userName, int tenantId) throws KlawException {
     getClusterApiProperties(tenantId);
     try {
@@ -652,7 +653,7 @@ public class ClusterApiService {
               .replace("userName", userName);
 
       HttpEntity<String> entity = getHttpEntity();
-      ResponseEntity<ApiResponse> apiResponseResponseEntity =
+      ResponseEntity<ServiceAccountDetails> apiResponseResponseEntity =
           getRestTemplate()
               .exchange(
                   uriGetServiceAccountDetails,

--- a/core/src/main/java/io/aiven/klaw/service/CommonUtilsService.java
+++ b/core/src/main/java/io/aiven/klaw/service/CommonUtilsService.java
@@ -32,7 +32,6 @@ import java.util.stream.Collectors;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.cache.annotation.Cacheable;
 import org.springframework.http.*;
 import org.springframework.http.client.HttpComponentsClientHttpRequestFactory;
 import org.springframework.security.core.Authentication;
@@ -308,7 +307,9 @@ public class CommonUtilsService {
     }
     final MetadataOperationType operationType =
         MetadataOperationType.of(kwMetadataUpdates.getOperationType());
-    if (entityType == EntityType.TEAM) {
+    if (entityType == EntityType.USERS) {
+      manageDatabase.loadUsersForAllTenants();
+    } else if (entityType == EntityType.TEAM) {
       manageDatabase.loadEnvsForOneTenant(kwMetadataUpdates.getTenantId());
       manageDatabase.loadTenantTeamsForOneTenant(null, kwMetadataUpdates.getTenantId());
     } else if (entityType == EntityType.CLUSTER && operationType == MetadataOperationType.DELETE) {
@@ -334,12 +335,9 @@ public class CommonUtilsService {
       manageDatabase.loadRolesPermissionsOneTenant(null, kwMetadataUpdates.getTenantId());
     } else if (entityType == EntityType.PROPERTIES) {
       manageDatabase.loadKwPropsPerOneTenant(null, kwMetadataUpdates.getTenantId());
+    } else if (entityType == EntityType.TOPICS) {
+      manageDatabase.loadTopicsForOneTenant(kwMetadataUpdates.getTenantId());
     }
-  }
-
-  @Cacheable(cacheNames = "tenantsusernames", key = "#userId")
-  public int getTenantId(String userId) {
-    return manageDatabase.getHandleDbRequests().getUsersInfo(userId).getTenantId();
   }
 
   public String getLoginUrl() {
@@ -428,12 +426,20 @@ public class CommonUtilsService {
         manageDatabase.getTeamsAndAllowedEnvs(getTeamId(userName), getTenantId(userName)));
   }
 
-  public Integer getTeamId(String userName) {
-    return manageDatabase.getHandleDbRequests().getUsersInfo(userName).getTeamId();
+  public int getTenantId(String userId) {
+    return manageDatabase.selectAllCachedUserInfo().stream()
+        .filter(userInfo -> userInfo.getUsername().equals(userId))
+        .findFirst()
+        .map(UserInfo::getTenantId)
+        .orElse(0);
   }
 
-  public boolean verifyIfTeamExists(int tenantId, String teamName) {
-    return manageDatabase.getTeamIdFromTeamName(tenantId, teamName) != null;
+  public Integer getTeamId(String userName) {
+    return manageDatabase.selectAllCachedUserInfo().stream()
+        .filter(userInfo -> userInfo.getUsername().equals(userName))
+        .findFirst()
+        .map(UserInfo::getTeamId)
+        .orElse(0);
   }
 
   public Object getPrincipal() {
@@ -529,5 +535,11 @@ public class CommonUtilsService {
     }
 
     return orderOfSchemaEnvs.toString();
+  }
+
+  public List<Topic> getTopicsForTopicName(String topicName, int tenantId) {
+    return manageDatabase.getTopicsForTenant(tenantId).stream()
+        .filter(topic -> topic.getTopicname().equals(topicName))
+        .toList();
   }
 }

--- a/core/src/main/java/io/aiven/klaw/service/SchemaRegistryControllerService.java
+++ b/core/src/main/java/io/aiven/klaw/service/SchemaRegistryControllerService.java
@@ -388,8 +388,7 @@ public class SchemaRegistryControllerService {
 
   private boolean userAndTopicOwnerAreOnTheSameTeam(
       String topicName, Integer userTeamId, Integer tenantId) {
-    List<Topic> topicsSearchList =
-        manageDatabase.getHandleDbRequests().getTopicTeam(topicName, tenantId);
+    List<Topic> topicsSearchList = commonUtilsService.getTopicsForTopicName(topicName, tenantId);
 
     // tenant filtering
     Integer topicOwnerTeam =

--- a/core/src/main/java/io/aiven/klaw/service/TopicControllerService.java
+++ b/core/src/main/java/io/aiven/klaw/service/TopicControllerService.java
@@ -40,7 +40,9 @@ import io.aiven.klaw.model.TopicInfo;
 import io.aiven.klaw.model.enums.AclPatternType;
 import io.aiven.klaw.model.enums.AclType;
 import io.aiven.klaw.model.enums.ApiResultStatus;
+import io.aiven.klaw.model.enums.EntityType;
 import io.aiven.klaw.model.enums.KafkaClustersType;
+import io.aiven.klaw.model.enums.MetadataOperationType;
 import io.aiven.klaw.model.enums.Order;
 import io.aiven.klaw.model.enums.PermissionType;
 import io.aiven.klaw.model.enums.RequestOperationType;
@@ -471,7 +473,7 @@ public class TopicControllerService {
             manageDatabase.getTeamNameFromTeamId(tenantId, stringTeamsFound.iterator().next()));
       }
     } else {
-      topics = manageDatabase.getHandleDbRequests().getTopicTeam(topicName, tenantId);
+      topics = commonUtilsService.getTopicsForTopicName(topicName, tenantId);
       // tenant filtering
       topics = commonUtilsService.getFilteredTopicsForTenant(topics);
 
@@ -735,6 +737,10 @@ public class TopicControllerService {
           invokeClusterApiForTopicRequest(userName, tenantId, topicRequest, dbHandle, topicConfig);
     }
 
+    if (updateTopicReqStatus.equals(ApiResultStatus.SUCCESS.value)) {
+      commonUtilsService.updateMetadata(tenantId, EntityType.TOPICS, MetadataOperationType.CREATE);
+    }
+
     return ApiResponse.builder()
         .success((updateTopicReqStatus.equals(ApiResultStatus.SUCCESS.value)))
         .message(updateTopicReqStatus)
@@ -916,7 +922,7 @@ public class TopicControllerService {
     topic.setDocumentation(topicInfo.getDocumentation());
 
     List<Topic> topicsSearchList =
-        manageDatabase.getHandleDbRequests().getTopicTeam(topicInfo.getTopicName(), tenantId);
+        commonUtilsService.getTopicsForTopicName(topicInfo.getTopicName(), tenantId);
 
     try {
       // tenant filtering
@@ -1334,7 +1340,7 @@ public class TopicControllerService {
   }
 
   public List<Topic> getTopicFromName(String topicName, int tenantId) {
-    List<Topic> topics = manageDatabase.getHandleDbRequests().getTopicTeam(topicName, tenantId);
+    List<Topic> topics = commonUtilsService.getTopicsForTopicName(topicName, tenantId);
 
     // tenant filtering
     topics = commonUtilsService.getFilteredTopicsForTenant(topics);

--- a/core/src/main/java/io/aiven/klaw/service/TopicControllerService.java
+++ b/core/src/main/java/io/aiven/klaw/service/TopicControllerService.java
@@ -891,10 +891,10 @@ public class TopicControllerService {
   public List<String> getAllTopics(boolean isMyTeamTopics, String envSelected) {
     log.debug("getAllTopics {}, envSelected {}", isMyTeamTopics, envSelected);
     String userName = getUserName();
+
     List<Topic> topicsFromSOT =
-        manageDatabase
-            .getHandleDbRequests()
-            .getSyncTopics(envSelected, null, commonUtilsService.getTenantId(getUserName()));
+        commonUtilsService.getTopics(
+            envSelected, null, commonUtilsService.getTenantId(getUserName()));
 
     // tenant filtering
     topicsFromSOT = commonUtilsService.getFilteredTopicsForTenant(topicsFromSOT);
@@ -1081,7 +1081,7 @@ public class TopicControllerService {
     }
 
     // Get Sync topics
-    List<Topic> topicsFromSOT = handleDbRequests.getSyncTopics(env, teamId, tenantId);
+    List<Topic> topicsFromSOT = commonUtilsService.getTopics(env, teamId, tenantId);
     topicsFromSOT = commonUtilsService.getFilteredTopicsForTenant(topicsFromSOT);
 
     // tenant filtering

--- a/core/src/main/java/io/aiven/klaw/service/TopicOverviewService.java
+++ b/core/src/main/java/io/aiven/klaw/service/TopicOverviewService.java
@@ -89,7 +89,7 @@ public class TopicOverviewService extends BaseOverviewService {
     List<AclInfo> aclInfo = new ArrayList<>();
     List<AclInfo> prefixedAclsInfo = new ArrayList<>();
     List<Topic> topicsSearchList =
-        manageDatabase.getHandleDbRequests().getTopicTeam(topicNameSearch, tenantId);
+        commonUtilsService.getTopicsForTopicName(topicNameSearch, tenantId);
     // tenant filtering
     Integer topicOwnerTeamId =
         commonUtilsService.getFilteredTopicsForTenant(topicsSearchList).get(0).getTeamId();

--- a/core/src/main/java/io/aiven/klaw/service/TopicSyncControllerService.java
+++ b/core/src/main/java/io/aiven/klaw/service/TopicSyncControllerService.java
@@ -1118,7 +1118,7 @@ public class TopicSyncControllerService {
   }
 
   public List<Topic> getTopicFromName(String topicName, int tenantId) {
-    List<Topic> topics = manageDatabase.getHandleDbRequests().getTopicTeam(topicName, tenantId);
+    List<Topic> topics = commonUtilsService.getTopicsForTopicName(topicName, tenantId);
 
     // tenant filtering
     topics = commonUtilsService.getFilteredTopicsForTenant(topics);

--- a/core/src/main/java/io/aiven/klaw/service/UsersTeamsControllerService.java
+++ b/core/src/main/java/io/aiven/klaw/service/UsersTeamsControllerService.java
@@ -234,6 +234,9 @@ public class UsersTeamsControllerService {
       }
 
       String result = dbHandle.updateUser(existingUserInfo);
+      if (result.equals(ApiResultStatus.SUCCESS.value)) {
+        commonUtilsService.updateMetadata(tenantId, EntityType.USERS, MetadataOperationType.UPDATE);
+      }
       return ApiResponse.builder()
           .success(result.equals(ApiResultStatus.SUCCESS.value))
           .message(result)
@@ -248,7 +251,6 @@ public class UsersTeamsControllerService {
     log.debug("getTeamDetails {} {}", teamId, tenantName);
 
     int tenantId = commonUtilsService.getTenantId(getUserName());
-
     Team teamDao = manageDatabase.getHandleDbRequests().selectTeamDetails(teamId, tenantId);
     if (teamDao != null) {
       TeamModelResponse teamModel = new TeamModelResponse();
@@ -530,7 +532,6 @@ public class UsersTeamsControllerService {
       } else {
         tenantId = newUser.getTenantId();
       }
-
       newUser.setTenantId(tenantId);
     }
 
@@ -581,6 +582,12 @@ public class UsersTeamsControllerService {
               commonUtilsService.getLoginUrl());
         }
       }
+
+      if (result.equals(ApiResultStatus.SUCCESS.value)) {
+        tenantId = commonUtilsService.getTenantId(getUserName());
+        commonUtilsService.updateMetadata(tenantId, EntityType.USERS, MetadataOperationType.CREATE);
+      }
+
       return ApiResponse.builder()
           .success(result.equals(ApiResultStatus.SUCCESS.value))
           .message(result)

--- a/core/src/main/resources/static/js/browseAcls.js
+++ b/core/src/main/resources/static/js/browseAcls.js
@@ -782,7 +782,7 @@ app.controller("browseAclsCtrl", function($scope, $http, $location, $window) {
                 },
             }).success(function(output) {
                 $scope.serviceAccountInfo = output;
-                if(!output.success)
+                if(!output.accountFound)
                 {
                     swal({
                         title: "Failure:",

--- a/core/src/main/resources/static/js/requestAcls.js
+++ b/core/src/main/resources/static/js/requestAcls.js
@@ -268,7 +268,7 @@ app.controller("requestAclsCtrl", function($scope, $http, $location, $window) {
                 headers : { 'Content-Type' : 'application/json' },
                 params: {'env' : environment},
             }).success(function(output) {
-                $scope.serviceAccounts = output.data;
+                $scope.serviceAccounts = output;
             }).error(
                 function(error)
                 {

--- a/core/src/test/java/io/aiven/klaw/UtilMethods.java
+++ b/core/src/test/java/io/aiven/klaw/UtilMethods.java
@@ -185,20 +185,24 @@ public class UtilMethods {
     return allTopicReqs;
   }
 
-  public List<Topic> getMultipleTopics(String topicPrefix, int size) {
+  public List<Topic> getMultipleTopics(String topicPrefix, int size, String env, int teamId) {
     List<Topic> listTopics = new ArrayList<>();
     Topic t;
+    if (env == null) {
+      env = "1";
+    }
+
+    if (teamId == 0) {
+      teamId = 101;
+    }
 
     for (int i = 0; i < size; i++) {
       t = new Topic();
 
-      if (i % 2 == 0) t.setTeamId(1);
-      else t.setTeamId(2);
-
       t.setTopicname(topicPrefix + i);
       t.setTopicid(i);
-      t.setEnvironment("1");
-      t.setTeamId(101);
+      t.setEnvironment(env);
+      t.setTeamId(teamId);
       t.setEnvironmentsList(new ArrayList<>());
 
       listTopics.add(t);

--- a/core/src/test/java/io/aiven/klaw/controller/AclControllerTest.java
+++ b/core/src/test/java/io/aiven/klaw/controller/AclControllerTest.java
@@ -1,5 +1,6 @@
 package io.aiven.klaw.controller;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.hamcrest.Matchers.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -7,6 +8,7 @@ import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
+import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.aiven.klaw.UtilMethods;
 import io.aiven.klaw.model.AclInfo;
@@ -16,13 +18,12 @@ import io.aiven.klaw.model.enums.ApiResultStatus;
 import io.aiven.klaw.model.enums.RequestOperationType;
 import io.aiven.klaw.model.requests.AclRequestsModel;
 import io.aiven.klaw.model.response.AclRequestsResponseModel;
+import io.aiven.klaw.model.response.ServiceAccountDetails;
 import io.aiven.klaw.model.response.TopicOverview;
 import io.aiven.klaw.service.AclControllerService;
 import io.aiven.klaw.service.AclSyncControllerService;
 import io.aiven.klaw.service.TopicOverviewService;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 import org.junit.jupiter.api.*;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.boot.test.mock.mockito.MockBean;
@@ -255,29 +256,31 @@ public class AclControllerTest {
 
   @Test
   public void getAivenServiceAccount() throws Exception {
-    Map<String, String> serviceAccountInfoMap = new HashMap<>();
-    serviceAccountInfoMap.put("password", "password");
-    serviceAccountInfoMap.put("username", "username");
+    ServiceAccountDetails serviceAccountDetails = new ServiceAccountDetails();
+    serviceAccountDetails.setPassword("password");
+    serviceAccountDetails.setUsername("username");
+    serviceAccountDetails.setAccountFound(true);
 
-    ApiResponse apiResponse =
-        ApiResponse.builder()
-            .message(ApiResultStatus.SUCCESS.value)
-            .data(serviceAccountInfoMap)
-            .build();
     when(aclControllerService.getAivenServiceAccountDetails(
             anyString(), anyString(), anyString(), anyString()))
-        .thenReturn(apiResponse);
+        .thenReturn(serviceAccountDetails);
 
-    mvcAcls
-        .perform(
-            MockMvcRequestBuilders.get("/getAivenServiceAccount")
-                .param("env", "DEV")
-                .param("topicName", "testtopic")
-                .param("userName", "kwuser")
-                .param("aclReqNo", "101")
-                .contentType(MediaType.APPLICATION_JSON)
-                .accept(MediaType.APPLICATION_JSON))
-        .andExpect(status().isOk())
-        .andExpect(jsonPath("$.data", aMapWithSize(2)));
+    String response =
+        mvcAcls
+            .perform(
+                MockMvcRequestBuilders.get("/getAivenServiceAccount")
+                    .param("env", "DEV")
+                    .param("topicName", "testtopic")
+                    .param("userName", "kwuser")
+                    .param("aclReqNo", "101")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .accept(MediaType.APPLICATION_JSON))
+            .andExpect(status().isOk())
+            .andReturn()
+            .getResponse()
+            .getContentAsString();
+    ServiceAccountDetails serviceAccountDetails1 =
+        new ObjectMapper().readValue(response, new TypeReference<>() {});
+    assertThat(serviceAccountDetails1.isAccountFound()).isTrue();
   }
 }

--- a/core/src/test/java/io/aiven/klaw/service/AclControllerServiceTest.java
+++ b/core/src/test/java/io/aiven/klaw/service/AclControllerServiceTest.java
@@ -136,7 +136,7 @@ public class AclControllerServiceTest {
     List<Topic> topicList = utilMethods.getTopics();
     Map<String, String> hashMap = new HashMap<>();
     hashMap.put("result", ApiResultStatus.SUCCESS.value);
-    when(handleDbRequests.getTopics(anyString(), anyInt())).thenReturn(topicList);
+    when(commonUtilsService.getTopicsForTopicName(anyString(), anyInt())).thenReturn(topicList);
     when(handleDbRequests.requestForAcl(any())).thenReturn(hashMap);
     stubUserInfo();
     mockKafkaFlavor();
@@ -154,7 +154,7 @@ public class AclControllerServiceTest {
     List<Topic> topicList = utilMethods.getTopics();
     Map<String, String> hashMap = new HashMap<>();
     hashMap.put("result", ApiResultStatus.SUCCESS.value);
-    when(handleDbRequests.getTopics(anyString(), anyInt())).thenReturn(topicList);
+    when(commonUtilsService.getTopicsForTopicName(anyString(), anyInt())).thenReturn(topicList);
     when(handleDbRequests.requestForAcl(any())).thenReturn(hashMap);
 
     mockKafkaFlavor();
@@ -171,7 +171,7 @@ public class AclControllerServiceTest {
     AclRequestsModel aclRequests = getAclRequestConsumer();
     copyProperties(aclRequests, aclRequestsDao);
     List<Topic> topicList = utilMethods.getTopics();
-    when(handleDbRequests.getTopics(anyString(), anyInt())).thenReturn(topicList);
+    when(commonUtilsService.getTopicsForTopicName(anyString(), anyInt())).thenReturn(topicList);
     when(handleDbRequests.requestForAcl(any()))
         .thenThrow(new RuntimeException("Failure in creating request"));
     stubUserInfo();
@@ -237,7 +237,7 @@ public class AclControllerServiceTest {
     Acl acl = new Acl();
     acl.setConsumergroup(aclRequestsModel.getConsumergroup());
 
-    when(handleDbRequests.getTopics(anyString(), anyInt())).thenReturn(topicList);
+    when(commonUtilsService.getTopicsForTopicName(anyString(), anyInt())).thenReturn(topicList);
     when(handleDbRequests.getUniqueConsumerGroups(anyInt()))
         .thenReturn(Collections.singletonList(acl));
     stubUserInfo();
@@ -261,7 +261,7 @@ public class AclControllerServiceTest {
     List<Topic> topicList = utilMethods.getTopics();
     Map<String, String> hashMap = new HashMap<>();
     hashMap.put("result", ApiResultStatus.SUCCESS.value);
-    when(handleDbRequests.getTopics(anyString(), anyInt())).thenReturn(topicList);
+    when(commonUtilsService.getTopicsForTopicName(anyString(), anyInt())).thenReturn(topicList);
     when(handleDbRequests.requestForAcl(any())).thenReturn(hashMap);
     stubUserInfo();
     mockKafkaFlavor();

--- a/core/src/test/java/io/aiven/klaw/service/CommonUtilsServiceTest.java
+++ b/core/src/test/java/io/aiven/klaw/service/CommonUtilsServiceTest.java
@@ -1,0 +1,115 @@
+package io.aiven.klaw.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+import io.aiven.klaw.UtilMethods;
+import io.aiven.klaw.config.ManageDatabase;
+import io.aiven.klaw.dao.Topic;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+@ExtendWith(SpringExtension.class)
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+public class CommonUtilsServiceTest {
+
+  private UtilMethods utilMethods;
+
+  @Mock private ManageDatabase manageDatabase;
+
+  private CommonUtilsService commonUtilsService;
+
+  @BeforeEach
+  public void setUp() throws Exception {
+    utilMethods = new UtilMethods();
+    commonUtilsService = new CommonUtilsService();
+    ReflectionTestUtils.setField(commonUtilsService, "manageDatabase", manageDatabase);
+  }
+
+  @Test
+  public void getTopicsForTopicName() {
+    List<Topic> topicList1 = utilMethods.getMultipleTopics("test1", 20, "1", 101);
+    List<Topic> topicList2 = utilMethods.getMultipleTopics("test2", 20, "2", 101);
+    topicList1.addAll(topicList2);
+    when(manageDatabase.getTopicsForTenant(1)).thenReturn(topicList1);
+    List<Topic> topicList = commonUtilsService.getTopicsForTopicName("test10", 1);
+    assertThat(topicList).hasSize(1);
+  }
+
+  @Test
+  public void getSyncTopicsAll() {
+    List<Topic> topicList1 = utilMethods.getMultipleTopics("test1", 20, "1", 101);
+    List<Topic> topicList2 = utilMethods.getMultipleTopics("test2", 20, "2", 101);
+    topicList1.addAll(topicList2);
+    when(manageDatabase.getTopicsForTenant(1)).thenReturn(topicList1);
+    List<Topic> topicList = commonUtilsService.getTopics(null, null, 1);
+    assertThat(topicList).hasSize(40);
+  }
+
+  @Test
+  public void getSyncTopicsFilterEnvAll() {
+    String env = "1";
+    when(manageDatabase.getTopicsForTenant(1))
+        .thenReturn(utilMethods.getMultipleTopics("test", 20, "1", 101));
+    List<Topic> topicList = commonUtilsService.getTopics(env, null, 1);
+    assertThat(topicList).hasSize(20);
+  }
+
+  @Test
+  public void getSyncTopicsFilterEnvNone() {
+    String env = "1";
+    when(manageDatabase.getTopicsForTenant(1))
+        .thenReturn(utilMethods.getMultipleTopics("test", 20, "2", 101));
+    List<Topic> topicList = commonUtilsService.getTopics(env, null, 1);
+    assertThat(topicList).hasSize(0);
+  }
+
+  @Test
+  public void getSyncTopicsFilterTeam() {
+    when(manageDatabase.getTopicsForTenant(1))
+        .thenReturn(utilMethods.getMultipleTopics("test", 20, "2", 102));
+    List<Topic> topicList = commonUtilsService.getTopics(null, 101, 1);
+    assertThat(topicList).hasSize(0);
+  }
+
+  @Test
+  public void getSyncTopicsFilterDifferentTeam() {
+    List<Topic> topicList1 = utilMethods.getMultipleTopics("test", 20, "1", 101);
+    List<Topic> topicList2 = utilMethods.getMultipleTopics("test", 5, "2", 102);
+    topicList1.addAll(topicList2);
+    when(manageDatabase.getTopicsForTenant(1)).thenReturn(topicList1);
+    List<Topic> topicList = commonUtilsService.getTopics(null, 102, 1);
+    assertThat(topicList).hasSize(5);
+  }
+
+  @Test
+  public void getSyncTopicsFilterTeamEnv() {
+    List<Topic> topicList1 = utilMethods.getMultipleTopics("test1", 20, "1", 101);
+    List<Topic> topicList2 = utilMethods.getMultipleTopics("test2", 5, "2", 102);
+    List<Topic> topicList3 = utilMethods.getMultipleTopics("test3", 10, "3", 102);
+    topicList1.addAll(topicList2);
+    topicList1.addAll(topicList3);
+    when(manageDatabase.getTopicsForTenant(1)).thenReturn(topicList1);
+    List<Topic> topicList = commonUtilsService.getTopics("3", 102, 1);
+    assertThat(topicList).hasSize(10);
+  }
+
+  @Test
+  public void getSyncTopicsFilterTeamMultipleEnv() {
+    List<Topic> topicList1 = utilMethods.getMultipleTopics("test1", 20, "1", 101);
+    List<Topic> topicList2 = utilMethods.getMultipleTopics("test2", 5, "2", 102);
+    List<Topic> topicList3 = utilMethods.getMultipleTopics("test2", 10, "3", 102);
+    topicList1.addAll(topicList2);
+    topicList1.addAll(topicList3);
+    when(manageDatabase.getTopicsForTenant(1)).thenReturn(topicList1);
+    List<Topic> topicList = commonUtilsService.getTopics("3", 102, 1);
+    assertThat(topicList).hasSize(15);
+  }
+}

--- a/core/src/test/java/io/aiven/klaw/service/ExportImportDataServiceTest.java
+++ b/core/src/test/java/io/aiven/klaw/service/ExportImportDataServiceTest.java
@@ -53,7 +53,8 @@ public class ExportImportDataServiceTest {
 
   @Test
   public void getKwData() {
-    when(handleDbRequests.getAllTopics()).thenReturn(utilMethods.getMultipleTopics("test", 10));
+    when(handleDbRequests.getAllTopics())
+        .thenReturn(utilMethods.getMultipleTopics("test", 10, null, 101));
     when(handleDbRequests.getAllConnectors())
         .thenReturn(Collections.singletonList(new KwKafkaConnector()));
     KwData kwData = exportImportDataService.getKwData(handleDbRequests, "");

--- a/core/src/test/java/io/aiven/klaw/service/SchemaRegistryControllerServiceTest.java
+++ b/core/src/test/java/io/aiven/klaw/service/SchemaRegistryControllerServiceTest.java
@@ -297,7 +297,8 @@ public class SchemaRegistryControllerServiceTest {
     when(commonUtilsService.getTenantId(anyString())).thenReturn(101);
     when(commonUtilsService.isNotAuthorizedUser(any(), any())).thenReturn(false);
     when(handleDbRequests.requestForSchema(any())).thenReturn(ApiResultStatus.SUCCESS.value);
-    when(handleDbRequests.getTopicTeam(anyString(), anyInt())).thenReturn(List.of(topic));
+    when(commonUtilsService.getTopicsForTopicName(anyString(), anyInt()))
+        .thenReturn(List.of(topic));
     when(commonUtilsService.getFilteredTopicsForTenant(any())).thenReturn(List.of(topic));
 
     ApiResponse resultResp = schemaRegistryControllerService.uploadSchema(schemaRequest);
@@ -317,7 +318,8 @@ public class SchemaRegistryControllerServiceTest {
     when(commonUtilsService.isNotAuthorizedUser(any(), any())).thenReturn(false);
     when(handleDbRequests.requestForSchema(any()))
         .thenThrow(new RuntimeException("Error from schema upload"));
-    when(handleDbRequests.getTopicTeam(anyString(), anyInt())).thenReturn(List.of(topic));
+    when(commonUtilsService.getTopicsForTopicName(anyString(), anyInt()))
+        .thenReturn(List.of(topic));
     when(commonUtilsService.getFilteredTopicsForTenant(any())).thenReturn(List.of(topic));
     when(clusterApiService.validateSchema(anyString(), anyString(), anyString(), anyInt()))
         .thenReturn(buildValidationResponse(true));
@@ -344,7 +346,8 @@ public class SchemaRegistryControllerServiceTest {
   @Order(10)
   public void promoteSchemaCanNotFindSourceEnvironmentSchema() throws Exception {
     when(commonUtilsService.getFilteredTopicsForTenant(any())).thenReturn(List.of(createTopic()));
-    when(handleDbRequests.getTopicTeam(anyString(), anyInt())).thenReturn(List.of(createTopic()));
+    when(commonUtilsService.getTopicsForTopicName(anyString(), anyInt()))
+        .thenReturn(List.of(createTopic()));
     when(commonUtilsService.getTeamId(any())).thenReturn(101);
     ApiResponse returnedValue =
         schemaRegistryControllerService.promoteSchema(buildPromoteSchemaRequest(false, "1"));
@@ -588,7 +591,8 @@ public class SchemaRegistryControllerServiceTest {
     when(commonUtilsService.getTenantId(anyString())).thenReturn(101);
     when(commonUtilsService.isNotAuthorizedUser(any(), any())).thenReturn(false);
     when(handleDbRequests.requestForSchema(any())).thenReturn(ApiResultStatus.SUCCESS.value);
-    when(handleDbRequests.getTopicTeam(anyString(), anyInt())).thenReturn(List.of(topic));
+    when(commonUtilsService.getTopicsForTopicName(anyString(), anyInt()))
+        .thenReturn(List.of(topic));
     when(commonUtilsService.getFilteredTopicsForTenant(any())).thenReturn(List.of(topic));
 
     ApiResponse resultResp = schemaRegistryControllerService.uploadSchema(schemaRequest);
@@ -736,7 +740,8 @@ public class SchemaRegistryControllerServiceTest {
     when(commonUtilsService.getTeamId(anyString())).thenReturn(101);
     when(commonUtilsService.getEnvsFromUserId(anyString()))
         .thenReturn(new HashSet<>(Collections.singletonList("1")));
-    when(handleDbRequests.getTopicTeam(anyString(), anyInt())).thenReturn(List.of(topic));
+    when(commonUtilsService.getTopicsForTopicName(anyString(), anyInt()))
+        .thenReturn(List.of(topic));
     when(commonUtilsService.getFilteredTopicsForTenant(any())).thenReturn(List.of(topic));
 
     when(handleDbRequests.requestForSchema(any())).thenReturn(ApiResultStatus.SUCCESS.value);

--- a/core/src/test/java/io/aiven/klaw/service/TopicControllerServiceTest.java
+++ b/core/src/test/java/io/aiven/klaw/service/TopicControllerServiceTest.java
@@ -803,8 +803,7 @@ public class TopicControllerServiceTest {
     stubUserInfo();
 
     when(commonUtilsService.getFilteredTopicsForTenant(any())).thenReturn(utilMethods.getTopics());
-    when(handleDbRequests.getSyncTopics(any(), any(), anyInt()))
-        .thenReturn(utilMethods.getTopics());
+    when(commonUtilsService.getTopics(any(), any(), anyInt())).thenReturn(utilMethods.getTopics());
 
     List<String> result = topicControllerService.getAllTopics(false, "DEV");
     assertThat(result).hasSize(1);
@@ -817,8 +816,7 @@ public class TopicControllerServiceTest {
     stubUserInfo();
 
     when(commonUtilsService.getFilteredTopicsForTenant(any())).thenReturn(utilMethods.getTopics());
-    when(handleDbRequests.getSyncTopics(any(), any(), anyInt()))
-        .thenReturn(utilMethods.getTopics());
+    when(commonUtilsService.getTopics(any(), any(), anyInt())).thenReturn(utilMethods.getTopics());
     when(commonUtilsService.getTeamId(anyString())).thenReturn(3);
 
     List<String> result = topicControllerService.getAllTopics(true, "DEV");
@@ -921,7 +919,7 @@ public class TopicControllerServiceTest {
     when(commonUtilsService.getEnvsFromUserId(anyString()))
         .thenReturn(new HashSet<>(Collections.singletonList("1")));
     when(commonUtilsService.deriveCurrentPage(anyString(), anyString(), anyInt())).thenReturn("1");
-    when(handleDbRequests.getSyncTopics(any(), any(), anyInt()))
+    when(commonUtilsService.getTopics(any(), any(), anyInt()))
         .thenReturn(getSyncTopics("topic", 4));
     when(manageDatabase.getKafkaEnvList(anyInt())).thenReturn(utilMethods.getEnvLists());
     when(manageDatabase.getTeamNameFromTeamId(anyInt(), anyInt()))
@@ -948,7 +946,7 @@ public class TopicControllerServiceTest {
     when(commonUtilsService.getEnvsFromUserId(anyString()))
         .thenReturn(new HashSet<>(Collections.singletonList("1")));
     when(commonUtilsService.deriveCurrentPage(anyString(), anyString(), anyInt())).thenReturn("1");
-    when(handleDbRequests.getSyncTopics(any(), any(), anyInt()))
+    when(commonUtilsService.getTopics(any(), any(), anyInt()))
         .thenReturn(getSyncTopics("topic", 4));
     when(manageDatabase.getKafkaEnvList(anyInt())).thenReturn(utilMethods.getEnvLists());
     when(manageDatabase.getTeamNameFromTeamId(anyInt(), anyInt()))
@@ -979,7 +977,7 @@ public class TopicControllerServiceTest {
     when(commonUtilsService.getEnvsFromUserId(anyString()))
         .thenReturn(new HashSet<>(Collections.singletonList("1")));
     when(commonUtilsService.deriveCurrentPage(anyString(), anyString(), anyInt())).thenReturn("1");
-    when(handleDbRequests.getSyncTopics(any(), any(), anyInt()))
+    when(commonUtilsService.getTopics(any(), any(), anyInt()))
         .thenReturn(getSyncTopics("topic", 4));
     when(manageDatabase.getKafkaEnvList(anyInt())).thenReturn(utilMethods.getEnvLists());
     when(manageDatabase.getTeamNameFromTeamId(anyInt(), anyInt()))
@@ -1015,7 +1013,7 @@ public class TopicControllerServiceTest {
     when(manageDatabase.getTeamsAndAllowedEnvs(anyInt(), anyInt()))
         .thenReturn(Collections.singletonList("1"));
     when(commonUtilsService.deriveCurrentPage(anyString(), anyString(), anyInt())).thenReturn("1");
-    when(handleDbRequests.getSyncTopics(envSel, null, 1)).thenReturn(getSyncTopics("topic", 4));
+    when(commonUtilsService.getTopics(envSel, null, 1)).thenReturn(getSyncTopics("topic", 4));
 
     List<List<TopicInfo>> topicsList =
         topicControllerService.getTopics(envSel, pageNo, "", topicNameSearch, 0, null);

--- a/core/src/test/java/io/aiven/klaw/service/TopicControllerServiceTest.java
+++ b/core/src/test/java/io/aiven/klaw/service/TopicControllerServiceTest.java
@@ -255,7 +255,7 @@ public class TopicControllerServiceTest {
     when(commonUtilsService.getTenantId(anyString())).thenReturn(101);
     when(handleDbRequests.selectTopicRequests(anyString(), anyString(), anyString(), anyInt()))
         .thenReturn(Collections.emptyList());
-    when(handleDbRequests.getTopicTeam(anyString(), anyInt()))
+    when(commonUtilsService.getTopicsForTopicName(anyString(), anyInt()))
         .thenReturn(List.of(getTopic(topicName)));
     when(commonUtilsService.getFilteredTopicsForTenant(any()))
         .thenReturn(List.of(getTopic(topicName)));
@@ -283,7 +283,7 @@ public class TopicControllerServiceTest {
     when(commonUtilsService.getTenantId(anyString())).thenReturn(101);
     when(handleDbRequests.selectTopicRequests(anyString(), anyString(), anyString(), anyInt()))
         .thenReturn(Collections.emptyList());
-    when(handleDbRequests.getTopicTeam(anyString(), anyInt()))
+    when(commonUtilsService.getTopicsForTopicName(anyString(), anyInt()))
         .thenReturn(List.of(getTopic(topicName)));
     when(commonUtilsService.getFilteredTopicsForTenant(any()))
         .thenReturn(List.of(getTopic(topicName)));
@@ -313,7 +313,7 @@ public class TopicControllerServiceTest {
     when(commonUtilsService.getTenantId(anyString())).thenReturn(101);
     when(handleDbRequests.selectTopicRequests(anyString(), anyString(), anyString(), anyInt()))
         .thenReturn(Collections.emptyList());
-    when(handleDbRequests.getTopicTeam(anyString(), anyInt()))
+    when(commonUtilsService.getTopicsForTopicName(anyString(), anyInt()))
         .thenReturn(List.of(getTopic(topicName)));
     when(manageDatabase.getTeamsAndAllowedEnvs(anyInt(), anyInt()))
         .thenReturn(Collections.singletonList("1"));
@@ -340,7 +340,7 @@ public class TopicControllerServiceTest {
     when(commonUtilsService.getTenantId(anyString())).thenReturn(101);
     when(handleDbRequests.selectTopicRequests(anyString(), anyString(), anyString(), anyInt()))
         .thenReturn(Collections.emptyList());
-    when(handleDbRequests.getTopicTeam(anyString(), anyInt()))
+    when(commonUtilsService.getTopicsForTopicName(anyString(), anyInt()))
         .thenReturn(List.of(getTopic(topicName)));
     when(commonUtilsService.getFilteredTopicsForTenant(any()))
         .thenReturn(List.of(getTopic(topicName)));
@@ -387,7 +387,7 @@ public class TopicControllerServiceTest {
     when(commonUtilsService.getTenantId(anyString())).thenReturn(101);
     when(handleDbRequests.selectTopicRequests(anyString(), anyString(), anyString(), anyInt()))
         .thenReturn(Collections.emptyList());
-    when(handleDbRequests.getTopicTeam(anyString(), anyInt()))
+    when(commonUtilsService.getTopicsForTopicName(anyString(), anyInt()))
         .thenReturn(List.of(getTopic(topicName)));
     when(commonUtilsService.getFilteredTopicsForTenant(any()))
         .thenReturn(List.of(getTopic(topicName)));
@@ -445,7 +445,8 @@ public class TopicControllerServiceTest {
         .thenReturn(topicRequests);
     when(commonUtilsService.deriveCurrentPage(anyString(), anyString(), anyInt())).thenReturn("1");
     when(manageDatabase.getTeamNameFromTeamId(anyInt(), anyInt())).thenReturn("INFRATEAM");
-    when(handleDbRequests.getTopicTeam(anyString(), anyInt())).thenReturn(utilMethods.getTopics());
+    when(commonUtilsService.getTopicsForTopicName(anyString(), anyInt()))
+        .thenReturn(utilMethods.getTopics());
     when(commonUtilsService.getFilteredTopicsForTenant(any())).thenReturn(utilMethods.getTopics());
 
     List<TopicRequestsResponseModel> listTopicRqs =
@@ -475,7 +476,8 @@ public class TopicControllerServiceTest {
         .thenReturn(topicRequests);
     when(commonUtilsService.deriveCurrentPage(anyString(), anyString(), anyInt())).thenReturn("1");
     when(manageDatabase.getTeamNameFromTeamId(anyInt(), anyInt())).thenReturn("INFRATEAM");
-    when(handleDbRequests.getTopicTeam(anyString(), anyInt())).thenReturn(utilMethods.getTopics());
+    when(commonUtilsService.getTopicsForTopicName(anyString(), anyInt()))
+        .thenReturn(utilMethods.getTopics());
     when(commonUtilsService.getFilteredTopicsForTenant(any())).thenReturn(utilMethods.getTopics());
 
     List<TopicRequestsResponseModel> listTopicRqs =
@@ -547,7 +549,7 @@ public class TopicControllerServiceTest {
     stubUserInfo();
     List<Topic> topicList = utilMethods.getTopics();
     when(commonUtilsService.getTenantId(anyString())).thenReturn(101);
-    when(handleDbRequests.getTopicTeam(anyString(), anyInt())).thenReturn(topicList);
+    when(commonUtilsService.getTopicsForTopicName(anyString(), anyInt())).thenReturn(topicList);
     when(commonUtilsService.getFilteredTopicsForTenant(any())).thenReturn(topicList);
     when(manageDatabase.getTeamNameFromTeamId(anyInt(), anyInt())).thenReturn(teamName);
     TopicTeamResponse topicTeamMap =
@@ -690,7 +692,7 @@ public class TopicControllerServiceTest {
     when(handleDbRequests.selectTopicRequestsForTopic(anyInt(), anyInt())).thenReturn(topicRequest);
     when(handleDbRequests.updateTopicRequest(any(), anyString()))
         .thenReturn(ApiResultStatus.SUCCESS.value);
-    when(handleDbRequests.getTopicTeam(anyString(), anyInt()))
+    when(commonUtilsService.getTopicsForTopicName(anyString(), anyInt()))
         .thenReturn(List.of(getTopic(topicName)));
     when(clusterApiService.approveTopicRequests(
             anyString(),
@@ -727,7 +729,7 @@ public class TopicControllerServiceTest {
     when(handleDbRequests.selectTopicRequestsForTopic(anyInt(), anyInt())).thenReturn(topicRequest);
     when(handleDbRequests.updateTopicRequest(any(), anyString()))
         .thenReturn(ApiResultStatus.SUCCESS.value);
-    when(handleDbRequests.getTopicTeam(anyString(), anyInt()))
+    when(commonUtilsService.getTopicsForTopicName(anyString(), anyInt()))
         .thenReturn(List.of(getTopic(topicName)));
     when(clusterApiService.approveTopicRequests(
             anyString(),
@@ -830,7 +832,7 @@ public class TopicControllerServiceTest {
     stubUserInfo();
     TopicInfo topicInfo = utilMethods.getTopicInfo();
     when(commonUtilsService.getTenantId(anyString())).thenReturn(101);
-    when(handleDbRequests.getTopicTeam(anyString(), anyInt()))
+    when(commonUtilsService.getTopicsForTopicName(anyString(), anyInt()))
         .thenReturn(List.of(getTopic("testtopic")));
     when(commonUtilsService.getFilteredTopicsForTenant(any())).thenReturn(utilMethods.getTopics());
     when(commonUtilsService.getTeamId(anyString())).thenReturn(3);
@@ -848,7 +850,7 @@ public class TopicControllerServiceTest {
     stubUserInfo();
     TopicInfo topicInfo = utilMethods.getTopicInfo();
     when(commonUtilsService.getTenantId(anyString())).thenReturn(101);
-    when(handleDbRequests.getTopicTeam(anyString(), anyInt()))
+    when(commonUtilsService.getTopicsForTopicName(anyString(), anyInt()))
         .thenReturn(List.of(getTopic("testtopic")));
     when(commonUtilsService.getFilteredTopicsForTenant(any())).thenReturn(utilMethods.getTopics());
     when(commonUtilsService.getTeamId(anyString())).thenReturn(1);
@@ -1063,7 +1065,7 @@ public class TopicControllerServiceTest {
   public void getTopicTeam() {
     String topicName = "testtopic";
     stubUserInfo();
-    when(handleDbRequests.getTopicTeam(anyString(), anyInt()))
+    when(commonUtilsService.getTopicsForTopicName(anyString(), anyInt()))
         .thenReturn(List.of(getTopic(topicName)));
     when(commonUtilsService.getFilteredTopicsForTenant(any()))
         .thenReturn(List.of(getTopic(topicName)));
@@ -1219,7 +1221,7 @@ public class TopicControllerServiceTest {
     when(commonUtilsService.getTenantId(anyString())).thenReturn(101);
     when(handleDbRequests.selectTopicRequests(anyString(), anyString(), anyString(), anyInt()))
         .thenReturn(Collections.emptyList());
-    when(handleDbRequests.getTopicTeam(anyString(), anyInt()))
+    when(commonUtilsService.getTopicsForTopicName(anyString(), anyInt()))
         .thenReturn(List.of(getTopic(topicName)));
     when(commonUtilsService.getFilteredTopicsForTenant(any()))
         .thenReturn(List.of(getTopic(topicName)));

--- a/core/src/test/java/io/aiven/klaw/service/TopicOverviewServiceTest.java
+++ b/core/src/test/java/io/aiven/klaw/service/TopicOverviewServiceTest.java
@@ -110,7 +110,7 @@ public class TopicOverviewServiceTest {
         .thenReturn(utilMethods.getTopics(TESTTOPIC));
     when(handleDbRequests.getSyncAcls(anyString(), anyString(), anyInt()))
         .thenReturn(getAclsSOT(TESTTOPIC));
-    when(handleDbRequests.getTopicTeam(anyString(), anyInt()))
+    when(commonUtilsService.getTopicsForTopicName(anyString(), anyInt()))
         .thenReturn(utilMethods.getTopics(TESTTOPIC));
     when(commonUtilsService.getFilteredTopicsForTenant(any()))
         .thenReturn(utilMethods.getTopics(TESTTOPIC));
@@ -147,7 +147,7 @@ public class TopicOverviewServiceTest {
         .thenReturn(utilMethods.getTopics(topicNameSearch));
     when(handleDbRequests.getSyncAcls(anyString(), anyString(), anyInt()))
         .thenReturn(getAclsSOT(topicNameSearch));
-    when(handleDbRequests.getTopicTeam(anyString(), anyInt()))
+    when(commonUtilsService.getTopicsForTopicName(anyString(), anyInt()))
         .thenReturn(utilMethods.getTopics(topicNameSearch));
     when(commonUtilsService.getFilteredTopicsForTenant(any()))
         .thenReturn(utilMethods.getTopics(topicNameSearch));
@@ -240,7 +240,7 @@ public class TopicOverviewServiceTest {
         .thenReturn(utilMethods.getTopics(TESTTOPIC));
     when(handleDbRequests.getSyncAcls(anyString(), anyString(), anyInt()))
         .thenReturn(getAclsSOT(TESTTOPIC));
-    when(handleDbRequests.getTopicTeam(anyString(), anyInt()))
+    when(commonUtilsService.getTopicsForTopicName(anyString(), anyInt()))
         .thenReturn(utilMethods.getTopics(TESTTOPIC));
     when(commonUtilsService.getFilteredTopicsForTenant(any()))
         .thenReturn(utilMethods.getTopics(TESTTOPIC));

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -4510,7 +4510,11 @@
             "content" : {
               "application/json" : {
                 "schema" : {
-                  "$ref" : "#/components/schemas/ApiResponse"
+                  "type" : "array",
+                  "items" : {
+                    "type" : "string"
+                  },
+                  "uniqueItems" : true
                 }
               }
             }
@@ -4557,7 +4561,7 @@
             "content" : {
               "application/json" : {
                 "schema" : {
-                  "$ref" : "#/components/schemas/ApiResponse"
+                  "$ref" : "#/components/schemas/ServiceAccountDetails"
                 }
               }
             }
@@ -7341,6 +7345,19 @@
           },
           "value" : {
             "type" : "string"
+          }
+        }
+      },
+      "ServiceAccountDetails" : {
+        "properties" : {
+          "username" : {
+            "type" : "string"
+          },
+          "password" : {
+            "type" : "string"
+          },
+          "accountFound" : {
+            "type" : "boolean"
           }
         }
       },


### PR DESCRIPTION
About this change - What it does

- All users are now part of internal memory, and retrieved from memory. When user added/modified, memory is updated.
- All topics are now part of memory, and when topic requests are approved, this memory is updated.
- get services accounts and get service account endpoints are updated to return custom class

Resolves: #1007
Why this way
To reduce number of db calls, users and topics can be part of memory, which should handle even 50k topics.
