### PR TITLE
refactor(coral): Fix api mocks in tests

### DIFF
--- a/coral/src/app/features/approvals/connectors/components/ConnectorApprovalsTable.test.tsx
+++ b/coral/src/app/features/approvals/connectors/components/ConnectorApprovalsTable.test.tsx
@@ -445,7 +445,7 @@ describe("ConnectorApprovalsTable", () => {
     const requestsWithStatusCreated = [
       mockedConnectorRequests[0],
       {
-        ...mockedConnectorRequests[0],
+        ...mockedConnectorRequests[1],
         connectorName: "Additional-topic",
         req_no: 1234,
       },

--- a/coral/src/app/features/components/filters/EnvironmentFilter.tsx
+++ b/coral/src/app/features/components/filters/EnvironmentFilter.tsx
@@ -30,7 +30,7 @@ function EnvironmentFilter({ environmentEndpoint }: EnvironmentFilterProps) {
   const { environment, setFilterValue } = useFiltersValues();
 
   const { data: environments } = useQuery<Environment[], HTTPError>(
-    ["topic-environments"],
+    [environmentEndpoint],
     {
       queryFn: environmentEndpointMap[environmentEndpoint],
     }

--- a/coral/src/app/features/topics/acl-request/TopicAclRequest.test.tsx
+++ b/coral/src/app/features/topics/acl-request/TopicAclRequest.test.tsx
@@ -26,6 +26,11 @@ jest.mock("react-router-dom", () => ({
   useNavigate: () => mockedNavigate,
 }));
 
+jest.mock("src/domain/acl/acl-api", () => ({
+  ...jest.requireActual("src/domain/acl/acl-api"),
+  getAivenServiceAccounts: jest.fn().mockReturnValue(["account"]),
+}));
+
 const dataSetup = ({ isAivenCluster }: { isAivenCluster: boolean }) => {
   mockGetEnvironments({
     mswInstance: server,
@@ -157,7 +162,7 @@ describe("<TopicAclRequest />", () => {
       expect(ipField).toBeDisabled();
       expect(ipField).not.toBeChecked();
 
-      const principalsField = await screen.findByRole("textbox", {
+      const principalsField = await screen.findByRole("combobox", {
         name: "Service accounts *",
       });
 
@@ -971,7 +976,7 @@ describe("<TopicAclRequest />", () => {
           screen.getByRole("radio", { name: "Service account" })
         );
 
-        const principalsField = await screen.findByRole("textbox", {
+        const principalsField = await screen.findByRole("combobox", {
           name: "Service accounts *",
         });
 
@@ -1044,7 +1049,7 @@ describe("<TopicAclRequest />", () => {
           screen.getByRole("radio", { name: "Service account" })
         );
 
-        const principalsField = await screen.findByRole("textbox", {
+        const principalsField = await screen.findByRole("combobox", {
           name: "Service accounts *",
         });
 
@@ -1087,7 +1092,7 @@ describe("<TopicAclRequest />", () => {
           screen.getByRole("radio", { name: "Service account" })
         );
 
-        const principalsField = await screen.findByRole("textbox", {
+        const principalsField = await screen.findByRole("combobox", {
           name: "Service accounts *",
         });
 
@@ -1120,7 +1125,7 @@ describe("<TopicAclRequest />", () => {
           screen.getByRole("radio", { name: "Service account" })
         );
 
-        const principalsField = await screen.findByRole("textbox", {
+        const principalsField = await screen.findByRole("combobox", {
           name: "Service accounts *",
         });
 
@@ -1159,7 +1164,7 @@ describe("<TopicAclRequest />", () => {
           screen.getByRole("radio", { name: "Service account" })
         );
 
-        const principalsField = await screen.findByRole("textbox", {
+        const principalsField = await screen.findByRole("combobox", {
           name: "Service accounts *",
         });
 

--- a/coral/src/app/pages/requests/connectors/index.test.tsx
+++ b/coral/src/app/pages/requests/connectors/index.test.tsx
@@ -1,7 +1,7 @@
 import { customRender } from "src/services/test-utils/render-with-wrappers";
 import { cleanup, screen, within } from "@testing-library/react";
 import { waitForElementToBeRemoved } from "@testing-library/react/pure";
-import { getEnvironments } from "src/domain/environment";
+import { getSyncConnectorsEnvironments } from "src/domain/environment";
 import { getConnectorRequests } from "src/domain/connector/connector-api";
 import ConnectorRequestsPage from "src/app/pages/requests/connectors/index";
 import { getTeams } from "src/domain/team";
@@ -11,9 +11,10 @@ jest.mock("src/domain/environment/environment-api.ts");
 jest.mock("src/domain/connector/connector-api.ts");
 
 const mockGetTeams = getTeams as jest.MockedFunction<typeof getTeams>;
-const mockGetEnvironments = getEnvironments as jest.MockedFunction<
-  typeof getEnvironments
->;
+const mockGetSyncConnectorsEnvironments =
+  getSyncConnectorsEnvironments as jest.MockedFunction<
+    typeof getSyncConnectorsEnvironments
+  >;
 const mockGetConnectorRequests = getConnectorRequests as jest.MockedFunction<
   typeof getConnectorRequests
 >;
@@ -21,7 +22,7 @@ const mockGetConnectorRequests = getConnectorRequests as jest.MockedFunction<
 describe("ConnectorRequestsPage", () => {
   beforeAll(async () => {
     mockGetTeams.mockResolvedValue([]);
-    mockGetEnvironments.mockResolvedValue([]);
+    mockGetSyncConnectorsEnvironments.mockResolvedValue([]);
     mockGetConnectorRequests.mockResolvedValue({
       entries: [],
       totalPages: 1,

--- a/coral/src/services/api-mocks/server.ts
+++ b/coral/src/services/api-mocks/server.ts
@@ -4,6 +4,7 @@ import { rest } from "msw";
 export const server = setupServer(
   rest.all("*", (req, res, ctx) => {
     console.error("Please mock all api calls in your tests.");
+    console.error("Request params: ", req.params);
 
     return res(ctx.status(404), ctx.json({}));
   })


### PR DESCRIPTION
# About this change - What it does

We had api calls in unit tests due to a missing mock. 

- added the missing mock
- update the query in test to check for the correct element (combobox)
    - before, it rendered a `textbox` because the call to aiven service accounts returned an error, so it defaulted to the `textbox`. it should render a `combobox` for an aiven service account though, which it now does after adding the correct mock

