### PR TITLE
fix(coral): Make `MultiSelect` controlled

### DIFF
--- a/coral/src/app/components/Form.tsx
+++ b/coral/src/app/components/Form.tsx
@@ -328,34 +328,41 @@ MultiInput.Skeleton = BaseMultiInput.Skeleton;
 //
 function _MultiSelect<T extends FieldValues, FieldValue>({
   name,
-  helperText,
   formContext: form,
   ...props
 }: BaseMultiSelectProps<FieldValue> &
   FormInputProps<T> &
   FormRegisterProps<T>) {
-  const error = parseFieldErrorMessage(form.formState, name);
-
   return (
-    <BaseMultiSelect
-      {...props}
-      {...form.register(name)}
-      onChange={(values) => {
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        form.setValue(name, values as any, {
-          shouldValidate: true,
-          shouldDirty: true,
-        });
+    <_Controller
+      name={name}
+      control={form.control}
+      render={({ field: { name } }) => {
+        const { isSubmitting } = form.formState;
+        const error = parseFieldErrorMessage(form.formState, name);
+        return (
+          <BaseMultiSelect
+            {...props}
+            name={name}
+            disabled={props.disabled || isSubmitting}
+            onChange={(values) => {
+              // eslint-disable-next-line @typescript-eslint/no-explicit-any
+              form.setValue(name, values as any, {
+                shouldValidate: true,
+                shouldDirty: true,
+              });
+            }}
+            valid={error === undefined}
+            helperText={error}
+            // If we do not explicitly pass value to the component
+            // It will not display values stored in the form object
+            // If they are set before the component is rendered
+            // This is because we are rendering BaseMultiSelect without a Controller
+            // But its value still needs to be controlled
+            // value={form.getValues(name)}
+          />
+        );
       }}
-      valid={error === undefined}
-      error={error}
-      helperText={helperText}
-      // If we do not explicitly pass value to the component
-      // It will not display values stored in the form object
-      // If they are set before the component is rendered
-      // This is because we are rendering BaseMultiSelect without a Controller
-      // But its value still needs to be controlled
-      value={form.getValues(name)}
     />
   );
 }

--- a/coral/src/app/features/topics/acl-request/fields/IpOrPrincipalField.test.tsx
+++ b/coral/src/app/features/topics/acl-request/fields/IpOrPrincipalField.test.tsx
@@ -26,10 +26,16 @@ describe("IpOrPrincipalField", () => {
   const onSubmit = jest.fn();
   const onError = jest.fn();
 
+  const originalConsoleError = console.error;
+  beforeEach(() => {
+    console.error = jest.fn();
+  });
+
   afterEach(() => {
     cleanup();
     onSubmit.mockClear();
     onError.mockClear();
+    console.error = originalConsoleError;
   });
 
   it("renders a field for Service accounts with options for existing service accounts (Aiven cluster)", async () => {
@@ -67,6 +73,7 @@ describe("IpOrPrincipalField", () => {
 
       expect(option).toBeEnabled();
     });
+    expect(console.error).not.toHaveBeenCalled();
   });
 
   it("renders a field for Service accounts which allows adding new service accounts (Aiven cluster)", async () => {
@@ -101,6 +108,7 @@ describe("IpOrPrincipalField", () => {
     const newOption = screen.getByRole("button", { name: "hello" });
     expect(newOption).toBeVisible();
     expect(newOption).toBeEnabled();
+    expect(console.error).not.toHaveBeenCalled();
   });
 
   it("renders a textbox field for Service accounts when getAivenServiceAccounts errors (Aiven cluster)", async () => {
@@ -126,6 +134,7 @@ describe("IpOrPrincipalField", () => {
     });
     expect(multiInput).toBeVisible();
     expect(multiInput).toBeEnabled();
+    expect(console.error).toHaveBeenCalledWith("mock-error");
   });
 
   it("renders a field for SSL DN strings / Usernames (not Aiven cluster)", () => {
@@ -144,6 +153,7 @@ describe("IpOrPrincipalField", () => {
     const multiInput = result.getByLabelText("SSL DN strings / Usernames*");
     expect(multiInput).toBeVisible();
     expect(multiInput).toBeEnabled();
+    expect(console.error).not.toHaveBeenCalled();
   });
 
   it("renders a field for IP addresses (Aiven cluster)", () => {
@@ -162,6 +172,7 @@ describe("IpOrPrincipalField", () => {
     const multiInput = result.getByLabelText("IP addresses*");
     expect(multiInput).toBeVisible();
     expect(multiInput).toBeEnabled();
+    expect(console.error).not.toHaveBeenCalled();
   });
 
   it("renders a field for IP addresses (not Aiven cluster)", () => {
@@ -180,5 +191,6 @@ describe("IpOrPrincipalField", () => {
     const multiInput = result.getByLabelText("IP addresses*");
     expect(multiInput).toBeVisible();
     expect(multiInput).toBeEnabled();
+    expect(console.error).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
# About this change - What it does

- `MultiSelect` in `Form` switched from uncontrolled to controlled components, it's now controlled
- adds more specific testing for the right error to be passed and makes sure there's only an error logged when we expect it

Resolves: #1059 


### Still works
(there are no service accounts currently, so I mocked the response for the recording)


https://user-images.githubusercontent.com/943800/233925113-30e35d98-f64d-43f8-90b1-5991c51f2e91.mov


