### PR TITLE
refactor(coral): Use API_PATHS map instead of hardcoded paths in `domain`

### DIFF
--- a/coral/src/domain/acl/acl-api.ts
+++ b/coral/src/domain/acl/acl-api.ts
@@ -11,7 +11,7 @@ import {
   RequestVerdictDecline,
   RequestVerdictDelete,
 } from "src/domain/requests/requests-types";
-import api from "src/services/api";
+import api, { API_PATHS } from "src/services/api";
 import {
   KlawApiRequest,
   KlawApiRequestQueryParameters,
@@ -19,13 +19,13 @@ import {
 } from "types/utils";
 
 const createAclRequest = (
-  aclParams:
+  aclPayload:
     | CreateAclRequestTopicTypeProducer
     | CreateAclRequestTopicTypeConsumer
 ): Promise<KlawApiResponse<"createAcl">> => {
   return api.post<KlawApiResponse<"createAcl">, KlawApiRequest<"createAcl">>(
-    "/createAcl",
-    aclParams
+    API_PATHS.createAcl,
+    aclPayload
   );
 };
 
@@ -61,7 +61,8 @@ const getAclRequestsForApprover = (
 
   return api
     .get<KlawApiResponse<"getAclRequestsForApprover">>(
-      `/getAclRequestsForApprover?${new URLSearchParams(filteredParams)}`
+      API_PATHS.getAclRequestsForApprover,
+      new URLSearchParams(filteredParams)
     )
     .then(transformAclRequestApiResponse);
 };
@@ -71,7 +72,8 @@ const getAclRequests = (params: GetCreatedAclRequestParameters) => {
 
   return api
     .get<KlawApiResponse<"getAclRequests">>(
-      `/getAclRequests?${new URLSearchParams(filteredParams)}`
+      API_PATHS.getAclRequests,
+      new URLSearchParams(filteredParams)
     )
     .then(transformAclRequestApiResponse);
 };
@@ -82,7 +84,7 @@ type ApproveRequestParams = {
 };
 const approveAclRequest = ({ reqIds }: ApproveRequestParams) => {
   return api.post<KlawApiResponse<"approveRequest">, ApproveAclRequestPayload>(
-    `/request/approve`,
+    API_PATHS.approveRequest,
     { requestEntityType: "ACL", reqIds }
   );
 };
@@ -94,7 +96,7 @@ type DeclineRequestParams = {
 };
 const declineAclRequest = ({ reqIds, reason }: DeclineRequestParams) => {
   return api.post<KlawApiResponse<"declineRequest">, DeclineAclRequestPayload>(
-    `/request/decline`,
+    API_PATHS.declineRequest,
     { requestEntityType: "ACL", reqIds, reason }
   );
 };
@@ -105,7 +107,7 @@ type DeleteRequestParams = {
 };
 const deleteAclRequest = ({ reqIds }: DeleteRequestParams) => {
   return api.post<KlawApiResponse<"deleteRequest">, DeleteAclRequestPayload>(
-    `/request/delete`,
+    API_PATHS.deleteRequest,
     { requestEntityType: "ACL", reqIds }
   );
 };
@@ -118,7 +120,8 @@ function getAivenServiceAccounts(
   params: GetAivenServiceAccountsParams
 ): Promise<GetAivenServiceAccountsResponse> {
   return api.get<GetAivenServiceAccountsResponse>(
-    `/getAivenServiceAccounts?${new URLSearchParams(params)}`
+    API_PATHS.getAivenServiceAccounts,
+    new URLSearchParams(params)
   );
 }
 

--- a/coral/src/domain/auth-user/auth-user-api.ts
+++ b/coral/src/domain/auth-user/auth-user-api.ts
@@ -3,7 +3,8 @@ import {
   AuthUserLoginData,
 } from "src/domain/auth-user/auth-user-types";
 
-import api from "src/services/api";
+import api, { API_PATHS } from "src/services/api";
+import { paths as ApiPaths } from "types/api";
 import { KlawApiResponse } from "types/utils";
 
 const getAuthUser = (userLogin: AuthUserLoginData): Promise<AuthUser> => {
@@ -11,12 +12,15 @@ const getAuthUser = (userLogin: AuthUserLoginData): Promise<AuthUser> => {
   data.append("username", userLogin.username);
   data.append("password", userLogin.password);
 
-  return api.post("/login", data);
+  // /login is a path which does not currently exist, because there is no auth flow in coral currently
+  // getAuthUser is used in a component that is currently never rendered (LoginForm)
+  // We coerce the keyof ApiPaths to avoid TS compiling error
+  return api.post("/login" as keyof ApiPaths, data);
 };
 
 function getUserTeamName(): Promise<string> {
   return api
-    .get<KlawApiResponse<"getAuth">>("/getAuth")
+    .get<KlawApiResponse<"getAuth">>(API_PATHS.getAuth)
     .then((response) => response.teamname);
 }
 

--- a/coral/src/domain/connector/connector-api.ts
+++ b/coral/src/domain/connector/connector-api.ts
@@ -8,7 +8,7 @@ import {
   RequestVerdictDecline,
   RequestVerdictDelete,
 } from "src/domain/requests/requests-types";
-import api from "src/services/api";
+import api, { API_PATHS } from "src/services/api";
 import { KlawApiRequestQueryParameters, KlawApiResponse } from "types/utils";
 import { convertQueryValuesToString } from "src/services/api-helper";
 
@@ -55,7 +55,8 @@ const getConnectors = (
 
   return api
     .get<KlawApiResponse<"getConnectors">>(
-      `/getConnectors?${new URLSearchParams(queryParams)}`
+      API_PATHS.getConnectors,
+      new URLSearchParams(queryParams)
     )
     .then(transformConnectorApiResponse);
 };
@@ -67,7 +68,8 @@ const getConnectorRequestsForApprover = (
 
   return api
     .get<KlawApiResponse<"getCreatedConnectorRequests">>(
-      `/getConnectorRequestsForApprover?${new URLSearchParams(filteredParams)}`
+      API_PATHS.getCreatedConnectorRequests,
+      new URLSearchParams(filteredParams)
     )
     .then(transformConnectorRequestApiResponse);
 };
@@ -79,7 +81,8 @@ const getConnectorRequests = (
 
   return api
     .get<KlawApiResponse<"getConnectorRequests">>(
-      `/getConnectorRequests?${new URLSearchParams(filteredParams)}`
+      API_PATHS.getConnectorRequests,
+      new URLSearchParams(filteredParams)
     )
     .then(transformConnectorRequestApiResponse);
 };
@@ -92,7 +95,7 @@ const approveConnectorRequest = ({ reqIds }: ApproveRequestParams) => {
   return api.post<
     KlawApiResponse<"approveRequest">,
     ApproveConnectorRequestPayload
-  >(`/request/approve`, { requestEntityType: "CONNECTOR", reqIds });
+  >(API_PATHS.approveRequest, { requestEntityType: "CONNECTOR", reqIds });
 };
 
 type DeclineConnectorRequestPayload = RequestVerdictDecline<"CONNECTOR">;
@@ -104,7 +107,11 @@ const declineConnectorRequest = ({ reqIds, reason }: DeclineRequestParams) => {
   return api.post<
     KlawApiResponse<"declineRequest">,
     DeclineConnectorRequestPayload
-  >(`/request/decline`, { requestEntityType: "CONNECTOR", reqIds, reason });
+  >(API_PATHS.declineRequest, {
+    requestEntityType: "CONNECTOR",
+    reqIds,
+    reason,
+  });
 };
 
 type DeleteConnectorRequestPayload = RequestVerdictDelete<"CONNECTOR">;
@@ -115,7 +122,7 @@ const deleteConnectorRequest = ({ reqIds }: DeleteRequestParams) => {
   return api.post<
     KlawApiResponse<"deleteRequest">,
     DeleteConnectorRequestPayload
-  >(`/request/delete`, { requestEntityType: "CONNECTOR", reqIds });
+  >(API_PATHS.deleteRequest, { requestEntityType: "CONNECTOR", reqIds });
 };
 
 export {

--- a/coral/src/domain/environment/environment-api.ts
+++ b/coral/src/domain/environment/environment-api.ts
@@ -1,30 +1,33 @@
 import { transformEnvironmentApiResponse } from "src/domain/environment/environment-transformer";
 import { Environment } from "src/domain/environment/environment-types";
-import api from "src/services/api";
+import api, { API_PATHS } from "src/services/api";
 import { KlawApiResponse } from "types/utils";
 
 const getEnvironments = async (): Promise<Environment[]> => {
   return api
-    .get<KlawApiResponse<"getEnvs">>("/getEnvs")
+    .get<KlawApiResponse<"getEnvs">>(API_PATHS.getEnvs)
     .then(transformEnvironmentApiResponse);
 };
 
 const getEnvironmentsForTeam = (): Promise<Environment[]> => {
-  const url = "/getEnvsBaseClusterFilteredForTeam";
   return api
-    .get<KlawApiResponse<"getEnvsBaseClusterFilteredForTeam">>(url)
+    .get<KlawApiResponse<"getEnvsBaseClusterFilteredForTeam">>(
+      API_PATHS.getEnvsBaseClusterFilteredForTeam
+    )
     .then(transformEnvironmentApiResponse);
 };
 
 const getSchemaRegistryEnvironments = (): Promise<Environment[]> => {
   return api
-    .get<KlawApiResponse<"getSchemaRegEnvs">>("/getSchemaRegEnvs")
+    .get<KlawApiResponse<"getSchemaRegEnvs">>(API_PATHS.getSchemaRegEnvs)
     .then(transformEnvironmentApiResponse);
 };
 
 const getSyncConnectorsEnvironments = (): Promise<Environment[]> => {
   return api
-    .get<KlawApiResponse<"getSyncConnectorsEnv">>("/getSyncConnectorsEnv")
+    .get<KlawApiResponse<"getSyncConnectorsEnv">>(
+      API_PATHS.getSyncConnectorsEnv
+    )
     .then(transformEnvironmentApiResponse);
 };
 
@@ -37,7 +40,8 @@ const getClusterInfo = async ({
 }): Promise<KlawApiResponse<"getClusterInfoFromEnv">> => {
   const params = new URLSearchParams({ envSelected, envType });
   return api.get<KlawApiResponse<"getClusterInfoFromEnv">>(
-    `/getClusterInfoFromEnv?${params}`
+    API_PATHS.getClusterInfoFromEnv,
+    params
   );
 };
 

--- a/coral/src/domain/requests/requests-api.ts
+++ b/coral/src/domain/requests/requests-api.ts
@@ -1,12 +1,13 @@
 import { getRequestsWaitingForApprovalTransformer } from "src/domain/requests/requests-transformers";
-import api from "src/services/api";
+import api, { API_PATHS } from "src/services/api";
 import { KlawApiRequestQueryParameters, KlawApiResponse } from "types/utils";
 
 const getRequestsStatistics = (
   params: KlawApiRequestQueryParameters<"getRequestStatistics">
 ): Promise<KlawApiResponse<"getRequestStatistics">> => {
   return api.get<KlawApiResponse<"getRequestStatistics">>(
-    `/requests/statistics?${new URLSearchParams(params)}`
+    API_PATHS.getRequestStatistics,
+    new URLSearchParams(params)
   );
 };
 

--- a/coral/src/domain/schema-request/schema-request-api.ts
+++ b/coral/src/domain/schema-request/schema-request-api.ts
@@ -5,7 +5,7 @@ import {
 } from "src/domain/requests/requests-types";
 import { transformGetSchemaRequests } from "src/domain/schema-request/schema-request-transformer";
 import { SchemaRequestApiResponse } from "src/domain/schema-request/schema-request-types";
-import api from "src/services/api";
+import api, { API_PATHS } from "src/services/api";
 import {
   KlawApiRequest,
   KlawApiRequestQueryParameters,
@@ -33,7 +33,7 @@ const createSchemaRequest = (
   };
 
   return api.post<KlawApiResponse<"uploadSchema">, CreateSchemaRequestPayload>(
-    `/uploadSchema`,
+    API_PATHS.uploadSchema,
     payload
   );
 };
@@ -66,7 +66,8 @@ const getSchemaRequestsForApprover = (
 
   return api
     .get<KlawApiResponse<"getSchemaRequestsForApprover">>(
-      `/getSchemaRequestsForApprover?${new URLSearchParams(queryObject)}`
+      API_PATHS.getSchemaRequestsForApprover,
+      new URLSearchParams(queryObject)
     )
     .then(transformGetSchemaRequests);
 };
@@ -100,7 +101,8 @@ const getSchemaRequests = (
 
   return api
     .get<KlawApiResponse<"getSchemaRequests">>(
-      `/getSchemaRequests?${new URLSearchParams(queryObject).toString()}`
+      API_PATHS.getSchemaRequests,
+      new URLSearchParams(queryObject)
     )
     .then(transformGetSchemaRequests);
 };
@@ -113,7 +115,7 @@ const approveSchemaRequest = ({
   return api.post<
     KlawApiResponse<"approveRequest">,
     RequestVerdictApproval<"SCHEMA">
-  >(`/request/approve`, {
+  >(API_PATHS.approveRequest, {
     reqIds,
     requestEntityType: "SCHEMA",
   });
@@ -126,7 +128,7 @@ const declineSchemaRequest = ({
   return api.post<
     KlawApiResponse<"declineRequest">,
     RequestVerdictDecline<"SCHEMA">
-  >(`/request/decline`, {
+  >(API_PATHS.declineRequest, {
     reqIds,
     reason,
     requestEntityType: "SCHEMA",
@@ -139,7 +141,7 @@ const deleteSchemaRequest = ({
   return api.post<
     KlawApiResponse<"deleteRequest">,
     RequestVerdictDelete<"SCHEMA">
-  >(`/request/delete`, {
+  >(API_PATHS.deleteRequest, {
     reqIds,
     requestEntityType: "SCHEMA",
   });

--- a/coral/src/domain/team/team-api.ts
+++ b/coral/src/domain/team/team-api.ts
@@ -1,8 +1,8 @@
-import api from "src/services/api";
+import api, { API_PATHS } from "src/services/api";
 import { KlawApiResponse } from "types/utils";
 
 const getTeams = () => {
-  return api.get<KlawApiResponse<"getAllTeamsSU">>("/getAllTeamsSU");
+  return api.get<KlawApiResponse<"getAllTeamsSU">>(API_PATHS.getAllTeamsSU);
 };
 
 export { getTeams };

--- a/coral/src/domain/topic/topic-api.test.ts
+++ b/coral/src/domain/topic/topic-api.test.ts
@@ -8,6 +8,7 @@ import {
   mockGetTopicRequestsForApprover,
   mockRequestTopic,
 } from "src/domain/topic/topic-api.msw";
+import { KlawApiRequestQueryParameters } from "types/utils";
 
 describe("topic-api", () => {
   beforeAll(() => {
@@ -56,15 +57,20 @@ describe("topic-api", () => {
         },
       });
     });
-    it("calls api.get with correct URL", async () => {
+    it("calls api.get with correct arguments", async () => {
       const getSpy = jest.spyOn(api, "get");
-      await getTopicRequestsForApprover({
+      const params: Pick<
+        KlawApiRequestQueryParameters<"getTopicRequestsForApprover">,
+        "pageNo" | "requestStatus"
+      > = {
         pageNo: "1",
         requestStatus: "CREATED",
-      });
+      };
+      await getTopicRequestsForApprover(params);
       expect(getSpy).toHaveBeenCalledTimes(1);
       expect(getSpy).toHaveBeenCalledWith(
-        "/getTopicRequestsForApprover?pageNo=1&requestStatus=CREATED"
+        "/getTopicRequestsForApprover",
+        new URLSearchParams(params)
       );
     });
   });

--- a/coral/src/domain/topic/topic-api.ts
+++ b/coral/src/domain/topic/topic-api.ts
@@ -14,7 +14,7 @@ import {
   TopicApiResponse,
   TopicRequestApiResponse,
 } from "src/domain/topic/topic-types";
-import api from "src/services/api";
+import api, { API_PATHS } from "src/services/api";
 import {
   KlawApiRequest,
   KlawApiRequestQueryParameters,
@@ -36,7 +36,8 @@ const getTopics = async (
 
   return api
     .get<KlawApiResponse<"getTopics">>(
-      `/getTopics?${new URLSearchParams(queryParams)}`
+      API_PATHS.getTopics,
+      new URLSearchParams(queryParams)
     )
     .then(transformTopicApiResponse);
 };
@@ -57,7 +58,8 @@ const getTopicNames = async ({
   };
 
   return api.get<KlawApiResponse<"getTopicsOnly">>(
-    `/getTopicsOnly?${new URLSearchParams(params)}`
+    API_PATHS.getTopicsOnly,
+    new URLSearchParams(params)
   );
 };
 
@@ -73,7 +75,8 @@ const getTopicTeam = async ({
   const params = { topicName, patternType };
 
   return api.get<KlawApiResponse<"getTopicTeam">>(
-    `/getTopicTeam?${new URLSearchParams(params)}`
+    API_PATHS.getTopicTeam,
+    new URLSearchParams(params)
   );
 };
 
@@ -81,7 +84,9 @@ const getTopicAdvancedConfigOptions = (): Promise<
   TopicAdvancedConfigurationOptions[]
 > =>
   api
-    .get<KlawApiResponse<"getAdvancedTopicConfigs">>("/getAdvancedTopicConfigs")
+    .get<KlawApiResponse<"getAdvancedTopicConfigs">>(
+      API_PATHS.getAdvancedTopicConfigs
+    )
     .then(transformGetTopicAdvancedConfigOptionsResponse);
 
 const requestTopic = (
@@ -90,7 +95,7 @@ const requestTopic = (
   return api.post<
     KlawApiResponse<"createTopicsCreateRequest">,
     KlawApiRequest<"createTopicsCreateRequest">
-  >("/createTopics", payload);
+  >(API_PATHS.createTopicsCreateRequest, payload);
 };
 
 const getTopicRequestsForApprover = (
@@ -112,7 +117,8 @@ const getTopicRequestsForApprover = (
 
   return api
     .get<KlawApiResponse<"getTopicRequestsForApprover">>(
-      `/getTopicRequestsForApprover?${new URLSearchParams(filteredParams)}`
+      API_PATHS.getTopicRequestsForApprover,
+      new URLSearchParams(filteredParams)
     )
     .then(transformGetTopicRequestsResponse);
 };
@@ -140,7 +146,8 @@ const getTopicRequests = (
 
   return api
     .get<KlawApiResponse<"getTopicRequests">>(
-      `/getTopicRequests?${new URLSearchParams(filteredParams)}`
+      API_PATHS.getTopicRequests,
+      new URLSearchParams(filteredParams)
     )
     .then(transformGetTopicRequestsResponse);
 };
@@ -153,7 +160,7 @@ const approveTopicRequest = ({
   return api.post<
     KlawApiResponse<"approveRequest">,
     RequestVerdictApproval<"TOPIC">
-  >(`/request/approve`, {
+  >(API_PATHS.approveRequest, {
     reqIds,
     requestEntityType: "TOPIC",
   });
@@ -166,7 +173,7 @@ const declineTopicRequest = ({
   return api.post<
     KlawApiResponse<"declineRequest">,
     RequestVerdictDecline<"TOPIC">
-  >(`/request/decline`, {
+  >(API_PATHS.declineRequest, {
     reqIds,
     reason,
     requestEntityType: "TOPIC",
@@ -179,7 +186,7 @@ const deleteTopicRequest = ({
   return api.post<
     KlawApiResponse<"deleteRequest">,
     RequestVerdictDelete<"TOPIC">
-  >(`/request/delete`, {
+  >(API_PATHS.deleteRequest, {
     reqIds,
     requestEntityType: "TOPIC",
   });

--- a/coral/src/services/api.test.ts
+++ b/coral/src/services/api.test.ts
@@ -1,5 +1,4 @@
 import api, {
-  AbsolutePathname,
   HTTPMethod,
   isClientError,
   isServerError,
@@ -10,6 +9,7 @@ import api, {
 import { server } from "src/services/api-mocks/server";
 import { rest } from "msw";
 import { getHTTPBaseAPIUrl } from "src/config";
+import { paths as ApiPaths } from "types/api";
 
 function apiUrl(path: string) {
   return `${getHTTPBaseAPIUrl()}${path}`;
@@ -75,34 +75,34 @@ describe("API client", () => {
   function generateScenarioForMethodWithData(
     name: HTTPMethod,
     func: (
-      url: AbsolutePathname,
+      url: keyof ApiPaths,
       data: Record<string, string>
     ) => Promise<unknown>
   ): HTTPScenario {
     const data = { not: "relevant" };
     return {
       functionName: name,
-      ok: () => func("/ok", data),
-      fakeOk: () => func("/fakeOk", data),
-      htmlResponse: () => func("/okButHTML", data),
-      unauthorized: () => func("/unauthorized", data),
-      badRequest: () => func("/clientError", data),
-      internalError: () => func("/serverError", data),
+      ok: () => func("/ok" as keyof ApiPaths, data),
+      fakeOk: () => func("/fakeOk" as keyof ApiPaths, data),
+      htmlResponse: () => func("/okButHTML" as keyof ApiPaths, data),
+      unauthorized: () => func("/unauthorized" as keyof ApiPaths, data),
+      badRequest: () => func("/clientError" as keyof ApiPaths, data),
+      internalError: () => func("/serverError" as keyof ApiPaths, data),
     };
   }
 
   function generateScenarioForMethod(
     name: HTTPMethod,
-    func: (url: AbsolutePathname) => Promise<unknown>
+    func: (pathname: keyof ApiPaths) => Promise<unknown>
   ): HTTPScenario {
     return {
       functionName: name,
-      ok: () => func("/ok"),
-      fakeOk: () => func("/fakeOk"),
-      htmlResponse: () => func("/okButHTML"),
-      unauthorized: () => func("/unauthorized"),
-      badRequest: () => func("/clientError"),
-      internalError: () => func("/serverError"),
+      ok: () => func("/ok" as keyof ApiPaths),
+      fakeOk: () => func("/fakeOk" as keyof ApiPaths),
+      htmlResponse: () => func("/okButHTML" as keyof ApiPaths),
+      unauthorized: () => func("/unauthorized" as keyof ApiPaths),
+      badRequest: () => func("/clientError" as keyof ApiPaths),
+      internalError: () => func("/serverError" as keyof ApiPaths),
     };
   }
 

--- a/coral/src/services/api.ts
+++ b/coral/src/services/api.ts
@@ -1,9 +1,13 @@
-import { getHTTPBaseAPIUrl } from "src/config";
-import isPlainObject from "lodash/isPlainObject";
-import { components } from "types/api";
-import { objectHasProperty } from "src/services/type-utils";
-import { ResolveIntersectionTypes } from "types/utils";
 import isArray from "lodash/isArray";
+import isPlainObject from "lodash/isPlainObject";
+import { getHTTPBaseAPIUrl } from "src/config";
+import { objectHasProperty } from "src/services/type-utils";
+import {
+  operations as ApiOperations,
+  paths as ApiPaths,
+  components,
+} from "types/api";
+import { ResolveIntersectionTypes } from "types/utils";
 
 type KlawApiResponse = ResolveIntersectionTypes<
   components["schemas"]["ApiResponse"]
@@ -25,11 +29,164 @@ type SomeObject =
   | Record<string, never>
   | Array<unknown>;
 
-type AbsolutePathname = `/${string}`;
-
 const CONTENT_TYPE_JSON = "application/json" as const;
 
 const API_BASE_URL = getHTTPBaseAPIUrl();
+
+const API_PATHS: { [key in keyof ApiOperations]: keyof ApiPaths } = {
+  validateSchema: "/validate/schema",
+  updateUserTeamFromSwitchTeams: "/user/updateTeam",
+  uploadSchema: "/uploadSchema",
+  updateUser: "/updateUser",
+  createTopicsUpdateRequest: "/updateTopics",
+  updateTeam: "/updateTeam",
+  updateSyncTopics: "/updateSyncTopics",
+  updateSyncTopicsBulk: "/updateSyncTopicsBulk",
+  updateSyncConnectors: "/updateSyncConnectors",
+  updateSyncBackTopics: "/updateSyncBackTopics",
+  updateSyncBackAcls: "/updateSyncBackAcls",
+  updateSyncAcls: "/updateSyncAcls",
+  updateProfile: "/updateProfile",
+  updatePermissions: "/updatePermissions",
+  updateKwCustomProperty: "/updateKwCustomProperty",
+  udpateTenant: "/udpateTenant",
+  udpateTenantExtension: "/udpateTenantExtension",
+  sendMessageToAdmin: "/sendMessageToAdmin",
+  saveTopicDocumentation: "/saveTopicDocumentation",
+  saveConnectorDocumentation: "/saveConnectorDocumentation",
+  resetPassword: "/resetPassword",
+  deleteRequest: "/request/delete",
+  declineRequest: "/request/decline",
+  approveRequest: "/request/approve",
+  registerUser: "/registerUser",
+  registerUserSaas: "/registerUserSaas",
+  promoteSchema: "/promote/schema",
+  logout: "/logout",
+  approveTopicRequests: "/execTopicRequests",
+  declineTopicRequests: "/execTopicRequestsDecline",
+  execSchemaRequests: "/execSchemaRequests",
+  execSchemaRequestsDecline: "/execSchemaRequestsDecline",
+  declineNewUserRequests: "/execNewUserRequestDecline",
+  approveNewUserRequests: "/execNewUserRequestApprove",
+  approveTopicRequests_1: "/execConnectorRequests",
+  declineConnectorRequests: "/execConnectorRequestsDecline",
+  approveAclRequests: "/execAclRequest",
+  declineAclRequests: "/execAclRequestDecline",
+  deleteUser: "/deleteUserRequest",
+  deleteTopicRequests: "/deleteTopicRequests",
+  deleteTenant: "/deleteTenant",
+  deleteTeam: "/deleteTeamRequest",
+  deleteSchemaRequests: "/deleteSchemaRequests",
+  deleteRole: "/deleteRole",
+  deleteEnvironment: "/deleteEnvironmentRequest",
+  deleteConnectorRequests: "/deleteConnectorRequests",
+  deleteCluster: "/deleteCluster",
+  deleteAclRequests: "/deleteAclRequests",
+  createTopicsCreateRequest: "/createTopics",
+  createTopicDeleteRequest: "/createTopicDeleteRequest",
+  deleteAclSubscriptionRequest: "/createDeleteAclSubscriptionRequest",
+  createConnectorRequest: "/createConnector",
+  createConnectorDeleteRequest: "/createConnectorDeleteRequest",
+  createClaimTopicRequest: "/createClaimTopicRequest",
+  createClaimConnectorRequest: "/createClaimConnectorRequest",
+  createAcl: "/createAcl",
+  changePwd: "/chPwd",
+  addTenantId: "/addTenantId",
+  addRoleId: "/addRoleId",
+  addNewUser: "/addNewUser",
+  addNewTeam: "/addNewTeam",
+  addNewEnv: "/addNewEnv",
+  addNewCluster: "/addNewCluster",
+  getSwitchTeams: "/user/{userId}/switchTeamsList",
+  testClusterApiConnection: "/testClusterApiConnection",
+  shutdownApp: "/shutdownContext",
+  showUsers: "/showUserList",
+  resetMemoryCache:
+    "/resetMemoryCache/{tenantName}/{entityType}/{operationType}",
+  resetCache: "/resetCache",
+  getRequestStatistics: "/requests/statistics",
+  getRegistrationInfoFromId: "/getUserInfoFromRegistrationId",
+  getUserDetails: "/getUserDetails",
+  getUpdateEnvStatus: "/getUpdateEnvStatus",
+  getTopics: "/getTopics",
+  getTopicsRowView: "/getTopicsRowView",
+  getTopicsOnly: "/getTopicsOnly",
+  getTopicsCountPerEnv: "/getTopicsCountPerEnv",
+  getTopicTeam: "/getTopicTeam",
+  getTopicRequests: "/getTopicRequests",
+  getTopicRequestsForApprover: "/getTopicRequestsForApprover",
+  getTopicEvents: "/getTopicEvents",
+  getTopicDetailsPerEnv: "/getTopicDetailsPerEnv",
+  getTenants: "/getTenants",
+  getTenantsInfo: "/getTenantsInfo",
+  getTeamsOverview: "/getTeamsOverview",
+  getTeamDetails: "/getTeamDetails",
+  getSyncTopics: "/getSyncTopics",
+  getSyncEnv: "/getSyncEnv",
+  getSyncTopics_1: "/getSyncConnectors",
+  getSyncConnectorsEnv: "/getSyncConnectorsEnv",
+  getSyncBackAcls: "/getSyncBackAcls",
+  getSyncAcls: "/getSyncAcls",
+  getStandardEnvNames: "/getStandardEnvNames",
+  getSchemaRequests: "/getSchemaRequests",
+  getSchemaRequestsForApprover: "/getSchemaRequestsForApprover",
+  getSchemaRegEnvs: "/getSchemaRegEnvs",
+  getSchemaOfTopic: "/getSchemaOfTopic",
+  getRoles: "/getRoles",
+  getRolesFromDb: "/getRolesFromDb",
+  getRequestTypeStatuses: "/getRequestTypeStatuses",
+  getPermissions: "/getPermissions",
+  getPermissionDescriptions: "/getPermissionDescriptions",
+  getNewUserRequests: "/getNewUserRequests",
+  getMyTenantInfo: "/getMyTenantInfo",
+  getMyProfileInfo: "/getMyProfileInfo",
+  getKwReport: "/getKwReport",
+  getKwPubkey: "/getKwPubkey",
+  getSupportedKafkaProtocols: "/getKafkaProtocols",
+  getKafkaConnectEnvs: "/getKafkaConnectEnvs",
+  getExtensionPeriods: "/getExtensionPeriods",
+  getEnvs: "/getEnvs",
+  getEnvsPaginated: "/getEnvsPaginated",
+  getRequestForSchemas: "/getEnvsForSchemaRequests",
+  getEnvsBaseCluster: "/getEnvsBaseCluster",
+  getEnvsBaseClusterFilteredForTeam: "/getEnvsBaseClusterFilteredForTeam",
+  getEnvParams: "/getEnvParams",
+  getEnvDetails: "/getEnvDetails",
+  getDbAuth: "/getDbAuth",
+  getDashboardStats: "/getDashboardStats",
+  getConsumerOffsets: "/getConsumerOffsets",
+  getConnectors: "/getConnectors",
+  getConnectorRequests: "/getConnectorRequests",
+  getCreatedConnectorRequests: "/getConnectorRequestsForApprover",
+  getConnectorOverview: "/getConnectorOverview",
+  getConnectorDetails: "/getConnectorDetails",
+  getConnectorDetailsPerEnv: "/getConnectorDetailsPerEnv",
+  getClusters: "/getClusters",
+  getClustersPaginated: "/getClustersPaginated",
+  getClusterInfoFromEnv: "/getClusterInfoFromEnv",
+  getClusterDetails: "/getClusterDetails",
+  getBrokerTopMetrics: "/getBrokerTopMetrics",
+  getBasicInfo: "/getBasicInfo",
+  getAuth: "/getAuth",
+  getAllTeamsSU: "/getAllTeamsSU",
+  getAllTeamsSUOnly: "/getAllTeamsSUOnly",
+  getAllTeamsSUFromRegisterUsers: "/getAllTeamsSUFromRegisterUsers",
+  getAllEditableProps: "/getAllServerEditableConfig",
+  getAllProperties: "/getAllServerConfig",
+  getAivenServiceAccounts: "/getAivenServiceAccounts",
+  getAivenServiceAccountDetails: "/getAivenServiceAccount",
+  getAdvancedTopicConfigs: "/getAdvancedTopicConfigs",
+  showActivityLog: "/getActivityLogPerEnv",
+  getActivityLogForTeamOverview: "/getActivityLogForTeamOverview",
+  getActivationInfo: "/getActivationInfo",
+  getAcls: "/getAcls",
+  getAclsCountPerEnv: "/getAclsCountPerEnv",
+  getAclRequests: "/getAclRequests",
+  getAclRequestsForApprover: "/getAclRequestsForApprover",
+  getAclCommand: "/getAclCommands",
+};
+
+type Params = URLSearchParams;
 
 type HTTPError = {
   status: number;
@@ -266,7 +423,8 @@ function handleError(
       }
 
       const httpError: HTTPError = {
-        data: bodyToCheck,
+        // bodycheck is unknown here, so we need to coerce its type to avoid TS errors
+        data: bodyToCheck as string | SomeObject,
         status: errorOrResponse.status,
         statusText: errorOrResponse.statusText,
         headers: errorOrResponse.headers,
@@ -294,7 +452,7 @@ function withPayloadAndVerb<
   TBody extends SomeObject | URLSearchParams
 >(
   method: HTTPMethod.POST | HTTPMethod.PUT | HTTPMethod.PATCH,
-  pathname: AbsolutePathname,
+  pathname: keyof ApiPaths,
   data: TBody
 ): Promise<TResponse> {
   return fetch(`${API_BASE_URL}${pathname}`, withPayload(method, data)).then(
@@ -304,21 +462,23 @@ function withPayloadAndVerb<
 
 function withoutPayloadAndWithVerb<TResponse extends SomeObject>(
   method: HTTPMethod.GET | HTTPMethod.DELETE | HTTPMethod.POST,
-  pathname: AbsolutePathname
+  pathname: keyof ApiPaths,
+  params?: Params
 ): Promise<TResponse> {
-  return fetch(`${API_BASE_URL}${pathname}`, withoutPayload(method)).then(
-    (response) => handleResponse<TResponse>(response)
-  );
+  return fetch(
+    `${API_BASE_URL}${pathname}?${params}`,
+    withoutPayload(method)
+  ).then((response) => handleResponse<TResponse>(response));
 }
 
-const get = <T extends SomeObject>(pathname: AbsolutePathname) =>
-  withoutPayloadAndWithVerb<T>(HTTPMethod.GET, pathname);
+const get = <T extends SomeObject>(pathname: keyof ApiPaths, params?: Params) =>
+  withoutPayloadAndWithVerb<T>(HTTPMethod.GET, pathname, params);
 
 const post = <
   TResponse extends SomeObject,
   TBody extends SomeObject | URLSearchParams | never
 >(
-  pathname: AbsolutePathname,
+  pathname: keyof ApiPaths,
   data?: TBody
 ): Promise<TResponse> => {
   if (data === undefined) {
@@ -328,16 +488,16 @@ const post = <
 };
 
 const put = <TBody extends SomeObject | URLSearchParams>(
-  pathname: AbsolutePathname,
+  pathname: keyof ApiPaths,
   data: TBody
 ) => withPayloadAndVerb(HTTPMethod.PUT, pathname, data);
 
 const patch = <TBody extends SomeObject | URLSearchParams>(
-  pathname: AbsolutePathname,
+  pathname: keyof ApiPaths,
   data: TBody
 ) => withPayloadAndVerb(HTTPMethod.PATCH, pathname, data);
 
-const delete_ = (pathname: AbsolutePathname) =>
+const delete_ = (pathname: keyof ApiPaths) =>
   withoutPayloadAndWithVerb(HTTPMethod.DELETE, pathname);
 
 // eslint-disable-next-line import/no-anonymous-default-export
@@ -349,8 +509,9 @@ export default {
   delete: delete_,
 };
 
-export type { AbsolutePathname, HTTPError, KlawApiResponse, KlawApiError };
+export type { HTTPError, KlawApiResponse, KlawApiError };
 export {
+  API_PATHS,
   HTTPMethod,
   isUnauthorizedError,
   isServerError,


### PR DESCRIPTION
## About this change - What it does

In `domain`, we write functions to interact with the Klaw API in `coral`. The way we used to write such functions  was like this:

```tsx
api
  .get<KlawApiResponse<"getAclRequests">>(
    `/getAclRequests?${new URLSearchParams(filteredParams)}`
  )
  
api
  .post<KlawApiResponse<"deleteRequest">, DeleteAclRequestPayload>(
    `/request/delete`,
    { requestEntityType: "ACL", reqIds }
  );
```

This relied entirely on typing the correct string as the path, which is uncomfortable and allows for easily avoidable errors.

This PR introduces an `API_PATHS` map, allowing to write such functions in this way, which is more ergonomic and more secure:

```tsx
api
  .get<KlawApiResponse<"getAclRequests">>(
     // no hardcoded path, autocomplete available
     API_PATHS.getAclRequests,            
     // no need for string interpolation of params, passed as second argument
     new URLSearchParams(filteredParams).
  )
    
api
  .post<KlawApiResponse<"deleteRequest">, DeleteAclRequestPayload>(
    // no hardcoded path, autocomplete available
    API_PATHS.deleteRequest,   
    // no change                
    { requestEntityType: "ACL", reqIds }.  
  );
```

Resolves: #743
