### PR TITLE
feat(coral): Enable users to change teams in coral

### DIFF
--- a/coral/src/app/features/team-info/SwitchTeamsDropdown.test.tsx
+++ b/coral/src/app/features/team-info/SwitchTeamsDropdown.test.tsx
@@ -1,0 +1,195 @@
+import { customRender } from "src/services/test-utils/render-with-wrappers";
+import { updateTeam, getTeamsOfUser } from "src/domain/team/team-api";
+import { cleanup, screen, within } from "@testing-library/react";
+import { SwitchTeamsDropdown } from "src/app/features/team-info/SwitchTeamsDropdown";
+import { waitForElementToBeRemoved } from "@testing-library/react/pure";
+import { KlawApiResponse } from "types/utils";
+import userEvent from "@testing-library/user-event";
+
+jest.mock("src/domain/team/team-api.ts");
+
+const mockGetTeamsOfUser = getTeamsOfUser as jest.MockedFunction<
+  typeof getTeamsOfUser
+>;
+const mockUpdateTeam = updateTeam as jest.MockedFunction<typeof updateTeam>;
+
+const testUsername = "testuser";
+const testCurrentTeam = "awesome team";
+
+const testTeams: KlawApiResponse<"getSwitchTeams"> = [
+  {
+    teamname: "new team",
+    teamphone: "string",
+    contactperson: "string",
+    teamId: 1234,
+    tenantId: 1,
+    showDeleteTeam: false,
+    tenantName: "string",
+  },
+  {
+    teamname: "other new team",
+    teamphone: "string",
+    contactperson: "string",
+    teamId: 4678,
+    tenantId: 1,
+    showDeleteTeam: false,
+    tenantName: "string",
+  },
+];
+
+describe("SwitchTeamsDropdown", () => {
+  describe("shows information about the users current team if the teamlist has less than 2 entries", () => {
+    beforeAll(() => {
+      mockGetTeamsOfUser.mockResolvedValue([]);
+      mockUpdateTeam.mockImplementation(jest.fn());
+    });
+    afterAll(() => {
+      cleanup();
+      jest.resetAllMocks();
+    });
+
+    it("shows the current team as text", async () => {
+      customRender(
+        <SwitchTeamsDropdown
+          userName={testUsername}
+          currentTeam={testCurrentTeam}
+        />,
+        {
+          queryClient: true,
+        }
+      );
+
+      const loading = screen.getByTestId("teams-loading");
+
+      await waitForElementToBeRemoved(loading);
+
+      const team = screen.getByText(testCurrentTeam);
+      const button = screen.queryByRole("button", { name: "Change your team" });
+
+      expect(team).toBeVisible();
+      expect(button).not.toBeInTheDocument();
+    });
+  });
+
+  describe("shows a dropdown to switch teams if the teamlist has more than 1 entry", () => {
+    beforeAll(async () => {
+      mockGetTeamsOfUser.mockResolvedValue(testTeams);
+      mockUpdateTeam.mockImplementation(jest.fn());
+
+      customRender(
+        <SwitchTeamsDropdown
+          userName={testUsername}
+          currentTeam={testCurrentTeam}
+        />,
+        {
+          queryClient: true,
+        }
+      );
+
+      await waitForElementToBeRemoved(screen.getByTestId("teams-loading"));
+    });
+
+    afterAll(() => {
+      cleanup();
+      jest.resetAllMocks();
+    });
+
+    it("shows a button to change team", async () => {
+      const button = screen.getByRole("button", { name: "Change your team" });
+
+      expect(button).toBeVisible();
+    });
+
+    it("show the current team hidden for screenreader", () => {
+      const button = screen.getByRole("button", { name: "Change your team" });
+      const text = within(button).getByText(testCurrentTeam);
+
+      expect(text).toBeVisible();
+      expect(text).toHaveAttribute("aria-hidden", "true");
+    });
+
+    it("indicates to user with assistive technology that button opens a menu", () => {
+      const button = screen.getByRole("button", { name: "Change your team" });
+
+      expect(button).toHaveAttribute("aria-haspopup", "true");
+    });
+
+    it("indicates to user with assistive technology that this menu is currently closed", () => {
+      const button = screen.getByRole("button", { name: "Change your team" });
+
+      expect(button).toHaveAttribute("aria-expanded", "false");
+    });
+  });
+
+  describe("enables user to switch team", () => {
+    const mockUpdateTeamFn = jest.fn();
+    beforeEach(async () => {
+      mockGetTeamsOfUser.mockResolvedValue(testTeams);
+      mockUpdateTeam.mockImplementation(mockUpdateTeamFn);
+
+      customRender(
+        <SwitchTeamsDropdown
+          userName={testUsername}
+          currentTeam={testCurrentTeam}
+        />,
+        {
+          queryClient: true,
+        }
+      );
+
+      await waitForElementToBeRemoved(screen.getByTestId("teams-loading"));
+    });
+
+    afterEach(() => {
+      cleanup();
+      jest.resetAllMocks();
+    });
+
+    it("indicates to user with assistive technology that this menu is open when users clicks", async () => {
+      const button = screen.getByRole("button", { name: "Change your team" });
+
+      expect(button).toHaveAttribute("aria-expanded", "false");
+
+      await userEvent.click(button);
+
+      expect(button).toHaveAttribute("aria-expanded", "true");
+    });
+
+    it("shows a menu when clicking the button", async () => {
+      const button = screen.getByRole("button", { name: "Change your team" });
+
+      await userEvent.click(button);
+
+      const menu = screen.getByRole("menu", { name: "Change your team" });
+
+      expect(menu).toBeVisible();
+    });
+
+    it("shows a list of teams as menu items", async () => {
+      const button = screen.getByRole("button", { name: "Change your team" });
+      await userEvent.click(button);
+      const menu = screen.getByRole("menu", { name: "Change your team" });
+      const menuItems = within(menu).getAllByRole("menuitem");
+
+      expect(menuItems).toHaveLength(testTeams.length);
+      expect(menuItems[0]).toHaveTextContent(testTeams[0].teamname);
+      expect(menuItems[0]).toHaveTextContent(testTeams[0].teamname);
+    });
+
+    it("enables user to change their team", async () => {
+      const button = screen.getByRole("button", { name: "Change your team" });
+      await userEvent.click(button);
+      const menu = screen.getByRole("menu", { name: "Change your team" });
+      const newTeamItem = within(menu).getByRole("menuitem", {
+        name: testTeams[1].teamname,
+      });
+
+      await userEvent.click(newTeamItem);
+
+      expect(mockUpdateTeamFn).toHaveBeenCalledWith({
+        userName: testUsername,
+        teamId: testTeams[1].teamId,
+      });
+    });
+  });
+});

