### PR TITLE
Topic overview per environment

### DIFF
--- a/coral/src/services/api.ts
+++ b/coral/src/services/api.ts
@@ -179,7 +179,7 @@ const API_PATHS: { [key in keyof ApiOperations]: keyof ApiPaths } = {
   showActivityLog: "/getActivityLogPerEnv",
   getActivityLogForTeamOverview: "/getActivityLogForTeamOverview",
   getActivationInfo: "/getActivationInfo",
-  getAcls: "/getAcls",
+  getTopicOverview: "/getTopicOverview",
   getAclsCountPerEnv: "/getAclsCountPerEnv",
   getAclRequests: "/getAclRequests",
   getAclRequestsForApprover: "/getAclRequestsForApprover",

--- a/coral/types/api.d.ts
+++ b/coral/types/api.d.ts
@@ -258,6 +258,9 @@ export type paths = {
   "/getTopicRequestsForApprover": {
     get: operations["getTopicRequestsForApprover"];
   };
+  "/getTopicOverview": {
+    get: operations["getTopicOverview"];
+  };
   "/getTopicEvents": {
     get: operations["getTopicEvents"];
   };
@@ -449,9 +452,6 @@ export type paths = {
   };
   "/getActivationInfo": {
     get: operations["getActivationInfo"];
-  };
-  "/getAcls": {
-    get: operations["getAcls"];
   };
   "/getAclsCountPerEnv": {
     get: operations["getAclsCountPerEnv"];
@@ -926,6 +926,64 @@ export type components = {
       deletable?: boolean;
       editable?: boolean;
     };
+    AclInfo: {
+      sequence?: string;
+      req_no?: string;
+      acl_ip?: string;
+      acl_ssl?: string;
+      acl_ips?: (string)[];
+      acl_ssls?: (string)[];
+      topicname?: string;
+      topictype?: string;
+      consumergroup?: string;
+      environment?: string;
+      environmentName?: string;
+      teamname?: string;
+      /** Format: int32 */
+      teamid?: number;
+      operation?: string;
+      permission?: string;
+      transactionalId?: string;
+      aclPatternType?: string;
+      totalNoPages?: string;
+      allPageNos?: (string)[];
+      possibleTeams?: (string)[];
+      currentPage?: string;
+      showDeleteAcl?: boolean;
+      /** @enum {string} */
+      kafkaFlavorType?: "APACHE_KAFKA" | "AIVEN_FOR_APACHE_KAFKA" | "CONFLUENT" | "CONFLUENT_CLOUD" | "OTHERS";
+    };
+    EnvIdInfo: {
+      id?: string;
+      name?: string;
+    };
+    TopicHistory: {
+      environmentName?: string;
+      teamName?: string;
+      requestedBy?: string;
+      requestedTime?: string;
+      approvedBy?: string;
+      approvedTime?: string;
+      remarks?: string;
+    };
+    TopicOverview: {
+      topicExists?: boolean;
+      schemaExists?: boolean;
+      prefixAclsExists?: boolean;
+      txnAclsExists?: boolean;
+      topicInfoList?: (components["schemas"]["TopicInfo"])[];
+      aclInfoList?: (components["schemas"]["AclInfo"])[];
+      prefixedAclInfoList?: (components["schemas"]["AclInfo"])[];
+      transactionalAclInfoList?: (components["schemas"]["AclInfo"])[];
+      topicHistoryList?: (components["schemas"]["TopicHistory"])[];
+      topicPromotionDetails?: {
+        [key: string]: string | undefined;
+      };
+      availableEnvironments?: (components["schemas"]["EnvIdInfo"])[];
+      topicDocumentation?: string;
+      /** Format: int32 */
+      topicIdForDocumentation?: number;
+    };
     TopicDetailsPerEnv: {
       topicExists: boolean;
       error?: string;
@@ -990,10 +1048,6 @@ export type components = {
       /** Format: int32 */
       allTopicsCount?: number;
     };
-    EnvIdInfo: {
-      id?: string;
-      name?: string;
-    };
     KafkaConnectorModelResponse: {
       /** Format: int32 */
       sequence?: number;
@@ -1042,33 +1096,6 @@ export type components = {
       maxReplicationFactor?: string;
       /** @enum {string} */
       clusterType?: "ALL" | "KAFKA" | "SCHEMA_REGISTRY" | "KAFKA_CONNECT";
-    };
-    AclInfo: {
-      sequence?: string;
-      req_no?: string;
-      acl_ip?: string;
-      acl_ssl?: string;
-      acl_ips?: (string)[];
-      acl_ssls?: (string)[];
-      topicname?: string;
-      topictype?: string;
-      consumergroup?: string;
-      environment?: string;
-      environmentName?: string;
-      teamname?: string;
-      /** Format: int32 */
-      teamid?: number;
-      operation?: string;
-      permission?: string;
-      transactionalId?: string;
-      aclPatternType?: string;
-      totalNoPages?: string;
-      allPageNos?: (string)[];
-      possibleTeams?: (string)[];
-      currentPage?: string;
-      showDeleteAcl?: boolean;
-      /** @enum {string} */
-      kafkaFlavorType?: "APACHE_KAFKA" | "AIVEN_FOR_APACHE_KAFKA" | "CONFLUENT" | "CONFLUENT_CLOUD" | "OTHERS";
     };
     SchemaRequestsResponseModel: {
       environment: string;
@@ -1201,15 +1228,6 @@ export type components = {
       /** Format: int32 */
       topicIdForDocumentation?: number;
     };
-    TopicHistory: {
-      environmentName?: string;
-      teamName?: string;
-      requestedBy?: string;
-      requestedTime?: string;
-      approvedBy?: string;
-      approvedTime?: string;
-      remarks?: string;
-    };
     ConnectorOverviewPerEnv: {
       connectorExists?: boolean;
       error?: string;
@@ -1328,23 +1346,6 @@ export type components = {
       totalNoPages?: string;
       currentPage?: string;
       allPageNos?: (string)[];
-    };
-    TopicOverview: {
-      topicExists?: boolean;
-      schemaExists?: boolean;
-      prefixAclsExists?: boolean;
-      txnAclsExists?: boolean;
-      topicInfoList?: (components["schemas"]["TopicInfo"])[];
-      aclInfoList?: (components["schemas"]["AclInfo"])[];
-      prefixedAclInfoList?: (components["schemas"]["AclInfo"])[];
-      transactionalAclInfoList?: (components["schemas"]["AclInfo"])[];
-      topicHistoryList?: (components["schemas"]["TopicHistory"])[];
-      topicPromotionDetails?: {
-        [key: string]: string | undefined;
-      };
-      topicDocumentation?: string;
-      /** Format: int32 */
-      topicIdForDocumentation?: number;
     };
     AclsCountPerEnv: {
       status?: string;
@@ -2700,6 +2701,23 @@ export type operations = {
       };
     };
   };
+  getTopicOverview: {
+    parameters: {
+      query: {
+        topicName: string;
+        environmentId?: string;
+        groupBy?: "NONE" | "TEAM";
+      };
+    };
+    responses: {
+      /** @description OK */
+      200: {
+        content: {
+          "application/json": components["schemas"]["TopicOverview"];
+        };
+      };
+    };
+  };
   getTopicEvents: {
     parameters: {
       query: {
@@ -2947,7 +2965,7 @@ export type operations = {
   getSchemaOfTopic: {
     parameters: {
       query: {
-        topicnamesearch: string;
+        topicName: string;
         schemaVersionSearch?: string;
         kafkaEnvIds: (string)[];
       };
@@ -3565,22 +3583,6 @@ export type operations = {
       200: {
         content: {
           "application/json": components["schemas"]["ApiResponse"];
-        };
-      };
-    };
-  };
-  getAcls: {
-    parameters: {
-      query: {
-        topicnamesearch: string;
-        groupBy?: "NONE" | "TEAM";
-      };
-    };
-    responses: {
-      /** @description OK */
-      200: {
-        content: {
-          "application/json": components["schemas"]["TopicOverview"];
         };
       };
     };

--- a/core/src/main/java/io/aiven/klaw/controller/AclController.java
+++ b/core/src/main/java/io/aiven/klaw/controller/AclController.java
@@ -173,15 +173,16 @@ public class AclController {
   }
 
   @RequestMapping(
-      value = "/getAcls",
+      value = "/getTopicOverview",
       method = RequestMethod.GET,
       produces = {MediaType.APPLICATION_JSON_VALUE})
-  public ResponseEntity<TopicOverview> getAcls(
-      @RequestParam(value = "topicnamesearch") String topicNameSearch,
+  public ResponseEntity<TopicOverview> getTopicOverview(
+      @RequestParam(value = "topicName") String topicName,
+      @RequestParam(value = "environmentId", defaultValue = "") String environmentId,
       @RequestParam(value = "groupBy", required = false, defaultValue = "NONE")
           AclGroupBy groupBy) {
     return new ResponseEntity<>(
-        topicOverviewService.getTopicOverview(topicNameSearch, groupBy), HttpStatus.OK);
+        topicOverviewService.getTopicOverview(topicName, environmentId, groupBy), HttpStatus.OK);
   }
 
   // getConsumerOffsets from kafka cluster

--- a/core/src/main/java/io/aiven/klaw/controller/SchemaRegistryController.java
+++ b/core/src/main/java/io/aiven/klaw/controller/SchemaRegistryController.java
@@ -178,7 +178,7 @@ public class SchemaRegistryController {
   }
 
   /**
-   * @param topicNameSearch Get schema of this topic
+   * @param topicName Get schema of this topic
    * @param schemaVersionSearch Version of the schema if applicable
    * @param kafkaEnvIds env ids of the topic where it exists
    * @return SchemaOverview which contains schema and list of versions, compatibility, and promotion
@@ -189,11 +189,11 @@ public class SchemaRegistryController {
       method = RequestMethod.GET,
       produces = {MediaType.APPLICATION_JSON_VALUE})
   public ResponseEntity<SchemaOverview> getSchemaOfTopic(
-      @RequestParam(value = "topicnamesearch") String topicNameSearch,
+      @RequestParam(value = "topicName") String topicName,
       @RequestParam(value = "schemaVersionSearch", defaultValue = "") String schemaVersionSearch,
       @RequestParam(value = "kafkaEnvIds") List<String> kafkaEnvIds) {
     return new ResponseEntity<>(
-        schemaOverviewService.getSchemaOfTopic(topicNameSearch, schemaVersionSearch, kafkaEnvIds),
+        schemaOverviewService.getSchemaOfTopic(topicName, schemaVersionSearch, kafkaEnvIds),
         HttpStatus.OK);
   }
 

--- a/core/src/main/java/io/aiven/klaw/helpers/KwConstants.java
+++ b/core/src/main/java/io/aiven/klaw/helpers/KwConstants.java
@@ -81,6 +81,10 @@ public class KwConstants {
   public static final String MAIL_SMTP_TLS = "true";
   public static final String MAIL_DEBUG = "false";
 
+  public static final String REQUEST_TOPICS_OF_ENVS = "REQUEST_TOPICS_OF_ENVS";
+
+  public static final String ORDER_OF_TOPIC_ENVS = "ORDER_OF_ENVS";
+
   public static final int DAYS_EXPIRY_DEFAULT_TENANT = 365 * 10;
   public static final int DAYS_TRIAL_PERIOD = 7;
 

--- a/core/src/main/java/io/aiven/klaw/model/response/TopicOverview.java
+++ b/core/src/main/java/io/aiven/klaw/model/response/TopicOverview.java
@@ -15,6 +15,7 @@ public class TopicOverview extends ResourceOverviewAttributes {
   List<AclInfo> transactionalAclInfoList;
   private List<TopicHistory> topicHistoryList;
   Map<String, String> topicPromotionDetails;
+  List<EnvIdInfo> availableEnvironments;
 
   String topicDocumentation;
   Integer topicIdForDocumentation;

--- a/core/src/main/java/io/aiven/klaw/service/BaseOverviewService.java
+++ b/core/src/main/java/io/aiven/klaw/service/BaseOverviewService.java
@@ -97,7 +97,6 @@ public abstract class BaseOverviewService {
       aclInfo = mergeReduceAclInfo(aclInfo);
       aclInfo.sort(
           Comparator.comparing(AclInfo::getTeamname, nullSafeStringComparator)
-              .thenComparing(AclInfo::getEnvironmentName, nullSafeStringComparator)
               .thenComparing(AclInfo::getConsumergroup, nullSafeStringComparator));
     }
 

--- a/core/src/main/java/io/aiven/klaw/service/BaseOverviewService.java
+++ b/core/src/main/java/io/aiven/klaw/service/BaseOverviewService.java
@@ -46,6 +46,7 @@ public abstract class BaseOverviewService {
   public static final TypeReference<ArrayList<TopicHistory>> VALUE_TYPE_REF =
       new TypeReference<>() {};
   private static final String MASKED_FOR_SECURITY = BASE_OVERVIEW_101;
+  public static final String NO_PROMOTION = "NO_PROMOTION";
   @Autowired protected ManageDatabase manageDatabase;
   @Autowired protected ClusterApiService clusterApiService;
   @Autowired protected CommonUtilsService commonUtilsService;
@@ -287,19 +288,27 @@ public abstract class BaseOverviewService {
       int tenantId, Map<String, String> hashMap, List<String> envList, String orderOfEnvs) {
     if (envList != null && envList.size() > 0) {
       // tenant filtering
-      envList.sort(Comparator.comparingInt(orderOfEnvs::indexOf));
+      if (orderOfEnvs == null || orderOfEnvs.equals("")) {
+        hashMap.put("status", NO_PROMOTION);
+        return;
+      }
+      envList.sort(Comparator.comparingInt(Objects.requireNonNull(orderOfEnvs)::indexOf));
 
       String lastEnv = envList.get(envList.size() - 1);
-      List<String> orderedEnvs = Arrays.asList(orderOfEnvs.split(","));
+      List<String> orderedEnvsList = Arrays.asList(orderOfEnvs.split(","));
 
-      if (orderedEnvs.indexOf(lastEnv) == orderedEnvs.size() - 1) {
-        hashMap.put("status", "NO_PROMOTION"); // PRD
+      if (orderedEnvsList.indexOf(lastEnv) == orderedEnvsList.size() - 1) {
+        hashMap.put("status", NO_PROMOTION);
       } else {
-        hashMap.put("status", ApiResultStatus.SUCCESS.value);
-        hashMap.put("sourceEnv", lastEnv);
-        String targetEnv = orderedEnvs.get(orderedEnvs.indexOf(lastEnv) + 1);
-        hashMap.put("targetEnv", getEnvDetails(targetEnv, tenantId).getName());
-        hashMap.put("targetEnvId", targetEnv);
+        if (orderedEnvsList.size() > 0) {
+          hashMap.put("status", ApiResultStatus.SUCCESS.value);
+          hashMap.put("sourceEnv", lastEnv);
+          String targetEnv = orderedEnvsList.get(orderedEnvsList.indexOf(lastEnv) + 1);
+          hashMap.put("targetEnv", getEnvDetails(targetEnv, tenantId).getName());
+          hashMap.put("targetEnvId", targetEnv);
+        } else {
+          hashMap.put("status", NO_PROMOTION);
+        }
       }
     }
   }

--- a/core/src/main/java/io/aiven/klaw/service/CommonUtilsService.java
+++ b/core/src/main/java/io/aiven/klaw/service/CommonUtilsService.java
@@ -1,5 +1,7 @@
 package io.aiven.klaw.service;
 
+import static io.aiven.klaw.helpers.KwConstants.ORDER_OF_TOPIC_ENVS;
+
 import io.aiven.klaw.config.ManageDatabase;
 import io.aiven.klaw.dao.Env;
 import io.aiven.klaw.dao.Topic;
@@ -514,7 +516,7 @@ public class CommonUtilsService {
   }
 
   protected String getSchemaPromotionEnvsFromKafkaEnvs(int tenantId) {
-    String kafkaEnvs = getEnvProperty(tenantId, "ORDER_OF_ENVS");
+    String kafkaEnvs = getEnvProperty(tenantId, ORDER_OF_TOPIC_ENVS);
     String[] kafkaEnvIdsList = kafkaEnvs.split(",");
     StringBuilder orderOfSchemaEnvs = new StringBuilder();
 

--- a/core/src/main/java/io/aiven/klaw/service/TopicOverviewService.java
+++ b/core/src/main/java/io/aiven/klaw/service/TopicOverviewService.java
@@ -1,9 +1,11 @@
 package io.aiven.klaw.service;
 
 import static io.aiven.klaw.error.KlawErrorMessages.TOPIC_OVW_ERR_101;
+import static io.aiven.klaw.helpers.KwConstants.ORDER_OF_TOPIC_ENVS;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import io.aiven.klaw.dao.Acl;
+import io.aiven.klaw.dao.Env;
 import io.aiven.klaw.dao.Topic;
 import io.aiven.klaw.helpers.HandleDbRequests;
 import io.aiven.klaw.model.AclInfo;
@@ -11,17 +13,19 @@ import io.aiven.klaw.model.TopicHistory;
 import io.aiven.klaw.model.TopicInfo;
 import io.aiven.klaw.model.enums.AclGroupBy;
 import io.aiven.klaw.model.enums.ApiResultStatus;
+import io.aiven.klaw.model.response.EnvIdInfo;
 import io.aiven.klaw.model.response.TopicOverview;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Comparator;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.tuple.Pair;
 import org.springframework.stereotype.Service;
 
 @Slf4j
@@ -32,11 +36,12 @@ public class TopicOverviewService extends BaseOverviewService {
     super(mailService);
   }
 
-  public TopicOverview getTopicOverview(String topicNameSearch, AclGroupBy groupBy) {
-    log.debug("getAcls {}", topicNameSearch);
+  public TopicOverview getTopicOverview(
+      String topicName, String environmentId, AclGroupBy groupBy) {
+    log.debug("getTopicOverview {}", topicName);
 
-    if (topicNameSearch != null) {
-      topicNameSearch = topicNameSearch.trim();
+    if (topicName != null) {
+      topicName = topicName.trim();
     } else {
       return null;
     }
@@ -46,7 +51,7 @@ public class TopicOverviewService extends BaseOverviewService {
     int tenantId = commonUtilsService.getTenantId(userName);
 
     Integer loggedInUserTeam = commonUtilsService.getTeamId(userName);
-    List<Topic> topics = commonUtilsService.getTopicsForTopicName(topicNameSearch, tenantId);
+    List<Topic> topics = commonUtilsService.getTopicsForTopicName(topicName, tenantId);
 
     // tenant filtering
     final Set<String> allowedEnvIdSet = commonUtilsService.getEnvsFromUserId(userName);
@@ -55,6 +60,7 @@ public class TopicOverviewService extends BaseOverviewService {
             .filter(topicObj -> allowedEnvIdSet.contains(topicObj.getEnvironment()))
             .collect(Collectors.toList());
 
+    List<Topic> originalSetTopics = new ArrayList<>(topics);
     TopicOverview topicOverview = new TopicOverview();
 
     if (topics.size() == 0) {
@@ -64,23 +70,17 @@ public class TopicOverviewService extends BaseOverviewService {
       topicOverview.setTopicExists(true);
     }
 
+    Pair<String, List<Topic>> topicsPair =
+        filterByEnvIdParameter(environmentId, tenantId, topics, topicOverview);
+    environmentId = topicsPair.getKey();
+    topics = topicsPair.getValue();
+
     String syncCluster;
-    String[] reqTopicsEnvs;
-    Set<String> reqTopicsEnvsList = new HashSet<>();
     try {
       syncCluster = manageDatabase.getTenantConfig().get(tenantId).getBaseSyncEnvironment();
     } catch (Exception exception) {
       log.error("Exception while getting syncCluster. Ignored. ", exception);
       syncCluster = null;
-    }
-
-    try {
-      String requestTopicsEnvs =
-          commonUtilsService.getEnvProperty(tenantId, "REQUEST_TOPICS_OF_ENVS");
-      reqTopicsEnvs = requestTopicsEnvs.split(",");
-      reqTopicsEnvsList = new HashSet<>(Arrays.asList(reqTopicsEnvs));
-    } catch (Exception exception) {
-      log.error("Error in getting req topic envs", exception);
     }
 
     List<TopicInfo> topicInfoList = new ArrayList<>();
@@ -89,14 +89,13 @@ public class TopicOverviewService extends BaseOverviewService {
         tenantId, topics, topicOverview, syncCluster, topicInfoList, topicHistoryList);
     List<AclInfo> aclInfo = new ArrayList<>();
     List<AclInfo> prefixedAclsInfo = new ArrayList<>();
-    List<Topic> topicsSearchList =
-        commonUtilsService.getTopicsForTopicName(topicNameSearch, tenantId);
+    List<Topic> topicsSearchList = commonUtilsService.getTopicsForTopicName(topicName, tenantId);
     // tenant filtering
     Integer topicOwnerTeamId =
         commonUtilsService.getFilteredTopicsForTenant(topicsSearchList).get(0).getTeamId();
 
     enrichTopicInfoList(
-        topicNameSearch,
+        topicName,
         handleDb,
         tenantId,
         loggedInUserTeam,
@@ -109,16 +108,64 @@ public class TopicOverviewService extends BaseOverviewService {
         getAclInfoList(tenantId, topicOverview, topicInfoList, aclInfo, prefixedAclsInfo, groupBy);
 
     updateTopicOverviewItems(
-        topicNameSearch,
+        topicName,
         tenantId,
         loggedInUserTeam,
-        topics,
+        originalSetTopics,
         topicOverview,
         topicInfoList,
         aclInfo,
-        topicOwnerTeamId);
+        topicOwnerTeamId,
+        environmentId);
 
     return topicOverview;
+  }
+
+  private Pair<String, List<Topic>> filterByEnvIdParameter(
+      String environmentId, int tenantId, List<Topic> topics, TopicOverview topicOverview) {
+    List<EnvIdInfo> availableEnvs = new ArrayList<>();
+    List<EnvIdInfo> availableEnvsNotInPromotionOrder = new ArrayList<>();
+    String orderOfEnvs = commonUtilsService.getEnvProperty(tenantId, ORDER_OF_TOPIC_ENVS);
+    List<String> orderOfEnvsArrayList = getOrderedEnvsList(orderOfEnvs);
+    topics.forEach(
+        topic -> {
+          EnvIdInfo envIdInfo = new EnvIdInfo();
+          envIdInfo.setId(topic.getEnvironment());
+          envIdInfo.setName(
+              manageDatabase.getKafkaEnvList(tenantId).stream()
+                  .filter(env -> env.getId().equals(topic.getEnvironment()))
+                  .map(Env::getName)
+                  .findFirst()
+                  .orElse("ENV_NOT_FOUND"));
+          if (orderOfEnvsArrayList.contains(envIdInfo.getId())) {
+            availableEnvs.add(envIdInfo);
+          } else {
+            availableEnvsNotInPromotionOrder.add(envIdInfo);
+          }
+        });
+
+    availableEnvs.sort(
+        Comparator.comparingInt(
+            topicEnv -> Objects.requireNonNull(orderOfEnvs).indexOf(topicEnv.getId())));
+    availableEnvs.addAll(availableEnvsNotInPromotionOrder);
+    topicOverview.setAvailableEnvironments(availableEnvs);
+
+    if (Objects.equals(environmentId, "")) {
+      environmentId = availableEnvs.get(0).getId();
+    }
+    String finalEnvironmentId = environmentId;
+    topics =
+        topics.stream().filter(topic -> topic.getEnvironment().equals(finalEnvironmentId)).toList();
+    return Pair.of(environmentId, topics);
+  }
+
+  private static List<String> getOrderedEnvsList(String orderOfEnvs) {
+    List<String> orderOfEnvsArrayList = new ArrayList<>();
+    if (orderOfEnvs != null && !orderOfEnvs.equals("")) {
+      String[] orderOfEnvsList = orderOfEnvs.split(",");
+      orderOfEnvsArrayList = Arrays.asList(orderOfEnvsList);
+    }
+    return orderOfEnvsArrayList;
   }
 
   private void enrichTopicInfoList(
@@ -210,15 +257,16 @@ public class TopicOverviewService extends BaseOverviewService {
       String topicNameSearch,
       int tenantId,
       Integer loggedInUserTeam,
-      List<Topic> topics,
+      List<Topic> originalSetTopics,
       TopicOverview topicOverview,
       List<TopicInfo> topicInfoList,
       List<AclInfo> aclInfo,
-      Integer topicOwnerTeam) {
+      Integer topicOwnerTeam,
+      String environmentId) {
     try {
       if (Objects.equals(topicOwnerTeam, loggedInUserTeam)) {
         topicOverview.setTopicPromotionDetails(
-            getTopicPromotionEnv(topicNameSearch, topics, tenantId));
+            getTopicPromotionEnv(topicNameSearch, originalSetTopics, tenantId, environmentId));
 
         if (topicInfoList.size() > 0) {
           TopicInfo lastItem = topicInfoList.get(topicInfoList.size() - 1);
@@ -241,23 +289,29 @@ public class TopicOverviewService extends BaseOverviewService {
   }
 
   private Map<String, String> getTopicPromotionEnv(
-      String topicSearch, List<Topic> topics, int tenantId) {
+      String topicSearch, List<Topic> topics, int tenantId, String environmentId) {
     Map<String, String> hashMap = new HashMap<>();
     try {
       if (topics == null) {
         topics = manageDatabase.getHandleDbRequests().getTopics(topicSearch, tenantId);
       }
-
       hashMap.put("topicName", topicSearch);
+      String orderEnvs = commonUtilsService.getEnvProperty(tenantId, ORDER_OF_TOPIC_ENVS);
+      List<String> envOrderList = getOrderedEnvsList(orderEnvs);
 
       if (topics != null && topics.size() > 0) {
         List<String> envList =
             topics.stream().map(Topic::getEnvironment).collect(Collectors.toList());
-        generatePromotionDetails(
-            tenantId,
-            hashMap,
-            envList,
-            commonUtilsService.getEnvProperty(tenantId, "ORDER_OF_ENVS"));
+
+        generatePromotionDetails(tenantId, hashMap, envList, orderEnvs);
+        if (hashMap.containsKey("targetEnvId")) {
+          String targetEnvId = hashMap.get("targetEnvId");
+          if (!((envOrderList.indexOf(targetEnvId) - envOrderList.indexOf(environmentId)) == 1)
+              || !envOrderList.contains(environmentId)) {
+            hashMap = new HashMap<>();
+          }
+        }
+
         return hashMap;
       }
     } catch (Exception e) {

--- a/core/src/main/java/io/aiven/klaw/service/TopicOverviewService.java
+++ b/core/src/main/java/io/aiven/klaw/service/TopicOverviewService.java
@@ -308,7 +308,7 @@ public class TopicOverviewService extends BaseOverviewService {
           String targetEnvId = hashMap.get("targetEnvId");
           if (!((envOrderList.indexOf(targetEnvId) - envOrderList.indexOf(environmentId)) == 1)
               || !envOrderList.contains(environmentId)) {
-            hashMap = new HashMap<>();
+            hashMap.put("status", NO_PROMOTION);
           }
         }
 

--- a/core/src/main/java/io/aiven/klaw/service/TopicOverviewService.java
+++ b/core/src/main/java/io/aiven/klaw/service/TopicOverviewService.java
@@ -273,8 +273,8 @@ public class TopicOverviewService extends BaseOverviewService {
           lastItem.setTopicDeletable(
               aclInfo.stream()
                   .noneMatch(
-                      aclItem -> Objects.equals(aclItem.getEnvironment(), lastItem.getEnvName())));
-          lastItem.setShowDeleteTopic(true);
+                      aclItem -> Objects.equals(aclItem.getEnvironment(), lastItem.getEnvId())));
+          lastItem.setShowDeleteTopic(lastItem.isTopicDeletable());
         }
       } else {
         Map<String, String> hashMap = new HashMap<>();
@@ -304,6 +304,8 @@ public class TopicOverviewService extends BaseOverviewService {
             topics.stream().map(Topic::getEnvironment).collect(Collectors.toList());
 
         generatePromotionDetails(tenantId, hashMap, envList, orderEnvs);
+        // Ex : If topic exists in D, T, then promotion to A is displayed when topic overview is for
+        // T env
         if (hashMap.containsKey("targetEnvId")) {
           String targetEnvId = hashMap.get("targetEnvId");
           if (!((envOrderList.indexOf(targetEnvId) - envOrderList.indexOf(environmentId)) == 1)

--- a/core/src/main/resources/static/js/browseAcls.js
+++ b/core/src/main/resources/static/js/browseAcls.js
@@ -17,6 +17,8 @@ app.controller("browseAclsCtrl", function($scope, $http, $location, $window) {
 	//$http.defaults.headers.common['Accept'] = 'application/json';
 	$scope.envSelectedParam;
 
+    $scope.groupBy = [{ 'id':'TEAM', 'name':'Team' },{'id':'NONE','name':'None'}];
+
 	$scope.showSubmitFailed = function(title, text){
 		swal({
 			 title: "",
@@ -596,21 +598,15 @@ app.controller("browseAclsCtrl", function($scope, $http, $location, $window) {
     }
 
     $scope.showAclTeamHeader = function(teamname) {
-
-    if($scope.selectedGroupBy=='NONE' || $scope.selectedGroupBy==null || $scope.selectedGroupBy == undefined ){
-    return false;
-    }
-
-    if($scope.firstTeam == teamname) {
-    console.log($scope.firstTeam  + " : " + teamname + " : nochange");
-    return false;
-    } else {
-    console.log($scope.firstTeam  + " : " + teamname + " : change");
-    $scope.firstTeam = teamname;
-    return true;
-    }
-
-
+        if($scope.selectedGroupBy==='NONE' || $scope.selectedGroupBy===null || $scope.selectedGroupBy === undefined ){
+            return false;
+        }
+        if($scope.firstTeam === teamname) {
+            return false;
+        } else {
+            $scope.firstTeam = teamname;
+            return true;
+        }
     }
 
 	$scope.getAcls = function() {
@@ -618,10 +614,9 @@ app.controller("browseAclsCtrl", function($scope, $http, $location, $window) {
         $scope.alertTopicDelete = null;
         $scope.alert = null;
         $scope.firstTeam=null;
-        if($scope.selectedGroupBy == undefined) {
-        $scope.selectedGroupBy = 'NONE';
+        if($scope.selectedGroupBy === undefined) {
+            $scope.selectedGroupBy = 'NONE';
         }
-        $scope.groupBy = [{ 'id':'TEAM', 'name':'Team' },{'id':'NONE','name':'None'}];
 
         var topicSelected;
 
@@ -648,12 +643,15 @@ app.controller("browseAclsCtrl", function($scope, $http, $location, $window) {
 		$scope.ShowSpinnerStatusTopics = true;
         $scope.schemaDetails = null;
         $scope.firstSchemaPromote = 'false';
+
 		$http({
 			method: "GET",
-			url: "getAcls",
+			url: "getTopicOverview",
             headers : { 'Content-Type' : 'application/json' },
-            params: {'topicnamesearch' : topicSelected,
-                     'groupBy' : groupAclBy
+            params: {
+                'topicName' : topicSelected,
+                'environmentId' : $scope.topicOverviewEnvId,
+                'groupBy' : groupAclBy
              }
 		}).success(function(output) {
 		    $scope.ShowSpinnerStatusTopics = false;
@@ -663,7 +661,11 @@ app.controller("browseAclsCtrl", function($scope, $http, $location, $window) {
 		        $scope.resultBrowseTxnId = output.transactionalAclInfoList;
             	$scope.topicOverview = output.topicInfoList;
             	$scope.topicPromotionDetails = output.topicPromotionDetails;
-            	$scope.schemaDetails = output.schemaDetails;
+                $scope.topicPromotionDetails = output.topicPromotionDetails;
+            	$scope.availableEnvironments = output.availableEnvironments;
+                if(!$scope.topicOverviewEnvId){
+                    $scope.topicOverviewEnvId = $scope.availableEnvironments[0].id;
+                }
 
             	$scope.schemaExists = output.schemaExists;
             	$scope.prefixAclsExists = output.prefixAclsExists;
@@ -696,17 +698,15 @@ app.controller("browseAclsCtrl", function($scope, $http, $location, $window) {
         $scope.ShowSpinnerStatusSchemas = true;
 
         const kafkaEnvIdsList = [];
-        if($scope.topicOverview){
-            for(let i=0; i<$scope.topicOverview.length; i++){
-                kafkaEnvIdsList.push($scope.topicOverview[i].envId);
-            }
+        if($scope.availableEnvironments){
+            kafkaEnvIdsList.push($scope.topicOverviewEnvId);
         }
 
             $http({
                 method: "GET",
                 url: "getSchemaOfTopic",
                 headers : { 'Content-Type' : 'application/json' },
-                params: {'topicnamesearch' : $scope.topicSelectedParam,
+                params: {'topicName' : $scope.topicSelectedParam,
                     'schemaVersionSearch' : $scope.newSchemaVersion,
                     'kafkaEnvIds' : kafkaEnvIdsList
                 }

--- a/core/src/main/resources/templates/browseAcls.html
+++ b/core/src/main/resources/templates/browseAcls.html
@@ -451,7 +451,9 @@
 						<div class="card-body">
 							<table width="100%">
 								<tr>
-									<td align="left"><h4 class="card-title">Topic : {{ topicSelectedParam }}</h4></td>
+									<td align="left">
+										<h4 class="card-title">Topic : {{ topicSelectedParam }}</h4>
+									</td>
 									<td align="right" width="15%">
 										<button ng-show="topicOverview[0].teamname != teamname && dashboardDetails.requestItems=='Authorized'" type="button" ng-click="onClaimTopic(topicSelectedParam, topicOverview[0].clusterId);"
 												class="btn waves-effect waves-light btn-rounded btn-sm btn-info">Claim Topic</button>
@@ -465,7 +467,17 @@
 									</td>
 								</tr>
 								<tr>
-									<td align="left"><span class="badge badge-warning">{{ topicOverview[0].teamname}}</span></td>
+									<td style="width: 5%;alignment:left">
+										<span class="badge badge-warning">{{ topicOverview[0].teamname}}</span>
+									</td>
+
+									<td style="alignment:left">
+										<select style="width: 20%" class="form-control custom-select" ng-change="getAcls();"
+												ng-model="topicOverviewEnvId" ng-options="env.id as env.name for env in availableEnvironments">
+										<option value="" selected="selected">
+											Select Env</option>
+										</select>
+									</td>
 									<td></td>
 								</tr>
 							</table>
@@ -637,12 +649,9 @@
 							<div class="tab-content">
 								<div class="tab-pane active" id="topicsubscriptions" role="tabpanel">
 									<div>
-
-											<label> Group ACLs By </label>
+											<label class="control-label"> Group ACLs By </label>
 											<select ng-model="selectedGroupBy" ng-options="group.id as group.name for group in groupBy"  ng-change="getAcls()">
-
 											</select>
-
 									</div>
 									<div class="ribbon-wrapper card" ng-show="resultBrowse.length==0">
 										<div class="ribbon ribbon-warning">Notification</div>
@@ -652,18 +661,21 @@
 									<div ng-show="resultBrowse!=null && resultBrowse.length!=0" ng-repeat="aclRequest in resultBrowse">
 
 										<div class="row">
-											<h5 ng-show="showAclTeamHeader(aclRequest.teamname)" style="float:center;"> {{aclRequest.teamname}}</h5>
+											<div ng-if="selectedGroupBy == 'TEAM'" class="card-body">
+												<div class="d-flex flex-row">
+													<h5 ng-show="showAclTeamHeader(aclRequest.teamname)">
+														{{aclRequest.teamname}}
+													</h5>
+												</div>
+											</div>
 											<div class="col-md-12">
 												<div class="card">
 													<div class="card-body">
-
 														<div class="d-flex flex-row">
-
 															<div ng-show="aclRequest.topictype == 'Producer'" style="width:15%" class="p-2 pl-0 border-right">
 																<h6 class="text-primary">AclType</h6><b>
 																<span class="badge badge-info">{{ aclRequest.topictype }}</span></b>
 															</div>
-
 															<div ng-show="aclRequest.topictype == 'Consumer'" style="width:15%" class="p-2 pl-0 border-right">
 																<h6 class="text-primary">AclType</h6><b>
 																<span class="badge badge-primary">{{ aclRequest.topictype }}</span></b>

--- a/core/src/main/resources/templates/browseAcls.html
+++ b/core/src/main/resources/templates/browseAcls.html
@@ -474,8 +474,6 @@
 									<td style="alignment:left">
 										<select style="width: 20%" class="form-control custom-select" ng-change="getAcls();"
 												ng-model="topicOverviewEnvId" ng-options="env.id as env.name for env in availableEnvironments">
-										<option value="" selected="selected">
-											Select Env</option>
 										</select>
 									</td>
 									<td></td>

--- a/core/src/test/java/io/aiven/klaw/TopicAclControllerIT.java
+++ b/core/src/test/java/io/aiven/klaw/TopicAclControllerIT.java
@@ -810,9 +810,9 @@ public class TopicAclControllerIT {
 
     String res =
         mvc.perform(
-                get("/getAcls")
+                get("/getTopicOverview")
                     .with(user(user3).password(PASSWORD))
-                    .param("topicnamesearch", topicName + topicId1)
+                    .param("topicName", topicName + topicId1)
                     .contentType(MediaType.APPLICATION_JSON)
                     .accept(MediaType.APPLICATION_JSON))
             .andExpect(status().isOk())

--- a/core/src/test/java/io/aiven/klaw/UtilMethods.java
+++ b/core/src/test/java/io/aiven/klaw/UtilMethods.java
@@ -185,6 +185,20 @@ public class UtilMethods {
     return allTopicReqs;
   }
 
+  public List<Topic> getTopicInMultipleEnvs(String topicName, int teamId, int sizeOfTopics) {
+    List<Topic> topicList = new ArrayList<>();
+    for (int i = 0; i < sizeOfTopics; i++) {
+      Topic topic1 = new Topic();
+      topic1.setEnvironment(i + 1 + "");
+      topic1.setTopicname(topicName);
+
+      topic1.setTeamId(teamId);
+      topicList.add(topic1);
+    }
+
+    return topicList;
+  }
+
   public List<Topic> getMultipleTopics(String topicPrefix, int size, String env, int teamId) {
     List<Topic> listTopics = new ArrayList<>();
     Topic t;

--- a/core/src/test/java/io/aiven/klaw/controller/AclControllerTest.java
+++ b/core/src/test/java/io/aiven/klaw/controller/AclControllerTest.java
@@ -206,13 +206,13 @@ public class AclControllerTest {
   public void getAcls1() throws Exception {
     TopicOverview topicOverview = utilMethods.getTopicOverview();
 
-    when(topicOverviewService.getTopicOverview("testtopic", AclGroupBy.NONE))
+    when(topicOverviewService.getTopicOverview("testtopic", "", AclGroupBy.NONE))
         .thenReturn(topicOverview);
 
     mvcAcls
         .perform(
-            MockMvcRequestBuilders.get("/getAcls")
-                .param("topicnamesearch", "testtopic")
+            MockMvcRequestBuilders.get("/getTopicOverview")
+                .param("topicName", "testtopic")
                 .contentType(MediaType.APPLICATION_JSON)
                 .accept(MediaType.APPLICATION_JSON))
         .andDo(print())
@@ -225,14 +225,15 @@ public class AclControllerTest {
   public void getAcls2() throws Exception {
     TopicOverview topicOverview = utilMethods.getTopicOverview();
 
-    when(topicOverviewService.getTopicOverview(null, AclGroupBy.NONE)).thenReturn(topicOverview);
+    when(topicOverviewService.getTopicOverview(null, "1", AclGroupBy.NONE))
+        .thenReturn(topicOverview);
 
     // TODO Consider returning an error response object (https://www.rfc-editor.org/rfc/rfc7807)
     // Just checking response code seems to be sufficient as the contentAsString() returns an empty
     // String.
     mvcAcls
         .perform(
-            MockMvcRequestBuilders.get("/getAcls")
+            MockMvcRequestBuilders.get("/getTopicOverview")
                 .contentType(MediaType.APPLICATION_JSON)
                 .accept(MediaType.APPLICATION_JSON))
         .andExpect(status().isBadRequest());

--- a/core/src/test/java/io/aiven/klaw/service/TopicOverviewServiceTest.java
+++ b/core/src/test/java/io/aiven/klaw/service/TopicOverviewServiceTest.java
@@ -125,7 +125,7 @@ public class TopicOverviewServiceTest {
     when(commonUtilsService.getEnvProperty(eq(101), eq("REQUEST_TOPICS_OF_ENVS"))).thenReturn("1");
     mockTenantConfig();
     List<AclInfo> aclList =
-        topicOverviewService.getTopicOverview(TESTTOPIC, AclGroupBy.NONE).getAclInfoList();
+        topicOverviewService.getTopicOverview(TESTTOPIC, "1", AclGroupBy.NONE).getAclInfoList();
 
     assertThat(aclList).hasSize(1);
 
@@ -162,7 +162,9 @@ public class TopicOverviewServiceTest {
     mockTenantConfig();
 
     List<AclInfo> aclList =
-        topicOverviewService.getTopicOverview(topicNameSearch, AclGroupBy.NONE).getAclInfoList();
+        topicOverviewService
+            .getTopicOverview(topicNameSearch, "1", AclGroupBy.NONE)
+            .getAclInfoList();
 
     assertThat(aclList).hasSize(1);
 
@@ -182,7 +184,8 @@ public class TopicOverviewServiceTest {
     when(commonUtilsService.getEnvProperty(eq(101), eq("REQUEST_TOPICS_OF_ENVS"))).thenReturn("1");
     when(commonUtilsService.getEnvProperty(eq(101), eq("ORDER_OF_ENVS"))).thenReturn("1");
 
-    TopicOverview returnedValue = topicOverviewService.getTopicOverview(TESTTOPIC, AclGroupBy.NONE);
+    TopicOverview returnedValue =
+        topicOverviewService.getTopicOverview(TESTTOPIC, "1", AclGroupBy.NONE);
     assertThat(returnedValue.getTopicPromotionDetails()).isNotNull();
     assertThat(returnedValue.getTopicPromotionDetails().containsKey("status")).isTrue();
     assertThat(returnedValue.getTopicPromotionDetails().get("status")).isEqualTo("NO_PROMOTION");
@@ -201,7 +204,8 @@ public class TopicOverviewServiceTest {
     when(commonUtilsService.getEnvProperty(eq(101), eq("ORDER_OF_ENVS")))
         .thenReturn("1,2,3,4,5,6,7,8,9,10,11,12,13,14,15");
 
-    TopicOverview returnedValue = topicOverviewService.getTopicOverview(TESTTOPIC, AclGroupBy.NONE);
+    TopicOverview returnedValue =
+        topicOverviewService.getTopicOverview(TESTTOPIC, "1", AclGroupBy.NONE);
     assertThat(returnedValue.getTopicPromotionDetails()).isNotNull();
     assertThat(returnedValue.getTopicPromotionDetails().containsKey("status")).isTrue();
     assertThat(returnedValue.getTopicPromotionDetails().get("status"))
@@ -219,7 +223,8 @@ public class TopicOverviewServiceTest {
 
     when(commonUtilsService.getEnvProperty(eq(101), eq("ORDER_OF_ENVS"))).thenReturn("1");
 
-    TopicOverview returnedValue = topicOverviewService.getTopicOverview(TESTTOPIC, AclGroupBy.NONE);
+    TopicOverview returnedValue =
+        topicOverviewService.getTopicOverview(TESTTOPIC, "1", AclGroupBy.NONE);
     assertThat(returnedValue.getTopicPromotionDetails()).isNullOrEmpty();
     assertThat(returnedValue.isTopicExists()).isFalse();
   }
@@ -253,7 +258,7 @@ public class TopicOverviewServiceTest {
     when(commonUtilsService.getEnvProperty(eq(101), eq("REQUEST_TOPICS_OF_ENVS"))).thenReturn("1");
     mockTenantConfig();
     List<AclInfo> aclList =
-        topicOverviewService.getTopicOverview(TESTTOPIC, AclGroupBy.NONE).getAclInfoList();
+        topicOverviewService.getTopicOverview(TESTTOPIC, "1", AclGroupBy.NONE).getAclInfoList();
 
     assertThat(aclList).hasSize(1);
 
@@ -292,7 +297,7 @@ public class TopicOverviewServiceTest {
 
     when(manageDatabase.getClusters(eq(KafkaClustersType.KAFKA), eq(101)))
         .thenReturn(getKwClusterMap());
-    TopicOverview returnedValue = topicOverviewService.getTopicOverview(TESTTOPIC, groupBy);
+    TopicOverview returnedValue = topicOverviewService.getTopicOverview(TESTTOPIC, "1", groupBy);
 
     if (AclGroupBy.TEAM.equals(groupBy)) {
       String previousTeam = returnedValue.getAclInfoList().get(0).getTeamname();

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -2618,6 +2618,49 @@
         }
       }
     },
+    "/getTopicOverview" : {
+      "get" : {
+        "tags" : [ "acl-controller" ],
+        "operationId" : "getTopicOverview",
+        "parameters" : [ {
+          "name" : "topicName",
+          "in" : "query",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        }, {
+          "name" : "environmentId",
+          "in" : "query",
+          "required" : false,
+          "schema" : {
+            "type" : "string",
+            "default" : ""
+          }
+        }, {
+          "name" : "groupBy",
+          "in" : "query",
+          "required" : false,
+          "schema" : {
+            "type" : "string",
+            "default" : "NONE",
+            "enum" : [ "NONE", "TEAM" ]
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "OK",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/TopicOverview"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/getTopicEvents" : {
       "get" : {
         "tags" : [ "topic-controller" ],
@@ -3300,7 +3343,7 @@
         "tags" : [ "schema-registry-controller" ],
         "operationId" : "getSchemaOfTopic",
         "parameters" : [ {
-          "name" : "topicnamesearch",
+          "name" : "topicName",
           "in" : "query",
           "required" : true,
           "schema" : {
@@ -4677,41 +4720,6 @@
               "application/json" : {
                 "schema" : {
                   "$ref" : "#/components/schemas/ApiResponse"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/getAcls" : {
-      "get" : {
-        "tags" : [ "acl-controller" ],
-        "operationId" : "getAcls",
-        "parameters" : [ {
-          "name" : "topicnamesearch",
-          "in" : "query",
-          "required" : true,
-          "schema" : {
-            "type" : "string"
-          }
-        }, {
-          "name" : "groupBy",
-          "in" : "query",
-          "required" : false,
-          "schema" : {
-            "type" : "string",
-            "default" : "NONE",
-            "enum" : [ "NONE", "TEAM" ]
-          }
-        } ],
-        "responses" : {
-          "200" : {
-            "description" : "OK",
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/TopicOverview"
                 }
               }
             }
@@ -6289,6 +6297,195 @@
         },
         "required" : [ "advancedTopicConfigEntries", "allPageNos", "approvingTeamDetails", "currentPage", "deleteAssociatedSchema", "description", "environment", "environmentName", "replicationfactor", "requestOperationType", "requestStatus", "requestor", "requesttime", "requesttimestring", "teamId", "teamname", "topicid", "topicname", "topicpartitions", "totalNoPages" ]
       },
+      "AclInfo" : {
+        "properties" : {
+          "sequence" : {
+            "type" : "string"
+          },
+          "req_no" : {
+            "type" : "string"
+          },
+          "acl_ip" : {
+            "type" : "string"
+          },
+          "acl_ssl" : {
+            "type" : "string"
+          },
+          "acl_ips" : {
+            "type" : "array",
+            "items" : {
+              "type" : "string"
+            },
+            "uniqueItems" : true
+          },
+          "acl_ssls" : {
+            "type" : "array",
+            "items" : {
+              "type" : "string"
+            },
+            "uniqueItems" : true
+          },
+          "topicname" : {
+            "type" : "string"
+          },
+          "topictype" : {
+            "type" : "string"
+          },
+          "consumergroup" : {
+            "type" : "string"
+          },
+          "environment" : {
+            "type" : "string"
+          },
+          "environmentName" : {
+            "type" : "string"
+          },
+          "teamname" : {
+            "type" : "string"
+          },
+          "teamid" : {
+            "type" : "integer",
+            "format" : "int32"
+          },
+          "operation" : {
+            "type" : "string"
+          },
+          "permission" : {
+            "type" : "string"
+          },
+          "transactionalId" : {
+            "type" : "string"
+          },
+          "aclPatternType" : {
+            "type" : "string"
+          },
+          "totalNoPages" : {
+            "type" : "string"
+          },
+          "allPageNos" : {
+            "type" : "array",
+            "items" : {
+              "type" : "string"
+            }
+          },
+          "possibleTeams" : {
+            "type" : "array",
+            "items" : {
+              "type" : "string"
+            }
+          },
+          "currentPage" : {
+            "type" : "string"
+          },
+          "showDeleteAcl" : {
+            "type" : "boolean"
+          },
+          "kafkaFlavorType" : {
+            "type" : "string",
+            "enum" : [ "APACHE_KAFKA", "AIVEN_FOR_APACHE_KAFKA", "CONFLUENT", "CONFLUENT_CLOUD", "OTHERS" ]
+          }
+        }
+      },
+      "EnvIdInfo" : {
+        "properties" : {
+          "id" : {
+            "type" : "string"
+          },
+          "name" : {
+            "type" : "string"
+          }
+        }
+      },
+      "TopicHistory" : {
+        "properties" : {
+          "environmentName" : {
+            "type" : "string"
+          },
+          "teamName" : {
+            "type" : "string"
+          },
+          "requestedBy" : {
+            "type" : "string"
+          },
+          "requestedTime" : {
+            "type" : "string"
+          },
+          "approvedBy" : {
+            "type" : "string"
+          },
+          "approvedTime" : {
+            "type" : "string"
+          },
+          "remarks" : {
+            "type" : "string"
+          }
+        }
+      },
+      "TopicOverview" : {
+        "properties" : {
+          "topicExists" : {
+            "type" : "boolean"
+          },
+          "schemaExists" : {
+            "type" : "boolean"
+          },
+          "prefixAclsExists" : {
+            "type" : "boolean"
+          },
+          "txnAclsExists" : {
+            "type" : "boolean"
+          },
+          "topicInfoList" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/components/schemas/TopicInfo"
+            }
+          },
+          "aclInfoList" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/components/schemas/AclInfo"
+            }
+          },
+          "prefixedAclInfoList" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/components/schemas/AclInfo"
+            }
+          },
+          "transactionalAclInfoList" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/components/schemas/AclInfo"
+            }
+          },
+          "topicHistoryList" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/components/schemas/TopicHistory"
+            }
+          },
+          "topicPromotionDetails" : {
+            "type" : "object",
+            "additionalProperties" : {
+              "type" : "string"
+            }
+          },
+          "availableEnvironments" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/components/schemas/EnvIdInfo"
+            }
+          },
+          "topicDocumentation" : {
+            "type" : "string"
+          },
+          "topicIdForDocumentation" : {
+            "type" : "integer",
+            "format" : "int32"
+          }
+        }
+      },
       "TopicDetailsPerEnv" : {
         "properties" : {
           "topicExists" : {
@@ -6476,16 +6673,6 @@
           }
         }
       },
-      "EnvIdInfo" : {
-        "properties" : {
-          "id" : {
-            "type" : "string"
-          },
-          "name" : {
-            "type" : "string"
-          }
-        }
-      },
       "KafkaConnectorModelResponse" : {
         "properties" : {
           "sequence" : {
@@ -6631,95 +6818,6 @@
           }
         },
         "required" : [ "allPageNos", "clusterId", "clusterName", "envStatus", "id", "name", "otherParams", "showDeleteEnv", "tenantId", "tenantName", "totalNoPages", "type" ]
-      },
-      "AclInfo" : {
-        "properties" : {
-          "sequence" : {
-            "type" : "string"
-          },
-          "req_no" : {
-            "type" : "string"
-          },
-          "acl_ip" : {
-            "type" : "string"
-          },
-          "acl_ssl" : {
-            "type" : "string"
-          },
-          "acl_ips" : {
-            "type" : "array",
-            "items" : {
-              "type" : "string"
-            },
-            "uniqueItems" : true
-          },
-          "acl_ssls" : {
-            "type" : "array",
-            "items" : {
-              "type" : "string"
-            },
-            "uniqueItems" : true
-          },
-          "topicname" : {
-            "type" : "string"
-          },
-          "topictype" : {
-            "type" : "string"
-          },
-          "consumergroup" : {
-            "type" : "string"
-          },
-          "environment" : {
-            "type" : "string"
-          },
-          "environmentName" : {
-            "type" : "string"
-          },
-          "teamname" : {
-            "type" : "string"
-          },
-          "teamid" : {
-            "type" : "integer",
-            "format" : "int32"
-          },
-          "operation" : {
-            "type" : "string"
-          },
-          "permission" : {
-            "type" : "string"
-          },
-          "transactionalId" : {
-            "type" : "string"
-          },
-          "aclPatternType" : {
-            "type" : "string"
-          },
-          "totalNoPages" : {
-            "type" : "string"
-          },
-          "allPageNos" : {
-            "type" : "array",
-            "items" : {
-              "type" : "string"
-            }
-          },
-          "possibleTeams" : {
-            "type" : "array",
-            "items" : {
-              "type" : "string"
-            }
-          },
-          "currentPage" : {
-            "type" : "string"
-          },
-          "showDeleteAcl" : {
-            "type" : "boolean"
-          },
-          "kafkaFlavorType" : {
-            "type" : "string",
-            "enum" : [ "APACHE_KAFKA", "AIVEN_FOR_APACHE_KAFKA", "CONFLUENT", "CONFLUENT_CLOUD", "OTHERS" ]
-          }
-        }
       },
       "SchemaRequestsResponseModel" : {
         "properties" : {
@@ -7088,31 +7186,6 @@
           }
         }
       },
-      "TopicHistory" : {
-        "properties" : {
-          "environmentName" : {
-            "type" : "string"
-          },
-          "teamName" : {
-            "type" : "string"
-          },
-          "requestedBy" : {
-            "type" : "string"
-          },
-          "requestedTime" : {
-            "type" : "string"
-          },
-          "approvedBy" : {
-            "type" : "string"
-          },
-          "approvedTime" : {
-            "type" : "string"
-          },
-          "remarks" : {
-            "type" : "string"
-          }
-        }
-      },
       "ConnectorOverviewPerEnv" : {
         "properties" : {
           "connectorExists" : {
@@ -7444,65 +7517,6 @@
             "items" : {
               "type" : "string"
             }
-          }
-        }
-      },
-      "TopicOverview" : {
-        "properties" : {
-          "topicExists" : {
-            "type" : "boolean"
-          },
-          "schemaExists" : {
-            "type" : "boolean"
-          },
-          "prefixAclsExists" : {
-            "type" : "boolean"
-          },
-          "txnAclsExists" : {
-            "type" : "boolean"
-          },
-          "topicInfoList" : {
-            "type" : "array",
-            "items" : {
-              "$ref" : "#/components/schemas/TopicInfo"
-            }
-          },
-          "aclInfoList" : {
-            "type" : "array",
-            "items" : {
-              "$ref" : "#/components/schemas/AclInfo"
-            }
-          },
-          "prefixedAclInfoList" : {
-            "type" : "array",
-            "items" : {
-              "$ref" : "#/components/schemas/AclInfo"
-            }
-          },
-          "transactionalAclInfoList" : {
-            "type" : "array",
-            "items" : {
-              "$ref" : "#/components/schemas/AclInfo"
-            }
-          },
-          "topicHistoryList" : {
-            "type" : "array",
-            "items" : {
-              "$ref" : "#/components/schemas/TopicHistory"
-            }
-          },
-          "topicPromotionDetails" : {
-            "type" : "object",
-            "additionalProperties" : {
-              "type" : "string"
-            }
-          },
-          "topicDocumentation" : {
-            "type" : "string"
-          },
-          "topicIdForDocumentation" : {
-            "type" : "integer",
-            "format" : "int32"
           }
         }
       },


### PR DESCRIPTION
About this change - What it does

Retrieves one environment details only in Topic overview page
- Topic envs
- Schema envs
- topic promotion details are only displayed in highest topic env
A drop down is displayed with all available envs of the topic
- getAcls endpoint changed to getTopicOverview

Resolves: #943 
Why this way
User gets a clear view of one env details of topic
