### PR TITLE
feat(coral): New connector request: add form to create new connector request

### DIFF
--- a/coral/src/app/features/connectors/request/ConnectorRequest.test.tsx
+++ b/coral/src/app/features/connectors/request/ConnectorRequest.test.tsx
@@ -1,0 +1,610 @@
+import { Context as AquariumContext } from "@aivenio/aquarium";
+import { cleanup, screen, waitFor, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import ConnectorRequest from "src/app/features/connectors/request/ConnectorRequest";
+import { createEnvironment } from "src/domain/environment/environment-test-helper";
+import { customRender } from "src/services/test-utils/render-with-wrappers";
+import { createConnectorRequest } from "src/domain/connector";
+import { getSyncConnectorsEnvironments } from "src/domain/environment";
+
+jest.mock("src/domain/environment/environment-api.ts");
+jest.mock("src/domain/connector/connector-api.ts");
+
+const mockGetConnectorEnvironmentRequest =
+  getSyncConnectorsEnvironments as jest.MockedFunction<
+    typeof getSyncConnectorsEnvironments
+  >;
+
+const mockCreateConnectorRequest =
+  createConnectorRequest as jest.MockedFunction<typeof createConnectorRequest>;
+
+const mockedUsedNavigate = jest.fn();
+jest.mock("react-router-dom", () => ({
+  ...jest.requireActual("react-router-dom"),
+  useNavigate: () => mockedUsedNavigate,
+}));
+
+describe("<ConnectorRequest />", () => {
+  const originalConsoleError = console.error;
+  let user: ReturnType<typeof userEvent.setup>;
+
+  beforeEach(() => {
+    console.error = jest.fn();
+    user = userEvent.setup();
+  });
+
+  afterEach(() => {
+    console.error = originalConsoleError;
+  });
+
+  describe("Environment select", () => {
+    describe("renders all necessary elements by default", () => {
+      beforeEach(() => {
+        mockGetConnectorEnvironmentRequest.mockResolvedValue([
+          createEnvironment({ id: "1", name: "DEV" }),
+          createEnvironment({ id: "2", name: "TST" }),
+          createEnvironment({ id: "3", name: "PROD" }),
+        ]);
+        customRender(<ConnectorRequest />, { queryClient: true });
+      });
+
+      afterEach(cleanup);
+
+      it("shows a required select element for 'Environment'", async () => {
+        const select = await screen.findByRole("combobox", {
+          name: "Environment *",
+        });
+        expect(select).toBeEnabled();
+        expect(select).toBeRequired();
+      });
+
+      it("shows an placeholder text for the select", async () => {
+        const select = await screen.findByRole("combobox", {
+          name: "Environment *",
+        });
+
+        expect(select).toHaveDisplayValue("-- Please select --");
+      });
+
+      it("shows all environment names as options", async () => {
+        await screen.findByRole("combobox", {
+          name: "Environment *",
+        });
+        const options = screen.getAllByRole("option");
+        // 3 environments + option for placeholder
+        expect(options.length).toBe(4);
+        expect(options.map((o) => o.textContent)).toEqual([
+          "-- Please select --",
+          "DEV",
+          "TST",
+          "PROD",
+        ]);
+      });
+
+      it("renders an enabled Submit button", () => {
+        const submitButton = screen.getByRole("button", {
+          name: "Submit request",
+        });
+        expect(submitButton).toBeEnabled();
+      });
+    });
+
+    describe("when field is clicked", () => {
+      beforeEach(() => {
+        mockGetConnectorEnvironmentRequest.mockResolvedValue([
+          createEnvironment({ id: "1", name: "DEV" }),
+          createEnvironment({ id: "2", name: "TST" }),
+          createEnvironment({ id: "3", name: "PROD" }),
+        ]);
+        customRender(<ConnectorRequest />, { queryClient: true });
+      });
+
+      afterEach(cleanup);
+
+      describe("when 'PROD' option is clicked", () => {
+        afterEach(cleanup);
+
+        it("selects 'PROD' value when user chooses the option", async () => {
+          const select = await screen.findByRole("combobox", {
+            name: "Environment *",
+          });
+          expect(select).toHaveDisplayValue("-- Please select --");
+
+          await user.selectOptions(select, "PROD");
+
+          const prodSelectOption: HTMLOptionElement = screen.getByRole(
+            "option",
+            { name: "PROD" }
+          );
+          expect(prodSelectOption.selected).toBe(true);
+          expect(select).toHaveDisplayValue("PROD");
+        });
+
+        it("disabled the placeholder value", async () => {
+          const select = await screen.findByRole("combobox", {
+            name: "Environment *",
+          });
+
+          const options = within(select).getAllByRole("option");
+          const placeholderOption = within(select).getByRole("option", {
+            name: "-- Please select --",
+          });
+
+          expect(placeholderOption).toBeDisabled();
+          expect(options.length).toBe(4);
+          expect(options.map((o) => o.textContent)).toEqual([
+            "-- Please select --",
+            "DEV",
+            "TST",
+            "PROD",
+          ]);
+        });
+      });
+    });
+  });
+
+  describe("Connector name", () => {
+    beforeEach(() => {
+      mockGetConnectorEnvironmentRequest.mockResolvedValue([
+        createEnvironment({ id: "1", name: "DEV" }),
+        createEnvironment({ id: "2", name: "TST" }),
+        createEnvironment({ id: "3", name: "PROD" }),
+      ]);
+      customRender(
+        <AquariumContext>
+          <ConnectorRequest />
+        </AquariumContext>,
+        { queryClient: true }
+      );
+    });
+
+    afterEach(cleanup);
+
+    it("validates that connector name is at least 5 characters", async () => {
+      const expectedErrorMsg = "String must contain at least 5 character(s)";
+      const connectorNameInput = screen.getByLabelText(/Connector name/);
+      await user.type(connectorNameInput, "test{tab}");
+      const errorMessage = await screen.findByText(expectedErrorMsg);
+      expect(errorMessage).toBeVisible();
+      await user.clear(connectorNameInput);
+      await user.type(connectorNameInput, "test-foobar{tab}");
+      expect(errorMessage).not.toBeVisible();
+    });
+  });
+
+  describe("Configuration", () => {
+    beforeEach(() => {
+      mockGetConnectorEnvironmentRequest.mockResolvedValue([
+        createEnvironment({ id: "1", name: "DEV" }),
+        createEnvironment({ id: "2", name: "TST" }),
+        createEnvironment({ id: "3", name: "PROD" }),
+      ]);
+      customRender(
+        <AquariumContext>
+          <ConnectorRequest />
+        </AquariumContext>,
+        { queryClient: true }
+      );
+    });
+
+    afterEach(cleanup);
+
+    it("checks that config is JSON", async () => {
+      const expectedErrorMsg = "Must be valid JSON";
+      const mockedAdvancedConfig = screen.getByTestId(
+        "connector-request-config"
+      );
+      await user.clear(mockedAdvancedConfig);
+      await user.type(mockedAdvancedConfig, ":");
+      const errorMessage = await screen.findByText(expectedErrorMsg);
+      expect(errorMessage).toBeVisible();
+      expect(mockedAdvancedConfig).toHaveDisplayValue(":");
+    });
+
+    it("checks that config is a JSON object", async () => {
+      const expectedErrorMsg = "Must be a JSON Object";
+      const mockedAdvancedConfig = screen.getByTestId(
+        "connector-request-config"
+      );
+      await user.type(mockedAdvancedConfig, "[[]");
+      const errorMessage = await screen.findByText(expectedErrorMsg);
+      expect(errorMessage).toBeVisible();
+      expect(mockedAdvancedConfig).toHaveDisplayValue(JSON.stringify([]));
+    });
+
+    it("checks that config includes tasks.max", async () => {
+      const expectedErrorMsg = 'Missing "tasks.max" configuration property.';
+      const mockedAdvancedConfig = screen.getByTestId(
+        "connector-request-config"
+      );
+      await user.type(
+        mockedAdvancedConfig,
+        '{{ "connector.class": "test", "topics": "test" }'
+      );
+      const errorMessage = await screen.findByText(expectedErrorMsg);
+      expect(errorMessage).toBeVisible();
+      expect(mockedAdvancedConfig).toHaveDisplayValue(
+        '{ "connector.class": "test", "topics": "test" }'
+      );
+    });
+
+    it("checks that config includes connector.class", async () => {
+      const expectedErrorMsg =
+        'Missing "connector.class" configuration property.';
+      const mockedAdvancedConfig = screen.getByTestId(
+        "connector-request-config"
+      );
+      await user.type(
+        mockedAdvancedConfig,
+        '{{ "topics": "test", "tasks.max": 10 }'
+      );
+      const errorMessage = await screen.findByText(expectedErrorMsg);
+      expect(errorMessage).toBeVisible();
+      expect(mockedAdvancedConfig).toHaveDisplayValue(
+        '{ "topics": "test", "tasks.max": 10 }'
+      );
+    });
+
+    it("checks that config includes topics or topics.regex", async () => {
+      const expectedErrorMsg =
+        'Missing "topics" or "topics.regex" configuration property.';
+      const mockedAdvancedConfig = screen.getByTestId(
+        "connector-request-config"
+      );
+      await user.type(
+        mockedAdvancedConfig,
+        '{{ "connector.class": "test", "tasks.max": 10 }'
+      );
+      const errorMessage = await screen.findByText(expectedErrorMsg);
+      expect(errorMessage).toBeVisible();
+      expect(mockedAdvancedConfig).toHaveDisplayValue(
+        '{ "connector.class": "test", "tasks.max": 10 }'
+      );
+    });
+  });
+
+  describe("Description", () => {
+    beforeEach(() => {
+      mockGetConnectorEnvironmentRequest.mockResolvedValue([
+        createEnvironment({ id: "1", name: "DEV" }),
+        createEnvironment({ id: "2", name: "TST" }),
+        createEnvironment({ id: "3", name: "PROD" }),
+      ]);
+      customRender(
+        <AquariumContext>
+          <ConnectorRequest />
+        </AquariumContext>,
+        { queryClient: true }
+      );
+    });
+
+    afterEach(cleanup);
+
+    it("validates that connector description is at least 5 characters", async () => {
+      const expectedErrorMsg = "String must contain at least 5 character(s)";
+      const connectorNameInput = screen.getByLabelText(/Connector description/);
+      await user.type(connectorNameInput, "test{tab}");
+      const errorMessage = await screen.findByText(expectedErrorMsg);
+      expect(errorMessage).toBeVisible();
+      await user.clear(connectorNameInput);
+      await user.type(connectorNameInput, "test-foobar{tab}");
+      expect(errorMessage).not.toBeVisible();
+    });
+  });
+
+  describe("Message for approval", () => {
+    beforeEach(() => {
+      mockGetConnectorEnvironmentRequest.mockResolvedValue([
+        createEnvironment({ id: "1", name: "DEV" }),
+        createEnvironment({ id: "2", name: "TST" }),
+        createEnvironment({ id: "3", name: "PROD" }),
+      ]);
+      customRender(
+        <AquariumContext>
+          <ConnectorRequest />
+        </AquariumContext>,
+        { queryClient: true }
+      );
+    });
+
+    afterEach(cleanup);
+
+    it("can be optionally provided", async () => {
+      const remarksInput = screen.getByLabelText("Message for approval");
+      await user.clear(remarksInput);
+      await user.type(remarksInput, "test");
+      expect(remarksInput).toHaveDisplayValue("test");
+    });
+  });
+
+  describe("form submission", () => {
+    beforeEach(async () => {
+      mockGetConnectorEnvironmentRequest.mockResolvedValue([
+        createEnvironment({ id: "1", name: "DEV" }),
+        createEnvironment({ id: "2", name: "TST" }),
+        createEnvironment({ id: "3", name: "PROD" }),
+      ]);
+      customRender(
+        <AquariumContext>
+          <ConnectorRequest />
+        </AquariumContext>,
+        { queryClient: true }
+      );
+
+      await waitFor(() =>
+        screen.getByRole("combobox", {
+          name: "Environment *",
+        })
+      );
+
+      await user.selectOptions(
+        screen.getByRole("combobox", {
+          name: "Environment *",
+        }),
+        "DEV"
+      );
+      await user.clear(screen.getByLabelText("Connector name*"));
+      await user.type(
+        screen.getByLabelText("Connector name*"),
+        "this-is-connector-name{tab}"
+      );
+      await user.type(
+        screen.getByTestId("connector-request-config"),
+        '{{ "connector.class": "test", "tasks.max": 10, "topics": "test" }'
+      );
+      await user.type(
+        screen.getByLabelText(/Connector description/),
+        "testing"
+      );
+    });
+
+    afterEach(() => {
+      jest.clearAllMocks();
+      cleanup();
+    });
+
+    describe("handles an error from the api", () => {
+      beforeEach(() => {
+        mockCreateConnectorRequest.mockRejectedValue({
+          success: false,
+          message: "Something went wrong",
+        });
+      });
+
+      afterEach(() => {
+        jest.clearAllMocks();
+        cleanup();
+      });
+
+      it("renders an error message", async () => {
+        await user.click(
+          screen.getByRole("button", { name: "Submit request" })
+        );
+        await waitFor(() =>
+          expect(createConnectorRequest).toHaveBeenCalledTimes(1)
+        );
+        expect(createConnectorRequest).toHaveBeenCalledWith({
+          connectorConfig:
+            '{ "connector.class": "test", "tasks.max": 10, "topics": "test" }',
+          connectorName: "this-is-connector-name",
+          description: "testing",
+          environment: "1",
+          remarks: "",
+        });
+        const alert = await screen.findByRole("alert");
+        expect(alert).toHaveTextContent("Something went wrong");
+      });
+    });
+
+    describe("enables user to create a new connector request", () => {
+      beforeEach(async () => {
+        mockCreateConnectorRequest.mockResolvedValue({
+          success: true,
+          message: "ok",
+        });
+      });
+
+      afterEach(() => cleanup());
+
+      it("creates a new connector request when input was valid", async () => {
+        await user.click(
+          screen.getByRole("button", { name: "Submit request" })
+        );
+        await waitFor(() => {
+          const btn = screen.getByRole("button", { name: "Submit request" });
+          expect(btn).toBeDisabled();
+        });
+        expect(createConnectorRequest).toHaveBeenCalledTimes(1);
+        expect(createConnectorRequest).toHaveBeenCalledWith({
+          connectorConfig:
+            '{ "connector.class": "test", "tasks.max": 10, "topics": "test" }',
+          connectorName: "this-is-connector-name",
+          description: "testing",
+          environment: "1",
+          remarks: "",
+        });
+      });
+
+      it("errors and does not create a new connector request when input was invalid", async () => {
+        await user.clear(screen.getByLabelText("Connector name*"));
+
+        await user.click(
+          screen.getByRole("button", { name: "Submit request" })
+        );
+
+        await waitFor(() =>
+          expect(
+            screen.getByText("String must contain at least 5 character(s)")
+          ).toBeVisible()
+        );
+
+        expect(createConnectorRequest).not.toHaveBeenCalled();
+        expect(
+          screen.getByRole("button", { name: "Submit request" })
+        ).toBeEnabled();
+      });
+
+      it("shows a dialog informing user that request was successful", async () => {
+        await user.click(
+          screen.getByRole("button", { name: "Submit request" })
+        );
+
+        await waitFor(() => {
+          const btn = screen.getByRole("button", { name: "Submit request" });
+          expect(btn).toBeDisabled();
+        });
+
+        expect(createConnectorRequest).toHaveBeenCalledTimes(1);
+
+        const successModal = await screen.findByRole("dialog");
+
+        expect(successModal).toBeVisible();
+        expect(successModal).toHaveTextContent("Connector request successful!");
+      });
+
+      it("user can continue to the next page without waiting for redirect in the dialog", async () => {
+        await user.click(
+          screen.getByRole("button", { name: "Submit request" })
+        );
+
+        await waitFor(() => {
+          const btn = screen.getByRole("button", { name: "Submit request" });
+          expect(btn).toBeDisabled();
+        });
+
+        expect(createConnectorRequest).toHaveBeenCalledTimes(1);
+
+        const successModal = await screen.findByRole("dialog");
+        const button = within(successModal).getByRole("button", {
+          name: "Continue",
+        });
+
+        await userEvent.click(button);
+
+        expect(mockedUsedNavigate).toHaveBeenCalledWith(
+          "/requests/connectors?status=CREATED"
+        );
+      });
+    });
+  });
+  describe("enables user to cancel the form input", () => {
+    beforeEach(async () => {
+      mockGetConnectorEnvironmentRequest.mockResolvedValue([
+        createEnvironment({ id: "1", name: "DEV" }),
+        createEnvironment({ id: "2", name: "TST" }),
+        createEnvironment({ id: "3", name: "PROD" }),
+      ]);
+
+      customRender(
+        <AquariumContext>
+          <ConnectorRequest />
+        </AquariumContext>,
+        { queryClient: true }
+      );
+
+      // Wait all API calls to resolve, which are required for the render
+      await screen.findByRole("combobox", {
+        name: "Environment *",
+      });
+      await screen.findByRole("option", { name: "DEV" });
+    });
+
+    afterEach(() => {
+      jest.clearAllMocks();
+      cleanup();
+    });
+
+    it("redirects user to the previous page if they click 'Cancel' on empty form", async () => {
+      const form = screen.getByRole("form", {
+        name: `Request a new connector`,
+      });
+
+      const button = within(form).getByRole("button", {
+        name: "Cancel",
+      });
+
+      await userEvent.click(button);
+
+      expect(mockedUsedNavigate).toHaveBeenCalledWith(-1);
+    });
+
+    it('shows a warning dialog if user clicks "Cancel" and has inputs in form', async () => {
+      const form = screen.getByRole("form", {
+        name: `Request a new connector`,
+      });
+
+      const nameInput = screen.getByRole("textbox", {
+        name: "Connector name *",
+      });
+      await userEvent.type(nameInput, "Some name");
+
+      const button = within(form).getByRole("button", {
+        name: "Cancel",
+      });
+
+      await userEvent.click(button);
+      const dialog = screen.getByRole("dialog");
+
+      expect(dialog).toBeVisible();
+      expect(dialog).toHaveTextContent("Cancel connector request?");
+      expect(dialog).toHaveTextContent(
+        "Do you want to cancel this request? The data added will be lost."
+      );
+
+      expect(mockedUsedNavigate).not.toHaveBeenCalled();
+    });
+
+    it("brings the user back to the form when they do not cancel", async () => {
+      const form = screen.getByRole("form", {
+        name: `Request a new connector`,
+      });
+
+      const nameInput = screen.getByRole("textbox", {
+        name: "Connector name *",
+      });
+      await userEvent.type(nameInput, "Some name");
+
+      const button = within(form).getByRole("button", {
+        name: "Cancel",
+      });
+
+      await userEvent.click(button);
+      const dialog = screen.getByRole("dialog");
+
+      const returnButton = screen.getByRole("button", {
+        name: "Continue with request",
+      });
+
+      await userEvent.click(returnButton);
+
+      expect(mockedUsedNavigate).not.toHaveBeenCalled();
+
+      expect(dialog).not.toBeInTheDocument();
+    });
+
+    it("redirects user to previous page if they cancel the request", async () => {
+      const form = screen.getByRole("form", {
+        name: `Request a new connector`,
+      });
+
+      const nameInput = screen.getByRole("textbox", {
+        name: "Connector name *",
+      });
+      await userEvent.type(nameInput, "Some name");
+
+      const button = within(form).getByRole("button", {
+        name: "Cancel",
+      });
+
+      await userEvent.click(button);
+
+      const returnButton = screen.getByRole("button", {
+        name: "Cancel request",
+      });
+
+      await userEvent.click(returnButton);
+
+      expect(mockedUsedNavigate).toHaveBeenCalledWith(-1);
+    });
+  });
+});

--- a/coral/src/app/features/connectors/request/ConnectorRequest.test.tsx
+++ b/coral/src/app/features/connectors/request/ConnectorRequest.test.tsx
@@ -161,7 +161,7 @@ describe("<ConnectorRequest />", () => {
     afterEach(cleanup);
 
     it("validates that connector name is at least 5 characters", async () => {
-      const expectedErrorMsg = "String must contain at least 5 character(s)";
+      const expectedErrorMsg = "Connector name must be at least 5 characters";
       const connectorNameInput = screen.getByLabelText(/Connector name/);
       await user.type(connectorNameInput, "test{tab}");
       const errorMessage = await screen.findByText(expectedErrorMsg);
@@ -281,7 +281,8 @@ describe("<ConnectorRequest />", () => {
     afterEach(cleanup);
 
     it("validates that connector description is at least 5 characters", async () => {
-      const expectedErrorMsg = "String must contain at least 5 character(s)";
+      const expectedErrorMsg =
+        "Connector description must be at least 5 characters";
       const connectorNameInput = screen.getByLabelText(/Connector description/);
       await user.type(connectorNameInput, "test{tab}");
       const errorMessage = await screen.findByText(expectedErrorMsg);
@@ -434,7 +435,7 @@ describe("<ConnectorRequest />", () => {
 
         await waitFor(() =>
           expect(
-            screen.getByText("String must contain at least 5 character(s)")
+            screen.getByText("Connector name must be at least 5 characters")
           ).toBeVisible()
         );
 

--- a/coral/src/app/features/connectors/request/ConnectorRequest.tsx
+++ b/coral/src/app/features/connectors/request/ConnectorRequest.tsx
@@ -73,7 +73,6 @@ function ConnectorRequest() {
 
   return (
     <>
-      {JSON.stringify(form.watch())}
       {successModalOpen && (
         <Dialog
           title={"Connector request successful!"}

--- a/coral/src/app/features/connectors/request/ConnectorRequest.tsx
+++ b/coral/src/app/features/connectors/request/ConnectorRequest.tsx
@@ -1,4 +1,12 @@
-import { Alert, Box, Button, Grid, Typography } from "@aivenio/aquarium";
+import {
+  Alert,
+  BorderBox,
+  Box,
+  Button,
+  Grid,
+  Label,
+  Typography,
+} from "@aivenio/aquarium";
 import MonacoEditor from "@monaco-editor/react";
 import { useMutation, useQuery } from "@tanstack/react-query";
 import { useState } from "react";
@@ -41,7 +49,7 @@ function ConnectorRequest() {
     queryFn: () => getSyncConnectorsEnvironments(),
   });
 
-  const schemaRequestMutation = useMutation(createConnectorRequest, {
+  const connectorRequestMutation = useMutation(createConnectorRequest, {
     onSuccess: () => {
       setSuccessModalOpen(true);
       setTimeout(() => {
@@ -55,7 +63,7 @@ function ConnectorRequest() {
   }
 
   function onSubmitForm(userInput: ConnectorRequestFormSchema) {
-    schemaRequestMutation.mutate(userInput);
+    connectorRequestMutation.mutate(userInput);
   }
 
   function cancelRequest() {
@@ -81,16 +89,16 @@ function ConnectorRequest() {
       )}
 
       <Box maxWidth={"7xl"}>
-        {schemaRequestMutation.isError && (
+        {connectorRequestMutation.isError && (
           <Box marginBottom={"l1"} role="alert">
             <Alert type="error">
-              {parseErrorMsg(schemaRequestMutation.error)}
+              {parseErrorMsg(connectorRequestMutation.error)}
             </Alert>
           </Box>
         )}
         <Form
           {...form}
-          ariaLabel={"Request a new schema"}
+          ariaLabel={"Request a new connector"}
           onSubmit={onSubmitForm}
         >
           {environmentsIsLoading && (
@@ -122,34 +130,53 @@ function ConnectorRequest() {
             required
           />
 
+          <Label labelText="Connector configuration" required />
           <_Controller<ConnectorRequestFormSchema>
             name={"connectorConfig"}
             control={form.control}
             render={({ fieldState: { error } }) => {
               return (
                 <>
-                  <MonacoEditor
-                    data-testid="connector-request-config"
-                    height="200px"
-                    language="json"
-                    theme={"light"}
-                    onChange={(value) =>
-                      value !== undefined &&
-                      form.setValue("connectorConfig", value, {
-                        shouldValidate: true,
-                      })
-                    }
-                    options={{
-                      language: "json",
-                      ariaLabel: "Connector configuration",
-                      renderControlCharacters: false,
-                      minimap: { enabled: false },
-                      folding: false,
-                      lineNumbers: "off",
-                      scrollBeyondLastLine: false,
-                      automaticLayout: true,
-                    }}
-                  />
+                  <BorderBox
+                    borderColor="grey-20"
+                    borderWidth={1}
+                    paddingY={"3"}
+                    borderRadius={2}
+                  >
+                    <MonacoEditor
+                      data-testid="connector-request-config"
+                      height="200px"
+                      language="json"
+                      theme={"light"}
+                      onChange={(value) =>
+                        value !== undefined &&
+                        form.setValue("connectorConfig", value, {
+                          shouldValidate: true,
+                        })
+                      }
+                      options={{
+                        language: "json",
+                        ariaLabel: "Connector configuration",
+                        renderControlCharacters: false,
+                        minimap: { enabled: false },
+                        folding: false,
+                        lineNumbers: "off",
+                        scrollBeyondLastLine: false,
+                        renderLineHighlight: "none",
+                        cursorBlinking: "solid",
+                        overviewRulerLanes: 0,
+                        wordBasedSuggestions: false,
+                        lineNumbersMinChars: 3,
+                        glyphMargin: false,
+                        cursorStyle: "line-thin",
+                        scrollbar: {
+                          useShadows: false,
+                          verticalScrollbarSize: 2,
+                        },
+                        fixedOverflowWidgets: true,
+                      }}
+                    />
+                  </BorderBox>
                   <Box marginTop={"1"} marginBottom={"3"} aria-hidden={"true"}>
                     <Typography.Caption color={"error-50"}>
                       {error !== undefined ? error.message : <>&nbsp;</>}
@@ -173,7 +200,9 @@ function ConnectorRequest() {
           </Grid>
 
           <Box display={"flex"} colGap={"l1"} marginTop={"3"}>
-            <SubmitButton>Submit request</SubmitButton>
+            <SubmitButton disabled={connectorRequestMutation.isLoading}>
+              Submit request
+            </SubmitButton>
             <Button
               type="button"
               kind={"secondary"}

--- a/coral/src/app/features/connectors/request/ConnectorRequest.tsx
+++ b/coral/src/app/features/connectors/request/ConnectorRequest.tsx
@@ -1,5 +1,211 @@
+import { Alert, Box, Button, Grid, Typography } from "@aivenio/aquarium";
+import MonacoEditor from "@monaco-editor/react";
+import { useMutation, useQuery } from "@tanstack/react-query";
+import { useState } from "react";
+import { Controller as _Controller } from "react-hook-form";
+import { useNavigate } from "react-router-dom";
+import { Dialog } from "src/app/components/Dialog";
+import {
+  Form,
+  NativeSelect,
+  SubmitButton,
+  TextInput,
+  Textarea,
+  useForm,
+} from "src/app/components/Form";
+import {
+  ConnectorRequestFormSchema,
+  connectorRequestFormSchema,
+} from "src/app/features/connectors/request/schemas/connector-request-form";
+import { createConnectorRequest } from "src/domain/connector";
+import {
+  Environment,
+  getSyncConnectorsEnvironments,
+} from "src/domain/environment";
+import { parseErrorMsg } from "src/services/mutation-utils";
+
 function ConnectorRequest() {
-  return <h1>Request connector</h1>;
+  const [cancelDialogVisible, setCancelDialogVisible] = useState(false);
+  const [successModalOpen, setSuccessModalOpen] = useState(false);
+
+  const navigate = useNavigate();
+  const form = useForm<ConnectorRequestFormSchema>({
+    schema: connectorRequestFormSchema,
+  });
+
+  const { data: environments, isLoading: environmentsIsLoading } = useQuery<
+    Environment[],
+    Error
+  >({
+    queryKey: ["getSyncConnectorsEnvironments"],
+    queryFn: () => getSyncConnectorsEnvironments(),
+  });
+
+  const schemaRequestMutation = useMutation(createConnectorRequest, {
+    onSuccess: () => {
+      setSuccessModalOpen(true);
+      setTimeout(() => {
+        redirectToMyRequests();
+      }, 5 * 1000);
+    },
+  });
+
+  function redirectToMyRequests() {
+    navigate("/requests/connectors?status=CREATED");
+  }
+
+  function onSubmitForm(userInput: ConnectorRequestFormSchema) {
+    schemaRequestMutation.mutate(userInput);
+  }
+
+  function cancelRequest() {
+    form.reset();
+    navigate(-1);
+  }
+
+  return (
+    <>
+      {JSON.stringify(form.watch())}
+      {successModalOpen && (
+        <Dialog
+          title={"Connector request successful!"}
+          primaryAction={{
+            text: "Continue",
+            onClick: redirectToMyRequests,
+          }}
+          type={"confirmation"}
+        >
+          Redirecting to My team&apos;s request page shortly. Select
+          &quot;Continue&quot; for an immediate redirect.
+        </Dialog>
+      )}
+
+      <Box maxWidth={"7xl"}>
+        {schemaRequestMutation.isError && (
+          <Box marginBottom={"l1"} role="alert">
+            <Alert type="error">
+              {parseErrorMsg(schemaRequestMutation.error)}
+            </Alert>
+          </Box>
+        )}
+        <Form
+          {...form}
+          ariaLabel={"Request a new schema"}
+          onSubmit={onSubmitForm}
+        >
+          {environmentsIsLoading && (
+            <div data-testid={"environments-select-loading"}>
+              <NativeSelect.Skeleton />
+            </div>
+          )}
+
+          {environments && (
+            <NativeSelect<ConnectorRequestFormSchema>
+              name={"environment"}
+              labelText={"Environment"}
+              placeholder={"-- Please select --"}
+              required
+            >
+              {environments.map((env) => {
+                return (
+                  <option key={env.id} value={env.id}>
+                    {env.name}
+                  </option>
+                );
+              })}
+            </NativeSelect>
+          )}
+
+          <TextInput<ConnectorRequestFormSchema>
+            name={"connectorName"}
+            labelText={"Connector name"}
+            required
+          />
+
+          <_Controller<ConnectorRequestFormSchema>
+            name={"connectorConfig"}
+            control={form.control}
+            render={({ fieldState: { error } }) => {
+              return (
+                <>
+                  <MonacoEditor
+                    data-testid="connector-request-config"
+                    height="200px"
+                    language="json"
+                    theme={"light"}
+                    onChange={(value) =>
+                      value !== undefined &&
+                      form.setValue("connectorConfig", value, {
+                        shouldValidate: true,
+                      })
+                    }
+                    options={{
+                      language: "json",
+                      ariaLabel: "Connector configuration",
+                      renderControlCharacters: false,
+                      minimap: { enabled: false },
+                      folding: false,
+                      lineNumbers: "off",
+                      scrollBeyondLastLine: false,
+                      automaticLayout: true,
+                    }}
+                  />
+                  <Box marginTop={"1"} marginBottom={"3"} aria-hidden={"true"}>
+                    <Typography.Caption color={"error-50"}>
+                      {error !== undefined ? error.message : <>&nbsp;</>}
+                    </Typography.Caption>
+                  </Box>
+                </>
+              );
+            }}
+          />
+
+          <Grid colGap={"l1"} marginTop={"3"} cols={"2"}>
+            <Textarea<ConnectorRequestFormSchema>
+              name={"description"}
+              labelText={"Connector description"}
+              required
+            />
+            <Textarea<ConnectorRequestFormSchema>
+              name={"remarks"}
+              labelText={"Message for approval"}
+            />
+          </Grid>
+
+          <Box display={"flex"} colGap={"l1"} marginTop={"3"}>
+            <SubmitButton>Submit request</SubmitButton>
+            <Button
+              type="button"
+              kind={"secondary"}
+              onClick={
+                form.formState.isDirty
+                  ? () => setCancelDialogVisible(true)
+                  : () => cancelRequest()
+              }
+            >
+              Cancel
+            </Button>
+          </Box>
+        </Form>
+      </Box>
+      {cancelDialogVisible && (
+        <Dialog
+          title={"Cancel connector request?"}
+          primaryAction={{
+            text: "Cancel request",
+            onClick: () => cancelRequest(),
+          }}
+          secondaryAction={{
+            text: "Continue with request",
+            onClick: () => setCancelDialogVisible(false),
+          }}
+          type={"warning"}
+        >
+          Do you want to cancel this request? The data added will be lost.
+        </Dialog>
+      )}
+    </>
+  );
 }
 
 export default ConnectorRequest;

--- a/coral/src/app/features/connectors/request/schemas/connector-request-form.ts
+++ b/coral/src/app/features/connectors/request/schemas/connector-request-form.ts
@@ -3,10 +3,10 @@ import isError from "lodash/isError";
 import z from "zod";
 
 const connectorRequestFormSchema = z.object({
-  environment: z
+  environment: z.string().min(1, { message: "Please select an environment" }),
+  connectorName: z
     .string()
-    .min(1, { message: "Selection Error: Please select an environment." }),
-  connectorName: z.string().min(5),
+    .min(5, { message: "Connector name must be at least 5 characters" }),
   connectorConfig: z
     .string()
     // Refines for JSON object and for each of the three required config properties
@@ -30,7 +30,9 @@ const connectorRequestFormSchema = z.object({
       },
       { message: 'Missing "topics" or "topics.regex" configuration property.' }
     ),
-  description: z.string().min(5),
+  description: z
+    .string()
+    .min(5, { message: "Connector description must be at least 5 characters" }),
   remarks: z.string().optional(),
 });
 

--- a/coral/src/app/features/connectors/request/schemas/connector-request-form.ts
+++ b/coral/src/app/features/connectors/request/schemas/connector-request-form.ts
@@ -1,0 +1,37 @@
+import z from "zod";
+
+const connectorRequestFormSchema = z.object({
+  environment: z
+    .string()
+    .min(1, { message: "Selection Error: Please select an environment." }),
+  connectorName: z.string().min(5),
+  connectorConfig: z
+    .string()
+    // Three refines for each of the three required config properties
+    // Only checking the presence of the properties, not their values
+    .refine(
+      (value) => {
+        return value.includes("tasks.max");
+      },
+      { message: `Missing "tasks.max" configuration property.` }
+    )
+    .refine(
+      (value) => {
+        return value.includes("connector.class");
+      },
+      { message: `Missing "connector.class" configuration property.` }
+    )
+    .refine(
+      (value) => {
+        return value.includes("topics");
+      },
+      { message: `Missing "topics" or "topics.regex" configuration property.` }
+    ),
+  description: z.string().min(5),
+  remarks: z.string().optional(),
+});
+
+type ConnectorRequestFormSchema = z.infer<typeof connectorRequestFormSchema>;
+
+export { connectorRequestFormSchema };
+export type { ConnectorRequestFormSchema };

--- a/coral/src/app/features/topics/acl-request/TopicAclRequest.test.tsx
+++ b/coral/src/app/features/topics/acl-request/TopicAclRequest.test.tsx
@@ -1002,6 +1002,8 @@ describe("<TopicAclRequest />", () => {
           topicname: "aivtopic1",
           environment: "1",
           aclType: "PRODUCER",
+          requestOperationType: "CREATE",
+          transactionalId: undefined,
           teamId: 1,
         });
 
@@ -1075,6 +1077,7 @@ describe("<TopicAclRequest />", () => {
           topicname: "aivtopic1",
           environment: "1",
           aclType: "PRODUCER",
+          requestOperationType: "CREATE",
           teamId: 1,
         });
       });
@@ -1394,6 +1397,7 @@ describe("<TopicAclRequest />", () => {
           aclType: "CONSUMER",
           teamId: 1,
           consumergroup: "group",
+          requestOperationType: "CREATE",
         });
 
         const alert = await screen.findByRole("alert");
@@ -1484,6 +1488,8 @@ describe("<TopicAclRequest />", () => {
           aclType: "CONSUMER",
           teamId: 1,
           consumergroup: "group",
+          requestOperationType: "CREATE",
+          transactionalId: undefined,
         });
       });
 

--- a/coral/src/domain/acl/acl-api.ts
+++ b/coral/src/domain/acl/acl-api.ts
@@ -25,7 +25,10 @@ const createAclRequest = (
 ): Promise<KlawApiResponse<"createAcl">> => {
   return api.post<KlawApiResponse<"createAcl">, KlawApiRequest<"createAcl">>(
     API_PATHS.createAcl,
-    aclPayload
+    {
+      ...aclPayload,
+      requestOperationType: "CREATE",
+    }
   );
 };
 

--- a/coral/src/domain/connector/connector-api.ts
+++ b/coral/src/domain/connector/connector-api.ts
@@ -137,8 +137,6 @@ const createConnectorRequest = (
     KlawApiRequest<"createConnectorRequest">
   >(API_PATHS.createConnectorRequest, {
     ...connectorPayload,
-    // This is a required property despite being typed as optional in openapi.yaml
-    // Will be fixed in the backend
     requestOperationType: "CREATE",
   });
 };

--- a/coral/src/domain/connector/connector-api.ts
+++ b/coral/src/domain/connector/connector-api.ts
@@ -130,7 +130,10 @@ const deleteConnectorRequest = ({ reqIds }: DeleteRequestParams) => {
 };
 
 const createConnectorRequest = (
-  connectorPayload: KlawApiRequest<"createConnectorRequest">
+  connectorPayload: Omit<
+    KlawApiRequest<"createConnectorRequest">,
+    "requestOperationType"
+  >
 ) => {
   return api.post<
     KlawApiResponse<"createConnectorRequest">,

--- a/coral/src/domain/connector/connector-api.ts
+++ b/coral/src/domain/connector/connector-api.ts
@@ -135,7 +135,12 @@ const createConnectorRequest = (
   return api.post<
     KlawApiResponse<"createConnectorRequest">,
     KlawApiRequest<"createConnectorRequest">
-  >(API_PATHS.createConnectorRequest, connectorPayload);
+  >(API_PATHS.createConnectorRequest, {
+    ...connectorPayload,
+    // This is a required property despite being typed as optional in openapi.yaml
+    // Will be fixed in the backend
+    requestOperationType: "CREATE",
+  });
 };
 
 export {

--- a/coral/src/domain/topic/topic-api.test.ts
+++ b/coral/src/domain/topic/topic-api.test.ts
@@ -40,6 +40,7 @@ describe("topic-api", () => {
         description: "this-is-description",
         remarks: "",
         topictype: "Create" as const,
+        requestOperationType: "CREATE" as const,
       };
       requestTopic(payload);
       expect(postSpy).toHaveBeenCalledTimes(1);

--- a/coral/types/api.d.ts
+++ b/coral/types/api.d.ts
@@ -473,7 +473,7 @@ export type components = {
   schemas: {
     SchemaRequestModel: {
       /** @enum {string} */
-      requestOperationType?: "CREATE" | "UPDATE" | "PROMOTE" | "CLAIM" | "DELETE";
+      requestOperationType: "CREATE" | "UPDATE" | "PROMOTE" | "CLAIM" | "DELETE";
       environment: string;
       appname?: string;
       remarks?: string;
@@ -514,7 +514,7 @@ export type components = {
     };
     TopicUpdateRequestModel: {
       /** @enum {string} */
-      requestOperationType?: "CREATE" | "UPDATE" | "PROMOTE" | "CLAIM" | "DELETE";
+      requestOperationType: "CREATE" | "UPDATE" | "PROMOTE" | "CLAIM" | "DELETE";
       environment: string;
       appname?: string;
       remarks?: string;
@@ -687,7 +687,7 @@ export type components = {
     };
     TopicCreateRequestModel: {
       /** @enum {string} */
-      requestOperationType?: "CREATE" | "UPDATE" | "PROMOTE" | "CLAIM" | "DELETE";
+      requestOperationType: "CREATE" | "UPDATE" | "PROMOTE" | "CLAIM" | "DELETE";
       environment: string;
       appname?: string;
       remarks?: string;
@@ -720,7 +720,7 @@ export type components = {
     };
     AclRequestsModel: {
       /** @enum {string} */
-      requestOperationType?: "CREATE" | "UPDATE" | "PROMOTE" | "CLAIM" | "DELETE";
+      requestOperationType: "CREATE" | "UPDATE" | "PROMOTE" | "CLAIM" | "DELETE";
       environment: string;
       appname?: string;
       remarks?: string;

--- a/coral/types/api.d.ts
+++ b/coral/types/api.d.ts
@@ -706,7 +706,7 @@ export type components = {
     };
     KafkaConnectorRequestModel: {
       /** @enum {string} */
-      requestOperationType?: "CREATE" | "UPDATE" | "PROMOTE" | "CLAIM" | "DELETE";
+      requestOperationType: "CREATE" | "UPDATE" | "PROMOTE" | "CLAIM" | "DELETE";
       environment: string;
       appname?: string;
       remarks?: string;

--- a/core/src/main/java/io/aiven/klaw/model/requests/BaseRequestModel.java
+++ b/core/src/main/java/io/aiven/klaw/model/requests/BaseRequestModel.java
@@ -13,7 +13,7 @@ import lombok.ToString;
 public class BaseRequestModel implements Serializable {
 
   // CREATE / DELETE / ..
-  private RequestOperationType requestOperationType;
+  @NotNull private RequestOperationType requestOperationType;
 
   @NotNull private String environment;
 

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -5693,7 +5693,7 @@
             "type" : "string"
           }
         },
-        "required" : [ "connectorConfig", "connectorName", "description", "environment" ]
+        "required" : [ "requestOperationType", "connectorConfig", "connectorName", "description", "environment" ]
       },
       "AclRequestsModel" : {
         "properties" : {

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -5004,7 +5004,7 @@
             "format" : "int32"
           }
         },
-        "required" : [ "environment", "schemafull", "topicname" ]
+        "required" : [ "environment", "requestOperationType", "schemafull", "topicname" ]
       },
       "ApiResponse" : {
         "properties" : {
@@ -5144,7 +5144,7 @@
             "type" : "string"
           }
         },
-        "required" : [ "description", "environment", "replicationfactor", "topicname", "topicpartitions" ]
+        "required" : [ "description", "environment", "replicationfactor", "requestOperationType", "topicname", "topicpartitions" ]
       },
       "TeamModel" : {
         "properties" : {
@@ -5654,7 +5654,7 @@
             "type" : "string"
           }
         },
-        "required" : [ "description", "environment", "replicationfactor", "topicname", "topicpartitions" ]
+        "required" : [ "description", "environment", "replicationfactor", "requestOperationType", "topicname", "topicpartitions" ]
       },
       "KafkaConnectorRequestModel" : {
         "properties" : {
@@ -5693,7 +5693,7 @@
             "type" : "string"
           }
         },
-        "required" : [ "requestOperationType", "connectorConfig", "connectorName", "description", "environment" ]
+        "required" : [ "connectorConfig", "connectorName", "description", "environment", "requestOperationType" ]
       },
       "AclRequestsModel" : {
         "properties" : {
@@ -5765,7 +5765,7 @@
             "type" : "string"
           }
         },
-        "required" : [ "aclIpPrincipleType", "aclPatternType", "aclType", "environment", "teamId", "topicname" ]
+        "required" : [ "aclIpPrincipleType", "aclPatternType", "aclType", "environment", "requestOperationType", "teamId", "topicname" ]
       },
       "KwTenantModel" : {
         "properties" : {


### PR DESCRIPTION
## About this change - What it does

Draft for Create connector request. Misssing:

- [x] tests
- [x] cosmetics : label for config, probably other things
- [x] better validation for config editor
- [x] backend changes: implement an object type for `connectorConfig` instead opf string for better validation
- [x] backend change: make `requestOperationType` a required property in payload OR set this value in the API automatically (which would make sense as it is the `createConnectorRequest` endpoint after all)

Resolves: #1055