--- a/coral/src/app/features/team-info/SwitchTeamsDropdown.tsx
+++ b/coral/src/app/features/team-info/SwitchTeamsDropdown.tsx
@@ -1,0 +1,77 @@
+import { Box, Button, DropdownMenu, Skeleton } from "@aivenio/aquarium";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { getTeamsOfUser, updateTeam } from "src/domain/team/team-api";
+
+type SwitchTeamsDropdownProps = {
+  userName: string;
+  currentTeam: string;
+};
+
+function SwitchTeamsDropdown({
+  userName,
+  currentTeam,
+}: SwitchTeamsDropdownProps) {
+  const queryClient = useQueryClient();
+
+  const { data: teams, isLoading: teamsLoading } = useQuery(
+    ["user-teams"],
+    () => getTeamsOfUser({ userName: userName })
+  );
+
+  const { mutate: updateTeamForUser, isLoading: updateIsLoading } = useMutation(
+    updateTeam,
+    {
+      onSuccess: async () => {
+        await queryClient.refetchQueries();
+      },
+      onError(error: Error) {
+        console.error(error);
+      },
+    }
+  );
+
+  if (teamsLoading || updateIsLoading) {
+    return (
+      <div data-testid={"teams-loading"}>
+        <Skeleton />
+      </div>
+    );
+  }
+
+  if (!teams || teams.length <= 1) {
+    return <>{currentTeam}</>;
+  }
+
+  return (
+    <>
+      <DropdownMenu
+        onAction={(teamId) => {
+          updateTeamForUser({
+            userName: userName,
+            teamId: Number(teamId),
+          });
+        }}
+      >
+        <DropdownMenu.Trigger>
+          <Button.SecondaryDropdown dense>
+            <Box width={"l7"} display={"flex"} alignContent={"left"}>
+              <span className={"visually-hidden"}>Change your team</span>
+              <span aria-hidden={"true"}>{currentTeam}</span>
+            </Box>
+          </Button.SecondaryDropdown>
+        </DropdownMenu.Trigger>
+        <DropdownMenu.Items>
+          {teams.map((team) => {
+            return (
+              <DropdownMenu.Item key={team.teamId}>
+                {team.teamname}
+              </DropdownMenu.Item>
+            );
+          })}
+        </DropdownMenu.Items>
+      </DropdownMenu>
+    </>
+  );
+}
+
+export { SwitchTeamsDropdown };

