### PR TITLE
refactor(coral): Add Icon as link indicator in tables

### DIFF
--- a/coral/src/app/features/connectors/browse/components/ConnectorTable.tsx
+++ b/coral/src/app/features/connectors/browse/components/ConnectorTable.tsx
@@ -4,8 +4,10 @@ import {
   EmptyState,
   Flexbox,
   StatusChip,
+  InlineIcon,
 } from "@aivenio/aquarium";
 import { Connector } from "src/domain/connector";
+import link from "@aivenio/aquarium/dist/src/icons/link";
 
 type ConnectorTableProps = {
   connectors: Connector[];
@@ -29,7 +31,7 @@ function ConnectorTable(props: ConnectorTableProps) {
       headerName: "Connector",
       UNSAFE_render: ({ connectorName }: ConnectorTableRow) => (
         <a href={`/connectorOverview?connectorName=${connectorName}`}>
-          {connectorName}
+          {connectorName} <InlineIcon icon={link} />
         </a>
       ),
     },

--- a/coral/src/app/features/topics/browse/components/TopicTable.tsx
+++ b/coral/src/app/features/topics/browse/components/TopicTable.tsx
@@ -4,9 +4,11 @@ import {
   EmptyState,
   Flexbox,
   StatusChip,
+  InlineIcon,
 } from "@aivenio/aquarium";
 import { createTopicOverviewLink } from "src/app/features/topics/browse/utils/create-topic-overview-link";
 import { Topic } from "src/domain/topic";
+import link from "@aivenio/aquarium/dist/src/icons/link";
 
 type TopicListProps = {
   topics: Topic[];
@@ -29,7 +31,9 @@ function TopicTable(props: TopicListProps) {
       field: "topicName",
       headerName: "Topic",
       UNSAFE_render: ({ topicName }: TopicsTableRow) => (
-        <a href={createTopicOverviewLink(topicName)}>{topicName}</a>
+        <a href={createTopicOverviewLink(topicName)}>
+          {topicName} <InlineIcon icon={link} />
+        </a>
       ),
     },
     {


### PR DESCRIPTION
# About this change - What it does

Adds a link Icon to make links in tables more discoverable.

Resolves: #990 


## Changes screenshot
<img width="1386" alt="Screenshot 2023-04-21 at 11 19 05" src="https://user-images.githubusercontent.com/943800/233599116-58b986e9-9df6-4416-ad6f-6dd3bc7d35ce.png">

<img width="1386" alt="Screenshot 2023-04-21 at 11 19 12" src="https://user-images.githubusercontent.com/943800/233599103-934f9d14-c030-4f18-9cff-ce93911dfea0.png">


