### PR TITLE
feat(coral): Add regex validation for topic request 

### DIFF
--- a/coral/src/app/features/topics/request/TopicRequest.test.tsx
+++ b/coral/src/app/features/topics/request/TopicRequest.test.tsx
@@ -266,7 +266,7 @@ describe("<TopicRequest />", () => {
 
         expect(topicNameInput).toHaveAttribute(
           "placeholder",
-          'Name has to follow pattern ".*Dev.*". Allowed characters: letter, digit, period, underscore, and hyphen.'
+          'Follow name pattern: ".*Dev.*". Allowed characters: letter, digit, period, underscore, and hyphen.'
         );
       });
     });

--- a/coral/src/app/features/topics/request/TopicRequest.tsx
+++ b/coral/src/app/features/topics/request/TopicRequest.tsx
@@ -85,6 +85,21 @@ function TopicRequest() {
     navigate(-1);
   }
 
+  function getTopicNamePlaceholder({
+    applyRegex,
+    regex,
+  }: {
+    applyRegex: boolean | undefined;
+    regex: string | undefined;
+  }) {
+    const defaultPlaceholder =
+      "Allowed characters: letter, digit, period, underscore, and hyphen.";
+    if (applyRegex && regex) {
+      return `Name has to follow pattern "${regex}". ${defaultPlaceholder}`;
+    }
+    return defaultPlaceholder;
+  }
+
   return (
     <>
       {successModalOpen && (
@@ -134,9 +149,13 @@ function TopicRequest() {
             <TextInput<Schema>
               name={"topicname"}
               labelText="Topic name"
-              placeholder="e.g. my-topic"
+              placeholder={getTopicNamePlaceholder({
+                applyRegex: selectedEnvironment?.params?.applyRegex,
+                regex: selectedEnvironment?.params?.topicRegex?.[0],
+              })}
               required={true}
             />
+            <span>Please enter a topic name</span>
             <Box component={Flexbox} gap={"l1"}>
               <Box component={FlexboxItem} grow={1} width={"1/2"}>
                 <SelectOrNumberInput

--- a/coral/src/app/features/topics/request/TopicRequest.tsx
+++ b/coral/src/app/features/topics/request/TopicRequest.tsx
@@ -27,7 +27,7 @@ import { getEnvironmentsForTeam } from "src/domain/environment/environment-api";
 import AdvancedConfiguration from "src/app/features/topics/request/components/AdvancedConfiguration";
 import { requestTopic } from "src/domain/topic/topic-api";
 import { parseErrorMsg } from "src/services/mutation-utils";
-import { createTopicRequestPayload } from "src/app/features/topics/request/utils";
+import { generateTopicNameDescription } from "src/app/features/topics/request/utils";
 import { Dialog } from "src/app/components/Dialog";
 import { useState } from "react";
 import { useNavigate } from "react-router-dom";
@@ -72,8 +72,7 @@ function TopicRequest() {
   const redirectToMyRequests = () =>
     navigate("/requests/topics?status=CREATED");
 
-  const onSubmit: SubmitHandler<Schema> = (data) =>
-    mutate(createTopicRequestPayload(data));
+  const onSubmit: SubmitHandler<Schema> = (data) => mutate(data);
 
   const [selectedEnvironment] = form.getValues(["environment"]);
   useExtendedFormValidationAndTriggers(form, {
@@ -83,21 +82,6 @@ function TopicRequest() {
   function cancelRequest() {
     form.reset();
     navigate(-1);
-  }
-
-  function getTopicNamePlaceholder({
-    applyRegex,
-    regex,
-  }: {
-    applyRegex: boolean | undefined;
-    regex: string | undefined;
-  }) {
-    const defaultPlaceholder =
-      "Allowed characters: letter, digit, period, underscore, and hyphen.";
-    if (applyRegex && regex) {
-      return `Name has to follow pattern "${regex}". ${defaultPlaceholder}`;
-    }
-    return defaultPlaceholder;
   }
 
   return (
@@ -149,10 +133,9 @@ function TopicRequest() {
             <TextInput<Schema>
               name={"topicname"}
               labelText="Topic name"
-              placeholder={getTopicNamePlaceholder({
-                applyRegex: selectedEnvironment?.params?.applyRegex,
-                regex: selectedEnvironment?.params?.topicRegex?.[0],
-              })}
+              placeholder={generateTopicNameDescription(
+                selectedEnvironment?.params
+              )}
               required={true}
             />
             <span>Please enter a topic name</span>

--- a/coral/src/app/features/topics/request/form-schemas/topic-request-form.ts
+++ b/coral/src/app/features/topics/request/form-schemas/topic-request-form.ts
@@ -102,6 +102,28 @@ function validateTopicName(
 ) {
   const { environment, topicname } = val;
 
+  if (topicname.length < 3) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      fatal: true,
+      message: "Topic name must contain at least 3 characters.",
+      path: ["topicname"],
+    });
+    return;
+  }
+
+  const defaultTopicNamePattern = /^[a-zA-Z0-9._-]{3,}$/;
+  if (!defaultTopicNamePattern.test(topicname)) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      fatal: true,
+      message:
+        "Topic name can only contain letters, digits, period, underscore, hyphen.",
+      path: ["topicname"],
+    });
+    return;
+  }
+
   const prefixToCheck = environment.params?.topicPrefix?.[0];
   if (prefixToCheck !== undefined && !topicname.startsWith(prefixToCheck)) {
     ctx.addIssue({

--- a/coral/src/app/features/topics/request/form-schemas/topic-request-form.ts
+++ b/coral/src/app/features/topics/request/form-schemas/topic-request-form.ts
@@ -128,7 +128,7 @@ function validateTopicName(
     return;
   }
 
-  const topicPrefix = environment.params?.topicPrefix
+  const topicPrefix = environment.params?.topicPrefix;
   if (
     topicPrefix !== undefined &&
     topicPrefix.length > 0 &&

--- a/coral/src/app/features/topics/request/utils.test.ts
+++ b/coral/src/app/features/topics/request/utils.test.ts
@@ -1,44 +1,11 @@
 import {
-  createTopicRequestPayload,
+  generateNamePatternString,
+  generateTopicNameDescription,
   transformAdvancedConfigEntries,
 } from "src/app/features/topics/request/utils";
+import { Environment } from "src/domain/environment";
 
 describe("TopicRequest utils", () => {
-  describe("createTopicRequestPayload", () => {
-    it("returns expected payload", () => {
-      const formData = {
-        environment: {
-          id: "1",
-          name: "DEV",
-          type: "kafka",
-          params: {
-            defaultPartitions: 2,
-            maxPartitions: 6,
-            defaultRepFactor: 3,
-            maxRepFactor: 3,
-          },
-        },
-        remarks: "please approve this topic asap",
-        replicationfactor: "2",
-        topicpartitions: "3",
-        topicname: "example-topic-name",
-        description: "example description",
-        advancedConfiguration: "{}",
-      };
-      const res = createTopicRequestPayload(formData);
-
-      expect(res).toEqual({
-        environment: "1",
-        topicname: "example-topic-name",
-        replicationfactor: "2",
-        topicpartitions: 3,
-        advancedTopicConfigEntries: [],
-        description: "example description",
-        remarks: "please approve this topic asap",
-        requestOperationType: "CREATE",
-      });
-    });
-  });
   describe("transformAdvancedConfigEntries", () => {
     it("transforms empty object into empty array", () => {
       const res = transformAdvancedConfigEntries("{}");
@@ -103,6 +70,190 @@ describe("TopicRequest utils", () => {
         })
       );
       expect(res.find((c) => c.configKey === "test.key")).toBe(undefined);
+    });
+  });
+
+  describe("generateTopicNameDescription", () => {
+    it("generates the default description for an env without special requirements", () => {
+      const envWithoutExtras: Environment["params"] = {
+        applyRegex: false,
+        topicPrefix: undefined,
+        topicRegex: undefined,
+        topicSuffix: undefined,
+      };
+
+      expect(generateTopicNameDescription(envWithoutExtras)).toEqual(
+        "Allowed characters: letter, digit, period, underscore, and hyphen."
+      );
+    });
+
+    it("generates the description for an env with one topic prefix", () => {
+      const envWithoutExtras: Environment["params"] = {
+        applyRegex: false,
+        topicPrefix: ["prefix_"],
+        topicRegex: undefined,
+        topicSuffix: undefined,
+      };
+
+      expect(generateTopicNameDescription(envWithoutExtras)).toEqual(
+        'Prefix name with: "prefix_". Allowed characters: letter, digit, period, underscore, and hyphen.'
+      );
+    });
+
+    it("generates the description for an env with one topic prefix", () => {
+      const envWithoutExtras: Environment["params"] = {
+        applyRegex: false,
+        topicPrefix: ["prefix_"],
+        topicRegex: undefined,
+        topicSuffix: undefined,
+      };
+
+      expect(generateTopicNameDescription(envWithoutExtras)).toEqual(
+        'Prefix name with: "prefix_". Allowed characters: letter, digit, period, underscore, and hyphen.'
+      );
+    });
+
+    it("generates the description for an env with two topic prefixes", () => {
+      const envWithoutExtras: Environment["params"] = {
+        applyRegex: false,
+        topicPrefix: ["prefix_", "prefix2_"],
+        topicRegex: undefined,
+        topicSuffix: undefined,
+      };
+
+      expect(generateTopicNameDescription(envWithoutExtras)).toEqual(
+        'Prefix name with: "prefix_" or "prefix2_". Allowed characters: letter, digit, period, underscore, and hyphen.'
+      );
+    });
+
+    it("generates the description for an env with three topic prefixes", () => {
+      const envWithoutExtras: Environment["params"] = {
+        applyRegex: false,
+        topicPrefix: ["prefix_", "prefix2_", "prefix3_"],
+        topicRegex: undefined,
+        topicSuffix: undefined,
+      };
+
+      expect(generateTopicNameDescription(envWithoutExtras)).toEqual(
+        'Prefix name with: "prefix_", "prefix2_" or "prefix3_". Allowed characters: letter, digit, period, underscore,' +
+          " and" +
+          " hyphen."
+      );
+    });
+
+    it("generates the description for an env with one topic suffix", () => {
+      const envWithoutExtras: Environment["params"] = {
+        applyRegex: false,
+        topicPrefix: undefined,
+        topicRegex: undefined,
+        topicSuffix: ["_suffix"],
+      };
+
+      expect(generateTopicNameDescription(envWithoutExtras)).toEqual(
+        'Suffix name with: "_suffix". Allowed characters: letter, digit, period, underscore, and hyphen.'
+      );
+    });
+
+    it("generates the description for an env with two topic suffix", () => {
+      const envWithoutExtras: Environment["params"] = {
+        applyRegex: false,
+        topicPrefix: undefined,
+        topicRegex: undefined,
+        topicSuffix: ["_suffix", "_suffix2"],
+      };
+
+      expect(generateTopicNameDescription(envWithoutExtras)).toEqual(
+        'Suffix name with: "_suffix" or "_suffix2". Allowed characters: letter, digit, period, underscore, and hyphen.'
+      );
+    });
+
+    it("generates the description for an env with four topic suffix", () => {
+      const envWithoutExtras: Environment["params"] = {
+        applyRegex: false,
+        topicPrefix: undefined,
+        topicRegex: undefined,
+        topicSuffix: ["_suffix", "_suffix2", "_suffix3", "_suffix4"],
+      };
+
+      expect(generateTopicNameDescription(envWithoutExtras)).toEqual(
+        'Suffix name with: "_suffix", "_suffix2", "_suffix3" or "_suffix4". Allowed characters: letter, digit,' +
+          " period," +
+          " underscore," +
+          " and hyphen."
+      );
+    });
+
+    it("generates the description for an env with one regex", () => {
+      const envWithoutExtras: Environment["params"] = {
+        applyRegex: true,
+        topicPrefix: undefined,
+        topicRegex: [".*Dev*."],
+        topicSuffix: undefined,
+      };
+
+      expect(generateTopicNameDescription(envWithoutExtras)).toEqual(
+        'Follow name pattern: ".*Dev*.". Allowed characters: letter, digit, period, underscore, and hyphen.'
+      );
+    });
+
+    it("generates the description for an env with two regex", () => {
+      const envWithoutExtras: Environment["params"] = {
+        applyRegex: true,
+        topicPrefix: undefined,
+        topicRegex: [".*Dev*.", ".*Dev2*."],
+        topicSuffix: undefined,
+      };
+
+      expect(generateTopicNameDescription(envWithoutExtras)).toEqual(
+        'Follow name pattern: ".*Dev*." or ".*Dev2*.". Allowed characters: letter, digit, period, underscore, and hyphen.'
+      );
+    });
+
+    it("generates the description for an env with three regex", () => {
+      const envWithoutExtras: Environment["params"] = {
+        applyRegex: true,
+        topicPrefix: undefined,
+        topicRegex: [".*Dev*.", ".*Dev2*.", ".*Dev3*."],
+        topicSuffix: undefined,
+      };
+
+      expect(generateTopicNameDescription(envWithoutExtras)).toEqual(
+        'Follow name pattern: ".*Dev*.", ".*Dev2*." or ".*Dev3*.". Allowed characters: letter, digit, period,' +
+          " underscore, and" +
+          " hyphen."
+      );
+    });
+  });
+
+  describe("generateNamePatternString", () => {
+    it("creates a string listing one pattern that can be used in a sentence", () => {
+      const input = ["prefix1_"];
+
+      expect(generateNamePatternString(input)).toEqual('"prefix1_"');
+    });
+
+    it("creates a string listing two pattern that can be used in a sentence", () => {
+      const input = ["_suffix1", "_suffix2"];
+
+      expect(generateNamePatternString(input)).toEqual(
+        '"_suffix1" or "_suffix2"'
+      );
+    });
+
+    it("creates a string listing three pattern that can be used in a sentence", () => {
+      const input = ["prefix1_", "prefix2_", "prefix3_"];
+
+      expect(generateNamePatternString(input)).toEqual(
+        '"prefix1_", "prefix2_" or "prefix3_"'
+      );
+    });
+
+    it("creates a string listing four pattern that can be used in a sentence", () => {
+      const input = ["_suffix1", "_suffix2", "_suffix3", "_suffix4"];
+
+      expect(generateNamePatternString(input)).toEqual(
+        '"_suffix1", "_suffix2", "_suffix3" or "_suffix4"'
+      );
     });
   });
 });

--- a/coral/src/app/features/topics/request/utils.ts
+++ b/coral/src/app/features/topics/request/utils.ts
@@ -1,34 +1,5 @@
 import isString from "lodash/isString";
-import { KlawApiRequest } from "types/utils";
-import { Schema } from "src/app/features/topics/request/form-schemas/topic-request-form";
-
-function createTopicRequestPayload(
-  formData: Schema
-): KlawApiRequest<"createTopicsCreateRequest"> {
-  return {
-    description: formData.description,
-    environment: formData.environment.id,
-    remarks: formData.remarks,
-    topicname: formData.topicname,
-    replicationfactor: formData.replicationfactor,
-    topicpartitions: parseInt(formData.topicpartitions, 10),
-    advancedTopicConfigEntries: transformAdvancedConfigEntries(
-      formData.advancedConfiguration
-    ),
-    requestOperationType: "CREATE",
-  };
-}
-function coerceToString(value: unknown): string | undefined {
-  switch (typeof value) {
-    case "string":
-      return value;
-    case "boolean":
-    case "number":
-      return value.toString();
-    default:
-      return undefined;
-  }
-}
+import { Environment } from "src/domain/environment";
 
 function transformAdvancedConfigEntries(
   formData: string | undefined
@@ -49,4 +20,72 @@ function transformAdvancedConfigEntries(
     }, [] as { configKey: string; configValue: string }[]);
 }
 
-export { transformAdvancedConfigEntries, createTopicRequestPayload };
+function coerceToString(value: unknown): string | undefined {
+  switch (typeof value) {
+    case "string":
+      return value;
+    case "boolean":
+    case "number":
+      return value.toString();
+    default:
+      return undefined;
+  }
+}
+
+function generateNamePatternString(patternList: string[]) {
+  if (patternList.length === 1) return `"${patternList[0]}"`;
+  return patternList
+    .map((entry, index) => {
+      if (
+        (patternList.length === 2 && index === 0) ||
+        index === patternList.length - 2
+      ) {
+        return `"${entry}" or `;
+      }
+      if (
+        (patternList.length === 2 && index === 1) ||
+        index === patternList.length - 1
+      ) {
+        return `"${entry}"`;
+      }
+      return `"${entry}", `;
+    })
+    .join("");
+}
+function generateTopicNameDescription(
+  environmentParams: Environment["params"] | undefined
+) {
+  const desc: string[] = [
+    "Allowed characters: letter, digit, period, underscore, and hyphen.",
+  ];
+
+  if (environmentParams) {
+    const { applyRegex, topicRegex, topicPrefix, topicSuffix } =
+      environmentParams;
+
+    if (applyRegex && topicRegex && topicRegex.length > 0) {
+      desc.unshift(
+        `Follow name pattern: ${generateNamePatternString(topicRegex)}.`
+      );
+    }
+
+    if (topicPrefix && topicPrefix.length > 0) {
+      desc.unshift(
+        `Prefix name with: ${generateNamePatternString(topicPrefix)}.`
+      );
+    }
+
+    if (topicSuffix && topicSuffix.length > 0) {
+      desc.unshift(
+        `Suffix name with: ${generateNamePatternString(topicSuffix)}.`
+      );
+    }
+  }
+  return desc.join(" ");
+}
+
+export {
+  transformAdvancedConfigEntries,
+  generateTopicNameDescription,
+  generateNamePatternString,
+};

--- a/coral/src/domain/environment/environment-transformer.test.ts
+++ b/coral/src/domain/environment/environment-transformer.test.ts
@@ -98,6 +98,8 @@ describe("environment-transformer.ts", () => {
             maxRepFactor: 4,
             topicPrefix: ["pre_"],
             topicSuffix: ["_suffix"],
+            topicRegex: ["\\bjon snow\\b"],
+            applyRegex: false,
           },
         },
       ];

--- a/coral/src/domain/environment/environment-transformer.test.ts
+++ b/coral/src/domain/environment/environment-transformer.test.ts
@@ -108,5 +108,37 @@ describe("environment-transformer.ts", () => {
         expectedResult
       );
     });
+
+    it("transforms API response objects into application domain model and removes empty strings where needed", () => {
+      const testInput: KlawApiModel<"EnvModelResponse">[] = [
+        createMockEnvironmentDTO({
+          name: "DEV",
+          id: "1001",
+          params: {
+            defaultPartitions: "1",
+            topicPrefix: ["dev-"],
+            topicSuffix: ["-one", "", "", "-two"],
+            topicRegex: [""],
+          },
+        }),
+      ];
+
+      const expectedResult: Environment[] = [
+        {
+          name: "DEV",
+          id: "1001",
+          type: "kafka",
+          params: {
+            defaultPartitions: 1,
+            topicPrefix: ["dev-"],
+            topicSuffix: ["-one", "-two"],
+            topicRegex: [],
+          },
+        },
+      ];
+      expect(transformEnvironmentApiResponse(testInput)).toEqual(
+        expectedResult
+      );
+    });
   });
 });

--- a/coral/src/domain/environment/environment-transformer.ts
+++ b/coral/src/domain/environment/environment-transformer.ts
@@ -25,11 +25,11 @@ function transformEnvironmentApiResponse(
             environment.params.maxPartitions
           ),
           maxRepFactor: parseNumberOrUndefined(environment.params.maxRepFactor),
+          applyRegex: environment.params.applyRegex,
           topicPrefix: environment.params.topicPrefix,
           topicSuffix: environment.params.topicSuffix,
-        },
-      }),
-
+          topicRegex: environment.params.topicRegex,
+      },}),
       type: environment?.type,
     };
     return rv;

