### PR TITLE
feat(coral): Add team filter in All Connectors view

### DIFF
--- a/coral/src/app/features/connectors/browse/BrowseConnectors.tsx
+++ b/coral/src/app/features/connectors/browse/BrowseConnectors.tsx
@@ -7,13 +7,14 @@ import { useSearchParams } from "react-router-dom";
 import EnvironmentFilter from "src/app/features/components/filters/EnvironmentFilter";
 import { useFiltersValues } from "src/app/features/components/filters/useFiltersValues";
 import SearchFilter from "src/app/features/components/filters/SearchFilter";
+import TeamFilter from "src/app/features/components/filters/TeamFilter";
 
 function BrowseConnectors() {
   const [searchParams, setSearchParams] = useSearchParams();
   const currentPage = searchParams.get("page")
     ? Number(searchParams.get("page"))
     : 1;
-  const { environment, search } = useFiltersValues();
+  const { environment, teamId, search } = useFiltersValues();
 
   const {
     data: connectors,
@@ -21,12 +22,13 @@ function BrowseConnectors() {
     isError,
     error,
   } = useQuery({
-    queryKey: ["browseConnectors", currentPage, environment, search],
+    queryKey: ["browseConnectors", currentPage, environment, teamId, search],
     queryFn: () =>
       getConnectors({
         pageNo: currentPage.toString(),
         env: environment,
         connectornamesearch: search.length === 0 ? undefined : search,
+        teamId: teamId !== "ALL" ? Number(teamId) : undefined,
       }),
     keepPreviousData: true,
   });
@@ -48,6 +50,7 @@ function BrowseConnectors() {
   return (
     <TableLayout
       filters={[
+        <TeamFilter key={"team"} />,
         <EnvironmentFilter
           key={"environment"}
           environmentEndpoint={"getSyncConnectorsEnvironments"}

--- a/coral/src/app/pages/requests/connectors/index.test.tsx
+++ b/coral/src/app/pages/requests/connectors/index.test.tsx
@@ -4,10 +4,13 @@ import { waitForElementToBeRemoved } from "@testing-library/react/pure";
 import { getEnvironments } from "src/domain/environment";
 import { getConnectorRequests } from "src/domain/connector/connector-api";
 import ConnectorRequestsPage from "src/app/pages/requests/connectors/index";
+import { getTeams } from "src/domain/team";
 
+jest.mock("src/domain/team/team-api.ts");
 jest.mock("src/domain/environment/environment-api.ts");
 jest.mock("src/domain/connector/connector-api.ts");
 
+const mockGetTeams = getTeams as jest.MockedFunction<typeof getTeams>;
 const mockGetEnvironments = getEnvironments as jest.MockedFunction<
   typeof getEnvironments
 >;
@@ -17,6 +20,7 @@ const mockGetConnectorRequests = getConnectorRequests as jest.MockedFunction<
 
 describe("ConnectorRequestsPage", () => {
   beforeAll(async () => {
+    mockGetTeams.mockResolvedValue([]);
     mockGetEnvironments.mockResolvedValue([]);
     mockGetConnectorRequests.mockResolvedValue({
       entries: [],


### PR DESCRIPTION
# About this change - What it does

- adds a select element for teams

## Screenshot

<img width="1167" alt="Screenshot 2023-04-19 at 12 05 48" src="https://user-images.githubusercontent.com/943800/233042145-deac5794-da23-42d0-a376-5e715c1d60f0.png">


Resolves: #1019