--- a/coral/src/app/features/team-info/TeamInfo.test.tsx
+++ b/coral/src/app/features/team-info/TeamInfo.test.tsx
@@ -1,0 +1,104 @@
+import { customRender } from "src/services/test-utils/render-with-wrappers";
+import { cleanup, screen } from "@testing-library/react";
+import { TeamInfo } from "src/app/features/team-info/TeamInfo";
+import { AuthUser } from "src/domain/auth-user";
+import { getTeamsOfUser } from "src/domain/team";
+import { KlawApiResponse } from "types/utils";
+
+const authUser: AuthUser = {
+  canSwitchTeams: "false",
+  teamId: "2",
+  teamname: "awesome-bunch-of-people",
+  username: "i-am-test-user",
+};
+
+const mockAuthUser = jest.fn();
+jest.mock("src/app/context-provider/AuthProvider", () => ({
+  useAuthContext: () => mockAuthUser(),
+}));
+
+jest.mock("src/domain/team/team-api.ts");
+const mockGetTeamsOfUser = getTeamsOfUser as jest.MockedFunction<
+  typeof getTeamsOfUser
+>;
+
+const testTeams: KlawApiResponse<"getSwitchTeams"> = [
+  {
+    teamname: "new team",
+    teamphone: "string",
+    contactperson: "string",
+    teamId: 1234,
+    tenantId: 1,
+    showDeleteTeam: false,
+    tenantName: "string",
+  },
+  {
+    teamname: "other new team",
+    teamphone: "string",
+    contactperson: "string",
+    teamId: 4678,
+    tenantId: 1,
+    showDeleteTeam: false,
+    tenantName: "string",
+  },
+];
+
+describe("TeamInfo", () => {
+  describe("shows a info about user's team when they can't switch teams", () => {
+    mockAuthUser.mockReturnValue(authUser);
+
+    beforeAll(() => {
+      mockGetTeamsOfUser.mockResolvedValue([]);
+      customRender(<TeamInfo />, {
+        queryClient: true,
+      });
+    });
+    afterAll(cleanup);
+
+    it("shows the the team headline", () => {
+      const teamHeading = screen.getByText("Team");
+
+      // screen.debug();
+      // since one part is wrapped in a span, we can't get the
+      // full text line with getByText
+      expect(teamHeading.parentNode).toHaveTextContent("Your");
+    });
+
+    it("shows team of the user as text", async () => {
+      const team = await screen.findByText(authUser.teamname);
+
+      expect(team).toBeVisible();
+    });
+
+    it("does not render a menu to change teams", async () => {
+      await screen.findByText(authUser.teamname);
+      const menuButton = screen.queryByRole("button", {
+        name: "Change your team",
+      });
+
+      expect(menuButton).not.toBeInTheDocument();
+    });
+  });
+
+  describe("shows a info about user's team and a dropdown to switch team", () => {
+    mockAuthUser.mockReturnValue({ ...authUser, canSwitchTeams: "true" });
+
+    beforeAll(() => {
+      mockGetTeamsOfUser.mockResolvedValue(testTeams);
+      customRender(<TeamInfo />, {
+        queryClient: true,
+      });
+    });
+    afterAll(cleanup);
+
+    it("shows team of the user as menu", async () => {
+      const team = await screen.findByText(authUser.teamname);
+      const menuButton = await screen.findByRole("button", {
+        name: "Change your team",
+      });
+
+      expect(menuButton).toBeEnabled();
+      expect(team).toHaveAttribute("aria-hidden", "true");
+    });
+  });
+});

