### PR TITLE
refactor(coral) Add nvmrc and define more broad version

### DIFF
--- a/coral/.nvmrc
+++ b/coral/.nvmrc
@@ -1,0 +1,1 @@
+lts/hydrogen

--- a/coral/README.md
+++ b/coral/README.md
@@ -23,7 +23,8 @@
 ## Installation and usage
 
 ** ℹRequirements**
-- [node](https://nodejs.org/en/) needs to be installed (see [npmcr](.npmrc) for version).
+- [node](https://nodejs.org/en/) needs to be installed <br/> 
+    -> see [nvmrc](.nvmrc) or the `engines` definition in [package.json](package.json) for version).
 - Coral uses [pnpm](https://pnpm.io/) (version 7) as a package manager. Read their official documentation [how to install](https://pnpm.io/installation) pnpm. 
 
 ### Usage: How to run Coral inside the Klaw application

--- a/coral/package.json
+++ b/coral/package.json
@@ -7,8 +7,8 @@
   "license": "Apache-2.0",
   "engineStrict": true,
   "engines": {
-    "node": ">=18.0.0 <=18.15.0",
-    "pnpm": ">=7.0.0 <8.0.0 ",
+    "node": ">=18.0.0 <19.0.0",
+    "pnpm": ">=7.0.0 <8.0.0",
     "yarn": "❗Please use pnpm to assure a consistent package management.",
     "npm": "❗Please use pnpm to assure a consistent package management."
   },


### PR DESCRIPTION
# About this change - What it does

- adds `.nvmrc` file
- allows a broader range of node-version to be used in package.json and also nvm