--- a/coral/src/domain/environment/environment-transformer.ts
+++ b/coral/src/domain/environment/environment-transformer.ts
@@ -26,9 +26,15 @@ function transformEnvironmentApiResponse(
           ),
           maxRepFactor: parseNumberOrUndefined(environment.params.maxRepFactor),
           applyRegex: environment.params.applyRegex,
-          topicPrefix: environment.params.topicPrefix,
-          topicSuffix: environment.params.topicSuffix,
-          topicRegex: environment.params.topicRegex,
+          topicPrefix: environment.params.topicPrefix?.filter(
+          (prefix) => prefix.length > 0
+        ),
+          topicSuffix: environment.params.topicSuffix?.filter(
+          (suffix) => suffix.length > 0
+        ),
+          topicRegex: environment.params.topicRegex?.filter(
+          (regex) => regex.length > 0
+        ),
       },}),
       type: environment?.type,
     };

--- a/coral/src/domain/environment/environment-transformer.ts
+++ b/coral/src/domain/environment/environment-transformer.ts
@@ -27,15 +27,16 @@ function transformEnvironmentApiResponse(
           maxRepFactor: parseNumberOrUndefined(environment.params.maxRepFactor),
           applyRegex: environment.params.applyRegex,
           topicPrefix: environment.params.topicPrefix?.filter(
-          (prefix) => prefix.length > 0
-        ),
+            (prefix) => prefix.length > 0
+          ),
           topicSuffix: environment.params.topicSuffix?.filter(
-          (suffix) => suffix.length > 0
-        ),
+            (suffix) => suffix.length > 0
+          ),
           topicRegex: environment.params.topicRegex?.filter(
-          (regex) => regex.length > 0
-        ),
-      },}),
+            (regex) => regex.length > 0
+          ),
+        },
+      }),
       type: environment?.type,
     };
     return rv;