--- a/coral/src/app/features/team-info/TeamInfo.tsx
+++ b/coral/src/app/features/team-info/TeamInfo.tsx
@@ -1,0 +1,70 @@
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { getUserTeamName } from "src/domain/auth-user";
+import { getTeamsOfUser } from "src/domain/team";
+import { NativeSelect } from "@aivenio/aquarium";
+import { updateTeam } from "src/domain/team/team-api";
+
+function TeamInfo() {
+  const queryClient = useQueryClient();
+
+  const { data: user, isLoading: userLoading } = useQuery(
+    ["user-getAuth-data"],
+    getUserTeamName
+  );
+
+  const { data: teams, isLoading: teamsLoading } = useQuery(
+    ["user-teams"],
+    () => getTeamsOfUser({ userName: user?.userName }),
+    {
+      enabled: Boolean(user?.canSwitchTeams),
+    }
+  );
+
+  const { mutate: updateTeamForUser } = useMutation(updateTeam, {
+    onSuccess: async () => {
+      queryClient.refetchQueries();
+    },
+    onError(error: Error) {
+      console.error(error);
+    },
+  });
+
+  if (userLoading) {
+    return <i className="text-grey-40">Fetching team...</i>;
+  }
+
+  if ((!userLoading && !user) || !user?.teamName) {
+    return <i>No team found</i>;
+  }
+
+  if (
+    !user.canSwitchTeams ||
+    (!teamsLoading && !teams) ||
+    (teams && teams.length === 0)
+  ) {
+    return <>{user.teamName}</>;
+  }
+
+  return (
+    <NativeSelect
+      value={user.teamId}
+      onChange={({ currentTarget: { value: teamId } }) => {
+        console.log(teamId);
+        updateTeamForUser({
+          userName: user.userName,
+          teamId: Number(teamId),
+        });
+      }}
+    >
+      {teams?.map((team) => {
+        return (
+          <option value={team.teamId} key={team.teamId}>
+            {team.teamname}
+          </option>
+        );
+      })}
+    </NativeSelect>
+  );
+}
+
+export { TeamInfo };

