### PR TITLE
Correct Approve Connector requests response

### DIFF
--- a/core/src/main/java/io/aiven/klaw/service/ClusterApiService.java
+++ b/core/src/main/java/io/aiven/klaw/service/ClusterApiService.java
@@ -424,7 +424,7 @@ public class ClusterApiService {
               .exchange(uri, HttpMethod.POST, request, new ParameterizedTypeReference<>() {});
 
       if (ApiResultStatus.SUCCESS.value.equals(
-          Objects.requireNonNull(response.getBody()).get("result"))) {
+          Objects.requireNonNull(response.getBody()).get("message"))) {
         return ApiResultStatus.SUCCESS.value;
       } else {
         return response.getBody().get("errorText");

--- a/core/src/main/java/io/aiven/klaw/service/KafkaConnectControllerService.java
+++ b/core/src/main/java/io/aiven/klaw/service/KafkaConnectControllerService.java
@@ -615,7 +615,6 @@ public class KafkaConnectControllerService {
                 kafkaConnectHost,
                 kwClusters.getClusterName() + kwClusters.getClusterId(),
                 tenantId);
-
       }
 
       if (Objects.equals(updateTopicReqStatus, ApiResultStatus.SUCCESS.value)) {

--- a/core/src/main/java/io/aiven/klaw/service/KafkaConnectControllerService.java
+++ b/core/src/main/java/io/aiven/klaw/service/KafkaConnectControllerService.java
@@ -605,6 +605,7 @@ public class KafkaConnectControllerService {
                 kwClusters.getClusterName() + kwClusters.getClusterId(),
                 tenantId);
       } else {
+
         updateTopicReqStatus =
             clusterApiService.approveConnectorRequests(
                 connectorRequest.getConnectorName(),
@@ -614,7 +615,9 @@ public class KafkaConnectControllerService {
                 kafkaConnectHost,
                 kwClusters.getClusterName() + kwClusters.getClusterId(),
                 tenantId);
+
       }
+
       if (Objects.equals(updateTopicReqStatus, ApiResultStatus.SUCCESS.value)) {
         setConnectorHistory(connectorRequest, userDetails, tenantId);
         updateTopicReqStatus = dbHandle.updateConnectorRequest(connectorRequest, userDetails);
@@ -630,7 +633,7 @@ public class KafkaConnectControllerService {
     }
 
     return ApiResponse.builder()
-        .success((updateTopicReqStatus.equals(ApiResultStatus.SUCCESS.value)))
+        .success(ApiResultStatus.SUCCESS.value.equalsIgnoreCase(updateTopicReqStatus))
         .message(updateTopicReqStatus)
         .build();
   }


### PR DESCRIPTION
Defect in processing the response from the cluster-api

About this change - What it does

Resolves: #xxxxx
Why this way
Resolves the defect.