### PR TITLE
Do a lookup for the superadmin or admin user for db look ups in migration utility

### DIFF
--- a/core/src/main/java/io/aiven/klaw/dao/migration/MigrateData2x2x0.java
+++ b/core/src/main/java/io/aiven/klaw/dao/migration/MigrateData2x2x0.java
@@ -8,9 +8,7 @@ import io.aiven.klaw.error.KlawDataMigrationException;
 import io.aiven.klaw.helpers.db.rdbms.SelectDataJdbc;
 import io.aiven.klaw.helpers.db.rdbms.UpdateDataJdbc;
 import io.aiven.klaw.model.enums.RequestOperationType;
-import io.aiven.klaw.model.enums.RolesType;
 import java.util.List;
-import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 import lombok.extern.slf4j.Slf4j;
@@ -42,33 +40,20 @@ public class MigrateData2x2x0 {
 
     for (int tenantId : tenantIds) {
       List<Team> teams = selectDataJdbc.selectAllTeams(tenantId);
-      List<UserInfo> users = selectDataJdbc.selectAllUsersInfo(tenantId);
-      Optional<UserInfo> superAdmin =
-          users.stream()
-              .filter(
-                  user ->
-                      user.getRole().equalsIgnoreCase(RolesType.SUPERADMIN.name())
-                          || user.getRole().equalsIgnoreCase(RolesType.ADMIN.name()))
-              .findFirst();
-      if (!superAdmin.isPresent()) {
-
-        throw new KlawDataMigrationException("Unable to find Superadmin or admin to run queries.");
-      }
 
       List<Integer> teamIds =
           teams.stream().map(team -> team.getTeamId()).collect(Collectors.toList());
-      migrateTopics(teamIds, tenantId, superAdmin.get().getUsername());
-      migrateConnectors(teamIds, tenantId, superAdmin.get().getUsername());
+      migrateTopics(teamIds, tenantId);
+      migrateConnectors(teamIds, tenantId);
     }
 
     return true;
   }
 