--- a/coral/src/app/features/team-info/TeamInfo.tsx
+++ b/coral/src/app/features/team-info/TeamInfo.tsx
@@ -5,7 +5,7 @@ import { SwitchTeamsDropdown } from "src/app/features/team-info/SwitchTeamsDropd
 function TeamInfo() {
   const authUser = useAuthContext();
 
-  function getTeamData() {
+  function renderTeamData() {
     if (!authUser) {
       return <></>;
     }
@@ -36,7 +36,7 @@ function TeamInfo() {
           Team
         </Typography.SmallTextBold>
       </Box>
-      {getTeamData()}
+      {renderTeamData()}
     </Box>
   );
 }

--- a/coral/src/app/features/team-info/TeamInfo.tsx
+++ b/coral/src/app/features/team-info/TeamInfo.tsx
@@ -1,64 +1,43 @@
-import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import { NativeSelect } from "@aivenio/aquarium";
-import { getTeamsOfUser, updateTeam } from "src/domain/team/team-api";
+import { Box, Typography } from "@aivenio/aquarium";
 import { useAuthContext } from "src/app/context-provider/AuthProvider";
+import { SwitchTeamsDropdown } from "src/app/features/team-info/SwitchTeamsDropdown";
 
 function TeamInfo() {
-  const queryClient = useQueryClient();
-
   const authUser = useAuthContext();
 
-  const { mutate: updateTeamForUser } = useMutation(updateTeam, {
-    onSuccess: async () => {
-      await queryClient.refetchQueries();
-    },
-    onError(error: Error) {
-      console.error(error);
-    },
-  });
-
-  const { data: teams, isLoading: teamsLoading } = useQuery(
-    ["user-teams"],
-    () => getTeamsOfUser({ userName: authUser?.username }),
-    {
-      enabled: Boolean(authUser && authUser?.canSwitchTeams),
+  function getTeamData() {
+    if (!authUser) {
+      return <></>;
     }
-  );
 
-  if (!authUser?.teamname || authUser.teamname.length === 0) {
-    return <i>No team found</i>;
-  }
+    if (authUser.canSwitchTeams !== "true") {
+      return <>{authUser.teamname}</>;
+    }
 
-  if (!authUser.canSwitchTeams) {
-    return <>{authUser.teamname}</>;
-  }
-
-  console.log(authUser);
-
-  if (teamsLoading) {
-    console.log(teamsLoading);
-    return <NativeSelect.Skeleton />;
+    return (
+      <SwitchTeamsDropdown
+        userName={authUser.username}
+        currentTeam={authUser.teamname}
+      />
+    );
   }
 
   return (
-    <NativeSelect
-      value={authUser.teamId}
-      onChange={({ currentTarget: { value: teamId } }) => {
-        console.log(teamId);
-        updateTeamForUser({
-          userName: authUser.username,
-          teamId: Number(teamId),
-        });
-      }}
+    <Box
+      display={"flex"}
+      flexDirection={"column"}
+      rowGap={"2"}
+      height={"l4"}
+      marginBottom={"l1"}
     >
-      {teams?.map((team) => {
-        return (
-          <option value={team.teamId} key={team.teamId}>
-            {team.teamname}
-          </option>
-        );
-      })}
-    </NativeSelect>
+      <Box display={"flex"} alignItems={"center"} colGap={"2"}>
+        <Typography.SmallTextBold color={"grey-50"}>
+          <span className={"visually-hidden"}>Your </span>
+          Team
+        </Typography.SmallTextBold>
+      </Box>
+      {getTeamData()}
+    </Box>
   );
 }
 

--- a/coral/src/app/layout/main-navigation/MainNavigation.test.tsx
+++ b/coral/src/app/layout/main-navigation/MainNavigation.test.tsx
@@ -15,6 +15,8 @@ const authUser: AuthUser = {
   username: "i-am-test-user",
 };
 
+jest.mock("src/domain/team/team-api.ts");
+
 jest.mock("src/app/context-provider/AuthProvider", () => ({
   useAuthContext: () => {
     return authUser;

--- a/coral/src/app/layout/main-navigation/MainNavigation.tsx
+++ b/coral/src/app/layout/main-navigation/MainNavigation.tsx
@@ -12,6 +12,7 @@ import MainNavigationLink from "src/app/layout/main-navigation/MainNavigationLin
 import MainNavigationSubmenuList from "src/app/layout/main-navigation/MainNavigationSubmenuList";
 import { Routes } from "src/app/router_utils";
 import { useAuthContext } from "src/app/context-provider/AuthProvider";
+import { TeamInfo } from "src/app/features/team-info/TeamInfo";
 
 function MainNavigation() {
   const authUser = useAuthContext();

--- a/coral/src/app/layout/main-navigation/MainNavigation.tsx
+++ b/coral/src/app/layout/main-navigation/MainNavigation.tsx
@@ -1,4 +1,4 @@
-import { Box, Divider, Flexbox } from "@aivenio/aquarium";
+import { Box, Divider } from "@aivenio/aquarium";
 import codeBlock from "@aivenio/aquarium/dist/src/icons/codeBlock";
 import cog from "@aivenio/aquarium/dist/src/icons/cog";
 import add from "@aivenio/aquarium/dist/src/icons/add";
@@ -11,11 +11,9 @@ import { useLocation } from "react-router-dom";
 import MainNavigationLink from "src/app/layout/main-navigation/MainNavigationLink";
 import MainNavigationSubmenuList from "src/app/layout/main-navigation/MainNavigationSubmenuList";
 import { Routes } from "src/app/router_utils";
-import { useAuthContext } from "src/app/context-provider/AuthProvider";
 import { TeamInfo } from "src/app/features/team-info/TeamInfo";
 
 function MainNavigation() {
-  const authUser = useAuthContext();
   const { pathname } = useLocation();
 
   return (
@@ -27,14 +25,7 @@ function MainNavigation() {
       minHeight={"full"}
       paddingTop={"l2"}
     >
-      {authUser?.teamname && (
-        <Flexbox direction={"column"} paddingLeft={"l3"}>
-          <div className="inline-block mb-2 typography-small-strong text-grey-60">
-            Team
-          </div>
-          <div>{authUser.teamname}</div>
-        </Flexbox>
-      )}
+      <TeamInfo />
       <Box aria-hidden={"true"} paddingTop={"l1"} paddingBottom={"l2"}>
         <Divider direction="horizontal" size={2} />
       </Box>

--- a/coral/src/app/layout/main-navigation/MainNavigation.tsx
+++ b/coral/src/app/layout/main-navigation/MainNavigation.tsx
@@ -25,7 +25,9 @@ function MainNavigation() {
       minHeight={"full"}
       paddingTop={"l2"}
     >
-      <TeamInfo />
+      <Box paddingX={"l3"}>
+        <TeamInfo />
+      </Box>
       <Box aria-hidden={"true"} paddingTop={"l1"} paddingBottom={"l2"}>
         <Divider direction="horizontal" size={2} />
       </Box>

--- a/coral/src/domain/team/index.ts
+++ b/coral/src/domain/team/index.ts
@@ -3,7 +3,7 @@ import {
   Team,
   TEAM_NOT_INITIALIZED,
 } from "src/domain/team/team-types";
-import { getTeams } from "src/domain/team/team-api";
+import { getTeams, getTeamsOfUser } from "src/domain/team/team-api";
 
 export type { Team };
-export { getTeams, ALL_TEAMS_VALUE, TEAM_NOT_INITIALIZED };
+export { getTeams, ALL_TEAMS_VALUE, TEAM_NOT_INITIALIZED, getTeamsOfUser };

--- a/coral/src/domain/team/team-api.ts
+++ b/coral/src/domain/team/team-api.ts
@@ -26,6 +26,8 @@ const updateTeam = ({
 
 const getTeamsOfUser = ({ userName }: { userName: string }) => {
   return api.get<KlawApiResponse<"getSwitchTeams">>(
+    // API_PATH does not cover arguments,
+    // follow up ticket: https://github.com/aiven/klaw/issues/1021
     // eslint-disable-next-line @typescript-eslint/ban-ts-comment
     // @ts-ignore
     `/user/${userName}/switchTeamsList`

--- a/coral/src/domain/team/team-api.ts
+++ b/coral/src/domain/team/team-api.ts
@@ -1,8 +1,37 @@
 import api, { API_PATHS } from "src/services/api";
-import { KlawApiResponse } from "types/utils";
+import { KlawApiRequest, KlawApiResponse } from "types/utils";
 
 const getTeams = () => {
   return api.get<KlawApiResponse<"getAllTeamsSU">>(API_PATHS.getAllTeamsSU);
 };
 
-export { getTeams };
+const updateTeam = ({
+  userName,
+  teamId,
+}: {
+  userName: string;
+  teamId: number;
+}) => {
+  const payload = {
+    username: userName,
+    teamId: teamId,
+  };
+
+  return api.post<
+    KlawApiResponse<"updateUserTeamFromSwitchTeams">,
+    KlawApiRequest<"updateUserTeamFromSwitchTeams">
+    //@ts-ignore
+  >("/user/updateTeam", payload);
+};
+
+const getTeamsOfUser = ({ userName }: { userName: string | undefined }) => {
+  if (!userName) {
+    return undefined;
+  }
+  return api.get<KlawApiResponse<"getSwitchTeams">>(
+    //@ts-ignore
+    `/user/${userName}/switchTeamsList`
+  );
+};
+
+export { getTeams, getTeamsOfUser, updateTeam };

--- a/coral/src/domain/team/team-api.ts
+++ b/coral/src/domain/team/team-api.ts
@@ -16,13 +16,12 @@ const updateTeam = ({
     username: userName,
     teamId: teamId,
   };
-  console.log("hello");
   return api.post<
     KlawApiResponse<"updateUserTeamFromSwitchTeams">,
     KlawApiRequest<"updateUserTeamFromSwitchTeams">
     // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-    //@ts-ignore
-  >("/user/updateTeam", payload);
+    // @ts-ignore
+  >(API_PATHS.updateUserTeamFromSwitchTeams, payload);
 };
 
 const getTeamsOfUser = ({ userName }: { userName: string }) => {

--- a/coral/src/domain/team/team-api.ts
+++ b/coral/src/domain/team/team-api.ts
@@ -16,10 +16,11 @@ const updateTeam = ({
     username: userName,
     teamId: teamId,
   };
-
+  console.log("hello");
   return api.post<
     KlawApiResponse<"updateUserTeamFromSwitchTeams">,
     KlawApiRequest<"updateUserTeamFromSwitchTeams">
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
     //@ts-ignore
   >("/user/updateTeam", payload);
 };
@@ -29,6 +30,7 @@ const getTeamsOfUser = ({ userName }: { userName: string | undefined }) => {
     return undefined;
   }
   return api.get<KlawApiResponse<"getSwitchTeams">>(
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
     //@ts-ignore
     `/user/${userName}/switchTeamsList`
   );

--- a/coral/src/domain/team/team-api.ts
+++ b/coral/src/domain/team/team-api.ts
@@ -25,13 +25,10 @@ const updateTeam = ({
   >("/user/updateTeam", payload);
 };
 
-const getTeamsOfUser = ({ userName }: { userName: string | undefined }) => {
-  if (!userName) {
-    return undefined;
-  }
+const getTeamsOfUser = ({ userName }: { userName: string }) => {
   return api.get<KlawApiResponse<"getSwitchTeams">>(
     // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-    //@ts-ignore
+    // @ts-ignore
     `/user/${userName}/switchTeamsList`
   );
 };

--- a/coral/src/domain/team/team-api.ts
+++ b/coral/src/domain/team/team-api.ts
@@ -19,6 +19,11 @@ const updateTeam = ({
   return api.post<
     KlawApiResponse<"updateUserTeamFromSwitchTeams">,
     KlawApiRequest<"updateUserTeamFromSwitchTeams">
+    // The openapi definition claims that it needs the full UserModel
+    // but for this it only needs username and teamId. We don't have
+    // the full UserModel available in coral and
+    // since it contains passwords we decided against that.
+    // follow up in BE needed for this
     // eslint-disable-next-line @typescript-eslint/ban-ts-comment
     // @ts-ignore
   >(API_PATHS.updateUserTeamFromSwitchTeams, payload);


### PR DESCRIPTION
## Description

If a user is able to switch teams, we want to enable them to do so in coral to make usage more comfortable. 

- adds a component to show a dropdown with possible teams for users that are able to switch teams
- adds a _temporary_ property to enable us to show a modal without any button. The DS as a UI Block component in progress that we will use in the future, so this is only a temporary solution.


Resolves: #1096

## Screenrecording 


https://github.com/aiven/klaw/assets/943800/4a7c9eda-1c0f-4a90-b880-f012a453ccb3



