### PR TITLE
feat(coral): Add createConnectorRequest in domain/connector, update API response to be `"application/json"`

### DIFF
--- a/coral/src/app/features/topics/acl-request/TopicAclRequest.test.tsx
+++ b/coral/src/app/features/topics/acl-request/TopicAclRequest.test.tsx
@@ -1010,7 +1010,10 @@ describe("<TopicAclRequest />", () => {
       beforeEach(async () => {
         mockCreateAclRequest({
           mswInstance: server,
-          response: { data: { status: "200 OK" } },
+          response: {
+            status: 200,
+            data: { success: true, message: "success" },
+          },
         });
       });
 
@@ -1366,7 +1369,10 @@ describe("<TopicAclRequest />", () => {
       beforeEach(async () => {
         mockCreateAclRequest({
           mswInstance: server,
-          response: { data: { status: "200 OK" } },
+          response: {
+            status: 200,
+            data: { success: true, message: "success" },
+          },
         });
       });
 

--- a/coral/src/app/features/topics/request/TopicRequest.test.tsx
+++ b/coral/src/app/features/topics/request/TopicRequest.test.tsx
@@ -780,7 +780,10 @@ describe("<TopicRequest />", () => {
       beforeEach(async () => {
         mockRequestTopic({
           mswInstance: server,
-          response: { data: { status: "200 OK" } },
+          response: {
+            status: 200,
+            data: { success: true, message: "success" },
+          },
         });
       });
 

--- a/coral/src/domain/connector/connector-api.ts
+++ b/coral/src/domain/connector/connector-api.ts
@@ -9,7 +9,11 @@ import {
   RequestVerdictDelete,
 } from "src/domain/requests/requests-types";
 import api, { API_PATHS } from "src/services/api";
-import { KlawApiRequestQueryParameters, KlawApiResponse } from "types/utils";
+import {
+  KlawApiRequest,
+  KlawApiRequestQueryParameters,
+  KlawApiResponse,
+} from "types/utils";
 import { convertQueryValuesToString } from "src/services/api-helper";
 
 const filterGetConnectorRequestParams = (
@@ -125,6 +129,15 @@ const deleteConnectorRequest = ({ reqIds }: DeleteRequestParams) => {
   >(API_PATHS.deleteRequest, { requestEntityType: "CONNECTOR", reqIds });
 };
 
+const createConnectorRequest = (
+  connectorPayload: KlawApiRequest<"createConnectorRequest">
+) => {
+  return api.post<
+    KlawApiResponse<"createConnectorRequest">,
+    KlawApiRequest<"createConnectorRequest">
+  >(API_PATHS.createConnectorRequest, connectorPayload);
+};
+
 export {
   getConnectorRequestsForApprover,
   getConnectorRequests,
@@ -132,4 +145,5 @@ export {
   declineConnectorRequest,
   deleteConnectorRequest,
   getConnectors,
+  createConnectorRequest,
 };

--- a/coral/src/domain/connector/connector-types.ts
+++ b/coral/src/domain/connector/connector-types.ts
@@ -1,4 +1,9 @@
-import { KlawApiModel, Paginated, ResolveIntersectionTypes } from "types/utils";
+import {
+  KlawApiModel,
+  KlawApiRequest,
+  Paginated,
+  ResolveIntersectionTypes,
+} from "types/utils";
 
 type Connector = KlawApiModel<"KafkaConnectorModelResponse">;
 type ConnectorApiResponse = ResolveIntersectionTypes<Paginated<Connector[]>>;
@@ -9,9 +14,12 @@ type ConnectorRequestsForApprover = ResolveIntersectionTypes<
   Paginated<ConnectorRequest[]>
 >;
 
+type CreateConnectorRequestPayload = KlawApiRequest<"createConnectorRequest">;
+
 export type {
   Connector,
   ConnectorApiResponse,
   ConnectorRequest,
   ConnectorRequestsForApprover,
+  CreateConnectorRequestPayload,
 };

--- a/coral/src/domain/connector/index.ts
+++ b/coral/src/domain/connector/index.ts
@@ -5,14 +5,21 @@ import {
   getConnectorRequestsForApprover,
   deleteConnectorRequest,
   getConnectors,
+  createConnectorRequest,
 } from "src/domain/connector/connector-api";
 import {
   ConnectorRequest,
   ConnectorRequestsForApprover,
   Connector,
+  CreateConnectorRequestPayload,
 } from "src/domain/connector/connector-types";
 
-export type { Connector, ConnectorRequestsForApprover, ConnectorRequest };
+export type {
+  Connector,
+  ConnectorRequestsForApprover,
+  ConnectorRequest,
+  CreateConnectorRequestPayload,
+};
 export {
   getConnectorRequestsForApprover,
   getConnectorRequests,
@@ -20,4 +27,5 @@ export {
   approveConnectorRequest,
   declineConnectorRequest,
   deleteConnectorRequest,
+  createConnectorRequest,
 };

--- a/coral/src/domain/topic/topic-api.test.ts
+++ b/coral/src/domain/topic/topic-api.test.ts
@@ -24,9 +24,8 @@ describe("topic-api", () => {
       mockRequestTopic({
         mswInstance: server,
         response: {
-          data: {
-            status: "200 OK",
-          },
+          status: 200,
+          data: { success: true, message: "success" },
         },
       });
     });

--- a/coral/types/api.d.ts
+++ b/coral/types/api.d.ts
@@ -1436,7 +1436,7 @@ export type operations = {
       /** @description OK */
       200: {
         content: {
-          "*/*": components["schemas"]["ApiResponse"];
+          "application/json": components["schemas"]["ApiResponse"];
         };
       };
     };
@@ -1466,7 +1466,7 @@ export type operations = {
       /** @description OK */
       200: {
         content: {
-          "*/*": components["schemas"]["ApiResponse"];
+          "application/json": components["schemas"]["ApiResponse"];
         };
       };
     };
@@ -1481,7 +1481,7 @@ export type operations = {
       /** @description OK */
       200: {
         content: {
-          "*/*": components["schemas"]["ApiResponse"];
+          "application/json": components["schemas"]["ApiResponse"];
         };
       };
     };
@@ -1496,7 +1496,7 @@ export type operations = {
       /** @description OK */
       200: {
         content: {
-          "*/*": components["schemas"]["ApiResponse"];
+          "application/json": components["schemas"]["ApiResponse"];
         };
       };
     };
@@ -1511,7 +1511,7 @@ export type operations = {
       /** @description OK */
       200: {
         content: {
-          "*/*": components["schemas"]["ApiResponse"];
+          "application/json": components["schemas"]["ApiResponse"];
         };
       };
     };
@@ -1526,7 +1526,7 @@ export type operations = {
       /** @description OK */
       200: {
         content: {
-          "*/*": components["schemas"]["ApiResponse"];
+          "application/json": components["schemas"]["ApiResponse"];
         };
       };
     };
@@ -1541,7 +1541,7 @@ export type operations = {
       /** @description OK */
       200: {
         content: {
-          "*/*": components["schemas"]["ApiResponse"];
+          "application/json": components["schemas"]["ApiResponse"];
         };
       };
     };
@@ -1556,7 +1556,7 @@ export type operations = {
       /** @description OK */
       200: {
         content: {
-          "*/*": components["schemas"]["ApiResponse"];
+          "application/json": components["schemas"]["ApiResponse"];
         };
       };
     };
@@ -1571,7 +1571,7 @@ export type operations = {
       /** @description OK */
       200: {
         content: {
-          "*/*": components["schemas"]["ApiResponse"];
+          "application/json": components["schemas"]["ApiResponse"];
         };
       };
     };
@@ -1586,7 +1586,7 @@ export type operations = {
       /** @description OK */
       200: {
         content: {
-          "*/*": components["schemas"]["ApiResponse"];
+          "application/json": components["schemas"]["ApiResponse"];
         };
       };
     };
@@ -1601,7 +1601,7 @@ export type operations = {
       /** @description OK */
       200: {
         content: {
-          "*/*": components["schemas"]["ApiResponse"];
+          "application/json": components["schemas"]["ApiResponse"];
         };
       };
     };
@@ -1616,7 +1616,7 @@ export type operations = {
       /** @description OK */
       200: {
         content: {
-          "*/*": components["schemas"]["ApiResponse"];
+          "application/json": components["schemas"]["ApiResponse"];
         };
       };
     };
@@ -1631,7 +1631,7 @@ export type operations = {
       /** @description OK */
       200: {
         content: {
-          "*/*": components["schemas"]["ApiResponse"];
+          "application/json": components["schemas"]["ApiResponse"];
         };
       };
     };
@@ -1646,7 +1646,7 @@ export type operations = {
       /** @description OK */
       200: {
         content: {
-          "*/*": components["schemas"]["ApiResponse"];
+          "application/json": components["schemas"]["ApiResponse"];
         };
       };
     };
@@ -1661,7 +1661,7 @@ export type operations = {
       /** @description OK */
       200: {
         content: {
-          "*/*": components["schemas"]["ApiResponse"];
+          "application/json": components["schemas"]["ApiResponse"];
         };
       };
     };
@@ -1692,7 +1692,7 @@ export type operations = {
       /** @description OK */
       200: {
         content: {
-          "*/*": components["schemas"]["ApiResponse"];
+          "application/json": components["schemas"]["ApiResponse"];
         };
       };
     };
@@ -1707,7 +1707,7 @@ export type operations = {
       /** @description OK */
       200: {
         content: {
-          "*/*": components["schemas"]["ApiResponse"];
+          "application/json": components["schemas"]["ApiResponse"];
         };
       };
     };
@@ -1722,7 +1722,7 @@ export type operations = {
       /** @description OK */
       200: {
         content: {
-          "*/*": components["schemas"]["ResetPasswordInfo"];
+          "application/json": components["schemas"]["ResetPasswordInfo"];
         };
       };
     };
@@ -1848,7 +1848,7 @@ export type operations = {
       /** @description OK */
       200: {
         content: {
-          "*/*": components["schemas"]["ApiResponse"];
+          "application/json": components["schemas"]["ApiResponse"];
         };
       };
     };
@@ -1863,7 +1863,7 @@ export type operations = {
       /** @description OK */
       200: {
         content: {
-          "*/*": components["schemas"]["ApiResponse"];
+          "application/json": components["schemas"]["ApiResponse"];
         };
       };
     };
@@ -1888,7 +1888,7 @@ export type operations = {
       /** @description OK */
       200: {
         content: {
-          "*/*": {
+          "application/json": {
             [key: string]: string | undefined;
           };
         };
@@ -1967,7 +1967,7 @@ export type operations = {
       /** @description OK */
       200: {
         content: {
-          "*/*": components["schemas"]["ApiResponse"];
+          "application/json": components["schemas"]["ApiResponse"];
         };
       };
     };
@@ -1982,7 +1982,7 @@ export type operations = {
       /** @description OK */
       200: {
         content: {
-          "*/*": components["schemas"]["ApiResponse"];
+          "application/json": components["schemas"]["ApiResponse"];
         };
       };
     };
@@ -2028,7 +2028,7 @@ export type operations = {
       /** @description OK */
       200: {
         content: {
-          "*/*": components["schemas"]["ApiResponse"];
+          "application/json": components["schemas"]["ApiResponse"];
         };
       };
     };
@@ -2044,7 +2044,7 @@ export type operations = {
       /** @description OK */
       200: {
         content: {
-          "*/*": components["schemas"]["ApiResponse"];
+          "application/json": components["schemas"]["ApiResponse"];
         };
       };
     };
@@ -2059,7 +2059,7 @@ export type operations = {
       /** @description OK */
       200: {
         content: {
-          "*/*": components["schemas"]["ApiResponse"];
+          "application/json": components["schemas"]["ApiResponse"];
         };
       };
     };
@@ -2084,7 +2084,7 @@ export type operations = {
       /** @description OK */
       200: {
         content: {
-          "*/*": components["schemas"]["ApiResponse"];
+          "application/json": components["schemas"]["ApiResponse"];
         };
       };
     };
@@ -2099,7 +2099,7 @@ export type operations = {
       /** @description OK */
       200: {
         content: {
-          "*/*": components["schemas"]["ApiResponse"];
+          "application/json": components["schemas"]["ApiResponse"];
         };
       };
     };
@@ -2129,7 +2129,7 @@ export type operations = {
       /** @description OK */
       200: {
         content: {
-          "*/*": components["schemas"]["ApiResponse"];
+          "application/json": components["schemas"]["ApiResponse"];
         };
       };
     };
@@ -2145,7 +2145,7 @@ export type operations = {
       /** @description OK */
       200: {
         content: {
-          "*/*": components["schemas"]["ApiResponse"];
+          "application/json": components["schemas"]["ApiResponse"];
         };
       };
     };
@@ -2175,7 +2175,7 @@ export type operations = {
       /** @description OK */
       200: {
         content: {
-          "*/*": components["schemas"]["ApiResponse"];
+          "application/json": components["schemas"]["ApiResponse"];
         };
       };
     };
@@ -2205,7 +2205,7 @@ export type operations = {
       /** @description OK */
       200: {
         content: {
-          "*/*": components["schemas"]["ApiResponse"];
+          "application/json": components["schemas"]["ApiResponse"];
         };
       };
     };
@@ -2237,7 +2237,7 @@ export type operations = {
       /** @description OK */
       200: {
         content: {
-          "*/*": components["schemas"]["ApiResponse"];
+          "application/json": components["schemas"]["ApiResponse"];
         };
       };
     };
@@ -2252,7 +2252,7 @@ export type operations = {
       /** @description OK */
       200: {
         content: {
-          "*/*": components["schemas"]["ApiResponse"];
+          "application/json": components["schemas"]["ApiResponse"];
         };
       };
     };
@@ -2315,7 +2315,7 @@ export type operations = {
       /** @description OK */
       200: {
         content: {
-          "*/*": components["schemas"]["ApiResponse"];
+          "application/json": components["schemas"]["ApiResponse"];
         };
       };
     };
@@ -2330,7 +2330,7 @@ export type operations = {
       /** @description OK */
       200: {
         content: {
-          "*/*": components["schemas"]["ApiResponse"];
+          "application/json": components["schemas"]["ApiResponse"];
         };
       };
     };
@@ -2345,7 +2345,7 @@ export type operations = {
       /** @description OK */
       200: {
         content: {
-          "*/*": components["schemas"]["ApiResponse"];
+          "application/json": components["schemas"]["ApiResponse"];
         };
       };
     };
@@ -2360,7 +2360,7 @@ export type operations = {
       /** @description OK */
       200: {
         content: {
-          "*/*": components["schemas"]["ApiResponse"];
+          "application/json": components["schemas"]["ApiResponse"];
         };
       };
     };
@@ -2375,7 +2375,7 @@ export type operations = {
       /** @description OK */
       200: {
         content: {
-          "*/*": components["schemas"]["ApiResponse"];
+          "application/json": components["schemas"]["ApiResponse"];
         };
       };
     };
@@ -2390,7 +2390,7 @@ export type operations = {
       /** @description OK */
       200: {
         content: {
-          "*/*": components["schemas"]["ApiResponse"];
+          "application/json": components["schemas"]["ApiResponse"];
         };
       };
     };
@@ -2405,7 +2405,7 @@ export type operations = {
       /** @description OK */
       200: {
         content: {
-          "*/*": components["schemas"]["ApiResponse"];
+          "application/json": components["schemas"]["ApiResponse"];
         };
       };
     };
@@ -2420,7 +2420,7 @@ export type operations = {
       /** @description OK */
       200: {
         content: {
-          "*/*": components["schemas"]["ApiResponse"];
+          "application/json": components["schemas"]["ApiResponse"];
         };
       };
     };

--- a/core/src/main/java/io/aiven/klaw/controller/AclController.java
+++ b/core/src/main/java/io/aiven/klaw/controller/AclController.java
@@ -38,7 +38,9 @@ public class AclController {
 
   @Autowired TopicOverviewService topicOverviewService;
 
-  @PostMapping(value = "/createAcl")
+  @PostMapping(
+      value = "/createAcl",
+      produces = {MediaType.APPLICATION_JSON_VALUE})
   public ResponseEntity<ApiResponse> createAcl(@Valid @RequestBody AclRequestsModel addAclRequest)
       throws KlawException {
     return new ResponseEntity<>(aclControllerService.createAcl(addAclRequest), HttpStatus.OK);
@@ -150,20 +152,26 @@ public class AclController {
     return new ResponseEntity<>(aclControllerService.deleteAclRequests(req_no), HttpStatus.OK);
   }
 
-  @PostMapping(value = "/execAclRequest")
+  @PostMapping(
+      value = "/execAclRequest",
+      produces = {MediaType.APPLICATION_JSON_VALUE})
   public ResponseEntity<ApiResponse> approveAclRequests(@RequestParam("req_no") String req_no)
       throws KlawException {
     return new ResponseEntity<>(aclControllerService.approveAclRequests(req_no), HttpStatus.OK);
   }
 
-  @PostMapping(value = "/createDeleteAclSubscriptionRequest")
+  @PostMapping(
+      value = "/createDeleteAclSubscriptionRequest",
+      produces = {MediaType.APPLICATION_JSON_VALUE})
   public ResponseEntity<ApiResponse> deleteAclSubscriptionRequest(
       @RequestParam("req_no") String req_no) throws KlawException {
     return new ResponseEntity<>(
         aclControllerService.createDeleteAclSubscriptionRequest(req_no), HttpStatus.OK);
   }
 
-  @PostMapping(value = "/execAclRequestDecline")
+  @PostMapping(
+      value = "/execAclRequestDecline",
+      produces = {MediaType.APPLICATION_JSON_VALUE})
   public ResponseEntity<ApiResponse> declineAclRequests(
       @RequestParam("req_no") String req_no,
       @RequestParam("reasonForDecline") String reasonForDecline)

--- a/core/src/main/java/io/aiven/klaw/controller/AclSyncController.java
+++ b/core/src/main/java/io/aiven/klaw/controller/AclSyncController.java
@@ -26,7 +26,9 @@ public class AclSyncController {
 
   @Autowired AclSyncControllerService aclSyncControllerService;
 
-  @PostMapping(value = "/updateSyncAcls")
+  @PostMapping(
+      value = "/updateSyncAcls",
+      produces = {MediaType.APPLICATION_JSON_VALUE})
   public ResponseEntity<ApiResponse> updateSyncAcls(
       @RequestBody List<SyncAclUpdates> syncAclUpdates) throws KlawException {
     return new ResponseEntity<>(
@@ -49,7 +51,9 @@ public class AclSyncController {
         HttpStatus.OK);
   }
 
-  @PostMapping(value = "/updateSyncBackAcls")
+  @PostMapping(
+      value = "/updateSyncBackAcls",
+      produces = {MediaType.APPLICATION_JSON_VALUE})
   public ResponseEntity<ApiResponse> updateSyncBackAcls(@RequestBody SyncBackAcls syncBackAcls)
       throws KlawException {
     return new ResponseEntity<>(

--- a/core/src/main/java/io/aiven/klaw/controller/EnvsClustersTenantsController.java
+++ b/core/src/main/java/io/aiven/klaw/controller/EnvsClustersTenantsController.java
@@ -91,14 +91,18 @@ public class EnvsClustersTenantsController {
         HttpStatus.OK);
   }
 
-  @PostMapping(value = "/deleteCluster")
+  @PostMapping(
+      value = "/deleteCluster",
+      produces = {MediaType.APPLICATION_JSON_VALUE})
   public ResponseEntity<ApiResponse> deleteCluster(@RequestParam("clusterId") String clusterId)
       throws KlawException {
     return new ResponseEntity<>(
         envsClustersTenantsControllerService.deleteCluster(clusterId), HttpStatus.OK);
   }
 
-  @PostMapping(value = "/addNewCluster")
+  @PostMapping(
+      value = "/addNewCluster",
+      produces = {MediaType.APPLICATION_JSON_VALUE})
   public ResponseEntity<ApiResponse> addNewCluster(
       @Valid @RequestBody KwClustersModel kwClustersModel) {
     return new ResponseEntity<>(
@@ -191,14 +195,18 @@ public class EnvsClustersTenantsController {
         envsClustersTenantsControllerService.getKafkaConnectEnvs(), HttpStatus.OK);
   }
 
-  @PostMapping(value = "/addNewEnv")
+  @PostMapping(
+      value = "/addNewEnv",
+      produces = {MediaType.APPLICATION_JSON_VALUE})
   public ResponseEntity<ApiResponse> addNewEnv(@Valid @RequestBody EnvModel newEnv)
       throws KlawException, KlawValidationException {
     return new ResponseEntity<>(
         envsClustersTenantsControllerService.addNewEnv(newEnv), HttpStatus.OK);
   }
 
-  @PostMapping(value = "/deleteEnvironmentRequest")
+  @PostMapping(
+      value = "/deleteEnvironmentRequest",
+      produces = {MediaType.APPLICATION_JSON_VALUE})
   public ResponseEntity<ApiResponse> deleteEnvironment(
       @RequestParam("envId") String envId, @RequestParam("envType") String envType)
       throws KlawException {
@@ -224,20 +232,26 @@ public class EnvsClustersTenantsController {
         envsClustersTenantsControllerService.getExtensionPeriods(), HttpStatus.OK);
   }
 
-  @PostMapping(value = "/addTenantId")
+  @PostMapping(
+      value = "/addTenantId",
+      produces = {MediaType.APPLICATION_JSON_VALUE})
   public ResponseEntity<ApiResponse> addTenantId(@Valid @RequestBody KwTenantModel kwTenantModel)
       throws KlawException {
     return new ResponseEntity<>(
         envsClustersTenantsControllerService.addTenantId(kwTenantModel, true), HttpStatus.OK);
   }
 
-  @PostMapping(value = "/deleteTenant")
+  @PostMapping(
+      value = "/deleteTenant",
+      produces = {MediaType.APPLICATION_JSON_VALUE})
   public ResponseEntity<ApiResponse> deleteTenant() throws KlawException {
     return new ResponseEntity<>(envsClustersTenantsControllerService.deleteTenant(), HttpStatus.OK);
   }
 
   // Pattern a-zA-z and/or spaces.
-  @PostMapping(value = "/udpateTenant")
+  @PostMapping(
+      value = "/udpateTenant",
+      produces = {MediaType.APPLICATION_JSON_VALUE})
   public ResponseEntity<ApiResponse> udpateTenant(
       @RequestParam("orgName") @Pattern(message = "Invalid Organization.", regexp = "^[a-zA-z ]*$")
           String orgName)
@@ -246,7 +260,9 @@ public class EnvsClustersTenantsController {
         envsClustersTenantsControllerService.updateTenant(orgName), HttpStatus.OK);
   }
 
-  @PostMapping(value = "/udpateTenantExtension")
+  @PostMapping(
+      value = "/udpateTenantExtension",
+      produces = {MediaType.APPLICATION_JSON_VALUE})
   public ResponseEntity<ApiResponse> udpateTenantExtension(
       @RequestParam("selectedTenantExtensionPeriod") String selectedTenantExtensionPeriod) {
     return new ResponseEntity<>(

--- a/core/src/main/java/io/aiven/klaw/controller/KafkaConnectController.java
+++ b/core/src/main/java/io/aiven/klaw/controller/KafkaConnectController.java
@@ -33,7 +33,9 @@ public class KafkaConnectController {
 
   @Autowired KafkaConnectControllerService kafkaConnectControllerService;
 
-  @PostMapping(value = "/createConnector")
+  @PostMapping(
+      value = "/createConnector",
+      produces = {MediaType.APPLICATION_JSON_VALUE})
   public ResponseEntity<ApiResponse> createConnectorRequest(
       @Valid @RequestBody KafkaConnectorRequestModel addTopicRequest) throws KlawException {
     return new ResponseEntity<>(
@@ -197,7 +199,9 @@ public class KafkaConnectController {
         HttpStatus.OK);
   }
 
-  @PostMapping(value = "/saveConnectorDocumentation")
+  @PostMapping(
+      value = "/saveConnectorDocumentation",
+      produces = {MediaType.APPLICATION_JSON_VALUE})
   public ResponseEntity<ApiResponse> saveConnectorDocumentation(
       @RequestBody KafkaConnectorModel topicInfo) {
     return new ResponseEntity<>(

--- a/core/src/main/java/io/aiven/klaw/controller/KafkaConnectSyncController.java
+++ b/core/src/main/java/io/aiven/klaw/controller/KafkaConnectSyncController.java
@@ -23,7 +23,9 @@ public class KafkaConnectSyncController {
 
   @Autowired KafkaConnectSyncControllerService kafkaConnectControllerService;
 
-  @PostMapping(value = "/updateSyncConnectors")
+  @PostMapping(
+      value = "/updateSyncConnectors",
+      produces = {MediaType.APPLICATION_JSON_VALUE})
   public ResponseEntity<ApiResponse> updateSyncConnectors(
       @RequestBody List<SyncConnectorUpdates> syncConnectorUpdates) throws KlawException {
     return new ResponseEntity<>(

--- a/core/src/main/java/io/aiven/klaw/controller/RolesPermissionsController.java
+++ b/core/src/main/java/io/aiven/klaw/controller/RolesPermissionsController.java
@@ -57,20 +57,26 @@ public class RolesPermissionsController {
         rolesPermissionsControllerService.getPermissions(true), HttpStatus.OK);
   }
 
-  @PostMapping(value = "/deleteRole")
+  @PostMapping(
+      value = "/deleteRole",
+      produces = {MediaType.APPLICATION_JSON_VALUE})
   public ResponseEntity<ApiResponse> deleteRole(@RequestParam("roleId") String roleId)
       throws KlawException {
     return new ResponseEntity<>(
         rolesPermissionsControllerService.deleteRole(roleId), HttpStatus.OK);
   }
 
-  @PostMapping(value = "/addRoleId")
+  @PostMapping(
+      value = "/addRoleId",
+      produces = {MediaType.APPLICATION_JSON_VALUE})
   public ResponseEntity<ApiResponse> addRoleId(@RequestParam("roleId") String roleId)
       throws KlawException {
     return new ResponseEntity<>(rolesPermissionsControllerService.addRoleId(roleId), HttpStatus.OK);
   }
 
-  @PostMapping(value = "/updatePermissions")
+  @PostMapping(
+      value = "/updatePermissions",
+      produces = {MediaType.APPLICATION_JSON_VALUE})
   public ResponseEntity<ApiResponse> updatePermissions(
       @RequestBody KwRolesPermissionsModel[] kwRolesPermissionsModels) throws KlawException {
     return new ResponseEntity<>(

--- a/core/src/main/java/io/aiven/klaw/controller/ServerConfigController.java
+++ b/core/src/main/java/io/aiven/klaw/controller/ServerConfigController.java
@@ -50,7 +50,9 @@ public class ServerConfigController {
     return new ResponseEntity<>(serverConfigService.resetCache(), HttpStatus.OK);
   }
 
-  @PostMapping(value = "/updateKwCustomProperty")
+  @PostMapping(
+      value = "/updateKwCustomProperty",
+      produces = {MediaType.APPLICATION_JSON_VALUE})
   public ResponseEntity<ApiResponse> updateKwCustomProperty(
       @RequestBody KwPropertiesModel kwPropertiesModel) throws KlawException {
     return new ResponseEntity<>(

--- a/core/src/main/java/io/aiven/klaw/controller/TopicController.java
+++ b/core/src/main/java/io/aiven/klaw/controller/TopicController.java
@@ -36,7 +36,9 @@ public class TopicController {
 
   @Autowired private TopicControllerService topicControllerService;
 
-  @PostMapping(value = "/createTopics")
+  @PostMapping(
+      value = "/createTopics",
+      produces = {MediaType.APPLICATION_JSON_VALUE})
   public ResponseEntity<ApiResponse> createTopicsCreateRequest(
       @Valid @RequestBody TopicCreateRequestModel addTopicRequest)
       throws KlawException, KlawNotAuthorizedException {
@@ -44,7 +46,9 @@ public class TopicController {
         topicControllerService.createTopicsCreateRequest(addTopicRequest), HttpStatus.OK);
   }
 
-  @PostMapping(value = "/updateTopics")
+  @PostMapping(
+      value = "/updateTopics",
+      produces = {MediaType.APPLICATION_JSON_VALUE})
   public ResponseEntity<ApiResponse> createTopicsUpdateRequest(
       @Valid @RequestBody TopicUpdateRequestModel addTopicRequest)
       throws KlawException, KlawNotAuthorizedException {
@@ -242,7 +246,9 @@ public class TopicController {
         topicControllerService.getTopicDetailsPerEnv(envId, topicName), HttpStatus.OK);
   }
 
-  @PostMapping(value = "/saveTopicDocumentation")
+  @PostMapping(
+      value = "/saveTopicDocumentation",
+      produces = {MediaType.APPLICATION_JSON_VALUE})
   public ResponseEntity<ApiResponse> saveTopicDocumentation(@RequestBody TopicInfo topicInfo)
       throws KlawException {
     return new ResponseEntity<>(

--- a/core/src/main/java/io/aiven/klaw/controller/TopicSyncController.java
+++ b/core/src/main/java/io/aiven/klaw/controller/TopicSyncController.java
@@ -26,14 +26,18 @@ public class TopicSyncController {
 
   @Autowired private TopicSyncControllerService topicSyncControllerService;
 
-  @PostMapping(value = "/updateSyncTopics")
+  @PostMapping(
+      value = "/updateSyncTopics",
+      produces = {MediaType.APPLICATION_JSON_VALUE})
   public ResponseEntity<ApiResponse> updateSyncTopics(
       @RequestBody List<SyncTopicUpdates> syncTopicUpdates) throws KlawException {
     return new ResponseEntity<>(
         topicSyncControllerService.updateSyncTopics(syncTopicUpdates), HttpStatus.OK);
   }
 
-  @PostMapping(value = "/updateSyncTopicsBulk")
+  @PostMapping(
+      value = "/updateSyncTopicsBulk",
+      produces = {MediaType.APPLICATION_JSON_VALUE})
   public ResponseEntity<ApiResponse> updateSyncTopicsBulk(
       @RequestBody SyncTopicsBulk syncTopicsBulk) throws KlawException {
     return new ResponseEntity<>(
@@ -58,7 +62,9 @@ public class TopicSyncController {
         HttpStatus.OK);
   }
 
-  @PostMapping(value = "/updateSyncBackTopics")
+  @PostMapping(
+      value = "/updateSyncBackTopics",
+      produces = {MediaType.APPLICATION_JSON_VALUE})
   public ResponseEntity<ApiResponse> updateSyncBackTopics(
       @RequestBody SyncBackTopics syncBackTopics) {
     return new ResponseEntity<>(

--- a/core/src/main/java/io/aiven/klaw/controller/UsersTeamsController.java
+++ b/core/src/main/java/io/aiven/klaw/controller/UsersTeamsController.java
@@ -59,48 +59,62 @@ public class UsersTeamsController {
     return new ResponseEntity<>(usersTeamsControllerService.getAllTeamsSUOnly(), HttpStatus.OK);
   }
 
-  @PostMapping(value = "/deleteTeamRequest")
+  @PostMapping(
+      value = "/deleteTeamRequest",
+      produces = {MediaType.APPLICATION_JSON_VALUE})
   public ResponseEntity<ApiResponse> deleteTeam(@RequestParam("teamId") Integer teamId)
       throws KlawException {
     return new ResponseEntity<>(usersTeamsControllerService.deleteTeam(teamId), HttpStatus.OK);
   }
 
-  @PostMapping(value = "/deleteUserRequest")
+  @PostMapping(
+      value = "/deleteUserRequest",
+      produces = {MediaType.APPLICATION_JSON_VALUE})
   public ResponseEntity<ApiResponse> deleteUser(@RequestParam("userId") String userId)
       throws KlawException {
     return new ResponseEntity<>(
         usersTeamsControllerService.deleteUser(userId, true), HttpStatus.OK);
   }
 
-  @PostMapping(value = "/updateUser")
+  @PostMapping(
+      value = "/updateUser",
+      produces = {MediaType.APPLICATION_JSON_VALUE})
   public ResponseEntity<ApiResponse> updateUser(@Valid @RequestBody UserInfoModel updateUserObj)
       throws KlawException {
     return new ResponseEntity<>(
         usersTeamsControllerService.updateUser(updateUserObj), HttpStatus.OK);
   }
 
-  @PostMapping(value = "/updateProfile")
+  @PostMapping(
+      value = "/updateProfile",
+      produces = {MediaType.APPLICATION_JSON_VALUE})
   public ResponseEntity<ApiResponse> updateProfile(@Valid @RequestBody UserInfoModel updateUserObj)
       throws KlawException {
     return new ResponseEntity<>(
         usersTeamsControllerService.updateProfile(updateUserObj), HttpStatus.OK);
   }
 
-  @PostMapping(value = "/addNewUser")
+  @PostMapping(
+      value = "/addNewUser",
+      produces = {MediaType.APPLICATION_JSON_VALUE})
   public ResponseEntity<ApiResponse> addNewUser(@Valid @RequestBody UserInfoModel newUser)
       throws KlawException {
     return new ResponseEntity<>(
         usersTeamsControllerService.addNewUser(newUser, true), HttpStatus.OK);
   }
 
-  @PostMapping(value = "/registerUser")
+  @PostMapping(
+      value = "/registerUser",
+      produces = {MediaType.APPLICATION_JSON_VALUE})
   public ResponseEntity<ApiResponse> registerUser(@Valid @RequestBody RegisterUserInfoModel newUser)
       throws KlawException {
     return new ResponseEntity<>(
         usersTeamsControllerService.registerUser(newUser, true), HttpStatus.OK);
   }
 
-  @PostMapping(value = "/registerUserSaas")
+  @PostMapping(
+      value = "/registerUserSaas",
+      produces = {MediaType.APPLICATION_JSON_VALUE})
   public ResponseEntity<ApiResponse> registerUserSaas(
       @Valid @RequestBody RegisterSaasUserInfoModel newUser) throws Exception {
     return new ResponseEntity<>(saasService.registerUserSaas(newUser), HttpStatus.OK);
@@ -134,28 +148,36 @@ public class UsersTeamsController {
         HttpStatus.OK);
   }
 
-  @PostMapping(value = "/execNewUserRequestApprove")
+  @PostMapping(
+      value = "/execNewUserRequestApprove",
+      produces = {MediaType.APPLICATION_JSON_VALUE})
   public ResponseEntity<ApiResponse> approveNewUserRequests(
       @RequestParam("username") String username) throws KlawException {
     return new ResponseEntity<>(
         usersTeamsControllerService.approveNewUserRequests(username, true, 0, ""), HttpStatus.OK);
   }
 
-  @PostMapping(value = "/execNewUserRequestDecline")
+  @PostMapping(
+      value = "/execNewUserRequestDecline",
+      produces = {MediaType.APPLICATION_JSON_VALUE})
   public ResponseEntity<ApiResponse> declineNewUserRequests(
       @RequestParam("username") String username) throws KlawException {
     return new ResponseEntity<>(
         usersTeamsControllerService.declineNewUserRequests(username), HttpStatus.OK);
   }
 
-  @PostMapping(value = "/addNewTeam")
+  @PostMapping(
+      value = "/addNewTeam",
+      produces = {MediaType.APPLICATION_JSON_VALUE})
   public ResponseEntity<ApiResponse> addNewTeam(@Valid @RequestBody TeamModel newTeam)
       throws KlawException {
     return new ResponseEntity<>(
         usersTeamsControllerService.addNewTeam(newTeam, true), HttpStatus.OK);
   }
 
-  @PostMapping(value = "/updateTeam")
+  @PostMapping(
+      value = "/updateTeam",
+      produces = {MediaType.APPLICATION_JSON_VALUE})
   public ResponseEntity<ApiResponse> updateTeam(@Valid @RequestBody TeamModel updateTeam)
       throws KlawException {
     return new ResponseEntity<>(usersTeamsControllerService.updateTeam(updateTeam), HttpStatus.OK);
@@ -172,7 +194,9 @@ public class UsersTeamsController {
         usersTeamsControllerService.getTeamDetails(teamId, tenantName), HttpStatus.OK);
   }
 
-  @PostMapping(value = "/chPwd")
+  @PostMapping(
+      value = "/chPwd",
+      produces = {MediaType.APPLICATION_JSON_VALUE})
   public ResponseEntity<ApiResponse> changePwd(@RequestParam("changePwd") String changePwd)
       throws KlawException {
     return new ResponseEntity<>(usersTeamsControllerService.changePwd(changePwd), HttpStatus.OK);
@@ -208,7 +232,9 @@ public class UsersTeamsController {
         usersTeamsControllerService.getUserInfoDetails(userId), HttpStatus.OK);
   }
 
-  @PostMapping(value = "/resetPassword")
+  @PostMapping(
+      value = "/resetPassword",
+      produces = {MediaType.APPLICATION_JSON_VALUE})
   public ResponseEntity<ResetPasswordInfo> resetPassword(
       @RequestParam("username") String username) {
     return new ResponseEntity<>(usersTeamsControllerService.resetPassword(username), HttpStatus.OK);
@@ -230,7 +256,9 @@ public class UsersTeamsController {
   Update base team for a user.
   Base team should be one of the switch teams.
    */
-  @PostMapping(value = "/user/updateTeam")
+  @PostMapping(
+      value = "/user/updateTeam",
+      produces = {MediaType.APPLICATION_JSON_VALUE})
   public ResponseEntity<ApiResponse> updateUserTeamFromSwitchTeams(
       @RequestBody UserInfoModel userInfoModel) {
     return new ResponseEntity<>(

--- a/core/src/main/java/io/aiven/klaw/controller/UtilController.java
+++ b/core/src/main/java/io/aiven/klaw/controller/UtilController.java
@@ -58,7 +58,9 @@ public class UtilController {
     return new ResponseEntity<>(utilControllerService.getBasicInfo(), HttpStatus.OK);
   }
 
-  @PostMapping(value = "/logout")
+  @PostMapping(
+      value = "/logout",
+      produces = {MediaType.APPLICATION_JSON_VALUE})
   public ResponseEntity<Map<String, String>> logout(
       HttpServletRequest request, HttpServletResponse response) {
     utilControllerService.getLogoutPage(request, response);

--- a/core/src/main/java/io/aiven/klaw/service/UsersTeamsControllerService.java
+++ b/core/src/main/java/io/aiven/klaw/service/UsersTeamsControllerService.java
@@ -1151,6 +1151,9 @@ public class UsersTeamsControllerService {
 
     String result =
         manageDatabase.getHandleDbRequests().updateUserTeam(userIdToBeUpdated, newTeamId);
+    if (result.equals(ApiResultStatus.SUCCESS.value)) {
+      manageDatabase.loadUsersForAllTenants();
+    }
     return ApiResponse.builder()
         .success(result.equals(ApiResultStatus.SUCCESS.value))
         .message(result)

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -67,7 +67,7 @@
           "200" : {
             "description" : "OK",
             "content" : {
-              "*/*" : {
+              "application/json" : {
                 "schema" : {
                   "$ref" : "#/components/schemas/ApiResponse"
                 }
@@ -123,7 +123,7 @@
           "200" : {
             "description" : "OK",
             "content" : {
-              "*/*" : {
+              "application/json" : {
                 "schema" : {
                   "$ref" : "#/components/schemas/ApiResponse"
                 }
@@ -151,7 +151,7 @@
           "200" : {
             "description" : "OK",
             "content" : {
-              "*/*" : {
+              "application/json" : {
                 "schema" : {
                   "$ref" : "#/components/schemas/ApiResponse"
                 }
@@ -179,7 +179,7 @@
           "200" : {
             "description" : "OK",
             "content" : {
-              "*/*" : {
+              "application/json" : {
                 "schema" : {
                   "$ref" : "#/components/schemas/ApiResponse"
                 }
@@ -210,7 +210,7 @@
           "200" : {
             "description" : "OK",
             "content" : {
-              "*/*" : {
+              "application/json" : {
                 "schema" : {
                   "$ref" : "#/components/schemas/ApiResponse"
                 }
@@ -238,7 +238,7 @@
           "200" : {
             "description" : "OK",
             "content" : {
-              "*/*" : {
+              "application/json" : {
                 "schema" : {
                   "$ref" : "#/components/schemas/ApiResponse"
                 }
@@ -269,7 +269,7 @@
           "200" : {
             "description" : "OK",
             "content" : {
-              "*/*" : {
+              "application/json" : {
                 "schema" : {
                   "$ref" : "#/components/schemas/ApiResponse"
                 }
@@ -297,7 +297,7 @@
           "200" : {
             "description" : "OK",
             "content" : {
-              "*/*" : {
+              "application/json" : {
                 "schema" : {
                   "$ref" : "#/components/schemas/ApiResponse"
                 }
@@ -325,7 +325,7 @@
           "200" : {
             "description" : "OK",
             "content" : {
-              "*/*" : {
+              "application/json" : {
                 "schema" : {
                   "$ref" : "#/components/schemas/ApiResponse"
                 }
@@ -356,7 +356,7 @@
           "200" : {
             "description" : "OK",
             "content" : {
-              "*/*" : {
+              "application/json" : {
                 "schema" : {
                   "$ref" : "#/components/schemas/ApiResponse"
                 }
@@ -384,7 +384,7 @@
           "200" : {
             "description" : "OK",
             "content" : {
-              "*/*" : {
+              "application/json" : {
                 "schema" : {
                   "$ref" : "#/components/schemas/ApiResponse"
                 }
@@ -415,7 +415,7 @@
           "200" : {
             "description" : "OK",
             "content" : {
-              "*/*" : {
+              "application/json" : {
                 "schema" : {
                   "$ref" : "#/components/schemas/ApiResponse"
                 }
@@ -443,7 +443,7 @@
           "200" : {
             "description" : "OK",
             "content" : {
-              "*/*" : {
+              "application/json" : {
                 "schema" : {
                   "$ref" : "#/components/schemas/ApiResponse"
                 }
@@ -470,7 +470,7 @@
           "200" : {
             "description" : "OK",
             "content" : {
-              "*/*" : {
+              "application/json" : {
                 "schema" : {
                   "$ref" : "#/components/schemas/ApiResponse"
                 }
@@ -496,7 +496,7 @@
           "200" : {
             "description" : "OK",
             "content" : {
-              "*/*" : {
+              "application/json" : {
                 "schema" : {
                   "$ref" : "#/components/schemas/ApiResponse"
                 }
@@ -557,7 +557,7 @@
           "200" : {
             "description" : "OK",
             "content" : {
-              "*/*" : {
+              "application/json" : {
                 "schema" : {
                   "$ref" : "#/components/schemas/ApiResponse"
                 }
@@ -585,7 +585,7 @@
           "200" : {
             "description" : "OK",
             "content" : {
-              "*/*" : {
+              "application/json" : {
                 "schema" : {
                   "$ref" : "#/components/schemas/ApiResponse"
                 }
@@ -611,7 +611,7 @@
           "200" : {
             "description" : "OK",
             "content" : {
-              "*/*" : {
+              "application/json" : {
                 "schema" : {
                   "$ref" : "#/components/schemas/ResetPasswordInfo"
                 }
@@ -855,7 +855,7 @@
           "200" : {
             "description" : "OK",
             "content" : {
-              "*/*" : {
+              "application/json" : {
                 "schema" : {
                   "$ref" : "#/components/schemas/ApiResponse"
                 }
@@ -883,7 +883,7 @@
           "200" : {
             "description" : "OK",
             "content" : {
-              "*/*" : {
+              "application/json" : {
                 "schema" : {
                   "$ref" : "#/components/schemas/ApiResponse"
                 }
@@ -929,7 +929,7 @@
           "200" : {
             "description" : "OK",
             "content" : {
-              "*/*" : {
+              "application/json" : {
                 "schema" : {
                   "type" : "object",
                   "additionalProperties" : {
@@ -1076,7 +1076,7 @@
           "200" : {
             "description" : "OK",
             "content" : {
-              "*/*" : {
+              "application/json" : {
                 "schema" : {
                   "$ref" : "#/components/schemas/ApiResponse"
                 }
@@ -1102,7 +1102,7 @@
           "200" : {
             "description" : "OK",
             "content" : {
-              "*/*" : {
+              "application/json" : {
                 "schema" : {
                   "$ref" : "#/components/schemas/ApiResponse"
                 }
@@ -1187,7 +1187,7 @@
           "200" : {
             "description" : "OK",
             "content" : {
-              "*/*" : {
+              "application/json" : {
                 "schema" : {
                   "$ref" : "#/components/schemas/ApiResponse"
                 }
@@ -1220,7 +1220,7 @@
           "200" : {
             "description" : "OK",
             "content" : {
-              "*/*" : {
+              "application/json" : {
                 "schema" : {
                   "$ref" : "#/components/schemas/ApiResponse"
                 }
@@ -1246,7 +1246,7 @@
           "200" : {
             "description" : "OK",
             "content" : {
-              "*/*" : {
+              "application/json" : {
                 "schema" : {
                   "$ref" : "#/components/schemas/ApiResponse"
                 }
@@ -1290,7 +1290,7 @@
           "200" : {
             "description" : "OK",
             "content" : {
-              "*/*" : {
+              "application/json" : {
                 "schema" : {
                   "$ref" : "#/components/schemas/ApiResponse"
                 }
@@ -1317,7 +1317,7 @@
           "200" : {
             "description" : "OK",
             "content" : {
-              "*/*" : {
+              "application/json" : {
                 "schema" : {
                   "$ref" : "#/components/schemas/ApiResponse"
                 }
@@ -1369,7 +1369,7 @@
           "200" : {
             "description" : "OK",
             "content" : {
-              "*/*" : {
+              "application/json" : {
                 "schema" : {
                   "$ref" : "#/components/schemas/ApiResponse"
                 }
@@ -1402,7 +1402,7 @@
           "200" : {
             "description" : "OK",
             "content" : {
-              "*/*" : {
+              "application/json" : {
                 "schema" : {
                   "$ref" : "#/components/schemas/ApiResponse"
                 }
@@ -1454,7 +1454,7 @@
           "200" : {
             "description" : "OK",
             "content" : {
-              "*/*" : {
+              "application/json" : {
                 "schema" : {
                   "$ref" : "#/components/schemas/ApiResponse"
                 }
@@ -1508,7 +1508,7 @@
           "200" : {
             "description" : "OK",
             "content" : {
-              "*/*" : {
+              "application/json" : {
                 "schema" : {
                   "$ref" : "#/components/schemas/ApiResponse"
                 }
@@ -1575,7 +1575,7 @@
           "200" : {
             "description" : "OK",
             "content" : {
-              "*/*" : {
+              "application/json" : {
                 "schema" : {
                   "$ref" : "#/components/schemas/ApiResponse"
                 }
@@ -1603,7 +1603,7 @@
           "200" : {
             "description" : "OK",
             "content" : {
-              "*/*" : {
+              "application/json" : {
                 "schema" : {
                   "$ref" : "#/components/schemas/ApiResponse"
                 }
@@ -1730,7 +1730,7 @@
           "200" : {
             "description" : "OK",
             "content" : {
-              "*/*" : {
+              "application/json" : {
                 "schema" : {
                   "$ref" : "#/components/schemas/ApiResponse"
                 }
@@ -1756,7 +1756,7 @@
           "200" : {
             "description" : "OK",
             "content" : {
-              "*/*" : {
+              "application/json" : {
                 "schema" : {
                   "$ref" : "#/components/schemas/ApiResponse"
                 }
@@ -1784,7 +1784,7 @@
           "200" : {
             "description" : "OK",
             "content" : {
-              "*/*" : {
+              "application/json" : {
                 "schema" : {
                   "$ref" : "#/components/schemas/ApiResponse"
                 }
@@ -1810,7 +1810,7 @@
           "200" : {
             "description" : "OK",
             "content" : {
-              "*/*" : {
+              "application/json" : {
                 "schema" : {
                   "$ref" : "#/components/schemas/ApiResponse"
                 }
@@ -1838,7 +1838,7 @@
           "200" : {
             "description" : "OK",
             "content" : {
-              "*/*" : {
+              "application/json" : {
                 "schema" : {
                   "$ref" : "#/components/schemas/ApiResponse"
                 }
@@ -1866,7 +1866,7 @@
           "200" : {
             "description" : "OK",
             "content" : {
-              "*/*" : {
+              "application/json" : {
                 "schema" : {
                   "$ref" : "#/components/schemas/ApiResponse"
                 }
@@ -1894,7 +1894,7 @@
           "200" : {
             "description" : "OK",
             "content" : {
-              "*/*" : {
+              "application/json" : {
                 "schema" : {
                   "$ref" : "#/components/schemas/ApiResponse"
                 }
@@ -1922,7 +1922,7 @@
           "200" : {
             "description" : "OK",
             "content" : {
-              "*/*" : {
+              "application/json" : {
                 "schema" : {
                   "$ref" : "#/components/schemas/ApiResponse"
                 }


### PR DESCRIPTION
## About this change - What it does

- Add `createConnectorRequest` to `domain/connector`

## Other changes

- All responses are typed as `application/json` in `openapi.yaml`
- Generate types and update outdated tests

Resolves: #1053