--- a/coral/src/domain/environment/environment-types.ts
+++ b/coral/src/domain/environment/environment-types.ts
@@ -27,6 +27,8 @@ type Environment = {
     defaultRepFactor?: number;
     maxPartitions?: number;
     maxRepFactor?: number;
+    applyRegex?: EnvironmentParams["applyRegex"];
+    topicRegex?: EnvironmentParams["topicRegex"];
     topicPrefix?: EnvironmentParams["topicPrefix"];
     topicSuffix?: EnvironmentParams["topicSuffix"];
   };

--- a/coral/src/domain/topic/topic-api.test.ts
+++ b/coral/src/domain/topic/topic-api.test.ts
@@ -9,7 +9,7 @@ import {
   mockRequestTopic,
 } from "src/domain/topic/topic-api.msw";
 import { KlawApiRequestQueryParameters } from "types/utils";
-import { Schema } from "src/app/features/topics/request/schemas/topic-request-form";
+import { Schema } from "src/app/features/topics/request/form-schemas/topic-request-form";
 import { Environment } from "src/domain/environment";
 
 describe("topic-api", () => {
@@ -58,9 +58,8 @@ describe("topic-api", () => {
           advancedTopicConfigEntries: [],
           description: "this-is-description",
           remarks: "",
-          requestOperationType: "CREATE",
-        requestOperationType: "CREATE" as const,
-      };
+          requestOperationType: "CREATE" as const,
+        };
       requestTopic(parameters);
       expect(postSpy).toHaveBeenCalledTimes(1);
       expect(postSpy).toHaveBeenCalledWith("/createTopics", payload);

--- a/coral/src/domain/topic/topic-api.test.ts
+++ b/coral/src/domain/topic/topic-api.test.ts
@@ -9,6 +9,8 @@ import {
   mockRequestTopic,
 } from "src/domain/topic/topic-api.msw";
 import { KlawApiRequestQueryParameters } from "types/utils";
+import { Schema } from "src/app/features/topics/request/schemas/topic-request-form";
+import { Environment } from "src/domain/environment";
 
 describe("topic-api", () => {
   beforeAll(() => {
@@ -31,18 +33,35 @@ describe("topic-api", () => {
     });
     it("calls api.post with correct payload", () => {
       const postSpy = jest.spyOn(api, "post");
-      const payload = {
-        environment: "DEV",
-        topicname: "topic-for-unittest",
-        topicpartitions: 1,
-        replicationfactor: "1",
-        advancedTopicConfigEntries: [],
+      const env: Environment = {
+        name: "DEV",
+        id: "1",
+        type: "kafka",
+        params: {},
+      };
+
+      const parameters: Schema = {
         description: "this-is-description",
+        environment: env,
         remarks: "",
-        topictype: "Create" as const,
+        replicationfactor: "1",
+        topicname: "topic-for-unittest",
+        topicpartitions: "1",
+      };
+
+      const payload: KlawApiRequestQueryParameters<"createTopicsCreateRequest"> =
+        {
+          environment: "1",
+          topicname: "topic-for-unittest",
+          topicpartitions: 1,
+          replicationfactor: "1",
+          advancedTopicConfigEntries: [],
+          description: "this-is-description",
+          remarks: "",
+          requestOperationType: "CREATE",
         requestOperationType: "CREATE" as const,
       };
-      requestTopic(payload);
+      requestTopic(parameters);
       expect(postSpy).toHaveBeenCalledTimes(1);
       expect(postSpy).toHaveBeenCalledWith("/createTopics", payload);
     });

--- a/coral/src/domain/topic/topic-api.ts
+++ b/coral/src/domain/topic/topic-api.ts
@@ -21,6 +21,8 @@ import {
   KlawApiResponse,
 } from "types/utils";
 import { convertQueryValuesToString } from "src/services/api-helper";
+import { Schema } from "src/app/features/topics/request/schemas/topic-request-form";
+import { transformAdvancedConfigEntries } from "src/app/features/topics/request/utils";
 
 const getTopics = async (
   params: KlawApiRequestQueryParameters<"getTopics">
@@ -89,9 +91,19 @@ const getTopicAdvancedConfigOptions = (): Promise<
     )
     .then(transformGetTopicAdvancedConfigOptionsResponse);
 
-const requestTopic = (
-  payload: KlawApiRequest<"createTopicsCreateRequest">
-): Promise<unknown> => {
+const requestTopic = (data: Schema): Promise<unknown> => {
+  const payload: KlawApiRequest<"createTopicsCreateRequest"> = {
+    description: data.description,
+    environment: data.environment.id,
+    remarks: data.remarks,
+    topicname: data.topicname,
+    replicationfactor: data.replicationfactor,
+    topicpartitions: parseInt(data.topicpartitions, 10),
+    advancedTopicConfigEntries: transformAdvancedConfigEntries(
+      data.advancedConfiguration
+    ),
+    requestOperationType: "CREATE",
+  };
   return api.post<
     KlawApiResponse<"createTopicsCreateRequest">,
     KlawApiRequest<"createTopicsCreateRequest">

--- a/coral/src/domain/topic/topic-api.ts
+++ b/coral/src/domain/topic/topic-api.ts
@@ -21,7 +21,7 @@ import {
   KlawApiResponse,
 } from "types/utils";
 import { convertQueryValuesToString } from "src/services/api-helper";
-import { Schema } from "src/app/features/topics/request/schemas/topic-request-form";
+import { Schema } from "src/app/features/topics/request/form-schemas/topic-request-form";
 import { transformAdvancedConfigEntries } from "src/app/features/topics/request/utils";
 
 const getTopics = async (


### PR DESCRIPTION
# About this change - What it does

#### 1. dynamic placeholder
Adds additional information about topic name pattern for users as placeholder. That's not ideal, because it's not a good way to inform users, but since DS component do not support a more usable/accessible way, it's a compromise. VO screenreader on mac does read a placeholder, too. (it's not readable on a small screen, outside of high contrast env, for people struggling with low contrast etc.)

I would create a follow up in DS to enable description of form inputs, then we can update and use proper description instead of placeholders. That also enables us to more text.

- the placeholder always inform about general pattern for topic name (regex is based on [backend](https://github.com/aiven/klaw/blob/main/core/src/main/java/io/aiven/klaw/model/requests/TopicRequestModel.java))
- if there is one or more prefix or suffix that a user should use, the placeholder informs about that
- if there is one or more regex a user should follow, the placeholder informs about that

#### 2. Form validation

- added "min 3 chars" in zod validation (see BE definition)
- added a check for the default regex in `validateTopicName` (using regex with zod shows the error to early to users, which is not a nice experience)
- added a more detailed check and messaging for prefix as well as suffix: 
    - topicPrefix as well as topicSuffix are lists of strings, because we want to enable multiple prefix/suffix (also regex) options in the future. 
    - the validation check that the topic name starts/ends with at least one of the prefix/suffix in the list _and_ has at least additional character ("prefix_" alone is not valid)
    
SInce topicPrefix, topicSuffix and topicRegex can contain an empty string (and do, as I learned while testing with endpoints on staging 😬 ), I updated the transformer function used in the API call to remove empty strings from the array. That way, outside of `/domain`, we can be sure we don't have the need to handle an empty string.

## Screenrecording 
I used mocked environments to be able to showcase all use cases. 
👁️👁️  on placeholder as well as error messages


https://user-images.githubusercontent.com/943800/234274528-b9798372-431a-4a6e-8877-de75f4df38bb.mov



Resolves: #1076



