### PR TITLE
Add custom exceptions in case of cluster api/connectivity failures

### DIFF
--- a/coral/types/api.d.ts
+++ b/coral/types/api.d.ts
@@ -812,6 +812,10 @@ export type components = {
       teammail?: string;
       envList?: (string)[];
     };
+    ConnectivityStatus: {
+      clusterType?: string;
+      connectionStatus?: string;
+    };
     UserInfoModelResponse: {
       username: string;
       fullname: string;
@@ -2445,9 +2449,7 @@ export type operations = {
       /** @description OK */
       200: {
         content: {
-          "application/json": {
-            [key: string]: string | undefined;
-          };
+          "application/json": components["schemas"]["ConnectivityStatus"];
         };
       };
     };

--- a/core/src/main/java/io/aiven/klaw/config/ManageDatabase.java
+++ b/core/src/main/java/io/aiven/klaw/config/ManageDatabase.java
@@ -182,10 +182,9 @@ public class ManageDatabase implements ApplicationContextAware, InitializingBean
 
     // add teams
     String infraTeam = "INFRATEAM", stagingTeam = "STAGINGTEAM";
-    Team team1 =
-        handleDbRequests.selectTeamDetailsFromName(infraTeam, KwConstants.DEFAULT_TENANT_ID);
+    Team team1 = handleDbRequests.getTeamDetailsFromName(infraTeam, KwConstants.DEFAULT_TENANT_ID);
     Team team2 =
-        handleDbRequests.selectTeamDetailsFromName(stagingTeam, KwConstants.DEFAULT_TENANT_ID);
+        handleDbRequests.getTeamDetailsFromName(stagingTeam, KwConstants.DEFAULT_TENANT_ID);
 
     if (team1 == null && team2 == null) {
       handleDbRequests.addNewTeam(
@@ -220,7 +219,7 @@ public class ManageDatabase implements ApplicationContextAware, InitializingBean
                 superAdminDefaultPwd,
                 KwConstants.SUPERADMIN_ROLE,
                 handleDbRequests
-                    .selectTeamDetailsFromName(infraTeam, KwConstants.DEFAULT_TENANT_ID)
+                    .getTeamDetailsFromName(infraTeam, KwConstants.DEFAULT_TENANT_ID)
                     .getTeamId(),
                 kwAdminMailId,
                 superAdminDefaultUserName,
@@ -230,7 +229,7 @@ public class ManageDatabase implements ApplicationContextAware, InitializingBean
 
     // add props
     List<KwProperties> kwProps =
-        handleDbRequests.selectAllKwPropertiesPerTenant(KwConstants.DEFAULT_TENANT_ID);
+        handleDbRequests.getAllKwPropertiesPerTenant(KwConstants.DEFAULT_TENANT_ID);
     List<KwRolesPermissions> kwRolesPerms =
         handleDbRequests.getRolesPermissionsPerTenant(KwConstants.DEFAULT_TENANT_ID);
     if (kwProps == null || kwProps.isEmpty()) {
@@ -247,7 +246,7 @@ public class ManageDatabase implements ApplicationContextAware, InitializingBean
 
     // product details
     String productName = "Klaw";
-    Optional<ProductDetails> productDetails = handleDbRequests.selectProductDetails(productName);
+    Optional<ProductDetails> productDetails = handleDbRequests.getProductDetails(productName);
     if (productDetails.isPresent()) {
       if (!Objects.equals(productDetails.get().getVersion(), kwVersion)) {
         handleDbRequests.insertProductDetails(
@@ -261,7 +260,7 @@ public class ManageDatabase implements ApplicationContextAware, InitializingBean
 
   // verify if there is atleast one user with superadmin access in default tenant
   private boolean validateUsersBeforeAdding() {
-    List<UserInfo> allUsers = handleDbRequests.selectAllUsersInfo(KwConstants.DEFAULT_TENANT_ID);
+    List<UserInfo> allUsers = handleDbRequests.getAllUsersInfo(KwConstants.DEFAULT_TENANT_ID);
     return allUsers.stream()
         .anyMatch(userInfo -> userInfo.getRole().equals(KwConstants.SUPERADMIN_ROLE));
   }
@@ -275,7 +274,7 @@ public class ManageDatabase implements ApplicationContextAware, InitializingBean
   }
 
   public List<UserInfo> selectAllUsersInfo() {
-    return handleDbRequests.selectAllUsersAllTenants();
+    return handleDbRequests.getAllUsersAllTenants();
   }
 
   public List<Env> getKafkaEnvListAllTenants(int tenantId) {
@@ -436,15 +435,15 @@ public class ManageDatabase implements ApplicationContextAware, InitializingBean
 
   public void loadEnvsForOneTenant(Integer tenantId) {
     List<Env> kafkaEnvList =
-        handleDbRequests.selectAllKafkaEnvs(tenantId).stream()
+        handleDbRequests.getAllKafkaEnvs(tenantId).stream()
             .filter(env -> "true".equals(env.getEnvExists()))
             .toList();
     List<Env> schemaEnvList =
-        handleDbRequests.selectAllSchemaRegEnvs(tenantId).stream()
+        handleDbRequests.getAllSchemaRegEnvs(tenantId).stream()
             .filter(env -> "true".equals(env.getEnvExists()))
             .toList();
     List<Env> kafkaConnectEnvList =
-        handleDbRequests.selectAllKafkaConnectEnvs(tenantId).stream()
+        handleDbRequests.getAllKafkaConnectEnvs(tenantId).stream()
             .filter(env -> "true".equals(env.getEnvExists()))
             .toList();
 
@@ -467,7 +466,7 @@ public class ManageDatabase implements ApplicationContextAware, InitializingBean
     List<Team> allTeams;
 
     for (Integer tenantId : tenantMap.keySet()) {
-      allTeams = handleDbRequests.selectAllTeams(tenantId);
+      allTeams = handleDbRequests.getAllTeams(tenantId);
       teamsPerTenant.put(tenantId, allTeams);
       loadTenantTeamsForOneTenant(allTeams, tenantId);
     }
@@ -479,7 +478,7 @@ public class ManageDatabase implements ApplicationContextAware, InitializingBean
     List<UserInfo> allUsers;
     allUsersAllTenants = new ArrayList<>();
     for (Integer tenantId : tenantMap.keySet()) {
-      allUsers = handleDbRequests.selectAllUsersInfo(tenantId);
+      allUsers = handleDbRequests.getAllUsersInfo(tenantId);
       usersPerTenant.put(tenantId, allUsers);
       allUsersAllTenants.addAll(allUsers);
     }
@@ -501,7 +500,7 @@ public class ManageDatabase implements ApplicationContextAware, InitializingBean
 
   public void loadTenantTeamsForOneTenant(List<Team> allTeams, Integer tenantId) {
     if (allTeams == null) {
-      allTeams = handleDbRequests.selectAllTeams(tenantId);
+      allTeams = handleDbRequests.getAllTeams(tenantId);
       teamsPerTenant.put(tenantId, allTeams);
     }
 
@@ -535,7 +534,7 @@ public class ManageDatabase implements ApplicationContextAware, InitializingBean
 
   private void loadKwPropertiesforAllTenants() {
     Map<Integer, Map<String, Map<String, String>>> kwPropertiesMap =
-        handleDbRequests.selectAllKwProperties();
+        handleDbRequests.getAllKwProperties();
     if (kwPropertiesMap.size() == 0) {
       log.info("Klaw Properties not loaded into database. Shutting down !!");
       shutdownApp();
@@ -549,7 +548,7 @@ public class ManageDatabase implements ApplicationContextAware, InitializingBean
   public void loadKwPropsPerOneTenant(
       Map<Integer, Map<String, Map<String, String>>> kwPropertiesMap, Integer tenantId) {
     if (kwPropertiesMap == null) {
-      kwPropertiesMap = handleDbRequests.selectAllKwProperties();
+      kwPropertiesMap = handleDbRequests.getAllKwProperties();
     }
 
     kwPropertiesMapPerTenant.put(tenantId, kwPropertiesMap.get(tenantId));
@@ -690,15 +689,15 @@ public class ManageDatabase implements ApplicationContextAware, InitializingBean
 
   public void loadEnvMapForOneTenant(Integer tenantId) {
     List<Env> kafkaEnvList =
-        handleDbRequests.selectAllKafkaEnvs(tenantId).stream()
+        handleDbRequests.getAllKafkaEnvs(tenantId).stream()
             .filter(env -> "true".equals(env.getEnvExists()))
             .collect(Collectors.toList());
     List<Env> schemaEnvList =
-        handleDbRequests.selectAllSchemaRegEnvs(tenantId).stream()
+        handleDbRequests.getAllSchemaRegEnvs(tenantId).stream()
             .filter(env -> "true".equals(env.getEnvExists()))
             .collect(Collectors.toList());
     List<Env> kafkaConnectEnvList =
-        handleDbRequests.selectAllKafkaConnectEnvs(tenantId).stream()
+        handleDbRequests.getAllKafkaConnectEnvs(tenantId).stream()
             .filter(env -> "true".equals(env.getEnvExists()))
             .collect(Collectors.toList());
     List<Env> allEnvList = new ArrayList<>();

--- a/core/src/main/java/io/aiven/klaw/controller/ServerConfigController.java
+++ b/core/src/main/java/io/aiven/klaw/controller/ServerConfigController.java
@@ -4,6 +4,7 @@ import io.aiven.klaw.error.KlawException;
 import io.aiven.klaw.model.ApiResponse;
 import io.aiven.klaw.model.KwPropertiesModel;
 import io.aiven.klaw.model.ServerConfigProperties;
+import io.aiven.klaw.model.response.ConnectivityStatus;
 import io.aiven.klaw.model.response.KwPropertiesResponse;
 import io.aiven.klaw.service.ServerConfigService;
 import java.util.List;
@@ -60,7 +61,7 @@ public class ServerConfigController {
       value = "/testClusterApiConnection",
       method = RequestMethod.GET,
       produces = {MediaType.APPLICATION_JSON_VALUE})
-  public ResponseEntity<Map<String, String>> testClusterApiConnection(
+  public ResponseEntity<ConnectivityStatus> testClusterApiConnection(
       @RequestParam("clusterApiUrl") String clusterApiUrl) throws KlawException {
     return new ResponseEntity<>(
         serverConfigService.testClusterApiConnection(clusterApiUrl), HttpStatus.OK);

--- a/core/src/main/java/io/aiven/klaw/controller/ServerConfigController.java
+++ b/core/src/main/java/io/aiven/klaw/controller/ServerConfigController.java
@@ -61,7 +61,7 @@ public class ServerConfigController {
       method = RequestMethod.GET,
       produces = {MediaType.APPLICATION_JSON_VALUE})
   public ResponseEntity<Map<String, String>> testClusterApiConnection(
-      @RequestParam("clusterApiUrl") String clusterApiUrl) {
+      @RequestParam("clusterApiUrl") String clusterApiUrl) throws KlawException {
     return new ResponseEntity<>(
         serverConfigService.testClusterApiConnection(clusterApiUrl), HttpStatus.OK);
   }

--- a/core/src/main/java/io/aiven/klaw/error/KlawErrorMessages.java
+++ b/core/src/main/java/io/aiven/klaw/error/KlawErrorMessages.java
@@ -125,6 +125,10 @@ public class KlawErrorMessages {
   public static final String CLUSTER_API_ERR_119 =
       "There seems to be a connectivity issue with the cluster. Please contact your administrator !!";
 
+  public static final String CLUSTER_API_ERR_120 = "ClientHttpRequestFactory must not be null";
+
+  public static final String CLUSTER_API_ERR_121 = "Connection refused";
+
   // Env clusters tenants service
   public static final String ENV_CLUSTER_TNT_ERR_101 =
       "Failure. Please choose a different name. This environment name already exists.";

--- a/core/src/main/java/io/aiven/klaw/error/KlawErrorMessages.java
+++ b/core/src/main/java/io/aiven/klaw/error/KlawErrorMessages.java
@@ -119,6 +119,12 @@ public class KlawErrorMessages {
   public static final String CLUSTER_API_ERR_117 =
       "CONFIGURE CLUSTER API SECRET FOR CLUSTER OPERATIONS. klaw.clusterapi.access.base64.secret";
 
+  public static final String CLUSTER_API_ERR_118 =
+      "There seems to be a connectivity issue with Cluster Api. Please contact your administrator !!";
+
+  public static final String CLUSTER_API_ERR_119 =
+      "There seems to be a connectivity issue with the cluster. Please contact your administrator !!";
+
   // Env clusters tenants service
   public static final String ENV_CLUSTER_TNT_ERR_101 =
       "Failure. Please choose a different name. This environment name already exists.";

--- a/core/src/main/java/io/aiven/klaw/helpers/HandleDbRequests.java
+++ b/core/src/main/java/io/aiven/klaw/helpers/HandleDbRequests.java
@@ -96,14 +96,13 @@ public interface HandleDbRequests {
       RequestOperationType requestOperationType,
       String search);
 
-  TopicRequest selectTopicRequestsForTopic(int topicId, int tenantId);
+  TopicRequest getTopicRequestsForTopic(int topicId, int tenantId);
 
-  KafkaConnectorRequest selectConnectorRequestsForConnector(int connectorId, int tenantId);
+  KafkaConnectorRequest getConnectorRequestsForConnector(int connectorId, int tenantId);
 
-  List<TopicRequest> selectTopicRequests(
-      String topicName, String envId, String status, int tenantId);
+  List<TopicRequest> getTopicRequests(String topicName, String envId, String status, int tenantId);
 
-  List<KafkaConnectorRequest> selectConnectorRequests(
+  List<KafkaConnectorRequest> getConnectorRequests(
       String connectorName, String envId, String status, int tenantId);
 
   List<Topic> getSyncTopics(String env, Integer teamId, int tenantId);
@@ -113,8 +112,6 @@ public interface HandleDbRequests {
   List<Topic> getTopics(String topicName, int tenantId);
 
   List<KwKafkaConnector> getConnectors(String connectorName, int tenantId);
-
-  List<Topic> getTopicDetailsPerEnv(String topicName, String envId, int tenantId);
 
   List<Topic> getTopicsFromEnv(String envId, int tenantId);
 
@@ -130,7 +127,7 @@ public interface HandleDbRequests {
 
   List<Acl> getUniqueConsumerGroups(int tenantId);
 
-  Acl selectSyncAclsFromReqNo(int reqNo, int tenantId);
+  Acl getSyncAclsFromReqNo(int reqNo, int tenantId);
 
   List<AclRequests> getAllAclRequests(
       boolean allReqs,
@@ -168,37 +165,35 @@ public interface HandleDbRequests {
       String search,
       boolean isMyRequest);
 
-  SchemaRequest selectSchemaRequest(int avroSchemaId, int tenantId);
+  SchemaRequest getSchemaRequest(int avroSchemaId, int tenantId);
 
-  List<Team> selectAllTeamsOfUsers(String username, int tenantId);
+  List<Team> getAllTeamsOfUsers(String username, int tenantId);
 
-  List<Team> selectAllTeams(int tenantId);
+  List<Team> getAllTeams(int tenantId);
 
-  Team selectTeamDetails(Integer teamId, int tenantId);
+  Team getTeamDetails(Integer teamId, int tenantId);
 
-  Team selectTeamDetailsFromName(String teamName, int defaultTenantId);
+  Team getTeamDetailsFromName(String teamName, int defaultTenantId);
 
   Map<String, String> getDashboardInfo(Integer teamId, int tenantId);
 
-  List<UserInfo> selectAllUsersInfo(int tenantId);
+  List<UserInfo> getAllUsersInfo(int tenantId);
 
-  List<UserInfo> selectAllUsersAllTenants();
+  List<UserInfo> getAllUsersAllTenants();
 
-  List<UserInfo> selectAllUsersInfoForTeam(Integer teamId, int tenantId);
+  List<UserInfo> getAllUsersInfoForTeam(Integer teamId, int tenantId);
 
-  List<RegisterUserInfo> selectAllRegisterUsersInfoForTenant(int tenantId);
+  List<RegisterUserInfo> getAllRegisterUsersInfoForTenant(int tenantId);
 
-  List<RegisterUserInfo> selectAllRegisterUsersInfo();
+  List<RegisterUserInfo> getAllRegisterUsersInformation();
 
-  List<RegisterUserInfo> selectAllStagingRegisterUsersInfo(String userId);
+  List<RegisterUserInfo> getAllStagingRegisterUsersInfo(String userId);
 
   UserInfo getUsersInfo(String username);
 
   RegisterUserInfo getRegisterUsersInfo(String username);
 
-  AclRequests selectAcl(int req_no, int tenantId);
-
-  List<Topic> getTopicTeam(String topicName, int tenantId);
+  AclRequests getAcl(int req_no, int tenantId);
 
   List<KwKafkaConnector> getConnectorsFromName(String connectorName, int tenantId);
 
@@ -208,21 +203,21 @@ public interface HandleDbRequests {
 
   List<Acl> getAllConsumerGroups(int tenantId);
 
-  List<Env> selectAllEnvs(int tenantId);
+  List<Env> getAllEnvs(int tenantId);
 
-  List<Env> selectAllKafkaEnvs(int tenantId);
+  List<Env> getAllKafkaEnvs(int tenantId);
 
-  List<Env> selectAllSchemaRegEnvs(int tenantId);
+  List<Env> getAllSchemaRegEnvs(int tenantId);
 
-  List<Env> selectAllKafkaConnectEnvs(int tenantId);
+  List<Env> getAllKafkaConnectEnvs(int tenantId);
 
-  Env selectEnvDetails(String env, int tenantId);
+  Env getEnvDetails(String env, int tenantId);
 
-  List<ActivityLog> selectActivityLog(String user, String env, boolean allReqs, int tenantId);
+  List<ActivityLog> getActivityLog(String user, String env, boolean allReqs, int tenantId);
 
-  Map<Integer, Map<String, Map<String, String>>> selectAllKwProperties();
+  Map<Integer, Map<String, Map<String, String>>> getAllKwProperties();
 
-  List<KwProperties> selectAllKwPropertiesPerTenant(int tenantId);
+  List<KwProperties> getAllKwPropertiesPerTenant(int tenantId);
 
   String insertDefaultKwProperties(List<KwProperties> kwPropertiesList);
 
@@ -250,27 +245,26 @@ public interface HandleDbRequests {
 
   DashboardStats getDashboardStats(Integer teamId, int tenantId);
 
-  List<Topic> selectAllTopicsByTopictypeAndTeamname(String topicType, Integer teamId, int tenantId);
+  List<Topic> getAllTopicsByTopictypeAndTeamname(String topicType, Integer teamId, int tenantId);
 
-  List<Map<String, String>> selectActivityLogForLastDays(
+  List<Map<String, String>> getActivityLogForLastDays(
       int numberOfDays, String[] envIdList, int tenantId);
 
-  List<Map<String, String>> selectActivityLogByTeam(Integer teamId, int numberOfDays, int tenantId);
+  List<Map<String, String>> getActivityLogByTeam(Integer teamId, int numberOfDays, int tenantId);
 
-  List<Map<String, String>> selectTopicsCountByTeams(Integer teamId, int tenantId);
+  List<Map<String, String>> getTopicsCountByTeams(Integer teamId, int tenantId);
 
-  List<Map<String, String>> selectTopicsCountByEnv(Integer tenantId);
+  List<Map<String, String>> getTopicsCountByEnv(Integer tenantId);
 
-  List<Map<String, String>> selectPartitionsCountByEnv(Integer teamId, Integer tenantId);
+  List<Map<String, String>> getPartitionsCountByEnv(Integer teamId, Integer tenantId);
 
-  List<Map<String, String>> selectAclsCountByEnv(Integer teamId, Integer tenantId);
+  List<Map<String, String>> getAclsCountByEnv(Integer teamId, Integer tenantId);
 
-  List<Map<String, String>> selectAclsCountByTeams(
-      String aclType, Integer teamId, Integer tenantId);
+  List<Map<String, String>> getAclsCountByTeams(String aclType, Integer teamId, Integer tenantId);
 
-  List<Map<String, String>> selectAllTopicsForTeamGroupByEnv(Integer teamId, int tenantId);
+  List<Map<String, String>> getAllTopicsForTeamGroupByEnv(Integer teamId, int tenantId);
 
-  List<Map<String, String>> selectAllMetrics(String metricsType, String metricsName, String env);
+  List<Map<String, String>> getAllMetrics(String metricsType, String metricsName, String env);
 
   /*--------------------Update */
   String updateTopicDocumentation(Topic topic);
@@ -320,8 +314,6 @@ public interface HandleDbRequests {
 
   String deleteAclRequest(int req_no, String userName, int tenantId);
 
-  String deleteAclSubscriptionRequest(int req_no, int tenantId);
-
   String deleteEnvironmentRequest(String envId, int tenantId);
 
   String deleteCluster(int clusterId, int tenantId);
@@ -348,27 +340,25 @@ public interface HandleDbRequests {
 
   String deleteTxnData(int tenantId);
 
-  String deleteTenant(int tenantId);
-
   String setTenantActivestatus(int tenantId, boolean status);
 
   String updateTenant(int tenantId, String organizationName);
 
   String disableTenant(int tenantId);
 
-  Optional<ProductDetails> selectProductDetails(String name);
+  Optional<ProductDetails> getProductDetails(String name);
 
-  int findAllKafkaComponentsCountForEnv(String env, int tenantId);
+  int getAllKafkaComponentsCountForEnv(String env, int tenantId);
 
-  int findAllConnectorComponentsCountForEnv(String env, int tenantId);
+  int getAllConnectorComponentsCountForEnv(String env, int tenantId);
 
-  int findAllSchemaComponentsCountForEnv(String env, int tenantId);
+  int getAllSchemaComponentsCountForEnv(String env, int tenantId);
 
-  int findAllComponentsCountForTeam(Integer teamId, int tenantId);
+  int getAllComponentsCountForTeam(Integer teamId, int tenantId);
 
   int getAllTopicsCountInAllTenants();
 
-  int findAllComponentsCountForUser(String userName, int tenantId);
+  int getAllComponentsCountForUser(String userName, int tenantId);
 
   List<Topic> getAllTopics();
 
@@ -384,17 +374,13 @@ public interface HandleDbRequests {
 
   List<SchemaRequest> getAllSchemaRequests();
 
-  List<MessageSchema> selectAllSchemas();
+  List<MessageSchema> getAllSchemas();
 
-  List<Team> selectTeams();
+  List<Team> getTeams();
 
-  List<RegisterUserInfo> getAllRegisterUsersInfo();
+  List<Env> getEnvs();
 
-  List<Env> selectEnvs();
-
-  List<ActivityLog> getAllActivityLog();
-
-  List<KwProperties> selectKwProperties();
+  List<KwProperties> getKwProperties();
 
   List<KwClusters> getClusters();
 }

--- a/core/src/main/java/io/aiven/klaw/helpers/HandleDbRequests.java
+++ b/core/src/main/java/io/aiven/klaw/helpers/HandleDbRequests.java
@@ -199,8 +199,6 @@ public interface HandleDbRequests {
 
   List<Topic> getTopicsforTeam(Integer teamId, int tenantId);
 
-  List<Topic> getTopicTeam(String topicName, int tenantId);
-
   List<Acl> getConsumerGroupsforTeam(Integer teamId, int tenantId);
 
   List<Acl> getAllConsumerGroups(int tenantId);

--- a/core/src/main/java/io/aiven/klaw/helpers/HandleDbRequests.java
+++ b/core/src/main/java/io/aiven/klaw/helpers/HandleDbRequests.java
@@ -199,6 +199,8 @@ public interface HandleDbRequests {
 
   List<Topic> getTopicsforTeam(Integer teamId, int tenantId);
 
+  List<Topic> getTopicTeam(String topicName, int tenantId);
+
   List<Acl> getConsumerGroupsforTeam(Integer teamId, int tenantId);
 
   List<Acl> getAllConsumerGroups(int tenantId);

--- a/core/src/main/java/io/aiven/klaw/helpers/db/rdbms/HandleDbRequestsJdbc.java
+++ b/core/src/main/java/io/aiven/klaw/helpers/db/rdbms/HandleDbRequestsJdbc.java
@@ -225,22 +225,22 @@ public class HandleDbRequestsJdbc implements HandleDbRequests {
         false);
   }
 
-  public TopicRequest selectTopicRequestsForTopic(int topicId, int tenantId) {
+  public TopicRequest getTopicRequestsForTopic(int topicId, int tenantId) {
     return jdbcSelectHelper.selectTopicRequestsForTopic(topicId, tenantId);
   }
 
-  public KafkaConnectorRequest selectConnectorRequestsForConnector(int connectorId, int tenantId) {
+  public KafkaConnectorRequest getConnectorRequestsForConnector(int connectorId, int tenantId) {
     return jdbcSelectHelper.selectConnectorRequestsForConnector(connectorId, tenantId);
   }
 
   @Override
-  public List<TopicRequest> selectTopicRequests(
+  public List<TopicRequest> getTopicRequests(
       String topicName, String envId, String status, int tenantId) {
     return jdbcSelectHelper.selectTopicRequests(topicName, envId, status, tenantId);
   }
 
   @Override
-  public List<KafkaConnectorRequest> selectConnectorRequests(
+  public List<KafkaConnectorRequest> getConnectorRequests(
       String connectorName, String envId, String status, int tenantId) {
     return jdbcSelectHelper.selectConnectorRequests(connectorName, envId, status, tenantId);
   }
@@ -263,11 +263,6 @@ public class HandleDbRequestsJdbc implements HandleDbRequests {
   @Override
   public List<KwKafkaConnector> getConnectors(String topicName, int tenantId) {
     return jdbcSelectHelper.getConnectors(topicName, false, tenantId);
-  }
-
-  @Override
-  public List<Topic> getTopicDetailsPerEnv(String topicName, String envId, int tenantId) {
-    return jdbcSelectHelper.getTopicDetailsPerEnv(topicName, envId, tenantId);
   }
 
   @Override
@@ -306,7 +301,7 @@ public class HandleDbRequestsJdbc implements HandleDbRequests {
   }
 
   @Override
-  public Acl selectSyncAclsFromReqNo(int reqNo, int tenantId) {
+  public Acl getSyncAclsFromReqNo(int reqNo, int tenantId) {
     return jdbcSelectHelper.selectSyncAclsFromReqNo(reqNo, tenantId);
   }
 
@@ -389,27 +384,27 @@ public class HandleDbRequestsJdbc implements HandleDbRequests {
   }
 
   @Override
-  public SchemaRequest selectSchemaRequest(int avroSchemaId, int tenantId) {
+  public SchemaRequest getSchemaRequest(int avroSchemaId, int tenantId) {
     return jdbcSelectHelper.selectSchemaRequest(avroSchemaId, tenantId);
   }
 
   @Override
-  public List<Team> selectAllTeamsOfUsers(String username, int tenantId) {
+  public List<Team> getAllTeamsOfUsers(String username, int tenantId) {
     return jdbcSelectHelper.selectTeamsOfUsers(username, tenantId);
   }
 
   @Override
-  public List<Team> selectAllTeams(int tenantId) {
+  public List<Team> getAllTeams(int tenantId) {
     return jdbcSelectHelper.selectAllTeams(tenantId);
   }
 
   @Override
-  public Team selectTeamDetails(Integer teamId, int tenantId) {
+  public Team getTeamDetails(Integer teamId, int tenantId) {
     return jdbcSelectHelper.selectTeamDetails(teamId, tenantId);
   }
 
   @Override
-  public Team selectTeamDetailsFromName(String teamName, int tenantId) {
+  public Team getTeamDetailsFromName(String teamName, int tenantId) {
     return jdbcSelectHelper.selectTeamDetailsFromName(teamName, tenantId);
   }
 
@@ -419,32 +414,32 @@ public class HandleDbRequestsJdbc implements HandleDbRequests {
   }
 
   @Override
-  public List<UserInfo> selectAllUsersInfo(int tenantId) {
+  public List<UserInfo> getAllUsersInfo(int tenantId) {
     return jdbcSelectHelper.selectAllUsersInfo(tenantId);
   }
 
   @Override
-  public List<UserInfo> selectAllUsersAllTenants() {
+  public List<UserInfo> getAllUsersAllTenants() {
     return jdbcSelectHelper.selectAllUsersAllTenants();
   }
 
   @Override
-  public List<UserInfo> selectAllUsersInfoForTeam(Integer teamId, int tenantId) {
+  public List<UserInfo> getAllUsersInfoForTeam(Integer teamId, int tenantId) {
     return jdbcSelectHelper.selectAllUsersInfoForTeam(teamId, tenantId);
   }
 
   @Override
-  public List<RegisterUserInfo> selectAllRegisterUsersInfoForTenant(int tenantId) {
+  public List<RegisterUserInfo> getAllRegisterUsersInfoForTenant(int tenantId) {
     return jdbcSelectHelper.selectAllRegisterUsersInfoForTenant(tenantId);
   }
 
   @Override
-  public List<RegisterUserInfo> selectAllRegisterUsersInfo() {
+  public List<RegisterUserInfo> getAllRegisterUsersInformation() {
     return jdbcSelectHelper.selectAllRegisterUsersInfo();
   }
 
   @Override
-  public List<RegisterUserInfo> selectAllStagingRegisterUsersInfo(String userName) {
+  public List<RegisterUserInfo> getAllStagingRegisterUsersInfo(String userName) {
     return jdbcSelectHelper.selectAllStagingRegisterUsersInfo(userName);
   }
 
@@ -458,13 +453,8 @@ public class HandleDbRequestsJdbc implements HandleDbRequests {
   }
 
   @Override
-  public AclRequests selectAcl(int req_no, int tenantId) {
+  public AclRequests getAcl(int req_no, int tenantId) {
     return jdbcSelectHelper.selectAcl(req_no, tenantId);
-  }
-
-  @Override
-  public List<Topic> getTopicTeam(String topicName, int tenantId) {
-    return jdbcSelectHelper.selectTopicDetails(topicName, tenantId);
   }
 
   public List<KwKafkaConnector> getConnectorsFromName(String connectorName, int tenantId) {
@@ -487,42 +477,41 @@ public class HandleDbRequestsJdbc implements HandleDbRequests {
   }
 
   @Override
-  public List<Env> selectAllEnvs(int tenantId) {
+  public List<Env> getAllEnvs(int tenantId) {
     return jdbcSelectHelper.selectAllEnvs(KafkaClustersType.ALL, tenantId);
   }
 
   @Override
-  public List<Env> selectAllKafkaEnvs(int tenantId) {
+  public List<Env> getAllKafkaEnvs(int tenantId) {
     return jdbcSelectHelper.selectAllEnvs(KafkaClustersType.KAFKA, tenantId);
   }
 
   @Override
-  public List<Env> selectAllSchemaRegEnvs(int tenantId) {
+  public List<Env> getAllSchemaRegEnvs(int tenantId) {
     return jdbcSelectHelper.selectAllEnvs(KafkaClustersType.SCHEMA_REGISTRY, tenantId);
   }
 
   @Override
-  public List<Env> selectAllKafkaConnectEnvs(int tenantId) {
+  public List<Env> getAllKafkaConnectEnvs(int tenantId) {
     return jdbcSelectHelper.selectAllEnvs(KafkaClustersType.KAFKA_CONNECT, tenantId);
   }
 
   @Override
-  public Env selectEnvDetails(String env, int tenantId) {
+  public Env getEnvDetails(String env, int tenantId) {
     return jdbcSelectHelper.selectEnvDetails(env, tenantId);
   }
 
-  public List<ActivityLog> selectActivityLog(
-      String user, String env, boolean allReqs, int tenantId) {
+  public List<ActivityLog> getActivityLog(String user, String env, boolean allReqs, int tenantId) {
     return jdbcSelectHelper.selectActivityLog(user, env, allReqs, tenantId);
   }
 
   @Override
-  public Map<Integer, Map<String, Map<String, String>>> selectAllKwProperties() {
+  public Map<Integer, Map<String, Map<String, String>>> getAllKwProperties() {
     return jdbcSelectHelper.selectAllKwProperties();
   }
 
   @Override
-  public List<KwProperties> selectAllKwPropertiesPerTenant(int tenantId) {
+  public List<KwProperties> getAllKwPropertiesPerTenant(int tenantId) {
     return jdbcSelectHelper.selectAllKwPropertiesPerTenant(tenantId);
   }
 
@@ -597,56 +586,56 @@ public class HandleDbRequestsJdbc implements HandleDbRequests {
   }
 
   @Override
-  public List<Topic> selectAllTopicsByTopictypeAndTeamname(
+  public List<Topic> getAllTopicsByTopictypeAndTeamname(
       String topicType, Integer teamId, int tenantId) {
     return jdbcSelectHelper.selectAllTopicsByTopictypeAndTeamname(topicType, teamId, tenantId);
   }
 
   @Override
-  public List<Map<String, String>> selectActivityLogForLastDays(
+  public List<Map<String, String>> getActivityLogForLastDays(
       int numberOfDays, String[] envId, int tenantId) {
     return jdbcSelectHelper.selectActivityLogForLastDays(numberOfDays, envId, tenantId);
   }
 
   @Override
-  public List<Map<String, String>> selectActivityLogByTeam(
+  public List<Map<String, String>> getActivityLogByTeam(
       Integer teamId, int numberOfDays, int tenantId) {
     return jdbcSelectHelper.selectActivityLogByTeam(teamId, numberOfDays, tenantId);
   }
 
   @Override
-  public List<Map<String, String>> selectTopicsCountByTeams(Integer teamId, int tenantId) {
+  public List<Map<String, String>> getTopicsCountByTeams(Integer teamId, int tenantId) {
     return jdbcSelectHelper.selectTopicsCountByTeams(teamId, tenantId);
   }
 
   @Override
-  public List<Map<String, String>> selectTopicsCountByEnv(Integer tenantId) {
+  public List<Map<String, String>> getTopicsCountByEnv(Integer tenantId) {
     return jdbcSelectHelper.selectTopicsCountByEnv(tenantId);
   }
 
   @Override
-  public List<Map<String, String>> selectPartitionsCountByEnv(Integer teamId, Integer tenantId) {
+  public List<Map<String, String>> getPartitionsCountByEnv(Integer teamId, Integer tenantId) {
     return jdbcSelectHelper.selectPartitionsCountByEnv(teamId, tenantId);
   }
 
   @Override
-  public List<Map<String, String>> selectAclsCountByEnv(Integer teamId, Integer tenantId) {
+  public List<Map<String, String>> getAclsCountByEnv(Integer teamId, Integer tenantId) {
     return jdbcSelectHelper.selectAclsCountByEnv(teamId, tenantId);
   }
 
   @Override
-  public List<Map<String, String>> selectAclsCountByTeams(
+  public List<Map<String, String>> getAclsCountByTeams(
       String aclType, Integer teamId, Integer tenantId) {
     return jdbcSelectHelper.selectAclsCountByTeams(aclType, teamId, tenantId);
   }
 
   @Override
-  public List<Map<String, String>> selectAllTopicsForTeamGroupByEnv(Integer teamId, int tenantId) {
+  public List<Map<String, String>> getAllTopicsForTeamGroupByEnv(Integer teamId, int tenantId) {
     return jdbcSelectHelper.selectAllTopicsForTeamGroupByEnv(teamId, tenantId);
   }
 
   @Override
-  public List<Map<String, String>> selectAllMetrics(
+  public List<Map<String, String>> getAllMetrics(
       String metricsType, String metricsName, String env) {
     return jdbcSelectHelper.selectAllMetrics(metricsType, metricsName, env);
   }
@@ -766,11 +755,6 @@ public class HandleDbRequestsJdbc implements HandleDbRequests {
   }
 
   @Override
-  public String deleteAclSubscriptionRequest(int req_no, int tenantId) {
-    return jdbcDeleteHelper.deleteAclSubscriptionRequest(req_no, tenantId);
-  }
-
-  @Override
   public String deleteEnvironmentRequest(String envId, int tenantId) {
     return jdbcDeleteHelper.deleteEnvironment(envId, tenantId);
   }
@@ -836,11 +820,6 @@ public class HandleDbRequestsJdbc implements HandleDbRequests {
   }
 
   @Override
-  public String deleteTenant(int tenantId) {
-    return jdbcDeleteHelper.deleteTenant(tenantId);
-  }
-
-  @Override
   public String setTenantActivestatus(int tenantId, boolean status) {
     return jdbcUpdateHelper.setTenantActivestatus(tenantId, status);
   }
@@ -856,32 +835,32 @@ public class HandleDbRequestsJdbc implements HandleDbRequests {
   }
 
   @Override
-  public Optional<ProductDetails> selectProductDetails(String name) {
+  public Optional<ProductDetails> getProductDetails(String name) {
     return jdbcSelectHelper.selectProductDetails(name);
   }
 
   @Override
-  public int findAllKafkaComponentsCountForEnv(String env, int tenantId) {
+  public int getAllKafkaComponentsCountForEnv(String env, int tenantId) {
     return jdbcSelectHelper.findAllKafkaComponentsCountForEnv(env, tenantId);
   }
 
   @Override
-  public int findAllConnectorComponentsCountForEnv(String env, int tenantId) {
+  public int getAllConnectorComponentsCountForEnv(String env, int tenantId) {
     return jdbcSelectHelper.findAllConnectorComponentsCountForEnv(env, tenantId);
   }
 
   @Override
-  public int findAllSchemaComponentsCountForEnv(String env, int tenantId) {
+  public int getAllSchemaComponentsCountForEnv(String env, int tenantId) {
     return jdbcSelectHelper.findAllSchemaComponentsCountForEnv(env, tenantId);
   }
 
   @Override
-  public int findAllComponentsCountForTeam(Integer teamId, int tenantId) {
+  public int getAllComponentsCountForTeam(Integer teamId, int tenantId) {
     return jdbcSelectHelper.findAllComponentsCountForTeam(teamId, tenantId);
   }
 
   @Override
-  public int findAllComponentsCountForUser(String userId, int tenantId) {
+  public int getAllComponentsCountForUser(String userId, int tenantId) {
     return jdbcSelectHelper.findAllComponentsCountForUser(userId, tenantId);
   }
 
@@ -926,32 +905,22 @@ public class HandleDbRequestsJdbc implements HandleDbRequests {
   }
 
   @Override
-  public List<MessageSchema> selectAllSchemas() {
+  public List<MessageSchema> getAllSchemas() {
     return jdbcSelectHelper.selectAllSchemas();
   }
 
   @Override
-  public List<Team> selectTeams() {
+  public List<Team> getTeams() {
     return jdbcSelectHelper.selectTeams();
   }
 
   @Override
-  public List<RegisterUserInfo> getAllRegisterUsersInfo() {
-    return jdbcSelectHelper.getAllRegisterUsersInfo();
-  }
-
-  @Override
-  public List<Env> selectEnvs() {
+  public List<Env> getEnvs() {
     return jdbcSelectHelper.selectEnvs();
   }
 
   @Override
-  public List<ActivityLog> getAllActivityLog() {
-    return jdbcSelectHelper.getAllActivityLog();
-  }
-
-  @Override
-  public List<KwProperties> selectKwProperties() {
+  public List<KwProperties> getKwProperties() {
     return jdbcSelectHelper.selectKwProperties();
   }
 

--- a/core/src/main/java/io/aiven/klaw/helpers/db/rdbms/HandleDbRequestsJdbc.java
+++ b/core/src/main/java/io/aiven/klaw/helpers/db/rdbms/HandleDbRequestsJdbc.java
@@ -276,11 +276,6 @@ public class HandleDbRequestsJdbc implements HandleDbRequests {
   }
 
   @Override
-  public List<Topic> getTopicTeam(String topicName, int tenantId) {
-    return jdbcSelectHelper.selectTopicDetails(topicName, tenantId);
-  }
-
-  @Override
   public List<Topic> getAllTopics(int tenantId) {
     return jdbcSelectHelper.getTopics("", true, tenantId);
   }

--- a/core/src/main/java/io/aiven/klaw/helpers/db/rdbms/HandleDbRequestsJdbc.java
+++ b/core/src/main/java/io/aiven/klaw/helpers/db/rdbms/HandleDbRequestsJdbc.java
@@ -276,6 +276,11 @@ public class HandleDbRequestsJdbc implements HandleDbRequests {
   }
 
   @Override
+  public List<Topic> getTopicTeam(String topicName, int tenantId) {
+    return jdbcSelectHelper.selectTopicDetails(topicName, tenantId);
+  }
+
+  @Override
   public List<Topic> getAllTopics(int tenantId) {
     return jdbcSelectHelper.getTopics("", true, tenantId);
   }

--- a/core/src/main/java/io/aiven/klaw/model/response/ConnectivityStatus.java
+++ b/core/src/main/java/io/aiven/klaw/model/response/ConnectivityStatus.java
@@ -1,0 +1,10 @@
+package io.aiven.klaw.model.response;
+
+import lombok.Data;
+
+@Data
+public class ConnectivityStatus {
+  private String clusterType;
+
+  private String connectionStatus;
+}

--- a/core/src/main/java/io/aiven/klaw/service/AclControllerService.java
+++ b/core/src/main/java/io/aiven/klaw/service/AclControllerService.java
@@ -701,7 +701,7 @@ public class AclControllerService {
         }
         updateAclReqStatus = dbHandle.updateAclRequest(aclReq, userDetails, jsonParams);
       } else {
-        updateAclReqStatus = ApiResultStatus.FAILURE.value;
+        updateAclReqStatus = Objects.requireNonNull(responseBody).getMessage();
       }
     } catch (Exception e) {
       log.error("Exception ", e);

--- a/core/src/main/java/io/aiven/klaw/service/AclControllerService.java
+++ b/core/src/main/java/io/aiven/klaw/service/AclControllerService.java
@@ -379,7 +379,7 @@ public class AclControllerService {
 
       if (RequestOperationType.DELETE == requestOperationType) teamId = team;
       List<UserInfo> userList =
-          manageDatabase.getHandleDbRequests().selectAllUsersInfoForTeam(teamId, tenantId);
+          manageDatabase.getHandleDbRequests().getAllUsersInfoForTeam(teamId, tenantId);
 
       StringBuilder approvingInfo =
           new StringBuilder(
@@ -579,7 +579,7 @@ public class AclControllerService {
 
     HandleDbRequests dbHandle = manageDatabase.getHandleDbRequests();
     Acl acl =
-        dbHandle.selectSyncAclsFromReqNo(
+        dbHandle.getSyncAclsFromReqNo(
             Integer.parseInt(req_no), commonUtilsService.getTenantId(userDetails));
 
     // Verify if user raising request belongs to the same team as the Subscription owner team
@@ -619,7 +619,7 @@ public class AclControllerService {
     }
 
     HandleDbRequests dbHandle = manageDatabase.getHandleDbRequests();
-    AclRequests aclReq = dbHandle.selectAcl(Integer.parseInt(req_no), tenantId);
+    AclRequests aclReq = dbHandle.getAcl(Integer.parseInt(req_no), tenantId);
 
     ApiResponse aclValidationResponse = validateAclRequest(aclReq, userDetails);
     if (!aclValidationResponse.isSuccess()) {
@@ -701,7 +701,7 @@ public class AclControllerService {
         }
         updateAclReqStatus = dbHandle.updateAclRequest(aclReq, userDetails, jsonParams);
       } else {
-        updateAclReqStatus = Objects.requireNonNull(responseBody).getMessage();
+        updateAclReqStatus = ApiResultStatus.FAILURE.value;
       }
     } catch (Exception e) {
       log.error("Exception ", e);
@@ -771,7 +771,7 @@ public class AclControllerService {
 
     HandleDbRequests dbHandle = manageDatabase.getHandleDbRequests();
     AclRequests aclReq =
-        dbHandle.selectAcl(Integer.parseInt(req_no), commonUtilsService.getTenantId(userDetails));
+        dbHandle.getAcl(Integer.parseInt(req_no), commonUtilsService.getTenantId(userDetails));
 
     if (aclReq.getReq_no() == null) {
       return ApiResponse.builder().success(false).message(ACL_ERR_105).build();
@@ -874,7 +874,7 @@ public class AclControllerService {
     try {
       HandleDbRequests dbHandle = manageDatabase.getHandleDbRequests();
       Acl acl =
-          dbHandle.selectSyncAclsFromReqNo(
+          dbHandle.getSyncAclsFromReqNo(
               Integer.parseInt(aclReqNo), commonUtilsService.getTenantId(loggedInUser));
 
       // Verify if loggedInUser belongs to the same team as the Subscription owner team

--- a/core/src/main/java/io/aiven/klaw/service/AclSyncControllerService.java
+++ b/core/src/main/java/io/aiven/klaw/service/AclSyncControllerService.java
@@ -162,7 +162,7 @@ public class AclSyncControllerService {
           Acl acl =
               manageDatabase
                   .getHandleDbRequests()
-                  .selectSyncAclsFromReqNo(Integer.parseInt(aclId), tenantId);
+                  .getSyncAclsFromReqNo(Integer.parseInt(aclId), tenantId);
           if (acl != null) {
             approveSyncBackAcls(syncBackAcls, resultMap, logArray, acl, tenantId);
           }
@@ -516,7 +516,7 @@ public class AclSyncControllerService {
             getPrincipal(), PermissionType.SYNC_BACK_TOPICS)) {
       // tenant filtering
       int tenantId = commonUtilsService.getTenantId(getUserName());
-      List<Team> teams = manageDatabase.getHandleDbRequests().selectAllTeams(tenantId);
+      List<Team> teams = manageDatabase.getHandleDbRequests().getAllTeams(tenantId);
       teams =
           teams.stream()
               .filter(t -> Objects.equals(t.getTenantId(), tenantId))

--- a/core/src/main/java/io/aiven/klaw/service/AnalyticsControllerService.java
+++ b/core/src/main/java/io/aiven/klaw/service/AnalyticsControllerService.java
@@ -83,7 +83,7 @@ public class AnalyticsControllerService {
     int tenantId = commonUtilsService.getTenantId(getCurrentUserName());
 
     List<Map<String, String>> aclsPerEnvList =
-        manageDatabase.getHandleDbRequests().selectAclsCountByEnv(null, tenantId);
+        manageDatabase.getHandleDbRequests().getAclsCountByEnv(null, tenantId);
     AclsCountPerEnv aclsCountPerEnv = new AclsCountPerEnv();
 
     // tenant filtering
@@ -114,7 +114,7 @@ public class AnalyticsControllerService {
     List<Map<String, String>> topicsCountList =
         manageDatabase
             .getHandleDbRequests()
-            .selectTopicsCountByEnv(commonUtilsService.getTenantId(getCurrentUserName()));
+            .getTopicsCountByEnv(commonUtilsService.getTenantId(getCurrentUserName()));
 
     TopicsCountPerEnv topicsCountPerEnv = new TopicsCountPerEnv();
     // tenant filtering
@@ -144,7 +144,7 @@ public class AnalyticsControllerService {
     List<Map<String, String>> producerAclsPerTeamList =
         manageDatabase
             .getHandleDbRequests()
-            .selectAclsCountByTeams(AclType.PRODUCER.value, teamId, tenantId);
+            .getAclsCountByTeams(AclType.PRODUCER.value, teamId, tenantId);
 
     String title = ANALYTICS_101;
     if (teamId != null) {
@@ -161,7 +161,7 @@ public class AnalyticsControllerService {
     List<Map<String, String>> consumerAclsPerTeamList =
         manageDatabase
             .getHandleDbRequests()
-            .selectAclsCountByTeams(AclType.CONSUMER.value, teamId, tenantId);
+            .getAclsCountByTeams(AclType.CONSUMER.value, teamId, tenantId);
 
     String title = ANALYTICS_102;
     if (teamId != null) {
@@ -177,7 +177,7 @@ public class AnalyticsControllerService {
   public ChartsJsOverview getTopicsTeamsOverview(Integer teamId, Integer tenantId) {
 
     List<Map<String, String>> teamCountList =
-        manageDatabase.getHandleDbRequests().selectTopicsCountByTeams(teamId, tenantId);
+        manageDatabase.getHandleDbRequests().getTopicsCountByTeams(teamId, tenantId);
     String title = ANALYTICS_103;
     if (teamId != null) {
       title += " (" + manageDatabase.getTeamNameFromTeamId(tenantId, teamId) + ")";
@@ -191,7 +191,7 @@ public class AnalyticsControllerService {
 
   public ChartsJsOverview getTopicsEnvOverview(Integer tenantId, PermissionType permissionType) {
     List<Map<String, String>> teamCountList =
-        manageDatabase.getHandleDbRequests().selectTopicsCountByEnv(tenantId);
+        manageDatabase.getHandleDbRequests().getTopicsCountByEnv(tenantId);
 
     // tenant filtering
     try {
@@ -220,9 +220,7 @@ public class AnalyticsControllerService {
     List<Map<String, String>> teamCountList = null;
     if (currentUserName != null) {
       teamCountList =
-          manageDatabase
-              .getHandleDbRequests()
-              .selectAllTopicsForTeamGroupByEnv(userTeamId, tenantId);
+          manageDatabase.getHandleDbRequests().getAllTopicsForTeamGroupByEnv(userTeamId, tenantId);
     }
 
     String title =
@@ -235,7 +233,7 @@ public class AnalyticsControllerService {
   public ChartsJsOverview getPartitionsEnvOverview(Integer teamId, Integer tenantId) {
 
     List<Map<String, String>> partitionsCountList =
-        manageDatabase.getHandleDbRequests().selectPartitionsCountByEnv(teamId, tenantId);
+        manageDatabase.getHandleDbRequests().getPartitionsCountByEnv(teamId, tenantId);
     String title = ANALYTICS_105;
     if (teamId != null) {
       title += " (" + manageDatabase.getTeamNameFromTeamId(tenantId, teamId) + ")";
@@ -270,7 +268,7 @@ public class AnalyticsControllerService {
   public ChartsJsOverview getAclsEnvOverview(Integer teamId, Integer tenantId) {
 
     List<Map<String, String>> aclsPerEnvList =
-        manageDatabase.getHandleDbRequests().selectAclsCountByEnv(teamId, tenantId);
+        manageDatabase.getHandleDbRequests().getAclsCountByEnv(teamId, tenantId);
     String title = ANALYTICS_106;
     if (teamId != null) {
       title += " (" + manageDatabase.getTeamNameFromTeamId(tenantId, teamId) + ")";
@@ -303,9 +301,7 @@ public class AnalyticsControllerService {
 
     if (teamId != null) {
       activityCountList =
-          manageDatabase
-              .getHandleDbRequests()
-              .selectActivityLogByTeam(teamId, numberOfDays, tenantId);
+          manageDatabase.getHandleDbRequests().getActivityLogByTeam(teamId, numberOfDays, tenantId);
       title = title + " (" + manageDatabase.getTeamNameFromTeamId(tenantId, teamId) + ")";
     } else {
       // tenant filtering
@@ -315,7 +311,7 @@ public class AnalyticsControllerService {
         activityCountList =
             manageDatabase
                 .getHandleDbRequests()
-                .selectActivityLogForLastDays(
+                .getActivityLogForLastDays(
                     numberOfDays, allowedEnvIdList.toArray(new String[0]), tenantId);
       } catch (Exception e) {
         log.error("No environments/clusters found.", e);

--- a/core/src/main/java/io/aiven/klaw/service/ClusterApiService.java
+++ b/core/src/main/java/io/aiven/klaw/service/ClusterApiService.java
@@ -455,7 +455,7 @@ public class ClusterApiService {
     ResponseEntity<ApiResponse> response;
     ClusterTopicRequest clusterTopicRequest;
     try {
-      Env envSelected = manageDatabase.getHandleDbRequests().selectEnvDetails(topicEnvId, tenantId);
+      Env envSelected = manageDatabase.getHandleDbRequests().getEnvDetails(topicEnvId, tenantId);
       KwClusters kwClusters =
           manageDatabase
               .getClusters(KafkaClustersType.KAFKA, tenantId)
@@ -496,7 +496,7 @@ public class ClusterApiService {
           Env schemaEnvSelected =
               manageDatabase
                   .getHandleDbRequests()
-                  .selectEnvDetails(envSelected.getAssociatedEnv().getId(), tenantId);
+                  .getEnvDetails(envSelected.getAssociatedEnv().getId(), tenantId);
           KwClusters kwClustersSchemaEnv =
               manageDatabase
                   .getClusters(KafkaClustersType.SCHEMA_REGISTRY, tenantId)
@@ -544,7 +544,7 @@ public class ClusterApiService {
       String uri;
 
       ClusterAclRequest clusterAclRequest;
-      Env envSelected = manageDatabase.getHandleDbRequests().selectEnvDetails(env, tenantId);
+      Env envSelected = manageDatabase.getHandleDbRequests().getEnvDetails(env, tenantId);
       KwClusters kwClusters =
           manageDatabase
               .getClusters(KafkaClustersType.KAFKA, tenantId)
@@ -707,7 +707,7 @@ public class ClusterApiService {
       boolean forceReg = Objects.requireNonNullElse(schemaRequest.getForceRegister(), false);
       String uri = clusterConnUrl + URI_POST_SCHEMA;
 
-      Env envSelected = manageDatabase.getHandleDbRequests().selectEnvDetails(env, tenantId);
+      Env envSelected = manageDatabase.getHandleDbRequests().getEnvDetails(env, tenantId);
       log.debug("forceRegister set to : {}", forceReg);
       KwClusters kwClusters =
           manageDatabase
@@ -749,7 +749,7 @@ public class ClusterApiService {
 
       String uri = clusterConnUrl + URI_VALIDATE_SCHEMA;
 
-      Env envSelected = manageDatabase.getHandleDbRequests().selectEnvDetails(env, tenantId);
+      Env envSelected = manageDatabase.getHandleDbRequests().getEnvDetails(env, tenantId);
 
       KwClusters kwClusters =
           manageDatabase

--- a/core/src/main/java/io/aiven/klaw/service/ClusterApiService.java
+++ b/core/src/main/java/io/aiven/klaw/service/ClusterApiService.java
@@ -1,22 +1,6 @@
 package io.aiven.klaw.service;
 
-import static io.aiven.klaw.error.KlawErrorMessages.CLUSTER_API_ERR_101;
-import static io.aiven.klaw.error.KlawErrorMessages.CLUSTER_API_ERR_102;
-import static io.aiven.klaw.error.KlawErrorMessages.CLUSTER_API_ERR_103;
-import static io.aiven.klaw.error.KlawErrorMessages.CLUSTER_API_ERR_104;
-import static io.aiven.klaw.error.KlawErrorMessages.CLUSTER_API_ERR_105;
-import static io.aiven.klaw.error.KlawErrorMessages.CLUSTER_API_ERR_106;
-import static io.aiven.klaw.error.KlawErrorMessages.CLUSTER_API_ERR_107;
-import static io.aiven.klaw.error.KlawErrorMessages.CLUSTER_API_ERR_108;
-import static io.aiven.klaw.error.KlawErrorMessages.CLUSTER_API_ERR_109;
-import static io.aiven.klaw.error.KlawErrorMessages.CLUSTER_API_ERR_110;
-import static io.aiven.klaw.error.KlawErrorMessages.CLUSTER_API_ERR_111;
-import static io.aiven.klaw.error.KlawErrorMessages.CLUSTER_API_ERR_112;
-import static io.aiven.klaw.error.KlawErrorMessages.CLUSTER_API_ERR_113;
-import static io.aiven.klaw.error.KlawErrorMessages.CLUSTER_API_ERR_114;
-import static io.aiven.klaw.error.KlawErrorMessages.CLUSTER_API_ERR_115;
-import static io.aiven.klaw.error.KlawErrorMessages.CLUSTER_API_ERR_116;
-import static io.aiven.klaw.error.KlawErrorMessages.CLUSTER_API_ERR_117;
+import static io.aiven.klaw.error.KlawErrorMessages.*;
 import static io.aiven.klaw.helpers.KwConstants.*;
 
 import com.fasterxml.jackson.core.type.TypeReference;
@@ -92,6 +76,7 @@ import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.http.client.HttpComponentsClientHttpRequestFactory;
@@ -447,6 +432,10 @@ public class ClusterApiService {
 
     } catch (Exception e) {
       log.error("approveConnectorRequests {} ", connectorName, e);
+      if (e.getMessage().contains("ClientHttpRequestFactory must not be null")
+          || e.getMessage().contains("Connection refused")) {
+        return CLUSTER_API_ERR_118;
+      }
       throw new KlawException(CLUSTER_API_ERR_105);
     }
   }
@@ -529,6 +518,16 @@ public class ClusterApiService {
       response = getRestTemplate().postForEntity(uri, request, ApiResponse.class);
     } catch (Exception e) {
       log.error("approveTopicRequests {}", topicName, e);
+      if (e.getMessage().contains("ClientHttpRequestFactory must not be null")
+          || e.getMessage().contains("Connection refused")) {
+        return new ResponseEntity<>(
+            ApiResponse.builder().success(false).message(CLUSTER_API_ERR_118).build(),
+            HttpStatus.INTERNAL_SERVER_ERROR);
+      } else if (e.getMessage().contains("Cannot connect to cluster.")) {
+        return new ResponseEntity<>(
+            ApiResponse.builder().success(false).message(CLUSTER_API_ERR_119).build(),
+            HttpStatus.INTERNAL_SERVER_ERROR);
+      }
       throw new KlawException(CLUSTER_API_ERR_106);
     }
     return response;
@@ -637,6 +636,12 @@ public class ClusterApiService {
       return response;
     } catch (Exception e) {
       log.error("Error from approveAclRequests", e);
+      if (e.getMessage().contains("ClientHttpRequestFactory must not be null")
+          || e.getMessage().contains("Connection refused")) {
+        return new ResponseEntity<>(
+            ApiResponse.builder().success(false).message(CLUSTER_API_ERR_118).build(),
+            HttpStatus.INTERNAL_SERVER_ERROR);
+      }
       throw new KlawException(CLUSTER_API_ERR_108);
     }
   }
@@ -725,6 +730,12 @@ public class ClusterApiService {
       response = getRestTemplate().postForEntity(uri, request, ApiResponse.class);
     } catch (Exception e) {
       log.error("Error from postSchema ", e);
+      if (e.getMessage().contains("ClientHttpRequestFactory must not be null")
+          || e.getMessage().contains("Connection refused")) {
+        return new ResponseEntity<>(
+            ApiResponse.builder().success(false).message(CLUSTER_API_ERR_118).build(),
+            HttpStatus.INTERNAL_SERVER_ERROR);
+      }
       throw new KlawException(CLUSTER_API_ERR_111);
     }
     return response;

--- a/core/src/main/java/io/aiven/klaw/service/ClusterApiService.java
+++ b/core/src/main/java/io/aiven/klaw/service/ClusterApiService.java
@@ -432,8 +432,8 @@ public class ClusterApiService {
 
     } catch (Exception e) {
       log.error("approveConnectorRequests {} ", connectorName, e);
-      if (e.getMessage().contains("ClientHttpRequestFactory must not be null")
-          || e.getMessage().contains("Connection refused")) {
+      if (e.getMessage().contains(CLUSTER_API_ERR_120)
+          || e.getMessage().contains(CLUSTER_API_ERR_121)) {
         return CLUSTER_API_ERR_118;
       }
       throw new KlawException(CLUSTER_API_ERR_105);
@@ -518,8 +518,8 @@ public class ClusterApiService {
       response = getRestTemplate().postForEntity(uri, request, ApiResponse.class);
     } catch (Exception e) {
       log.error("approveTopicRequests {}", topicName, e);
-      if (e.getMessage().contains("ClientHttpRequestFactory must not be null")
-          || e.getMessage().contains("Connection refused")) {
+      if (e.getMessage().contains(CLUSTER_API_ERR_120)
+          || e.getMessage().contains(CLUSTER_API_ERR_121)) {
         return new ResponseEntity<>(
             ApiResponse.builder().success(false).message(CLUSTER_API_ERR_118).build(),
             HttpStatus.INTERNAL_SERVER_ERROR);
@@ -636,8 +636,8 @@ public class ClusterApiService {
       return response;
     } catch (Exception e) {
       log.error("Error from approveAclRequests", e);
-      if (e.getMessage().contains("ClientHttpRequestFactory must not be null")
-          || e.getMessage().contains("Connection refused")) {
+      if (e.getMessage().contains(CLUSTER_API_ERR_120)
+          || e.getMessage().contains(CLUSTER_API_ERR_121)) {
         return new ResponseEntity<>(
             ApiResponse.builder().success(false).message(CLUSTER_API_ERR_118).build(),
             HttpStatus.INTERNAL_SERVER_ERROR);
@@ -730,8 +730,8 @@ public class ClusterApiService {
       response = getRestTemplate().postForEntity(uri, request, ApiResponse.class);
     } catch (Exception e) {
       log.error("Error from postSchema ", e);
-      if (e.getMessage().contains("ClientHttpRequestFactory must not be null")
-          || e.getMessage().contains("Connection refused")) {
+      if (e.getMessage().contains(CLUSTER_API_ERR_120)
+          || e.getMessage().contains(CLUSTER_API_ERR_121)) {
         return new ResponseEntity<>(
             ApiResponse.builder().success(false).message(CLUSTER_API_ERR_118).build(),
             HttpStatus.INTERNAL_SERVER_ERROR);

--- a/core/src/main/java/io/aiven/klaw/service/EnvsClustersTenantsControllerService.java
+++ b/core/src/main/java/io/aiven/klaw/service/EnvsClustersTenantsControllerService.java
@@ -132,7 +132,7 @@ public class EnvsClustersTenantsControllerService {
       }
     }
 
-    Env env = manageDatabase.getHandleDbRequests().selectEnvDetails(envSelected, tenantId);
+    Env env = manageDatabase.getHandleDbRequests().getEnvDetails(envSelected, tenantId);
     if (env != null && "false".equals(env.getEnvExists())) {
       return null;
     }
@@ -393,7 +393,7 @@ public class EnvsClustersTenantsControllerService {
             envModel.setShowDeleteEnv(
                 manageDatabase
                         .getHandleDbRequests()
-                        .findAllKafkaComponentsCountForEnv(envModel.getId(), tenantId)
+                        .getAllKafkaComponentsCountForEnv(envModel.getId(), tenantId)
                     <= 0);
           });
     }
@@ -567,7 +567,7 @@ public class EnvsClustersTenantsControllerService {
             envModel.setShowDeleteEnv(
                 manageDatabase
                         .getHandleDbRequests()
-                        .findAllConnectorComponentsCountForEnv(envModel.getId(), tenantId)
+                        .getAllConnectorComponentsCountForEnv(envModel.getId(), tenantId)
                     <= 0);
           });
     }
@@ -645,7 +645,7 @@ public class EnvsClustersTenantsControllerService {
             envModel.setShowDeleteEnv(
                 manageDatabase
                         .getHandleDbRequests()
-                        .findAllConnectorComponentsCountForEnv(envModel.getId(), tenantId)
+                        .getAllConnectorComponentsCountForEnv(envModel.getId(), tenantId)
                     <= 0);
           });
     }
@@ -668,7 +668,7 @@ public class EnvsClustersTenantsControllerService {
 
     newEnv.setName(newEnv.getName().toUpperCase());
     String envIdAlreadyExistsInDeleteStatus = "";
-    List<Env> envActualList = manageDatabase.getHandleDbRequests().selectAllEnvs(tenantId);
+    List<Env> envActualList = manageDatabase.getHandleDbRequests().getAllEnvs(tenantId);
     List<Env> kafkaEnvs = manageDatabase.getKafkaEnvList(tenantId);
     List<Env> schemaEnvs = manageDatabase.getSchemaRegEnvList(tenantId);
     List<Integer> kafkaClusterIds = kafkaEnvs.stream().map(Env::getClusterId).toList();
@@ -931,7 +931,7 @@ public class EnvsClustersTenantsControllerService {
 
     switch (envType) {
       case "kafka":
-        if (manageDatabase.getHandleDbRequests().findAllKafkaComponentsCountForEnv(envId, tenantId)
+        if (manageDatabase.getHandleDbRequests().getAllKafkaComponentsCountForEnv(envId, tenantId)
             > 0) {
           return ApiResponse.builder().success(false).message(ENV_CLUSTER_TNT_ERR_105).build();
         }
@@ -939,13 +939,13 @@ public class EnvsClustersTenantsControllerService {
       case "kafkaconnect":
         if (manageDatabase
                 .getHandleDbRequests()
-                .findAllConnectorComponentsCountForEnv(envId, tenantId)
+                .getAllConnectorComponentsCountForEnv(envId, tenantId)
             > 0) {
           return ApiResponse.builder().success(false).message(ENV_CLUSTER_TNT_ERR_106).build();
         }
         break;
       case "schemaregistry":
-        if (manageDatabase.getHandleDbRequests().findAllSchemaComponentsCountForEnv(envId, tenantId)
+        if (manageDatabase.getHandleDbRequests().getAllSchemaComponentsCountForEnv(envId, tenantId)
             > 0) {
           return ApiResponse.builder().success(false).message(ENV_CLUSTER_TNT_ERR_107).build();
         }
@@ -974,12 +974,12 @@ public class EnvsClustersTenantsControllerService {
 
     if (KafkaClustersType.KAFKA.value.equals(envType)
         || KafkaClustersType.SCHEMA_REGISTRY.value.equals(envType)) {
-      Env env = manageDatabase.getHandleDbRequests().selectEnvDetails(envId, tenantId);
+      Env env = manageDatabase.getHandleDbRequests().getEnvDetails(envId, tenantId);
       if (env.getAssociatedEnv() != null) {
         Env linkedEnv =
             manageDatabase
                 .getHandleDbRequests()
-                .selectEnvDetails(env.getAssociatedEnv().getId(), tenantId);
+                .getEnvDetails(env.getAssociatedEnv().getId(), tenantId);
         linkedEnv.setAssociatedEnv(null);
         manageDatabase.getHandleDbRequests().addNewEnv(linkedEnv);
       }
@@ -1011,14 +1011,14 @@ public class EnvsClustersTenantsControllerService {
 
   private EnvTag getKafkaAssociation(EnvTag KafkaEnvTag, String kafkaEnvId, int tenantId) {
     if (KafkaEnvTag == null) {
-      Env existing = manageDatabase.getHandleDbRequests().selectEnvDetails(kafkaEnvId, tenantId);
+      Env existing = manageDatabase.getHandleDbRequests().getEnvDetails(kafkaEnvId, tenantId);
       KafkaEnvTag = existing != null ? existing.getAssociatedEnv() : KafkaEnvTag;
     }
     return KafkaEnvTag;
   }
 
   private void removeAssociationWithKafkaEnv(EnvTag envTag, String envId, int tenantId) {
-    Env existingEnv = manageDatabase.getHandleDbRequests().selectEnvDetails(envId, tenantId);
+    Env existingEnv = manageDatabase.getHandleDbRequests().getEnvDetails(envId, tenantId);
     // envTag is equal to null we don't need to check if the associated env is the same as the
     // passed env tag because this is actualy an operation to remove an association.
     if (existingEnv != null
@@ -1027,7 +1027,7 @@ public class EnvsClustersTenantsControllerService {
       Env linkedEnv =
           manageDatabase
               .getHandleDbRequests()
-              .selectEnvDetails(existingEnv.getAssociatedEnv().getId(), tenantId);
+              .getEnvDetails(existingEnv.getAssociatedEnv().getId(), tenantId);
       linkedEnv.setAssociatedEnv(null);
       manageDatabase.getHandleDbRequests().addNewEnv(linkedEnv);
     }
@@ -1035,7 +1035,7 @@ public class EnvsClustersTenantsControllerService {
 
   private void associateWithKafkaEnv(EnvTag envTag, String envId, String envName, int tenantId)
       throws KlawValidationException {
-    Env linkedEnv = manageDatabase.getHandleDbRequests().selectEnvDetails(envTag.getId(), tenantId);
+    Env linkedEnv = manageDatabase.getHandleDbRequests().getEnvDetails(envTag.getId(), tenantId);
 
     if (linkedEnv.getAssociatedEnv() != null
         && !linkedEnv.getAssociatedEnv().getId().equals(envId)) {
@@ -1062,7 +1062,7 @@ public class EnvsClustersTenantsControllerService {
       List<KwTenants> tenants = dbHandle.getTenants();
       List<KwTenantModel> tenantModels = new ArrayList<>();
 
-      List<UserInfo> allUsers = dbHandle.selectAllUsersAllTenants();
+      List<UserInfo> allUsers = dbHandle.getAllUsersAllTenants();
 
       KwTenantModel kwTenantModel;
       for (KwTenants tenant : tenants) {
@@ -1248,7 +1248,7 @@ public class EnvsClustersTenantsControllerService {
     }
     String tenantName = manageDatabase.getTenantMap().get(tenantId);
 
-    List<UserInfo> allUsers = manageDatabase.getHandleDbRequests().selectAllUsersInfo(tenantId);
+    List<UserInfo> allUsers = manageDatabase.getHandleDbRequests().getAllUsersInfo(tenantId);
     for (UserInfo userInfo : allUsers) {
       try {
         usersTeamsControllerService.deleteUser(userInfo.getUsername(), false); // internal delete
@@ -1368,7 +1368,7 @@ public class EnvsClustersTenantsControllerService {
   public EnvUpdatedStatus getUpdateEnvStatus(String envId) throws KlawException {
     EnvUpdatedStatus envUpdatedStatus = new EnvUpdatedStatus();
     int tenantId = commonUtilsService.getTenantId(getUserName());
-    Env env = manageDatabase.getHandleDbRequests().selectEnvDetails(envId, tenantId);
+    Env env = manageDatabase.getHandleDbRequests().getEnvDetails(envId, tenantId);
 
     String status;
     try {
@@ -1422,7 +1422,7 @@ public class EnvsClustersTenantsControllerService {
       }
     }
 
-    Env env = manageDatabase.getHandleDbRequests().selectEnvDetails(envSelected, tenantId);
+    Env env = manageDatabase.getHandleDbRequests().getEnvDetails(envSelected, tenantId);
     KwClusters kwClusters =
         manageDatabase.getHandleDbRequests().getClusterDetails(env.getClusterId(), tenantId);
 

--- a/core/src/main/java/io/aiven/klaw/service/ExportImportDataService.java
+++ b/core/src/main/java/io/aiven/klaw/service/ExportImportDataService.java
@@ -89,19 +89,18 @@ public class ExportImportDataService {
   public KwAdminConfig getAdminConfig(HandleDbRequests handleDbRequests, String timeStamp) {
     log.info(
         "Selecting Kw Admin Config (tenants, clusters, environments, roles, permissions, teams, users, properties) --- STARTED");
-    List<UserInfo> userList = getUpdatedUserList(handleDbRequests.selectAllUsersAllTenants());
+    List<UserInfo> userList = getUpdatedUserList(handleDbRequests.getAllUsersAllTenants());
 
     KwAdminConfig kwMetadata =
         KwAdminConfig.builder()
             .tenants(handleDbRequests.getTenants())
             .clusters(handleDbRequests.getClusters())
-            .environments(handleDbRequests.selectEnvs())
+            .environments(handleDbRequests.getEnvs())
             .rolesPermissions(handleDbRequests.getRolesPermissions())
-            .teams(handleDbRequests.selectTeams())
+            .teams(handleDbRequests.getTeams())
             .users(userList)
-            .properties(handleDbRequests.selectKwProperties())
-            .productDetails(
-                handleDbRequests.selectProductDetails("Klaw").orElse(new ProductDetails()))
+            .properties(handleDbRequests.getKwProperties())
+            .productDetails(handleDbRequests.getProductDetails("Klaw").orElse(new ProductDetails()))
             .klawVersion(klawVersion)
             .createdTime(timeStamp)
             .build();
@@ -125,7 +124,7 @@ public class ExportImportDataService {
         KwData.builder()
             .topics(handleDbRequests.getAllTopics())
             .subscriptions(handleDbRequests.getAllSubscriptions())
-            .schemas(handleDbRequests.selectAllSchemas())
+            .schemas(handleDbRequests.getAllSchemas())
             .kafkaConnectors(handleDbRequests.getAllConnectors())
             .klawVersion(klawVersion)
             .createdTime(timeStamp)

--- a/core/src/main/java/io/aiven/klaw/service/KafkaConnectControllerService.java
+++ b/core/src/main/java/io/aiven/klaw/service/KafkaConnectControllerService.java
@@ -184,7 +184,7 @@ public class KafkaConnectControllerService {
 
     if (manageDatabase
             .getHandleDbRequests()
-            .selectConnectorRequests(
+            .getConnectorRequests(
                 connectorRequestModel.getConnectorName(),
                 connectorRequestModel.getEnvironment(),
                 RequestStatus.CREATED.value,
@@ -537,7 +537,7 @@ public class KafkaConnectControllerService {
     KafkaConnectorRequest connectorRequest =
         manageDatabase
             .getHandleDbRequests()
-            .selectConnectorRequestsForConnector(Integer.parseInt(connectorId), tenantId);
+            .getConnectorRequestsForConnector(Integer.parseInt(connectorId), tenantId);
 
     String jsonConnectorConfig;
 
@@ -584,7 +584,7 @@ public class KafkaConnectControllerService {
       Env envSelected =
           manageDatabase
               .getHandleDbRequests()
-              .selectEnvDetails(connectorRequest.getEnvironment(), tenantId);
+              .getEnvDetails(connectorRequest.getEnvironment(), tenantId);
       KwClusters kwClusters =
           manageDatabase
               .getClusters(KafkaClustersType.KAFKA_CONNECT, tenantId)
@@ -689,7 +689,7 @@ public class KafkaConnectControllerService {
 
     HandleDbRequests dbHandle = manageDatabase.getHandleDbRequests();
     KafkaConnectorRequest connectorRequest =
-        dbHandle.selectConnectorRequestsForConnector(Integer.parseInt(connectorId), tenantId);
+        dbHandle.getConnectorRequestsForConnector(Integer.parseInt(connectorId), tenantId);
 
     if (!RequestStatus.CREATED.value.equals(connectorRequest.getRequestStatus())) {
       return ApiResponse.builder().success(false).message(REQ_ERR_101).build();
@@ -765,7 +765,7 @@ public class KafkaConnectControllerService {
 
     if (manageDatabase
             .getHandleDbRequests()
-            .selectConnectorRequests(
+            .getConnectorRequests(
                 kafkaConnectorRequest.getConnectorName(),
                 kafkaConnectorRequest.getEnvironment(),
                 RequestStatus.CREATED.value,
@@ -875,7 +875,7 @@ public class KafkaConnectControllerService {
 
     if (manageDatabase
             .getHandleDbRequests()
-            .selectConnectorRequests(connectorName, envId, RequestStatus.CREATED.value, tenantId)
+            .getConnectorRequests(connectorName, envId, RequestStatus.CREATED.value, tenantId)
             .size()
         > 0) {
       return ApiResponse.builder().success(false).message(KAFKA_CONNECT_ERR_117).build();
@@ -884,7 +884,7 @@ public class KafkaConnectControllerService {
     List<KwKafkaConnector> topics = getConnectorsFromName(connectorName, tenantId);
     Integer topicOwnerTeam = topics.get(0).getTeamId();
     Optional<UserInfo> topicOwnerContact =
-        manageDatabase.getHandleDbRequests().selectAllUsersInfo(tenantId).stream()
+        manageDatabase.getHandleDbRequests().getAllUsersInfo(tenantId).stream()
             .filter(user -> Objects.equals(user.getTeamId(), topicOwnerTeam))
             .findFirst();
 
@@ -1113,7 +1113,7 @@ public class KafkaConnectControllerService {
     String loggedInUserTeam =
         manageDatabase
             .getHandleDbRequests()
-            .selectAllTeamsOfUsers(getUserName(), tenantId)
+            .getAllTeamsOfUsers(getUserName(), tenantId)
             .get(0)
             .getTeamname();
     if (!Objects.equals(loggedInUserTeam, connectorModel.getTeamName())) {
@@ -1218,7 +1218,7 @@ public class KafkaConnectControllerService {
     List<String> approverRoles =
         rolesPermissionsControllerService.getApproverRoles("CONNECTORS", tenantId);
     List<UserInfo> userList =
-        manageDatabase.getHandleDbRequests().selectAllUsersInfoForTeam(userTeamId, tenantId);
+        manageDatabase.getHandleDbRequests().getAllUsersInfoForTeam(userTeamId, tenantId);
 
     for (KafkaConnectorRequest connectorRequest : topicsList) {
       kafkaConnectorRequestModel = new KafkaConnectorRequestsResponseModel();
@@ -1240,7 +1240,7 @@ public class KafkaConnectControllerService {
               updateApproverInfo(
                   manageDatabase
                       .getHandleDbRequests()
-                      .selectAllUsersInfoForTeam(topics.get(0).getTeamId(), tenantId),
+                      .getAllUsersInfoForTeam(topics.get(0).getTeamId(), tenantId),
                   manageDatabase.getTeamNameFromTeamId(tenantId, topics.get(0).getTeamId()),
                   approverRoles,
                   kafkaConnectorRequestModel.getRequestor()));

--- a/core/src/main/java/io/aiven/klaw/service/KafkaConnectSyncControllerService.java
+++ b/core/src/main/java/io/aiven/klaw/service/KafkaConnectSyncControllerService.java
@@ -476,7 +476,7 @@ public class KafkaConnectSyncControllerService {
     if (!commonUtilsService.isNotAuthorizedUser(getPrincipal(), PermissionType.SYNC_CONNECTORS)) {
       // tenant filtering
       int tenantId = commonUtilsService.getTenantId(getUserName());
-      List<Team> teams = manageDatabase.getHandleDbRequests().selectAllTeams(tenantId);
+      List<Team> teams = manageDatabase.getHandleDbRequests().getAllTeams(tenantId);
 
       List<String> teamListUpdated = new ArrayList<>();
       for (Team teamsItem : teams) {

--- a/core/src/main/java/io/aiven/klaw/service/MailUtils.java
+++ b/core/src/main/java/io/aiven/klaw/service/MailUtils.java
@@ -347,7 +347,7 @@ public class MailUtils {
             }
 
             try {
-              List<Team> allTeams = dbHandle.selectAllTeamsOfUsers(username, tenantId);
+              List<Team> allTeams = dbHandle.getAllTeamsOfUsers(username, tenantId);
               if (!allTeams.isEmpty()) emailIdTeam = allTeams.get(0).getTeammail();
             } catch (Exception e) {
               log.error("Exception :", e);

--- a/core/src/main/java/io/aiven/klaw/service/MetricsControllerService.java
+++ b/core/src/main/java/io/aiven/klaw/service/MetricsControllerService.java
@@ -94,8 +94,7 @@ public class MetricsControllerService {
       metricsCountList =
           manageDatabase
               .getHandleDbRequests()
-              .selectAllMetrics(
-                  "kafka.server:type=BrokerTopicMetrics", "name=MessagesInPerSec", "1");
+              .getAllMetrics("kafka.server:type=BrokerTopicMetrics", "name=MessagesInPerSec", "1");
     } catch (Exception e) {
       log.error("No environments/clusters found.", e);
       metricsCountList = new ArrayList<>();

--- a/core/src/main/java/io/aiven/klaw/service/SaasService.java
+++ b/core/src/main/java/io/aiven/klaw/service/SaasService.java
@@ -59,7 +59,7 @@ public class SaasService {
     resultMap.put("result", ApiResultStatus.FAILURE.value);
 
     // check if user exists
-    List<UserInfo> userList = manageDatabase.getHandleDbRequests().selectAllUsersAllTenants();
+    List<UserInfo> userList = manageDatabase.getHandleDbRequests().getAllUsersAllTenants();
     if (userList.stream()
         .anyMatch(user -> Objects.equals(user.getUsername(), newUser.getMailid()))) {
       resultMap.put("error", SAAS_ERR_101);
@@ -246,7 +246,7 @@ public class SaasService {
     }
 
     // check if user exists
-    List<UserInfo> userList = manageDatabase.getHandleDbRequests().selectAllUsersAllTenants();
+    List<UserInfo> userList = manageDatabase.getHandleDbRequests().getAllUsersAllTenants();
     if (userList.stream()
         .anyMatch(user -> Objects.equals(user.getUsername(), newUser.getMailid()))) {
       resultMap.put("error", SAAS_ERR_101);
@@ -254,7 +254,7 @@ public class SaasService {
     }
 
     List<RegisterUserInfo> registerUserInfoList =
-        manageDatabase.getHandleDbRequests().selectAllRegisterUsersInfo();
+        manageDatabase.getHandleDbRequests().getAllRegisterUsersInformation();
     if (registerUserInfoList.stream()
         .anyMatch(user -> Objects.equals(user.getUsername(), newUser.getMailid()))) {
       resultMap.put("error", SAAS_ERR_104);

--- a/core/src/main/java/io/aiven/klaw/service/SchemaOverviewService.java
+++ b/core/src/main/java/io/aiven/klaw/service/SchemaOverviewService.java
@@ -62,13 +62,13 @@ public class SchemaOverviewService extends BaseOverviewService {
       List<Env> schemaEnvs = new ArrayList<>();
       // Get first base kafka env
       Env kafkaEnv =
-          manageDatabase.getHandleDbRequests().selectEnvDetails(kafkaEnvIds.get(0), tenantId);
+          manageDatabase.getHandleDbRequests().getEnvDetails(kafkaEnvIds.get(0), tenantId);
       EnvTag associatedSchemaEnv = kafkaEnv.getAssociatedEnv();
       if (associatedSchemaEnv != null) {
         Env schemaEnv =
             manageDatabase
                 .getHandleDbRequests()
-                .selectEnvDetails(associatedSchemaEnv.getId(), tenantId);
+                .getEnvDetails(associatedSchemaEnv.getId(), tenantId);
         schemaEnvs.add(schemaEnv);
       }
 
@@ -212,7 +212,7 @@ public class SchemaOverviewService extends BaseOverviewService {
     String kafkaEnvId =
         manageDatabase
             .getHandleDbRequests()
-            .selectEnvDetails(promotionDetails.get("targetEnvId"), tenantId)
+            .getEnvDetails(promotionDetails.get("targetEnvId"), tenantId)
             .getAssociatedEnv()
             .getId();
     return kafkaEnvIds.contains(kafkaEnvId);

--- a/core/src/main/java/io/aiven/klaw/service/SchemaRegistryControllerService.java
+++ b/core/src/main/java/io/aiven/klaw/service/SchemaRegistryControllerService.java
@@ -102,7 +102,7 @@ public class SchemaRegistryControllerService {
 
     Integer userTeamId = commonUtilsService.getTeamId(userName);
     List<UserInfo> userList =
-        manageDatabase.getHandleDbRequests().selectAllUsersInfoForTeam(userTeamId, tenantId);
+        manageDatabase.getHandleDbRequests().getAllUsersInfoForTeam(userTeamId, tenantId);
 
     List<String> approverRoles =
         rolesPermissionsControllerService.getApproverRoles("CONNECTORS", tenantId);
@@ -115,7 +115,7 @@ public class SchemaRegistryControllerService {
         schemaReq.setEnvironmentName(
             manageDatabase
                 .getHandleDbRequests()
-                .selectEnvDetails(schemaReq.getEnvironment(), tenantId)
+                .getEnvDetails(schemaReq.getEnvironment(), tenantId)
                 .getName());
         copyProperties(schemaReq, schemaRequestModel);
         schemaRequestModel.setRequestStatus(RequestStatus.of(schemaReq.getRequestStatus()));
@@ -255,7 +255,7 @@ public class SchemaRegistryControllerService {
     SchemaRequest schemaRequest =
         manageDatabase
             .getHandleDbRequests()
-            .selectSchemaRequest(Integer.parseInt(avroSchemaId), tenantId);
+            .getSchemaRequest(Integer.parseInt(avroSchemaId), tenantId);
 
     if (Objects.equals(schemaRequest.getRequestor(), userDetails))
       return ApiResponse.builder().success(false).message(SCHEMA_ERR_101).build();
@@ -319,7 +319,7 @@ public class SchemaRegistryControllerService {
     int tenantId = commonUtilsService.getTenantId(getUserName());
     HandleDbRequests dbHandle = manageDatabase.getHandleDbRequests();
     SchemaRequest schemaRequest =
-        dbHandle.selectSchemaRequest(Integer.parseInt(avroSchemaId), tenantId);
+        dbHandle.getSchemaRequest(Integer.parseInt(avroSchemaId), tenantId);
     final Set<String> allowedEnvIdSet = commonUtilsService.getEnvsFromUserId(getUserName());
 
     if (!allowedEnvIdSet.contains(schemaRequest.getEnvironment())) {

--- a/core/src/main/java/io/aiven/klaw/service/ServerConfigService.java
+++ b/core/src/main/java/io/aiven/klaw/service/ServerConfigService.java
@@ -567,12 +567,10 @@ public class ServerConfigService {
     String clusterApiStatus = clusterApiService.getClusterApiStatus(clusterApiUrl, true, tenantId);
     if ("ONLINE".equals(clusterApiStatus)) {
       clusterApiStatus = ApiResultStatus.SUCCESS.value;
-      {
-        KwPropertiesModel kwPropertiesModel = new KwPropertiesModel();
-        kwPropertiesModel.setKwKey(CLUSTER_CONN_URL_KEY);
-        kwPropertiesModel.setKwValue(clusterApiUrl);
-        updateKwCustomProperty(kwPropertiesModel);
-      }
+      KwPropertiesModel kwPropertiesModel = new KwPropertiesModel();
+      kwPropertiesModel.setKwKey(CLUSTER_CONN_URL_KEY);
+      kwPropertiesModel.setKwValue(clusterApiUrl);
+      updateKwCustomProperty(kwPropertiesModel);
     } else {
       clusterApiStatus = ApiResultStatus.FAILURE.value;
     }

--- a/core/src/main/java/io/aiven/klaw/service/ServerConfigService.java
+++ b/core/src/main/java/io/aiven/klaw/service/ServerConfigService.java
@@ -6,6 +6,7 @@ import static io.aiven.klaw.error.KlawErrorMessages.SERVER_CONFIG_ERR_103;
 import static io.aiven.klaw.error.KlawErrorMessages.SERVER_CONFIG_ERR_104;
 import static io.aiven.klaw.error.KlawErrorMessages.SERVER_CONFIG_ERR_105;
 import static io.aiven.klaw.error.KlawErrorMessages.SERVER_CONFIG_ERR_106;
+import static io.aiven.klaw.helpers.KwConstants.CLUSTER_CONN_URL_KEY;
 import static io.aiven.klaw.service.UsersTeamsControllerService.MASKED_PWD;
 import static org.springframework.beans.BeanUtils.copyProperties;
 
@@ -560,14 +561,20 @@ public class ServerConfigService {
     return hashMap;
   }
 
-  public Map<String, String> testClusterApiConnection(String clusterApiUrl) {
+  public Map<String, String> testClusterApiConnection(String clusterApiUrl) throws KlawException {
     Map<String, String> hashMap = new HashMap<>();
     int tenantId = commonUtilsService.getTenantId(getUserName());
     String clusterApiStatus = clusterApiService.getClusterApiStatus(clusterApiUrl, true, tenantId);
     if ("ONLINE".equals(clusterApiStatus)) {
-      clusterApiStatus = "successful.";
+      clusterApiStatus = ApiResultStatus.SUCCESS.value;
+      {
+        KwPropertiesModel kwPropertiesModel = new KwPropertiesModel();
+        kwPropertiesModel.setKwKey(CLUSTER_CONN_URL_KEY);
+        kwPropertiesModel.setKwValue(clusterApiUrl);
+        updateKwCustomProperty(kwPropertiesModel);
+      }
     } else {
-      clusterApiStatus = "failure.";
+      clusterApiStatus = ApiResultStatus.FAILURE.value;
     }
     hashMap.put("result", clusterApiStatus);
     return hashMap;

--- a/core/src/main/java/io/aiven/klaw/service/ServerConfigService.java
+++ b/core/src/main/java/io/aiven/klaw/service/ServerConfigService.java
@@ -27,6 +27,7 @@ import io.aiven.klaw.model.enums.ApiResultStatus;
 import io.aiven.klaw.model.enums.EntityType;
 import io.aiven.klaw.model.enums.MetadataOperationType;
 import io.aiven.klaw.model.enums.PermissionType;
+import io.aiven.klaw.model.response.ConnectivityStatus;
 import io.aiven.klaw.model.response.KwPropertiesResponse;
 import jakarta.annotation.PostConstruct;
 import java.io.IOException;
@@ -561,8 +562,8 @@ public class ServerConfigService {
     return hashMap;
   }
 
-  public Map<String, String> testClusterApiConnection(String clusterApiUrl) throws KlawException {
-    Map<String, String> hashMap = new HashMap<>();
+  public ConnectivityStatus testClusterApiConnection(String clusterApiUrl) throws KlawException {
+    ConnectivityStatus connectivityStatus = new ConnectivityStatus();
     int tenantId = commonUtilsService.getTenantId(getUserName());
     String clusterApiStatus = clusterApiService.getClusterApiStatus(clusterApiUrl, true, tenantId);
     if ("ONLINE".equals(clusterApiStatus)) {
@@ -574,8 +575,8 @@ public class ServerConfigService {
     } else {
       clusterApiStatus = ApiResultStatus.FAILURE.value;
     }
-    hashMap.put("result", clusterApiStatus);
-    return hashMap;
+    connectivityStatus.setConnectionStatus(clusterApiStatus);
+    return connectivityStatus;
   }
 
   private Object getPrincipal() {

--- a/core/src/main/java/io/aiven/klaw/service/TopicControllerService.java
+++ b/core/src/main/java/io/aiven/klaw/service/TopicControllerService.java
@@ -189,7 +189,7 @@ public class TopicControllerService {
 
     // check if already a delete topic request exists
     if (!dbHandle
-        .selectTopicRequests(topicName, envId, RequestStatus.CREATED.value, tenantId)
+        .getTopicRequests(topicName, envId, RequestStatus.CREATED.value, tenantId)
         .isEmpty()) {
       return ApiResponse.builder().success(false).message(TOPICS_ERR_103).build();
     }
@@ -269,7 +269,7 @@ public class TopicControllerService {
     int tenantId = commonUtilsService.getTenantId(userName);
 
     if (!dbHandle
-        .selectTopicRequests(topicName, envId, RequestStatus.CREATED.value, tenantId)
+        .getTopicRequests(topicName, envId, RequestStatus.CREATED.value, tenantId)
         .isEmpty()) {
       return ApiResponse.builder().success(false).message(TOPICS_ERR_107).build();
     }
@@ -277,7 +277,7 @@ public class TopicControllerService {
     List<Topic> topics = getTopicFromName(topicName, tenantId);
     Integer topicOwnerTeamId = topics.get(0).getTeamId();
     Optional<UserInfo> topicOwnerContact =
-        dbHandle.selectAllUsersInfo(tenantId).stream()
+        dbHandle.getAllUsersInfo(tenantId).stream()
             .filter(user -> Objects.equals(user.getTeamId(), topicOwnerTeamId))
             .findFirst();
 
@@ -570,7 +570,7 @@ public class TopicControllerService {
     List<String> approverRoles =
         rolesPermissionsControllerService.getApproverRoles("TOPICS", tenantId);
     List<UserInfo> userList =
-        manageDatabase.getHandleDbRequests().selectAllUsersInfoForTeam(userTeamId, tenantId);
+        manageDatabase.getHandleDbRequests().getAllUsersInfoForTeam(userTeamId, tenantId);
 
     for (TopicRequest topicReq : topicsList) {
       topicRequestModel = new TopicRequestsResponseModel();
@@ -593,7 +593,7 @@ public class TopicControllerService {
               updateApproverInfo(
                   manageDatabase
                       .getHandleDbRequests()
-                      .selectAllUsersInfoForTeam(topics.get(0).getTeamId(), tenantId),
+                      .getAllUsersInfoForTeam(topics.get(0).getTeamId(), tenantId),
                   manageDatabase.getTeamNameFromTeamId(tenantId, topics.get(0).getTeamId()),
                   approverRoles,
                   topicRequestModel.getRequestor()));
@@ -697,7 +697,7 @@ public class TopicControllerService {
     TopicRequest topicRequest =
         manageDatabase
             .getHandleDbRequests()
-            .selectTopicRequestsForTopic(Integer.parseInt(topicId), tenantId);
+            .getTopicRequestsForTopic(Integer.parseInt(topicId), tenantId);
 
     ApiResponse validationResponse = validateTopicRequest(topicRequest, userName);
     if (!validationResponse.isSuccess()) {
@@ -852,7 +852,7 @@ public class TopicControllerService {
     String userName = getUserName();
     HandleDbRequests dbHandle = manageDatabase.getHandleDbRequests();
     TopicRequest topicRequest =
-        dbHandle.selectTopicRequestsForTopic(
+        dbHandle.getTopicRequestsForTopic(
             Integer.parseInt(topicId), commonUtilsService.getTenantId(userName));
 
     if (!RequestStatus.CREATED.value.equals(topicRequest.getRequestStatus())) {
@@ -950,7 +950,7 @@ public class TopicControllerService {
     int tenantId = commonUtilsService.getTenantId(userName);
 
     TopicInfo topicInfo = new TopicInfo();
-    List<Topic> topics = manageDatabase.getHandleDbRequests().getTopics(topicName, tenantId);
+    List<Topic> topics = commonUtilsService.getTopicsForTopicName(topicName, tenantId);
 
     // tenant filtering
     final Set<String> allowedEnvIdSet = commonUtilsService.getEnvsFromUserId(userName);
@@ -1069,7 +1069,7 @@ public class TopicControllerService {
     if ((AclType.PRODUCER.value.equals(topicType) || AclType.CONSUMER.value.equals(topicType))
         && teamId != 0) {
       producerConsumerTopics =
-          handleDbRequests.selectAllTopicsByTopictypeAndTeamname(topicType, teamId, tenantId);
+          handleDbRequests.getAllTopicsByTopictypeAndTeamname(topicType, teamId, tenantId);
 
       // tenant filtering, not really necessary though, as based on team is searched.
       producerConsumerTopics =
@@ -1328,7 +1328,7 @@ public class TopicControllerService {
       TopicRequestModel topicRequestModel, int tenantId) {
     return manageDatabase
         .getHandleDbRequests()
-        .selectTopicRequests(
+        .getTopicRequests(
             topicRequestModel.getTopicname(),
             topicRequestModel.getEnvironment(),
             RequestStatus.CREATED.value,

--- a/core/src/main/java/io/aiven/klaw/service/TopicOverviewService.java
+++ b/core/src/main/java/io/aiven/klaw/service/TopicOverviewService.java
@@ -45,7 +45,7 @@ public class TopicOverviewService extends BaseOverviewService {
     int tenantId = commonUtilsService.getTenantId(userName);
 
     Integer loggedInUserTeam = commonUtilsService.getTeamId(userName);
-    List<Topic> topics = handleDb.getTopics(topicNameSearch, tenantId);
+    List<Topic> topics = commonUtilsService.getTopicsForTopicName(topicNameSearch, tenantId);
 
     // tenant filtering
     final Set<String> allowedEnvIdSet = commonUtilsService.getEnvsFromUserId(userName);

--- a/core/src/main/java/io/aiven/klaw/service/TopicSyncControllerService.java
+++ b/core/src/main/java/io/aiven/klaw/service/TopicSyncControllerService.java
@@ -441,7 +441,7 @@ public class TopicSyncControllerService {
             getPrincipal(), PermissionType.SYNC_BACK_TOPICS)) {
       // tenant filtering
       int tenantId = commonUtilsService.getTenantId(getUserName());
-      List<Team> teams = manageDatabase.getHandleDbRequests().selectAllTeams(tenantId);
+      List<Team> teams = manageDatabase.getHandleDbRequests().getAllTeams(tenantId);
       List<String> teamListUpdated = new ArrayList<>();
       for (Team teamsItem : teams) {
         teamListUpdated.add(teamsItem.getTeamname());
@@ -612,7 +612,7 @@ public class TopicSyncControllerService {
     if ((AclType.PRODUCER.value.equals(topicType) || AclType.CONSUMER.value.equals(topicType))
         && teamId != 0) {
       producerConsumerTopics =
-          handleDbRequests.selectAllTopicsByTopictypeAndTeamname(topicType, teamId, tenantId);
+          handleDbRequests.getAllTopicsByTopictypeAndTeamname(topicType, teamId, tenantId);
 
       // tenant filtering, not really necessary though, as based on team is searched.
       producerConsumerTopics =

--- a/core/src/main/java/io/aiven/klaw/service/UiConfigControllerService.java
+++ b/core/src/main/java/io/aiven/klaw/service/UiConfigControllerService.java
@@ -54,12 +54,12 @@ public class UiConfigControllerService {
       origActivityList =
           manageDatabase
               .getHandleDbRequests()
-              .selectActivityLog(userName, env, false, tenantId); // only your team reqs
+              .getActivityLog(userName, env, false, tenantId); // only your team reqs
     } else {
       origActivityList =
           manageDatabase
               .getHandleDbRequests()
-              .selectActivityLog(userName, env, true, tenantId); // all teams reqs
+              .getActivityLog(userName, env, true, tenantId); // all teams reqs
     }
 
     return getActivityLogsPaginated(pageNo, origActivityList, currentPage, tenantId);

--- a/core/src/main/java/io/aiven/klaw/service/UsersTeamsControllerService.java
+++ b/core/src/main/java/io/aiven/klaw/service/UsersTeamsControllerService.java
@@ -251,7 +251,7 @@ public class UsersTeamsControllerService {
     log.debug("getTeamDetails {} {}", teamId, tenantName);
 
     int tenantId = commonUtilsService.getTenantId(getUserName());
-    Team teamDao = manageDatabase.getHandleDbRequests().selectTeamDetails(teamId, tenantId);
+    Team teamDao = manageDatabase.getHandleDbRequests().getTeamDetails(teamId, tenantId);
     if (teamDao != null) {
       TeamModelResponse teamModel = new TeamModelResponse();
       copyProperties(teamDao, teamModel);
@@ -347,7 +347,7 @@ public class UsersTeamsControllerService {
   public List<TeamModelResponse> getAllTeamsSUFromRegisterUsers() {
     int tenantId = commonUtilsService.getTenantId(getUserName());
     List<TeamModelResponse> teamModels =
-        getTeamModels(manageDatabase.getHandleDbRequests().selectAllTeams(tenantId));
+        getTeamModels(manageDatabase.getHandleDbRequests().getAllTeams(tenantId));
 
     teamModels.forEach(
         teamModel ->
@@ -369,7 +369,7 @@ public class UsersTeamsControllerService {
             teamModel.setShowDeleteTeam(
                 manageDatabase
                         .getHandleDbRequests()
-                        .findAllComponentsCountForTeam(teamModel.getTeamId(), tenantId)
+                        .getAllComponentsCountForTeam(teamModel.getTeamId(), tenantId)
                     <= 0);
           });
     }
@@ -388,7 +388,7 @@ public class UsersTeamsControllerService {
     String myTeamName =
         manageDatabase
             .getHandleDbRequests()
-            .selectAllTeamsOfUsers(userDetails, tenantId)
+            .getAllTeamsOfUsers(userDetails, tenantId)
             .get(0)
             .getTeamname();
 
@@ -420,12 +420,11 @@ public class UsersTeamsControllerService {
     }
 
     int tenantId = commonUtilsService.getTenantId(getUserName());
-    if (manageDatabase.getHandleDbRequests().selectAllUsersInfoForTeam(teamId, tenantId).size()
-        > 0) {
+    if (manageDatabase.getHandleDbRequests().getAllUsersInfoForTeam(teamId, tenantId).size() > 0) {
       return ApiResponse.builder().success(false).message(TEAMS_ERR_103).build();
     }
 
-    if (manageDatabase.getHandleDbRequests().findAllComponentsCountForTeam(teamId, tenantId) > 0) {
+    if (manageDatabase.getHandleDbRequests().getAllComponentsCountForTeam(teamId, tenantId) > 0) {
       return ApiResponse.builder().success(false).message(TEAMS_ERR_104).build();
     }
 
@@ -477,7 +476,7 @@ public class UsersTeamsControllerService {
       return ApiResponse.builder().success(false).message(TEAMS_ERR_106).build();
     }
 
-    if (manageDatabase.getHandleDbRequests().findAllComponentsCountForUser(userIdToDelete, tenantId)
+    if (manageDatabase.getHandleDbRequests().getAllComponentsCountForUser(userIdToDelete, tenantId)
         > 0) {
       return ApiResponse.builder().success(false).message(TEAMS_ERR_107).build();
     }
@@ -747,7 +746,7 @@ public class UsersTeamsControllerService {
 
     List<UserInfoModelResponse> userInfoModels = new ArrayList<>();
     int tenantId = commonUtilsService.getTenantId(getUserName());
-    List<UserInfo> userList = manageDatabase.getHandleDbRequests().selectAllUsersInfo(tenantId);
+    List<UserInfo> userList = manageDatabase.getHandleDbRequests().getAllUsersInfo(tenantId);
 
     if (userSearchStr != null && !userSearchStr.equals("")) {
       userList =
@@ -858,7 +857,7 @@ public class UsersTeamsControllerService {
     HandleDbRequests dbHandle = manageDatabase.getHandleDbRequests();
 
     // check if user exists
-    List<UserInfo> userList = manageDatabase.getHandleDbRequests().selectAllUsersAllTenants();
+    List<UserInfo> userList = manageDatabase.getHandleDbRequests().getAllUsersAllTenants();
     if (userList.stream()
         .anyMatch(user -> Objects.equals(user.getUsername(), newUser.getMailid()))) {
       return ApiResponse.builder().success(false).message(TEAMS_ERR_115).build();
@@ -869,7 +868,7 @@ public class UsersTeamsControllerService {
 
     // check if registration exists
     List<RegisterUserInfo> registerUserInfoList =
-        manageDatabase.getHandleDbRequests().selectAllRegisterUsersInfo();
+        manageDatabase.getHandleDbRequests().getAllRegisterUsersInformation();
     if (registerUserInfoList.stream()
         .anyMatch(user -> user.getUsername().equals(newUser.getMailid()))) {
       return ApiResponse.builder().success(false).message(TEAMS_ERR_115).build();
@@ -880,9 +879,7 @@ public class UsersTeamsControllerService {
 
     // get the user details from db
     List<RegisterUserInfo> stagingRegisterUsersInfo =
-        manageDatabase
-            .getHandleDbRequests()
-            .selectAllStagingRegisterUsersInfo(newUser.getUsername());
+        manageDatabase.getHandleDbRequests().getAllStagingRegisterUsersInfo(newUser.getUsername());
 
     // enrich user info
     if (!stagingRegisterUsersInfo.isEmpty()) {
@@ -974,9 +971,9 @@ public class UsersTeamsControllerService {
 
     if (SAAS.equals(kwInstallationType)) {
       registerUserInfoList =
-          manageDatabase.getHandleDbRequests().selectAllRegisterUsersInfoForTenant(tenantId);
+          manageDatabase.getHandleDbRequests().getAllRegisterUsersInfoForTenant(tenantId);
     } else {
-      registerUserInfoList = manageDatabase.getHandleDbRequests().selectAllRegisterUsersInfo();
+      registerUserInfoList = manageDatabase.getHandleDbRequests().getAllRegisterUsersInformation();
     }
 
     List<RegisterUserInfoModelResponse> registerUserInfoModels = new ArrayList<>();

--- a/core/src/main/java/io/aiven/klaw/service/UtilControllerService.java
+++ b/core/src/main/java/io/aiven/klaw/service/UtilControllerService.java
@@ -209,7 +209,7 @@ public class UtilControllerService {
       allConnectorReqs = new ArrayList<>();
     }
 
-    List<RegisterUserInfo> allUserReqs = reqsHandle.selectAllRegisterUsersInfoForTenant(tenantId);
+    List<RegisterUserInfo> allUserReqs = reqsHandle.getAllRegisterUsersInfoForTenant(tenantId);
 
     countList.put("topics", allTopicReqs.size() + "");
     countList.put("acls", allAclReqs.size() + "");

--- a/core/src/main/resources/static/js/serverConfig.js
+++ b/core/src/main/resources/static/js/serverConfig.js
@@ -138,16 +138,18 @@ app.controller("serverConfigCtrl", function($scope, $http, $location, $window) {
 
 
          $scope.testClusterApiConnection = function(kwkey, kwvalue){
+             var testClusterApiUrl = document.getElementById("klaw.clusterapi.url").value;
+
             $http({
                     method: "GET",
                     url: "testClusterApiConnection",
                     headers : { 'Content-Type' : 'application/json' },
-                    params: {'clusterApiUrl' : kwvalue}
+                    params: {'clusterApiUrl' : testClusterApiUrl}
                 }).success(function(output) {
-                    $scope.alert = "Cluster Api Connection Url " + kwvalue  + ", status: " + output.result;
+                    $scope.alert = "Cluster Api Connection Url " + testClusterApiUrl  + ", status: " + output.result;
                     swal({
                             title: "",
-                            text: "Cluster Api Connection " + kwvalue + ". Status: " + output.result,
+                            text: "Cluster Api Connection " + testClusterApiUrl + ". Status: " + output.result,
                             timer: 2000,
                             showConfirmButton: false
                         });
@@ -181,7 +183,6 @@ app.controller("serverConfigCtrl", function($scope, $http, $location, $window) {
                      method: "POST",
                      url: "updateKwCustomProperty",
                      headers : { 'Content-Type' : 'application/json' },
-                     params: {'kwPropertiesModel' : serviceInput },
                      data: serviceInput
                  }).success(function(output) {
                      $scope.alert = "Property ("+ output.data +") update status : " + output.message;

--- a/core/src/main/resources/static/js/serverConfig.js
+++ b/core/src/main/resources/static/js/serverConfig.js
@@ -146,10 +146,10 @@ app.controller("serverConfigCtrl", function($scope, $http, $location, $window) {
                     headers : { 'Content-Type' : 'application/json' },
                     params: {'clusterApiUrl' : testClusterApiUrl}
                 }).success(function(output) {
-                    $scope.alert = "Cluster Api Connection Url " + testClusterApiUrl  + ", status: " + output.result;
+                    $scope.alert = "Cluster Api Connection Url " + testClusterApiUrl  + ", status: " + output.connectionStatus;
                     swal({
                             title: "",
-                            text: "Cluster Api Connection " + testClusterApiUrl + ". Status: " + output.result,
+                            text: "Cluster Api Connection " + testClusterApiUrl + ". Status: " + output.connectionStatus,
                             timer: 2000,
                             showConfirmButton: false
                         });

--- a/core/src/main/resources/templates/serverConfig.html
+++ b/core/src/main/resources/templates/serverConfig.html
@@ -488,7 +488,7 @@
 
 										</td>
 										<td>
-											<textarea ng-model="oneEditableProp.kwvalue" class="form-control" rows="3"></textarea>
+											<textarea id="{{ oneEditableProp.kwkey }}" ng-model="oneEditableProp.kwvalue" class="form-control" rows="3"></textarea>
 											<br>
 											<textarea cols="87" rows="20" ng-show="oneEditableProp.kwkey=='klaw.tenant.config'" disabled>Example json:
 {
@@ -507,7 +507,8 @@
 											</textarea>
 										</td>
 										<td>
-											<button ng-click="updateEditableConfig(oneEditableProp.kwkey, oneEditableProp.kwvalue);" class="btn btn-outline-info"> <i class="fas fa-save"></i>
+											<button ng-click="updateEditableConfig(oneEditableProp.kwkey, oneEditableProp.kwvalue);" class="btn btn-outline-info">
+												<i class="fas fa-save"></i>
 												Save</button> <br><br>
 											<button ng-show="oneEditableProp.kwkey=='klaw.clusterapi.url'" ng-click="testClusterApiConnection(oneEditableProp.kwkey, oneEditableProp.kwvalue);" class="btn btn-rounded btn-block btn-warning btn-xs"> <i class="fa fa-check"></i>
 												Test Connection</button>

--- a/core/src/test/java/io/aiven/klaw/service/AclControllerServiceTest.java
+++ b/core/src/test/java/io/aiven/klaw/service/AclControllerServiceTest.java
@@ -324,7 +324,7 @@ public class AclControllerServiceTest {
     when(manageDatabase.getTeamNameFromTeamId(anyInt(), anyInt())).thenReturn(teamName);
     when(commonUtilsService.getTopicsForTopicName(anyString(), anyInt())).thenReturn(topicList);
     when(commonUtilsService.getFilteredTopicsForTenant(any())).thenReturn(topicList);
-    when(handleDbRequests.selectAllUsersInfoForTeam(anyInt(), anyInt())).thenReturn(userList);
+    when(handleDbRequests.getAllUsersInfoForTeam(anyInt(), anyInt())).thenReturn(userList);
 
     List<AclRequestsResponseModel> aclReqs =
         aclControllerService.getAclRequests(
@@ -483,7 +483,7 @@ public class AclControllerServiceTest {
     AclRequests aclReq = getAclRequestDao();
 
     stubUserInfo();
-    when(handleDbRequests.selectAcl(anyInt(), anyInt())).thenReturn(aclReq);
+    when(handleDbRequests.getAcl(anyInt(), anyInt())).thenReturn(aclReq);
 
     ApiResponse apiResponse =
         ApiResponse.builder().success(true).message(ApiResultStatus.SUCCESS.value).build();
@@ -504,7 +504,7 @@ public class AclControllerServiceTest {
     AclRequests aclReq = getAclRequestDao();
 
     stubUserInfo();
-    when(handleDbRequests.selectAcl(anyInt(), anyInt())).thenReturn(aclReq);
+    when(handleDbRequests.getAcl(anyInt(), anyInt())).thenReturn(aclReq);
 
     Map<String, String> dataObj = new HashMap<>();
     String aivenAclIdKey = "aivenaclid";
@@ -542,7 +542,7 @@ public class AclControllerServiceTest {
     stubUserInfo();
     AclRequests aclReq = getAclRequestDao();
     aclReq.setRequestor("kwusera");
-    when(handleDbRequests.selectAcl(anyInt(), anyInt())).thenReturn(aclReq);
+    when(handleDbRequests.getAcl(anyInt(), anyInt())).thenReturn(aclReq);
     ApiResponse apiResp = aclControllerService.approveAclRequests("112");
     assertThat(apiResp.getMessage())
         .isEqualTo("You are not allowed to approve your own subscription requests.");
@@ -556,7 +556,7 @@ public class AclControllerServiceTest {
     stubUserInfo();
     when(commonUtilsService.getEnvsFromUserId(anyString()))
         .thenReturn(new HashSet<>(Collections.singletonList("1")));
-    when(handleDbRequests.selectAcl(anyInt(), anyInt())).thenReturn(aclReq);
+    when(handleDbRequests.getAcl(anyInt(), anyInt())).thenReturn(aclReq);
 
     ApiResponse apiResponse = ApiResponse.builder().message("failure").build();
     when(clusterApiService.approveAclRequests(any(), anyInt()))
@@ -573,11 +573,12 @@ public class AclControllerServiceTest {
     AclRequests aclReq = getAclRequestDao();
 
     stubUserInfo();
-    when(handleDbRequests.selectAcl(anyInt(), anyInt())).thenReturn(aclReq);
+    when(handleDbRequests.getAcl(anyInt(), anyInt())).thenReturn(aclReq);
     when(commonUtilsService.getEnvsFromUserId(anyString()))
         .thenReturn(new HashSet<>(Collections.singletonList("1")));
 
-    ApiResponse apiResponse = ApiResponse.builder().message(ApiResultStatus.SUCCESS.value).build();
+    ApiResponse apiResponse =
+        ApiResponse.builder().success(true).message(ApiResultStatus.SUCCESS.value).build();
     when(clusterApiService.approveAclRequests(any(), anyInt()))
         .thenReturn(new ResponseEntity<>(apiResponse, HttpStatus.OK));
     when(handleDbRequests.updateAclRequest(any(), any(), anyString()))
@@ -595,7 +596,7 @@ public class AclControllerServiceTest {
     aclReq.setRequestStatus(RequestStatus.APPROVED.value);
 
     stubUserInfo();
-    when(handleDbRequests.selectAcl(anyInt(), anyInt())).thenReturn(aclReq);
+    when(handleDbRequests.getAcl(anyInt(), anyInt())).thenReturn(aclReq);
     when(manageDatabase.getTeamsAndAllowedEnvs(anyInt(), anyInt()))
         .thenReturn(Collections.singletonList("1"));
 
@@ -610,7 +611,7 @@ public class AclControllerServiceTest {
     AclRequests aclReq = getAclRequestDao();
 
     stubUserInfo();
-    when(handleDbRequests.selectAcl(anyInt(), anyInt())).thenReturn(aclReq);
+    when(handleDbRequests.getAcl(anyInt(), anyInt())).thenReturn(aclReq);
     when(commonUtilsService.getEnvsFromUserId(anyString()))
         .thenReturn(new HashSet<>(Collections.singletonList("1")));
     when(handleDbRequests.declineAclRequest(any(), any()))
@@ -627,7 +628,7 @@ public class AclControllerServiceTest {
     AclRequests aclReq = getAclRequestDao();
 
     stubUserInfo();
-    when(handleDbRequests.selectAcl(anyInt(), anyInt())).thenReturn(aclReq);
+    when(handleDbRequests.getAcl(anyInt(), anyInt())).thenReturn(aclReq);
     when(commonUtilsService.getEnvsFromUserId(anyString()))
         .thenReturn(new HashSet<>(Collections.singletonList("1")));
 
@@ -650,7 +651,7 @@ public class AclControllerServiceTest {
     when(commonUtilsService.getTeamId(anyString())).thenReturn(101);
     when(commonUtilsService.getEnvsFromUserId(anyString()))
         .thenReturn(new HashSet<>(Collections.singletonList("1")));
-    when(handleDbRequests.selectSyncAclsFromReqNo(anyInt(), anyInt())).thenReturn(acl);
+    when(handleDbRequests.getSyncAclsFromReqNo(anyInt(), anyInt())).thenReturn(acl);
     Map<String, String> hashMap = new HashMap<>();
     hashMap.put("result", ApiResultStatus.SUCCESS.value);
     when(handleDbRequests.requestForAcl(any())).thenReturn(hashMap);
@@ -676,7 +677,7 @@ public class AclControllerServiceTest {
     when(commonUtilsService.getTeamId(anyString())).thenReturn(101);
     when(commonUtilsService.getEnvsFromUserId(anyString()))
         .thenReturn(new HashSet<>(Collections.singletonList("1")));
-    when(handleDbRequests.selectSyncAclsFromReqNo(anyInt(), anyInt())).thenReturn(acl);
+    when(handleDbRequests.getSyncAclsFromReqNo(anyInt(), anyInt())).thenReturn(acl);
     when(clusterApiService.getAivenServiceAccountDetails(
             anyString(), anyString(), anyString(), anyInt()))
         .thenReturn(serviceAccountDetails);
@@ -702,7 +703,7 @@ public class AclControllerServiceTest {
     when(commonUtilsService.getTeamId(anyString())).thenReturn(101);
     when(commonUtilsService.getEnvsFromUserId(anyString()))
         .thenReturn(new HashSet<>(Collections.singletonList("1")));
-    when(handleDbRequests.selectSyncAclsFromReqNo(anyInt(), anyInt())).thenReturn(acl);
+    when(handleDbRequests.getSyncAclsFromReqNo(anyInt(), anyInt())).thenReturn(acl);
     when(clusterApiService.getAivenServiceAccountDetails(
             anyString(), anyString(), anyString(), anyInt()))
         .thenReturn(serviceAccountDetails);

--- a/core/src/test/java/io/aiven/klaw/service/AclSyncControllerServiceTest.java
+++ b/core/src/test/java/io/aiven/klaw/service/AclSyncControllerServiceTest.java
@@ -162,7 +162,7 @@ public class AclSyncControllerServiceTest {
     when(manageDatabase.getKafkaEnvList(anyInt())).thenReturn(utilMethods.getEnvLists());
     when(clusterApiService.getAcls(anyString(), any(), any(KafkaSupportedProtocol.class), anyInt()))
         .thenReturn(utilMethods.getClusterAcls());
-    when(handleDbRequests.selectAllTeamsOfUsers(anyString(), anyInt()))
+    when(handleDbRequests.getAllTeamsOfUsers(anyString(), anyInt()))
         .thenReturn(getAvailableTeams());
     when(handleDbRequests.getSyncAcls(anyString(), anyInt())).thenReturn(getAclsSOT0());
     when(manageDatabase.getClusters(any(KafkaClustersType.class), anyInt()))
@@ -188,7 +188,7 @@ public class AclSyncControllerServiceTest {
     when(manageDatabase.getKafkaEnvList(anyInt())).thenReturn(utilMethods.getEnvLists());
     when(clusterApiService.getAcls(anyString(), any(), any(KafkaSupportedProtocol.class), anyInt()))
         .thenReturn(utilMethods.getClusterAcls());
-    when(handleDbRequests.selectAllTeamsOfUsers(anyString(), anyInt()))
+    when(handleDbRequests.getAllTeamsOfUsers(anyString(), anyInt()))
         .thenReturn(getAvailableTeams());
     when(handleDbRequests.getSyncAcls(anyString(), anyInt())).thenReturn(getAclsSOT0());
     when(manageDatabase.getClusters(any(KafkaClustersType.class), anyInt()))

--- a/core/src/test/java/io/aiven/klaw/service/ClusterApiServiceTest.java
+++ b/core/src/test/java/io/aiven/klaw/service/ClusterApiServiceTest.java
@@ -213,7 +213,7 @@ public class ClusterApiServiceTest {
     topicRequest.setEnvironment("DEV");
     topicRequest.setRequestOperationType(RequestOperationType.CREATE.value);
 
-    when(handleDbRequests.selectEnvDetails(anyString(), anyInt())).thenReturn(this.env);
+    when(handleDbRequests.getEnvDetails(anyString(), anyInt())).thenReturn(this.env);
     when(manageDatabase.getClusters(any(KafkaClustersType.class), anyInt()))
         .thenReturn(clustersHashMap);
     when(clustersHashMap.get(any())).thenReturn(kwClusters);
@@ -239,7 +239,7 @@ public class ClusterApiServiceTest {
     topicRequest.setEnvironment("DEV");
     topicRequest.setRequestOperationType(RequestOperationType.CREATE.value);
 
-    when(handleDbRequests.selectEnvDetails(anyString(), anyInt())).thenReturn(this.env);
+    when(handleDbRequests.getEnvDetails(anyString(), anyInt())).thenReturn(this.env);
     when(manageDatabase.getClusters(any(KafkaClustersType.class), anyInt()))
         .thenReturn(clustersHashMap);
     when(clustersHashMap.get(any())).thenReturn(kwClusters);
@@ -269,7 +269,7 @@ public class ClusterApiServiceTest {
     ApiResponse apiResponse = ApiResponse.builder().message(ApiResultStatus.SUCCESS.value).build();
     ResponseEntity<ApiResponse> responseEntity = new ResponseEntity<>(apiResponse, HttpStatus.OK);
 
-    when(handleDbRequests.selectEnvDetails(anyString(), anyInt())).thenReturn(this.env);
+    when(handleDbRequests.getEnvDetails(anyString(), anyInt())).thenReturn(this.env);
     when(manageDatabase.getClusters(any(KafkaClustersType.class), anyInt()))
         .thenReturn(clustersHashMap);
     when(clustersHashMap.get(any())).thenReturn(kwClusters);
@@ -301,7 +301,7 @@ public class ClusterApiServiceTest {
     ApiResponse apiResponse = ApiResponse.builder().message(ApiResultStatus.SUCCESS.value).build();
     ResponseEntity<ApiResponse> responseEntity = new ResponseEntity<>(apiResponse, HttpStatus.OK);
 
-    when(handleDbRequests.selectEnvDetails(anyString(), anyInt())).thenReturn(this.env);
+    when(handleDbRequests.getEnvDetails(anyString(), anyInt())).thenReturn(this.env);
     when(manageDatabase.getClusters(any(KafkaClustersType.class), anyInt()))
         .thenReturn(clustersHashMap);
     when(clustersHashMap.get(any())).thenReturn(kwClusters);
@@ -344,7 +344,7 @@ public class ClusterApiServiceTest {
     ApiResponse apiResponse = ApiResponse.builder().message(ApiResultStatus.SUCCESS.value).build();
     ResponseEntity<ApiResponse> response = new ResponseEntity<>(apiResponse, HttpStatus.OK);
 
-    when(handleDbRequests.selectEnvDetails(anyString(), anyInt())).thenReturn(this.env);
+    when(handleDbRequests.getEnvDetails(anyString(), anyInt())).thenReturn(this.env);
     when(manageDatabase.getClusters(any(KafkaClustersType.class), anyInt()))
         .thenReturn(clustersHashMap);
     when(clustersHashMap.get(any())).thenReturn(kwClusters);
@@ -372,7 +372,7 @@ public class ClusterApiServiceTest {
     ApiResponse apiResponse = ApiResponse.builder().message(ApiResultStatus.SUCCESS.value).build();
     ResponseEntity<ApiResponse> response = new ResponseEntity<>(apiResponse, HttpStatus.OK);
 
-    when(handleDbRequests.selectEnvDetails(anyString(), anyInt())).thenReturn(this.env);
+    when(handleDbRequests.getEnvDetails(anyString(), anyInt())).thenReturn(this.env);
     when(manageDatabase.getClusters(any(KafkaClustersType.class), anyInt()))
         .thenReturn(clustersHashMap);
     when(clustersHashMap.get(anyInt())).thenReturn(kwClusters);
@@ -404,7 +404,7 @@ public class ClusterApiServiceTest {
     ApiResponse apiResponse = ApiResponse.builder().message(ApiResultStatus.SUCCESS.value).build();
     ResponseEntity<ApiResponse> response = new ResponseEntity<>(apiResponse, HttpStatus.OK);
 
-    when(handleDbRequests.selectEnvDetails(anyString(), anyInt())).thenReturn(this.env);
+    when(handleDbRequests.getEnvDetails(anyString(), anyInt())).thenReturn(this.env);
     when(manageDatabase.getClusters(any(KafkaClustersType.class), anyInt()))
         .thenReturn(clustersHashMap);
     when(clustersHashMap.get(anyInt())).thenReturn(kwClusters);
@@ -433,7 +433,7 @@ public class ClusterApiServiceTest {
     String envSel = "DEV";
     String topicName = "testtopic";
 
-    when(handleDbRequests.selectEnvDetails("DEV", 1)).thenReturn(this.env);
+    when(handleDbRequests.getEnvDetails("DEV", 1)).thenReturn(this.env);
     when(restTemplate.postForEntity(Mockito.anyString(), Mockito.any(), eq(String.class)))
         .thenThrow(new RuntimeException("error"));
 

--- a/core/src/test/java/io/aiven/klaw/service/EnvsClustersTenantsControllerServiceTest.java
+++ b/core/src/test/java/io/aiven/klaw/service/EnvsClustersTenantsControllerServiceTest.java
@@ -76,7 +76,7 @@ class EnvsClustersTenantsControllerServiceTest {
     EnvModel env = getTestEnvModel(null);
     Env SchemaEnv = generateKafkaEnv("9", "Schema");
     when(handleDbRequestsJdbc.addNewEnv(any())).thenReturn(ApiResultStatus.SUCCESS.value);
-    when(handleDbRequestsJdbc.selectEnvDetails(anyString(), anyInt())).thenReturn(SchemaEnv);
+    when(handleDbRequestsJdbc.getEnvDetails(anyString(), anyInt())).thenReturn(SchemaEnv);
     ApiResponse response = service.addNewEnv(env);
     assertThat(response.getMessage()).contains("success");
   }
@@ -87,7 +87,7 @@ class EnvsClustersTenantsControllerServiceTest {
       authorities = {"ADMIN", "USER"})
   void addNewEnvNameAlreadyInUse() throws KlawException, KlawValidationException {
     EnvModel env = getTestEnvModel(null);
-    when(handleDbRequestsJdbc.selectAllEnvs(anyInt()))
+    when(handleDbRequestsJdbc.getAllEnvs(anyInt()))
         .thenReturn(
             List.of(
                 buildEnv("4", 101, "DEV", KafkaClustersType.KAFKA, 4),
@@ -107,7 +107,7 @@ class EnvsClustersTenantsControllerServiceTest {
     EnvModel env = getTestSchemaEnvModel(new EnvTag("1", "Kafka"));
     Env kafkaEnv = generateKafkaEnv("1", "Kafka");
     when(handleDbRequestsJdbc.addNewEnv(any())).thenReturn(ApiResultStatus.SUCCESS.value);
-    when(handleDbRequestsJdbc.selectEnvDetails(eq("1"), eq(101)))
+    when(handleDbRequestsJdbc.getEnvDetails(eq("1"), eq(101)))
         .thenReturn(kafkaEnv)
         .thenReturn(null);
     ApiResponse response = service.addNewEnv(env);
@@ -133,10 +133,10 @@ class EnvsClustersTenantsControllerServiceTest {
 
     Env kafkaEnv = generateKafkaEnv("1", "Kafka");
     when(handleDbRequestsJdbc.addNewEnv(any())).thenReturn(ApiResultStatus.SUCCESS.value);
-    when(handleDbRequestsJdbc.selectEnvDetails(eq("1"), eq(101)))
+    when(handleDbRequestsJdbc.getEnvDetails(eq("1"), eq(101)))
         .thenReturn(kafkaEnv)
         .thenReturn(SchemaEnv);
-    when(handleDbRequestsJdbc.selectEnvDetails(eq("2"), eq(101)))
+    when(handleDbRequestsJdbc.getEnvDetails(eq("2"), eq(101)))
         .thenReturn(generateKafkaEnv("2", "Kafka"));
     ApiResponse response = service.addNewEnv(env);
     kafkaEnv.setAssociatedEnv(env.getAssociatedEnv());
@@ -160,7 +160,7 @@ class EnvsClustersTenantsControllerServiceTest {
     SchemaEnv.setAssociatedEnv(new EnvTag("2", "Kafka"));
     Env kafkaEnv = generateKafkaEnv("1", "Kafka");
     kafkaEnv.setAssociatedEnv(new EnvTag("2", "TST_SCH"));
-    when(handleDbRequestsJdbc.selectEnvDetails(eq("1"), eq(101))).thenReturn(kafkaEnv);
+    when(handleDbRequestsJdbc.getEnvDetails(eq("1"), eq(101))).thenReturn(kafkaEnv);
 
     assertThatExceptionOfType(KlawValidationException.class)
         .isThrownBy(
@@ -178,7 +178,7 @@ class EnvsClustersTenantsControllerServiceTest {
     Env env1 = generateKafkaEnv("1", "Kafka");
     env1.setType(KafkaClustersType.SCHEMA_REGISTRY.value);
 
-    when(handleDbRequestsJdbc.selectEnvDetails(eq("1"), eq(101))).thenReturn(env1).thenReturn(null);
+    when(handleDbRequestsJdbc.getEnvDetails(eq("1"), eq(101))).thenReturn(env1).thenReturn(null);
     when(handleDbRequestsJdbc.addNewEnv(any())).thenReturn(ApiResultStatus.SUCCESS.value);
     ApiResponse response = service.addNewEnv(env);
 
@@ -195,8 +195,8 @@ class EnvsClustersTenantsControllerServiceTest {
     Env env1 = generateKafkaEnv("1", "Kafka");
     env1.setType(KafkaClustersType.SCHEMA_REGISTRY.value);
     env1.setAssociatedEnv(new EnvTag("2", "TST_SCH"));
-    when(handleDbRequestsJdbc.selectEnvDetails(eq("1"), eq(101))).thenReturn(env1);
-    when(handleDbRequestsJdbc.selectEnvDetails(eq("2"), eq(101)))
+    when(handleDbRequestsJdbc.getEnvDetails(eq("1"), eq(101))).thenReturn(env1);
+    when(handleDbRequestsJdbc.getEnvDetails(eq("2"), eq(101)))
         .thenReturn(generateKafkaEnv("2", "Kafka"));
     when(handleDbRequestsJdbc.addNewEnv(any())).thenReturn(ApiResultStatus.SUCCESS.value);
     ApiResponse response = service.addNewEnv(env);

--- a/core/src/test/java/io/aiven/klaw/service/ExportImportDataServiceTest.java
+++ b/core/src/test/java/io/aiven/klaw/service/ExportImportDataServiceTest.java
@@ -42,8 +42,7 @@ public class ExportImportDataServiceTest {
 
   @Test
   public void getAdminConfig() {
-    when(handleDbRequests.selectAllUsersAllTenants())
-        .thenReturn(utilMethods.getUserInfoList("", ""));
+    when(handleDbRequests.getAllUsersAllTenants()).thenReturn(utilMethods.getUserInfoList("", ""));
     when(handleDbRequests.getClusters())
         .thenReturn(Collections.singletonList(utilMethods.getKwClusters()));
     KwAdminConfig kwAdminConfig = exportImportDataService.getAdminConfig(handleDbRequests, "");

--- a/core/src/test/java/io/aiven/klaw/service/KafkaConnectControllerServiceTest.java
+++ b/core/src/test/java/io/aiven/klaw/service/KafkaConnectControllerServiceTest.java
@@ -204,7 +204,7 @@ public class KafkaConnectControllerServiceTest {
     stubUserInfo();
     when(commonUtilsService.isNotAuthorizedUser(any(), any())).thenReturn(false);
     when(commonUtilsService.getTenantId(any())).thenReturn(101);
-    when(handleDbRequests.selectConnectorRequests(
+    when(handleDbRequests.getConnectorRequests(
             "ConnectorOne", "1", RequestStatus.CREATED.value, 101))
         .thenReturn(List.of(new KafkaConnectorRequest()));
     ApiResponse apiResponse =

--- a/core/src/test/java/io/aiven/klaw/service/SchemaOverviewServiceTest.java
+++ b/core/src/test/java/io/aiven/klaw/service/SchemaOverviewServiceTest.java
@@ -217,7 +217,7 @@ public class SchemaOverviewServiceTest {
     List<Env> listOfEnvs = createListOfEnvs(KafkaClustersType.SCHEMA_REGISTRY, numberOfEnvs);
     when(manageDatabase.getAllEnvList(101)).thenReturn(listOfEnvs);
     when(commonUtilsService.getTenantId(any())).thenReturn(101);
-    when(handleDbRequests.selectAllSchemaRegEnvs(101)).thenReturn(listOfEnvs);
+    when(handleDbRequests.getAllSchemaRegEnvs(101)).thenReturn(listOfEnvs);
     when(manageDatabase.getClusters(eq(KafkaClustersType.SCHEMA_REGISTRY), eq(101)))
         .thenReturn(createClusterMap(numberOfEnvs));
     when(clusterApiService.getAvroSchema(any(), any(), any(), eq(testtopic), eq(101)))
@@ -254,10 +254,10 @@ public class SchemaOverviewServiceTest {
     schemaEnv2.setClusterId(1);
     schemaEnv2.setAssociatedEnv(new EnvTag("2", "TST"));
 
-    when(handleDbRequests.selectEnvDetails("1", 101)).thenReturn(kafkaEnv1);
-    when(handleDbRequests.selectEnvDetails("2", 101)).thenReturn(kafkaEnv2);
-    when(handleDbRequests.selectEnvDetails("3", 101)).thenReturn(schemaEnv1);
-    when(handleDbRequests.selectEnvDetails("4", 101)).thenReturn(schemaEnv2);
+    when(handleDbRequests.getEnvDetails("1", 101)).thenReturn(kafkaEnv1);
+    when(handleDbRequests.getEnvDetails("2", 101)).thenReturn(kafkaEnv2);
+    when(handleDbRequests.getEnvDetails("3", 101)).thenReturn(schemaEnv1);
+    when(handleDbRequests.getEnvDetails("4", 101)).thenReturn(schemaEnv2);
   }
 
   private void stubKafkaPromotion(String testtopic, int numberOfEnvs) throws Exception {

--- a/core/src/test/java/io/aiven/klaw/service/SchemaRegistryControllerServiceTest.java
+++ b/core/src/test/java/io/aiven/klaw/service/SchemaRegistryControllerServiceTest.java
@@ -142,9 +142,8 @@ public class SchemaRegistryControllerServiceTest {
         .thenReturn(List.of(""));
     when(commonUtilsService.getEnvsFromUserId(anyString()))
         .thenReturn(new HashSet<>(Collections.singletonList("1")));
-    when(handleDbRequests.selectAllUsersInfoForTeam(anyInt(), anyInt()))
-        .thenReturn(List.of(userInfo));
-    when(handleDbRequests.selectEnvDetails(anyString(), anyInt())).thenReturn(this.env);
+    when(handleDbRequests.getAllUsersInfoForTeam(anyInt(), anyInt())).thenReturn(List.of(userInfo));
+    when(handleDbRequests.getEnvDetails(anyString(), anyInt())).thenReturn(this.env);
     when(commonUtilsService.deriveCurrentPage(anyString(), anyString(), anyInt())).thenReturn("1");
     when(manageDatabase.getTeamNameFromTeamId(anyInt(), anyInt())).thenReturn("teamname");
 
@@ -205,7 +204,7 @@ public class SchemaRegistryControllerServiceTest {
     schemaRequest.setTopicname("topic");
 
     stubUserInfo();
-    when(handleDbRequests.selectSchemaRequest(anyInt(), anyInt())).thenReturn(schemaRequest);
+    when(handleDbRequests.getSchemaRequest(anyInt(), anyInt())).thenReturn(schemaRequest);
     when(clusterApiService.postSchema(any(), anyString(), anyString(), anyInt()))
         .thenReturn(response);
     when(handleDbRequests.updateSchemaRequest(any(), anyString()))
@@ -233,7 +232,7 @@ public class SchemaRegistryControllerServiceTest {
     schemaRequest.setTopicname("topic");
 
     stubUserInfo();
-    when(handleDbRequests.selectSchemaRequest(anyInt(), anyInt())).thenReturn(schemaRequest);
+    when(handleDbRequests.getSchemaRequest(anyInt(), anyInt())).thenReturn(schemaRequest);
     when(clusterApiService.postSchema(any(), anyString(), anyString(), anyInt()))
         .thenReturn(response);
     when(handleDbRequests.updateSchemaRequest(any(), anyString()))
@@ -262,7 +261,7 @@ public class SchemaRegistryControllerServiceTest {
     schemaRequest.setTopicname("topic");
 
     stubUserInfo();
-    when(handleDbRequests.selectSchemaRequest(anyInt(), anyInt())).thenReturn(schemaRequest);
+    when(handleDbRequests.getSchemaRequest(anyInt(), anyInt())).thenReturn(schemaRequest);
     try {
       when(clusterApiService.postSchema(any(), anyString(), anyString(), anyInt()))
           .thenReturn(response);
@@ -647,9 +646,8 @@ public class SchemaRegistryControllerServiceTest {
         .thenReturn(List.of(""));
     when(commonUtilsService.getEnvsFromUserId(anyString()))
         .thenReturn(new HashSet<>(Collections.singletonList("1")));
-    when(handleDbRequests.selectAllUsersInfoForTeam(anyInt(), anyInt()))
-        .thenReturn(List.of(userInfo));
-    when(handleDbRequests.selectEnvDetails(anyString(), anyInt())).thenReturn(this.env);
+    when(handleDbRequests.getAllUsersInfoForTeam(anyInt(), anyInt())).thenReturn(List.of(userInfo));
+    when(handleDbRequests.getEnvDetails(anyString(), anyInt())).thenReturn(this.env);
     when(commonUtilsService.deriveCurrentPage(anyString(), anyString(), anyInt())).thenReturn("1");
     when(manageDatabase.getTeamNameFromTeamId(anyInt(), anyInt())).thenReturn("teamname");
 
@@ -695,9 +693,8 @@ public class SchemaRegistryControllerServiceTest {
         .thenReturn(List.of(""));
     when(commonUtilsService.getEnvsFromUserId(anyString()))
         .thenReturn(new HashSet<>(Collections.singletonList("1")));
-    when(handleDbRequests.selectAllUsersInfoForTeam(anyInt(), anyInt()))
-        .thenReturn(List.of(userInfo));
-    when(handleDbRequests.selectEnvDetails(anyString(), anyInt())).thenReturn(this.env);
+    when(handleDbRequests.getAllUsersInfoForTeam(anyInt(), anyInt())).thenReturn(List.of(userInfo));
+    when(handleDbRequests.getEnvDetails(anyString(), anyInt())).thenReturn(this.env);
     when(commonUtilsService.deriveCurrentPage(anyString(), anyString(), anyInt())).thenReturn("1");
     when(manageDatabase.getTeamNameFromTeamId(anyInt(), anyInt())).thenReturn("teamname");
 

--- a/core/src/test/java/io/aiven/klaw/service/TopicControllerServiceTest.java
+++ b/core/src/test/java/io/aiven/klaw/service/TopicControllerServiceTest.java
@@ -231,7 +231,7 @@ public class TopicControllerServiceTest {
     String envId = "1";
     when(commonUtilsService.isNotAuthorizedUser(any(), any())).thenReturn(false);
     when(commonUtilsService.getTenantId(anyString())).thenReturn(101);
-    when(handleDbRequests.selectTopicRequests(anyString(), anyString(), anyString(), anyInt()))
+    when(handleDbRequests.getTopicRequests(anyString(), anyString(), anyString(), anyInt()))
         .thenReturn(getListTopicRequests());
     try {
       ApiResponse apiResponse =
@@ -253,7 +253,7 @@ public class TopicControllerServiceTest {
     stubUserInfo();
     when(commonUtilsService.isNotAuthorizedUser(any(), any())).thenReturn(false);
     when(commonUtilsService.getTenantId(anyString())).thenReturn(101);
-    when(handleDbRequests.selectTopicRequests(anyString(), anyString(), anyString(), anyInt()))
+    when(handleDbRequests.getTopicRequests(anyString(), anyString(), anyString(), anyInt()))
         .thenReturn(Collections.emptyList());
     when(commonUtilsService.getTopicsForTopicName(anyString(), anyInt()))
         .thenReturn(List.of(getTopic(topicName)));
@@ -281,7 +281,7 @@ public class TopicControllerServiceTest {
     when(commonUtilsService.getTeamId(anyString())).thenReturn(1);
     when(commonUtilsService.isNotAuthorizedUser(any(), any())).thenReturn(false);
     when(commonUtilsService.getTenantId(anyString())).thenReturn(101);
-    when(handleDbRequests.selectTopicRequests(anyString(), anyString(), anyString(), anyInt()))
+    when(handleDbRequests.getTopicRequests(anyString(), anyString(), anyString(), anyInt()))
         .thenReturn(Collections.emptyList());
     when(commonUtilsService.getTopicsForTopicName(anyString(), anyInt()))
         .thenReturn(List.of(getTopic(topicName)));
@@ -311,7 +311,7 @@ public class TopicControllerServiceTest {
     when(userInfo.getTeamId()).thenReturn(1);
     when(commonUtilsService.isNotAuthorizedUser(any(), any())).thenReturn(false);
     when(commonUtilsService.getTenantId(anyString())).thenReturn(101);
-    when(handleDbRequests.selectTopicRequests(anyString(), anyString(), anyString(), anyInt()))
+    when(handleDbRequests.getTopicRequests(anyString(), anyString(), anyString(), anyInt()))
         .thenReturn(Collections.emptyList());
     when(commonUtilsService.getTopicsForTopicName(anyString(), anyInt()))
         .thenReturn(List.of(getTopic(topicName)));
@@ -338,7 +338,7 @@ public class TopicControllerServiceTest {
     when(commonUtilsService.getTeamId(anyString())).thenReturn(1);
     when(commonUtilsService.isNotAuthorizedUser(any(), any())).thenReturn(false);
     when(commonUtilsService.getTenantId(anyString())).thenReturn(101);
-    when(handleDbRequests.selectTopicRequests(anyString(), anyString(), anyString(), anyInt()))
+    when(handleDbRequests.getTopicRequests(anyString(), anyString(), anyString(), anyInt()))
         .thenReturn(Collections.emptyList());
     when(commonUtilsService.getTopicsForTopicName(anyString(), anyInt()))
         .thenReturn(List.of(getTopic(topicName)));
@@ -367,7 +367,7 @@ public class TopicControllerServiceTest {
     String envId = "1";
     stubUserInfo();
     when(commonUtilsService.getTenantId(anyString())).thenReturn(101);
-    when(handleDbRequests.selectTopicRequests(anyString(), anyString(), anyString(), anyInt()))
+    when(handleDbRequests.getTopicRequests(anyString(), anyString(), anyString(), anyInt()))
         .thenReturn(getListTopicRequests());
     try {
       ApiResponse apiResponse = topicControllerService.createClaimTopicRequest(topicName, envId);
@@ -385,7 +385,7 @@ public class TopicControllerServiceTest {
     String envId = "1";
     stubUserInfo();
     when(commonUtilsService.getTenantId(anyString())).thenReturn(101);
-    when(handleDbRequests.selectTopicRequests(anyString(), anyString(), anyString(), anyInt()))
+    when(handleDbRequests.getTopicRequests(anyString(), anyString(), anyString(), anyInt()))
         .thenReturn(Collections.emptyList());
     when(commonUtilsService.getTopicsForTopicName(anyString(), anyInt()))
         .thenReturn(List.of(getTopic(topicName)));
@@ -393,7 +393,7 @@ public class TopicControllerServiceTest {
         .thenReturn(List.of(getTopic(topicName)));
     List<UserInfo> userList = utilMethods.getUserInfoList("testuser", "");
     userList.get(0).setTeamId(1);
-    when(handleDbRequests.selectAllUsersInfo(anyInt())).thenReturn(userList);
+    when(handleDbRequests.getAllUsersInfo(anyInt())).thenReturn(userList);
     Map<String, String> claimReqResult = new HashMap<>();
     claimReqResult.put("result", ApiResultStatus.SUCCESS.value);
     when(handleDbRequests.requestForTopic(any())).thenReturn(claimReqResult);
@@ -659,7 +659,7 @@ public class TopicControllerServiceTest {
     ApiResponse apiResponse = ApiResponse.builder().message(ApiResultStatus.SUCCESS.value).build();
 
     stubUserInfo();
-    when(handleDbRequests.selectTopicRequestsForTopic(anyInt(), anyInt())).thenReturn(topicRequest);
+    when(handleDbRequests.getTopicRequestsForTopic(anyInt(), anyInt())).thenReturn(topicRequest);
     when(handleDbRequests.updateTopicRequest(any(), anyString()))
         .thenReturn(ApiResultStatus.SUCCESS.value);
     when(clusterApiService.approveTopicRequests(
@@ -689,7 +689,7 @@ public class TopicControllerServiceTest {
     ApiResponse apiResponse = ApiResponse.builder().message(ApiResultStatus.SUCCESS.value).build();
 
     stubUserInfo();
-    when(handleDbRequests.selectTopicRequestsForTopic(anyInt(), anyInt())).thenReturn(topicRequest);
+    when(handleDbRequests.getTopicRequestsForTopic(anyInt(), anyInt())).thenReturn(topicRequest);
     when(handleDbRequests.updateTopicRequest(any(), anyString()))
         .thenReturn(ApiResultStatus.SUCCESS.value);
     when(commonUtilsService.getTopicsForTopicName(anyString(), anyInt()))
@@ -726,7 +726,7 @@ public class TopicControllerServiceTest {
     ApiResponse apiResponse = ApiResponse.builder().message(ApiResultStatus.SUCCESS.value).build();
 
     stubUserInfo();
-    when(handleDbRequests.selectTopicRequestsForTopic(anyInt(), anyInt())).thenReturn(topicRequest);
+    when(handleDbRequests.getTopicRequestsForTopic(anyInt(), anyInt())).thenReturn(topicRequest);
     when(handleDbRequests.updateTopicRequest(any(), anyString()))
         .thenReturn(ApiResultStatus.SUCCESS.value);
     when(commonUtilsService.getTopicsForTopicName(anyString(), anyInt()))
@@ -761,7 +761,7 @@ public class TopicControllerServiceTest {
     ApiResponse apiResponse = ApiResponse.builder().message(ApiResultStatus.FAILURE.value).build();
 
     stubUserInfo();
-    when(handleDbRequests.selectTopicRequestsForTopic(anyInt(), anyInt())).thenReturn(topicRequest);
+    when(handleDbRequests.getTopicRequestsForTopic(anyInt(), anyInt())).thenReturn(topicRequest);
     when(handleDbRequests.updateTopicRequest(any(), anyString()))
         .thenReturn(ApiResultStatus.SUCCESS.value);
     when(clusterApiService.approveTopicRequests(
@@ -790,7 +790,7 @@ public class TopicControllerServiceTest {
     topicRequest.setRequestor("kwusera");
 
     stubUserInfo();
-    when(handleDbRequests.selectTopicRequestsForTopic(anyInt(), anyInt())).thenReturn(topicRequest);
+    when(handleDbRequests.getTopicRequestsForTopic(anyInt(), anyInt())).thenReturn(topicRequest);
 
     ApiResponse apiResponse1 = topicControllerService.approveTopicRequests("" + topicId);
     assertThat(apiResponse1.getMessage())
@@ -866,7 +866,8 @@ public class TopicControllerServiceTest {
     stubUserInfo();
     String envId = "1", topicName = "testtopic";
     when(commonUtilsService.getTenantId(anyString())).thenReturn(101);
-    when(handleDbRequests.getTopics(anyString(), anyInt())).thenReturn(Collections.emptyList());
+    when(commonUtilsService.getTopicsForTopicName(anyString(), anyInt()))
+        .thenReturn(Collections.emptyList());
     when(commonUtilsService.getEnvsFromUserId(anyString()))
         .thenReturn(new HashSet<>(Collections.singletonList("1")));
 
@@ -881,7 +882,8 @@ public class TopicControllerServiceTest {
     stubUserInfo();
     String envId = "1", topicName = "testtopic";
     when(commonUtilsService.getTenantId(anyString())).thenReturn(101);
-    when(handleDbRequests.getTopics(anyString(), anyInt())).thenReturn(utilMethods.getTopics());
+    when(commonUtilsService.getTopicsForTopicName(anyString(), anyInt()))
+        .thenReturn(utilMethods.getTopics());
     when(commonUtilsService.getEnvsFromUserId(anyString()))
         .thenReturn(new HashSet<>(Collections.singletonList("1")));
     when(manageDatabase.getKafkaEnvList(anyInt())).thenReturn(utilMethods.getEnvLists());
@@ -898,7 +900,8 @@ public class TopicControllerServiceTest {
     stubUserInfo();
     String envId = "1", topicName = "testtopic";
     when(commonUtilsService.getTenantId(anyString())).thenReturn(101);
-    when(handleDbRequests.getTopics(anyString(), anyInt())).thenReturn(utilMethods.getTopics());
+    when(commonUtilsService.getTopicsForTopicName(anyString(), anyInt()))
+        .thenReturn(utilMethods.getTopics());
     when(commonUtilsService.getEnvsFromUserId(anyString()))
         .thenReturn(new HashSet<>(Collections.singletonList("1")));
     when(manageDatabase.getKafkaEnvList(anyInt())).thenReturn(utilMethods.getEnvLists());
@@ -955,7 +958,7 @@ public class TopicControllerServiceTest {
             KwConstants.INFRATEAM,
             KwConstants.INFRATEAM,
             KwConstants.INFRATEAM);
-    when(handleDbRequests.selectAllTopicsByTopictypeAndTeamname(anyString(), anyInt(), anyInt()))
+    when(handleDbRequests.getAllTopicsByTopictypeAndTeamname(anyString(), anyInt(), anyInt()))
         .thenReturn(getSyncTopics("topic", 4));
     when(commonUtilsService.getEnvProperty(anyInt(), anyString())).thenReturn("1");
     when(commonUtilsService.groupTopicsByEnv(any())).thenReturn(getSyncTopics("topic", 4));
@@ -989,7 +992,7 @@ public class TopicControllerServiceTest {
     List<Topic> syncTopics = getSyncTopics("topic", 4);
     syncTopics.get(0).setEnvironmentsList(List.of("1", "2"));
     syncTopics.get(0).setTopicname("testtopic");
-    when(handleDbRequests.selectAllTopicsByTopictypeAndTeamname(anyString(), anyInt(), anyInt()))
+    when(handleDbRequests.getAllTopicsByTopictypeAndTeamname(anyString(), anyInt(), anyInt()))
         .thenReturn(getSyncTopics("topic", 4));
     when(commonUtilsService.getEnvProperty(anyInt(), anyString())).thenReturn("1");
     when(commonUtilsService.groupTopicsByEnv(any())).thenReturn(getSyncTopics("topic", 4));
@@ -1029,7 +1032,7 @@ public class TopicControllerServiceTest {
     TopicRequest topicRequest = getTopicRequest(topicName);
 
     stubUserInfo();
-    when(handleDbRequests.selectTopicRequestsForTopic(anyInt(), anyInt())).thenReturn(topicRequest);
+    when(handleDbRequests.getTopicRequestsForTopic(anyInt(), anyInt())).thenReturn(topicRequest);
     when(commonUtilsService.isNotAuthorizedUser(any(), any())).thenReturn(false);
     when(commonUtilsService.getEnvsFromUserId(anyString()))
         .thenReturn(new HashSet<>(Collections.singletonList("1")));
@@ -1049,7 +1052,7 @@ public class TopicControllerServiceTest {
     topicRequest.setRequestStatus(RequestStatus.APPROVED.value);
 
     stubUserInfo();
-    when(handleDbRequests.selectTopicRequestsForTopic(anyInt(), anyInt())).thenReturn(topicRequest);
+    when(handleDbRequests.getTopicRequestsForTopic(anyInt(), anyInt())).thenReturn(topicRequest);
     when(commonUtilsService.isNotAuthorizedUser(any(), any())).thenReturn(false);
     when(handleDbRequests.declineTopicRequest(any(), anyString()))
         .thenReturn(ApiResultStatus.SUCCESS.value);
@@ -1098,7 +1101,7 @@ public class TopicControllerServiceTest {
   @Test
   @Order(43)
   public void getExistingTopicRequests() {
-    when(handleDbRequests.selectTopicRequests(anyString(), anyString(), anyString(), anyInt()))
+    when(handleDbRequests.getTopicRequests(anyString(), anyString(), anyString(), anyInt()))
         .thenReturn(utilMethods.getTopicRequests());
     List<TopicRequest> topicReqResponse =
         topicControllerService.getExistingTopicRequests(
@@ -1217,7 +1220,7 @@ public class TopicControllerServiceTest {
     String envId = "1";
     stubUserInfo();
     when(commonUtilsService.getTenantId(anyString())).thenReturn(101);
-    when(handleDbRequests.selectTopicRequests(anyString(), anyString(), anyString(), anyInt()))
+    when(handleDbRequests.getTopicRequests(anyString(), anyString(), anyString(), anyInt()))
         .thenReturn(Collections.emptyList());
     when(commonUtilsService.getTopicsForTopicName(anyString(), anyInt()))
         .thenReturn(List.of(getTopic(topicName)));
@@ -1225,7 +1228,7 @@ public class TopicControllerServiceTest {
         .thenReturn(List.of(getTopic(topicName)));
     List<UserInfo> userList = utilMethods.getUserInfoList("testuser", "");
     userList.get(0).setTeamId(1);
-    when(handleDbRequests.selectAllUsersInfo(anyInt())).thenReturn(userList);
+    when(handleDbRequests.getAllUsersInfo(anyInt())).thenReturn(userList);
     Map<String, String> claimReqResult = new HashMap<>();
     claimReqResult.put("result", ApiResultStatus.SUCCESS.value);
     when(handleDbRequests.requestForTopic(any())).thenReturn(claimReqResult);

--- a/core/src/test/java/io/aiven/klaw/service/TopicOverviewServiceTest.java
+++ b/core/src/test/java/io/aiven/klaw/service/TopicOverviewServiceTest.java
@@ -273,9 +273,7 @@ public class TopicOverviewServiceTest {
     stubSchemaPromotionInfo(TESTTOPIC, KafkaClustersType.KAFKA, 15);
 
     when(commonUtilsService.getEnvProperty(eq(101), eq("ORDER_OF_ENVS"))).thenReturn("1");
-    when(handleDbRequests.getTopicTeam(eq(TESTTOPIC), eq(101)))
-        .thenReturn(List.of(createTopic(TESTTOPIC)));
-    when(handleDbRequests.getTopics(eq(TESTTOPIC), eq(101)))
+    when(commonUtilsService.getTopicsForTopicName(eq(TESTTOPIC), eq(101)))
         .thenReturn(List.of(createTopic(TESTTOPIC)));
     when(handleDbRequests.getSyncAcls(anyString(), eq(TESTTOPIC), eq(101)))
         .thenReturn(createAcls(20));

--- a/core/src/test/java/io/aiven/klaw/service/TopicOverviewServiceTest.java
+++ b/core/src/test/java/io/aiven/klaw/service/TopicOverviewServiceTest.java
@@ -104,10 +104,8 @@ public class TopicOverviewServiceTest {
         .thenReturn(new HashSet<>(Collections.singletonList("1")));
     when(manageDatabase.getKwPropertyValue(anyString(), anyInt())).thenReturn("true");
     when(manageDatabase.getKafkaEnvList(anyInt())).thenReturn(utilMethods.getEnvLists());
-    when(handleDbRequests.selectAllTeamsOfUsers(anyString(), anyInt()))
+    when(handleDbRequests.getAllTeamsOfUsers(anyString(), anyInt()))
         .thenReturn(utilMethods.getTeams());
-    when(handleDbRequests.getTopics(anyString(), anyInt()))
-        .thenReturn(utilMethods.getTopics(TESTTOPIC));
     when(handleDbRequests.getSyncAcls(anyString(), anyString(), anyInt()))
         .thenReturn(getAclsSOT(TESTTOPIC));
     when(commonUtilsService.getTopicsForTopicName(anyString(), anyInt()))
@@ -141,7 +139,7 @@ public class TopicOverviewServiceTest {
         .thenReturn(new HashSet<>(Collections.singletonList("1")));
     when(manageDatabase.getKwPropertyValue(anyString(), anyInt())).thenReturn("true");
     when(manageDatabase.getKafkaEnvList(anyInt())).thenReturn(utilMethods.getEnvLists());
-    when(handleDbRequests.selectAllTeamsOfUsers(anyString(), anyInt()))
+    when(handleDbRequests.getAllTeamsOfUsers(anyString(), anyInt()))
         .thenReturn(utilMethods.getTeams());
     when(handleDbRequests.getTopics(anyString(), anyInt()))
         .thenReturn(utilMethods.getTopics(topicNameSearch));
@@ -175,8 +173,8 @@ public class TopicOverviewServiceTest {
     stubUserInfo();
     stubKafkaPromotion(TESTTOPIC, 1);
     stubSchemaPromotionInfo(TESTTOPIC, KafkaClustersType.KAFKA, 15);
-    when(handleDbRequests.getTopics(TESTTOPIC, 101))
-        .thenReturn(Arrays.asList(createTopic(TESTTOPIC)));
+    when(commonUtilsService.getTopicsForTopicName(TESTTOPIC, 101))
+        .thenReturn(List.of(createTopic(TESTTOPIC)));
     when(commonUtilsService.getEnvProperty(eq(101), eq("REQUEST_TOPICS_OF_ENVS"))).thenReturn("1");
     when(commonUtilsService.getEnvProperty(eq(101), eq("ORDER_OF_ENVS"))).thenReturn("1");
 
@@ -192,7 +190,7 @@ public class TopicOverviewServiceTest {
     stubUserInfo();
     stubKafkaPromotion(TESTTOPIC, 15);
     stubSchemaPromotionInfo(TESTTOPIC, KafkaClustersType.KAFKA, 15);
-    when(handleDbRequests.getTopics(TESTTOPIC, 101))
+    when(commonUtilsService.getTopicsForTopicName(TESTTOPIC, 101))
         .thenReturn(Arrays.asList(createTopic(TESTTOPIC)));
     when(commonUtilsService.getEnvProperty(eq(101), eq("REQUEST_TOPICS_OF_ENVS")))
         .thenReturn("1,2,3,4,5,6,7,8,9,10,11,12,13,14,15");
@@ -234,10 +232,8 @@ public class TopicOverviewServiceTest {
         .thenReturn(new HashSet<>(Collections.singletonList("1")));
     when(manageDatabase.getKwPropertyValue(anyString(), anyInt())).thenReturn("true");
     when(manageDatabase.getKafkaEnvList(anyInt())).thenReturn(utilMethods.getEnvLists());
-    when(handleDbRequests.selectAllTeamsOfUsers(anyString(), anyInt()))
+    when(handleDbRequests.getAllTeamsOfUsers(anyString(), anyInt()))
         .thenReturn(utilMethods.getTeams());
-    when(handleDbRequests.getTopics(anyString(), anyInt()))
-        .thenReturn(utilMethods.getTopics(TESTTOPIC));
     when(handleDbRequests.getSyncAcls(anyString(), anyString(), anyInt()))
         .thenReturn(getAclsSOT(TESTTOPIC));
     when(commonUtilsService.getTopicsForTopicName(anyString(), anyInt()))
@@ -316,7 +312,7 @@ public class TopicOverviewServiceTest {
     when(manageDatabase.getAllEnvList(101))
         .thenReturn(createListOfEnvs(KafkaClustersType.SCHEMA_REGISTRY, numberOfEnvs));
     when(commonUtilsService.getTenantId(any())).thenReturn(101);
-    when(handleDbRequests.selectAllSchemaRegEnvs(101))
+    when(handleDbRequests.getAllSchemaRegEnvs(101))
         .thenReturn(createListOfEnvs(KafkaClustersType.SCHEMA_REGISTRY, numberOfEnvs));
     when(manageDatabase.getClusters(KafkaClustersType.SCHEMA_REGISTRY, 101))
         .thenReturn(createClusterMap(numberOfEnvs));

--- a/core/src/test/java/io/aiven/klaw/service/TopicOverviewServiceTest.java
+++ b/core/src/test/java/io/aiven/klaw/service/TopicOverviewServiceTest.java
@@ -141,8 +141,6 @@ public class TopicOverviewServiceTest {
     when(manageDatabase.getKafkaEnvList(anyInt())).thenReturn(utilMethods.getEnvLists());
     when(handleDbRequests.getAllTeamsOfUsers(anyString(), anyInt()))
         .thenReturn(utilMethods.getTeams());
-    when(handleDbRequests.getTopics(anyString(), anyInt()))
-        .thenReturn(utilMethods.getTopics(topicNameSearch));
     when(handleDbRequests.getSyncAcls(anyString(), anyString(), anyInt()))
         .thenReturn(getAclsSOT(topicNameSearch));
     when(commonUtilsService.getTopicsForTopicName(anyString(), anyInt()))

--- a/core/src/test/java/io/aiven/klaw/service/TopicSyncControllerServiceTest.java
+++ b/core/src/test/java/io/aiven/klaw/service/TopicSyncControllerServiceTest.java
@@ -187,7 +187,7 @@ public class TopicSyncControllerServiceTest {
     when(clusterApiService.getAllTopics(
             anyString(), any(KafkaSupportedProtocol.class), anyString(), anyString(), anyInt()))
         .thenReturn(utilMethods.getClusterApiTopics("topic", 10));
-    when(handleDbRequests.selectAllTeamsOfUsers(anyString(), anyInt()))
+    when(handleDbRequests.getAllTeamsOfUsers(anyString(), anyInt()))
         .thenReturn(getAvailableTeams());
     when(manageDatabase.getClusters(any(KafkaClustersType.class), anyInt()))
         .thenReturn(clustersHashMap);

--- a/core/src/test/java/io/aiven/klaw/service/UiConfigControllerServiceTest.java
+++ b/core/src/test/java/io/aiven/klaw/service/UiConfigControllerServiceTest.java
@@ -125,7 +125,7 @@ public class UiConfigControllerServiceTest {
     stubUserInfo();
     when(commonUtilsService.isNotAuthorizedUser(any(), any())).thenReturn(false);
 
-    when(handleDbRequests.selectAllSchemaRegEnvs(1)).thenReturn(getAllSchemaEnvs());
+    when(handleDbRequests.getAllSchemaRegEnvs(1)).thenReturn(getAllSchemaEnvs());
     List<EnvModelResponse> envsList = envsClustersTenantsControllerService.getSchemaRegEnvs();
 
     assertThat(envsList).isEmpty();
@@ -138,7 +138,7 @@ public class UiConfigControllerServiceTest {
     when(commonUtilsService.isNotAuthorizedUser(any(), any())).thenReturn(false);
     when(commonUtilsService.getEnvProperty(eq(101), eq("ORDER_OF_ENVS"))).thenReturn("DEV,TST");
     when(commonUtilsService.getEnvProperty(eq(101), eq("REQUEST_SCHEMA_OF_ENVS"))).thenReturn("");
-    when(handleDbRequests.selectAllSchemaRegEnvs(1)).thenReturn(getAllSchemaEnvs());
+    when(handleDbRequests.getAllSchemaRegEnvs(1)).thenReturn(getAllSchemaEnvs());
     when(manageDatabase.getSchemaRegEnvList(eq(101))).thenReturn(getAllSchemaEnvs());
     List<EnvModelResponse> envsList =
         envsClustersTenantsControllerService.getEnvsForSchemaRequests();
@@ -155,7 +155,7 @@ public class UiConfigControllerServiceTest {
     when(commonUtilsService.getEnvProperty(eq(101), eq("ORDER_OF_ENVS"))).thenReturn("DEV,TST");
     when(commonUtilsService.getEnvProperty(eq(101), eq("REQUEST_SCHEMA_OF_ENVS")))
         .thenReturn("DEV");
-    when(handleDbRequests.selectAllSchemaRegEnvs(1)).thenReturn(getAllSchemaEnvs());
+    when(handleDbRequests.getAllSchemaRegEnvs(1)).thenReturn(getAllSchemaEnvs());
     when(manageDatabase.getSchemaRegEnvList(eq(101))).thenReturn(getAllSchemaEnvs());
     when(manageDatabase.getClusters(eq(KafkaClustersType.SCHEMA_REGISTRY), eq(101)))
         .thenReturn(getSchemaRegistryClusters());
@@ -175,7 +175,7 @@ public class UiConfigControllerServiceTest {
     when(commonUtilsService.getEnvProperty(eq(101), eq("ORDER_OF_ENVS"))).thenReturn("DEV,TST");
     when(commonUtilsService.getEnvProperty(eq(101), eq("REQUEST_SCHEMA_OF_ENVS")))
         .thenReturn("DEV,sTT");
-    when(handleDbRequests.selectAllSchemaRegEnvs(1)).thenReturn(getAllSchemaEnvs());
+    when(handleDbRequests.getAllSchemaRegEnvs(1)).thenReturn(getAllSchemaEnvs());
     when(manageDatabase.getSchemaRegEnvList(eq(101))).thenReturn(getAllSchemaEnvs());
     when(manageDatabase.getClusters(eq(KafkaClustersType.SCHEMA_REGISTRY), eq(101)))
         .thenReturn(getSchemaRegistryClusters());
@@ -195,7 +195,7 @@ public class UiConfigControllerServiceTest {
     when(commonUtilsService.getEnvProperty(eq(101), eq("ORDER_OF_ENVS"))).thenReturn("DEV,TST");
     when(commonUtilsService.getEnvProperty(eq(101), eq("REQUEST_SCHEMA_OF_ENVS")))
         .thenReturn("DEV,TST");
-    when(handleDbRequests.selectAllSchemaRegEnvs(1)).thenReturn(getAllSchemaEnvs());
+    when(handleDbRequests.getAllSchemaRegEnvs(1)).thenReturn(getAllSchemaEnvs());
     when(manageDatabase.getSchemaRegEnvList(eq(101))).thenReturn(getAllSchemaEnvs());
     when(manageDatabase.getClusters(eq(KafkaClustersType.SCHEMA_REGISTRY), eq(101)))
         .thenReturn(getSchemaRegistryClusters());
@@ -216,7 +216,7 @@ public class UiConfigControllerServiceTest {
     when(commonUtilsService.getEnvProperty(eq(101), eq("ORDER_OF_ENVS"))).thenReturn("DEV,TST,UAT");
     when(commonUtilsService.getEnvProperty(eq(101), eq("REQUEST_SCHEMA_OF_ENVS")))
         .thenReturn("DEV,TST,UAT");
-    when(handleDbRequests.selectAllSchemaRegEnvs(1)).thenReturn(getAllSchemaEnvs());
+    when(handleDbRequests.getAllSchemaRegEnvs(1)).thenReturn(getAllSchemaEnvs());
     when(manageDatabase.getSchemaRegEnvList(eq(101))).thenReturn(getAllSchemaEnvs());
     when(manageDatabase.getClusters(eq(KafkaClustersType.SCHEMA_REGISTRY), eq(101)))
         .thenReturn(getSchemaRegistryClusters());

--- a/core/src/test/java/io/aiven/klaw/service/UsersTeamsControllerServiceTest.java
+++ b/core/src/test/java/io/aiven/klaw/service/UsersTeamsControllerServiceTest.java
@@ -147,7 +147,7 @@ public class UsersTeamsControllerServiceTest {
     when(mailService.getUserName(any())).thenReturn("testuser");
     when(manageDatabase.getRolesPermissionsPerTenant(anyInt()))
         .thenReturn(utilMethods.getRolesPermsMap());
-    when(handleDbRequests.selectAllUsersInfoForTeam(teamId, tenantId))
+    when(handleDbRequests.getAllUsersInfoForTeam(teamId, tenantId))
         .thenReturn(Collections.singletonList(new UserInfo()));
     ApiResponse apiResponse = usersTeamsControllerService.deleteTeam(teamId);
     assertThat(apiResponse.getMessage())
@@ -162,7 +162,7 @@ public class UsersTeamsControllerServiceTest {
     when(commonUtilsService.getTenantId(anyString())).thenReturn(101);
     when(mailService.getUserName(any())).thenReturn("testuser");
     when(manageDatabase.getRolesPermissionsPerTenant(anyInt())).thenReturn(new HashMap<>());
-    when(handleDbRequests.findAllComponentsCountForUser("testuser", 101)).thenReturn(1);
+    when(handleDbRequests.getAllComponentsCountForUser("testuser", 101)).thenReturn(1);
     ApiResponse apiResponse = usersTeamsControllerService.deleteUser("testuser", false);
     assertThat(apiResponse.getMessage())
         .isEqualTo(
@@ -178,7 +178,7 @@ public class UsersTeamsControllerServiceTest {
     when(mailService.getUserName(any())).thenReturn("testuser");
     when(manageDatabase.getRolesPermissionsPerTenant(anyInt()))
         .thenReturn(utilMethods.getRolesPermsMap());
-    when(handleDbRequests.findAllComponentsCountForUser("testuser", 101)).thenReturn(1);
+    when(handleDbRequests.getAllComponentsCountForUser("testuser", 101)).thenReturn(1);
     ApiResponse apiResponse = usersTeamsControllerService.deleteUser("testuser", false);
     assertThat(apiResponse.getMessage())
         .isEqualTo("Not Authorized. Cannot delete a user with SUPERADMIN access.");

--- a/docker-scripts/deploy-kubernetes.yaml
+++ b/docker-scripts/deploy-kubernetes.yaml
@@ -1,0 +1,96 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: klaw-core
+spec:
+  selector:
+    app: klaw-core
+  ports:
+    - name: http
+      port: 9097
+      targetPort: 9097
+  type: ClusterIP
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: klaw-core
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: klaw-core
+  template:
+    metadata:
+      labels:
+        app: klaw-core
+    spec:
+      containers:
+        - name: klaw-core
+          image: aivenoy/klaw-core:latest
+          env:
+            - name: KLAW_CLUSTERAPI_ACCESS_BASE64_SECRET
+              value: "dGhpcyBpcyBhIHNlY3JldCB0byBhY2Nlc3MgY2x1c3RlcmFwaQ=="
+            - name: SPRING_DATASOURCE_URL
+              value: "jdbc:h2:file:/klaw/klawprodb;DB_CLOSE_ON_EXIT=FALSE;DB_CLOSE_DELAY=-1;MODE=MySQL;CASE_INSENSITIVE_IDENTIFIERS=TRUE;"
+          volumeMounts:
+            - name: klaw-data
+              mountPath: /klaw
+      volumes:
+        - name: klaw-data
+          persistentVolumeClaim:
+            claimName: klaw-data
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: klaw-cluster-api
+spec:
+  selector:
+    app: klaw-cluster-api
+  ports:
+    - name: http
+      port: 9343
+      targetPort: 9343
+  type: ClusterIP
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: klaw-cluster-api
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: klaw-cluster-api
+  template:
+    metadata:
+      labels:
+        app: klaw-cluster-api
+    spec:
+      containers:
+        - name: klaw-cluster-api
+          image: aivenoy/klaw-cluster-api:latest
+          env:
+            - name: KLAW_CLUSTERAPI_ACCESS_BASE64_SECRET
+              value: "dGhpcyBpcyBhIHNlY3JldCB0byBhY2Nlc3MgY2x1c3RlcmFwaQ=="
+          volumeMounts:
+            - name: klaw-data
+              mountPath: /klaw
+      volumes:
+        - name: klaw-data
+          persistentVolumeClaim:
+            claimName: klaw-data
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: klaw-data
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 1Gi
+  storageClassName: kops-csi-1-21
+

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1979,10 +1979,7 @@
             "content" : {
               "application/json" : {
                 "schema" : {
-                  "type" : "object",
-                  "additionalProperties" : {
-                    "type" : "string"
-                  }
+                  "$ref" : "#/components/schemas/ConnectivityStatus"
                 }
               }
             }
@@ -5969,6 +5966,16 @@
           }
         },
         "required" : [ "contactperson", "showDeleteTeam", "teamId", "teamname", "teamphone", "tenantId", "tenantName" ]
+      },
+      "ConnectivityStatus" : {
+        "properties" : {
+          "clusterType" : {
+            "type" : "string"
+          },
+          "connectionStatus" : {
+            "type" : "string"
+          }
+        }
       },
       "UserInfoModelResponse" : {
         "properties" : {


### PR DESCRIPTION
About this change - What it does

- Display relevant errors in case of cluster api connectivity errors
- Cluster api url test connectivity without saving url first, and if success, save directly.
- Renaming "select*" methods in DbHelper to "get*"
- Replace getTopics call in TopicOverviewService with commonUtils

Resolves: #959
Why this way

For better user experience