### PR TITLE
fix(coral): Add controlled value for MultiSelect

### DIFF
--- a/coral/src/app/components/Form.tsx
+++ b/coral/src/app/components/Form.tsx
@@ -363,6 +363,12 @@ function _MultiSelect<T extends FieldValues, FieldValue>({
       valid={error === undefined}
       error={error}
       helperText={helperText}
+      // If we do not explicitly pass value to the component
+      // It will not display values stored in the form object
+      // If they are set before the component is rendered
+      // This is because we are rendering BaseMultiSelect without a Controller
+      // But its value still needs to be controlled
+      value={form.getValues(name)}
     />
   );
 }


### PR DESCRIPTION
## What happened

Having `MultiSelect` be rendered oustide of a `Controller` component had the side effect of introducing a desync bwteen the value stored in the `form` and the value displayed by the component. This would happen when a value is set in the `form` before the component is rendered, most notably in ACL request form, when switching between an Aiven cluster environment and a non Aiven cluster environment:


https://user-images.githubusercontent.com/20607294/232729487-ac14a38e-d149-4378-bf9d-18f1ce601da6.mov

## How we fix it

We make `BaseMultiSelect` a controlled input by adding the `value` prop explicitly, fixing the issue:

https://user-images.githubusercontent.com/20607294/232730139-cc1a9e65-4f39-4f66-ac26-d0d9bbd029ca.mov




 