-  private void migrateConnectors(List<Integer> teams, Integer tenantId, String superadmin) {
+  private void migrateConnectors(List<Integer> teams, int tenantId) {
     int numberOfRequests = 0, numberOfRequestsUpdated = 0;
     List<KafkaConnectorRequest> kcRequests =
-        selectDataJdbc.selectFilteredKafkaConnectorRequests(
-            false, superadmin, null, null, true, Integer.valueOf(tenantId), null, null, false);
+        selectDataJdbc.getAllConnectorRequestsByTenantId(tenantId);
 
     kcRequests =
         kcRequests.stream()
@@ -97,21 +82,9 @@ public class MigrateData2x2x0 {
         numberOfRequestsUpdated);
   }
 
-  private void migrateTopics(List<Integer> teams, Integer tenantId, String superadmin) {
+  private void migrateTopics(List<Integer> teams, int tenantId) {
     int numberOfRequests = 0, numberOfRequestsUpdated = 0;
-    log.debug("Superuser {} used to execute instructions for tenantId: {}", superadmin, tenantId);
-    List<TopicRequest> topicRequests =
-        selectDataJdbc.selectFilteredTopicRequests(
-            false,
-            superadmin,
-            null,
-            true,
-            Integer.valueOf(tenantId),
-            null,
-            null,
-            null,
-            null,
-            false);
+    List<TopicRequest> topicRequests = selectDataJdbc.getAllTopicRequestsByTenantId(tenantId);
 
     topicRequests =
         topicRequests.stream()

--- a/core/src/main/java/io/aiven/klaw/helpers/db/rdbms/SelectDataJdbc.java
+++ b/core/src/main/java/io/aiven/klaw/helpers/db/rdbms/SelectDataJdbc.java
@@ -1662,6 +1662,14 @@ public class SelectDataJdbc {
     requestObjList.forEach(reqObj -> countsMap.put((String) reqObj[0], (Long) reqObj[1]));
   }
 
+  public List<TopicRequest> getAllTopicRequestsByTenantId(int tenantId) {
+    return Lists.newArrayList(topicRequestsRepo.findAllByTenantId(tenantId));
+  }
+
+  public List<KafkaConnectorRequest> getAllConnectorRequestsByTenantId(int tenantId) {
+    return Lists.newArrayList(kafkaConnectorRequestsRepo.findAllByTenantId(tenantId));
+  }
+
   public List<KwClusters> getClusters() {
     return Lists.newArrayList(kwClusterRepo.findAll());
   }

--- a/core/src/test/java/io/aiven/klaw/dao/migration/MigrateData2x2x0Test.java
+++ b/core/src/test/java/io/aiven/klaw/dao/migration/MigrateData2x2x0Test.java
@@ -15,12 +15,15 @@ import io.aiven.klaw.dao.TopicRequest;
 import io.aiven.klaw.dao.UserInfo;
 import io.aiven.klaw.dao.test.MigrationTestData2x1x0;
 import io.aiven.klaw.dao.test.MigrationTestData2x2x0;
+import io.aiven.klaw.error.KlawDataMigrationException;
 import io.aiven.klaw.helpers.db.rdbms.SelectDataJdbc;
 import io.aiven.klaw.helpers.db.rdbms.UpdateDataJdbc;
 import io.aiven.klaw.model.enums.RequestOperationType;
+import io.aiven.klaw.model.enums.RolesType;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
+import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -53,8 +56,8 @@ class MigrateData2x2x0Test {
   }
 
   @Test
-  public void givenNoTenantsDoNotMigrateAnyData() {
-
+  public void givenNoTenantsDoNotMigrateAnyData() throws KlawDataMigrationException {
+    when(selectDataJdbc.selectAllUsersInfo(anyInt())).thenReturn(getSuperAdmin());
     when(selectDataJdbc.selectAllUsersAllTenants()).thenReturn(getUserAndTenantInfo(0));
     when(selectDataJdbc.selectAllTeams(anyInt())).thenReturn(getTeams(0));
 
@@ -89,8 +92,10 @@ class MigrateData2x2x0Test {
   }
 
   @Test
-  public void givenOneTenantButNoClaimsRequestsDoNotMigrateData() {
+  public void givenOneTenantButNoClaimsRequestsDoNotMigrateData()
+      throws KlawDataMigrationException {
     // Setup
+    when(selectDataJdbc.selectAllUsersInfo(anyInt())).thenReturn(getSuperAdmin());
     when(selectDataJdbc.selectAllUsersAllTenants()).thenReturn(getUserAndTenantInfo(1));
     when(selectDataJdbc.selectAllTeams(anyInt())).thenReturn(getTeams(2));
     when(selectDataJdbc.selectFilteredTopicRequests(
@@ -121,6 +126,7 @@ class MigrateData2x2x0Test {
     boolean success = migrateData2x2x0.migrate();
 
     // Verify
+    when(selectDataJdbc.selectAllUsersInfo(anyInt())).thenReturn(getSuperAdmin());
     verify(selectDataJdbc, times(1)).selectAllUsersAllTenants();
     verify(selectDataJdbc, times(1))
         .selectFilteredTopicRequests(
@@ -152,8 +158,10 @@ class MigrateData2x2x0Test {
   }
 
   @Test
-  public void givenOneTenantWithReqeuestsButNoClaimsRequestsDoNotMigrateData() {
+  public void givenOneTenantWithReqeuestsButNoClaimsRequestsDoNotMigrateData()
+      throws KlawDataMigrationException {
     // Setup
+    when(selectDataJdbc.selectAllUsersInfo(anyInt())).thenReturn(getSuperAdmin());
     when(selectDataJdbc.selectAllUsersAllTenants()).thenReturn(getUserAndTenantInfo(1));
     when(selectDataJdbc.selectAllTeams(anyInt())).thenReturn(getTeams(2));
     when(selectDataJdbc.selectFilteredTopicRequests(
@@ -215,8 +223,10 @@ class MigrateData2x2x0Test {
   }
 
   @Test
-  public void givenOneTenantWithReqeuestsAndOneClaimsRequestsMigrateOneData() {
+  public void givenOneTenantWithReqeuestsAndOneClaimsRequestsMigrateOneData()
+      throws KlawDataMigrationException {
     // Setup
+    when(selectDataJdbc.selectAllUsersInfo(anyInt())).thenReturn(getSuperAdmin());
     when(selectDataJdbc.selectAllUsersAllTenants()).thenReturn(getUserAndTenantInfo(1));
     when(selectDataJdbc.selectAllTeams(anyInt())).thenReturn(getTeams(2));
     when(selectDataJdbc.selectFilteredTopicRequests(
@@ -247,6 +257,7 @@ class MigrateData2x2x0Test {
     boolean success = migrateData2x2x0.migrate();
 
     // Verify
+    when(selectDataJdbc.selectAllUsersInfo(anyInt())).thenReturn(getSuperAdmin());
     verify(selectDataJdbc, times(1)).selectAllUsersAllTenants();
     verify(selectDataJdbc, times(1))
         .selectFilteredTopicRequests(
@@ -280,8 +291,10 @@ class MigrateData2x2x0Test {
 
   @Test
   public void
-      givenOneTenantWithReqeuestsAndOneClaimsRequestsButDataInDescriptionIsNotTeamIdDoNotMigrateOneData() {
+      givenOneTenantWithReqeuestsAndOneClaimsRequestsButDataInDescriptionIsNotTeamIdDoNotMigrateOneData()
+          throws KlawDataMigrationException {
     // Setup
+    when(selectDataJdbc.selectAllUsersInfo(anyInt())).thenReturn(getSuperAdmin());
     when(selectDataJdbc.selectAllUsersAllTenants()).thenReturn(getUserAndTenantInfo(1));
     when(selectDataJdbc.selectAllTeams(anyInt())).thenReturn(getTeams(2));
     when(selectDataJdbc.selectFilteredTopicRequests(
@@ -312,6 +325,7 @@ class MigrateData2x2x0Test {
     boolean success = migrateData2x2x0.migrate();
 
     // Verify
+    when(selectDataJdbc.selectAllUsersInfo(anyInt())).thenReturn(getSuperAdmin());
     verify(selectDataJdbc, times(1)).selectAllUsersAllTenants();
     verify(selectDataJdbc, times(1))
         .selectFilteredTopicRequests(
@@ -344,8 +358,10 @@ class MigrateData2x2x0Test {
   }
 
   @Test
-  public void givenOneTenantWithReqeuestsAndAlreadyMigratedClaimsRequestsDoNotMigrateData() {
+  public void givenOneTenantWithReqeuestsAndAlreadyMigratedClaimsRequestsDoNotMigrateData()
+      throws KlawDataMigrationException {
     // Setup
+    when(selectDataJdbc.selectAllUsersInfo(anyInt())).thenReturn(getSuperAdmin());
     when(selectDataJdbc.selectAllUsersAllTenants()).thenReturn(getUserAndTenantInfo(1));
     when(selectDataJdbc.selectAllTeams(anyInt())).thenReturn(getTeams(2));
     when(selectDataJdbc.selectFilteredTopicRequests(
@@ -409,8 +425,10 @@ class MigrateData2x2x0Test {
   }
 
   @Test
-  public void givenOneTenantWithReqeuestsAndNoMigratedClaimsRequestsMigrateData() {
+  public void givenOneTenantWithReqeuestsAndNoMigratedClaimsRequestsMigrateData()
+      throws KlawDataMigrationException {
     // Setup
+    when(selectDataJdbc.selectAllUsersInfo(anyInt())).thenReturn(getSuperAdmin());
     when(selectDataJdbc.selectAllUsersAllTenants()).thenReturn(getUserAndTenantInfo(1));
     when(selectDataJdbc.selectAllTeams(anyInt())).thenReturn(getTeams(2));
     when(selectDataJdbc.selectFilteredTopicRequests(
@@ -474,8 +492,10 @@ class MigrateData2x2x0Test {
   }
 
   @Test
-  public void givenThreeTenantsWithAMixOfRequestsToMigrateAndNotMigrateMigrateData() {
+  public void givenThreeTenantsWithAMixOfRequestsToMigrateAndNotMigrateMigrateData()
+      throws KlawDataMigrationException {
     // Setup
+    when(selectDataJdbc.selectAllUsersInfo(anyInt())).thenReturn(getSuperAdmin());
     when(selectDataJdbc.selectAllUsersAllTenants()).thenReturn(getUserAndTenantInfo(3));
     when(selectDataJdbc.selectAllTeams(anyInt())).thenReturn(getTeams(2));
     when(selectDataJdbc.selectFilteredTopicRequests(
@@ -541,6 +561,22 @@ class MigrateData2x2x0Test {
     verify(updateDataJdbc, times(21)).updateConnectorRequest(any());
 
     assertThat(success).isTrue();
+  }
+
+  @Test
+  public void givenNoSuperAdminOrAdminThrowError() {
+    // Setup
+    when(selectDataJdbc.selectAllUsersInfo(anyInt())).thenReturn(new ArrayList<>());
+    when(selectDataJdbc.selectAllUsersAllTenants()).thenReturn(getUserAndTenantInfo(3));
+    when(selectDataJdbc.selectAllTeams(anyInt())).thenReturn(getTeams(2));
+
+    // Execute
+
+    Assertions.assertThatExceptionOfType(KlawDataMigrationException.class)
+        .isThrownBy(
+            () -> {
+              migrateData2x2x0.migrate();
+            });
   }
 
   private List<TopicRequest> getListOfTopicRequests(
@@ -626,6 +662,19 @@ class MigrateData2x2x0Test {
     }
 
     return users;
+  }
+
+  private List<UserInfo> getSuperAdmin() {
+
+    UserInfo info = new UserInfo();
+    info.setTenantId(101);
+    info.setTeamId(1);
+    info.setRole(RolesType.SUPERADMIN.name());
+    info.setUsername("superadmin");
+    info.setFullname("superadmin");
+    info.setSwitchTeams(false);
+
+    return List.of(info);
   }
 
   private List<Team> getTeams(int numberOfEntries) {


### PR DESCRIPTION
Do a look up for the superadmin or admin to run the queries for migration to 2.0.0 Klaw

About this change - What it does
Instead of using the default superadmin user a look up is done to find the superuser if the superuser is not found, it will throw an error preventing startup.

Tested on a brand new system which does not have any db yet (starts fine)
Tested on an existing system requiring update (starts fine)
Resolves: #xxxxx
Why this way
The default superadmin user is not available when single sign on is being used for Klaw.
