### PR TITLE
fix(coral):  Add handling for missing params in `Environment`

### DIFF
--- a/coral/src/domain/environment/environment-transformer.test.ts
+++ b/coral/src/domain/environment/environment-transformer.test.ts
@@ -5,6 +5,39 @@ import { Environment } from "src/domain/environment/environment-types";
 
 describe("environment-transformer.ts", () => {
   describe("transformEnvironmentApiResponse", () => {
+    // even though the openapi definition defines `params` as required
+    // some endpoints don't have a `params` property
+    // so we need to add a handling for that, too
+    it("transforms API response objects into application domain model without params", () => {
+      const emptyParamsEnv: KlawApiModel<"EnvModelResponse"> =
+        createMockEnvironmentDTO({
+          name: "DEV",
+          id: "1337",
+        });
+
+      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+      // @ts-ignore
+      delete emptyParamsEnv.params;
+
+      const testInput: Omit<KlawApiModel<"EnvModelResponse">, "params">[] = [
+        emptyParamsEnv,
+      ];
+
+      const expectedResult: Environment[] = [
+        {
+          name: "DEV",
+          id: "1337",
+          type: "kafka",
+        },
+      ];
+
+      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+      //@ts-ignore
+      expect(transformEnvironmentApiResponse(testInput)).toEqual(
+        expectedResult
+      );
+    });
+
     it("transforms API response objects into application domain model with a few params", () => {
       const testInput: KlawApiModel<"EnvModelResponse">[] = [
         createMockEnvironmentDTO({

--- a/coral/src/domain/environment/environment-transformer.ts
+++ b/coral/src/domain/environment/environment-transformer.ts
@@ -13,18 +13,23 @@ function transformEnvironmentApiResponse(
     const rv: Environment = {
       name: environment.name,
       id: environment.id,
-      params: {
-        defaultPartitions: parseNumberOrUndefined(
-          environment.params.defaultPartitions
-        ),
-        defaultRepFactor: parseNumberOrUndefined(
-          environment.params.defaultRepFactor
-        ),
-        maxPartitions: parseNumberOrUndefined(environment.params.maxPartitions),
-        maxRepFactor: parseNumberOrUndefined(environment.params.maxRepFactor),
-        topicPrefix: environment.params.topicPrefix,
-        topicSuffix: environment.params.topicSuffix,
-      },
+      ...(environment.params && {
+        params: {
+          defaultPartitions: parseNumberOrUndefined(
+            environment.params.defaultPartitions
+          ),
+          defaultRepFactor: parseNumberOrUndefined(
+            environment.params.defaultRepFactor
+          ),
+          maxPartitions: parseNumberOrUndefined(
+            environment.params.maxPartitions
+          ),
+          maxRepFactor: parseNumberOrUndefined(environment.params.maxRepFactor),
+          topicPrefix: environment.params.topicPrefix,
+          topicSuffix: environment.params.topicSuffix,
+        },
+      }),
+
       type: environment?.type,
     };
     return rv;

--- a/coral/src/domain/environment/environment-types.ts
+++ b/coral/src/domain/environment/environment-types.ts
@@ -16,7 +16,11 @@ type Environment = {
   name: KlawApiModel<"EnvModelResponse">["name"];
   id: KlawApiModel<"EnvModelResponse">["id"];
   type: KlawApiModel<"EnvModelResponse">["type"];
-  params: {
+  // even though the openapi definition defines `params` as required
+  // some endpoints don't have a `params` property
+  // so we need to make sure that we know where to
+  // handle a potential missing params property
+  params?: {
     // will be changed to Integer in BE at some point
     // and we need it best as a number
     defaultPartitions?: number;

--- a/coral/src/services/api.ts
+++ b/coral/src/services/api.ts
@@ -8,7 +8,6 @@ import {
   components,
 } from "types/api";
 import { ResolveIntersectionTypes } from "types/utils";
-import isEmpty from "lodash/isEmpty";
 
 type KlawApiResponse = ResolveIntersectionTypes<
   components["schemas"]["ApiResponse"]

--- a/coral/src/services/api.ts
+++ b/coral/src/services/api.ts
@@ -8,6 +8,7 @@ import {
   components,
 } from "types/api";
 import { ResolveIntersectionTypes } from "types/utils";
+import isEmpty from "lodash/isEmpty";
 
 type KlawApiResponse = ResolveIntersectionTypes<
   components["schemas"]["ApiResponse"]
@@ -466,7 +467,7 @@ function withoutPayloadAndWithVerb<TResponse extends SomeObject>(
   params?: Params
 ): Promise<TResponse> {
   return fetch(
-    `${API_BASE_URL}${pathname}?${params}`,
+    `${API_BASE_URL}${pathname}${!params ? "" : `?${params}`}`,
     withoutPayload(method)
   ).then((response) => handleResponse<TResponse>(response));
 }


### PR DESCRIPTION
# About this change - What it does

This is a 🐛  fix for #1085

## Problem

- based on the `openapi.yaml` [definition](https://github.com/aiven/klaw/blob/main/openapi.yaml#L6782), the `params` property for `EnvResponseModel` is required, that's what our api functions and transformers are based of
- the endpoints `getSchemaRegEnvs` and `getSyncConnectorsEnv` return a `EnvResponeModel` based on openapi, but in reality they can return environments that don't have a `params` property (and they do so on the current staging env, that's how I noticed the bug

## Fix
(Temporary fix for now, we should see why the openapi defines it that way and see if we can make that better)

Since we can't be 100% certain that there are `params` on the Environment, I updated our own type `Environment`, updated the transformer and all usage accordingly, so we're on the safe side. 


### Recording

1. all filters that are using environments
(using staging api)

https://user-images.githubusercontent.com/943800/234326536-95a217aa-498a-4ab8-a12b-3bb8a63f5f11.mov

2. topic request that uses params to pre-fill (and validate)  Topic partitions and Replication factor
(using mocked api responses)
https://user-images.githubusercontent.com/943800/234326724-1d06c341-698f-4cce-984d-62028c668a13.mov



