### PR TITLE
[POC] Use Layout as root element in router

### DIFF
--- a/coral/src/app/layout/Layout.tsx
+++ b/coral/src/app/layout/Layout.tsx
@@ -1,10 +1,11 @@
 import { Box, Grid, GridItem } from "@aivenio/aquarium";
-import MainNavigation from "src/app/layout/main-navigation/MainNavigation";
+import { useRef } from "react";
+import { Outlet } from "react-router-dom";
 import Header from "src/app/layout/header/Header";
+import MainNavigation from "src/app/layout/main-navigation/MainNavigation";
 import SkipLink from "src/app/layout/skip-link/SkipLink";
-import { ReactNode, useRef } from "react";
 
-function Layout({ children }: { children: ReactNode }) {
+function Layout() {
   const ref = useRef<HTMLDivElement>(null);
   return (
     <>
@@ -38,7 +39,9 @@ function Layout({ children }: { children: ReactNode }) {
             padding={"l2"}
             width={"full"}
           >
-            <div ref={ref}>{children}</div>
+            <div ref={ref}>
+              <Outlet />
+            </div>
           </Box>
         </GridItem>
       </Grid>

--- a/coral/src/app/layout/LayoutWithoutNav.tsx
+++ b/coral/src/app/layout/LayoutWithoutNav.tsx
@@ -1,0 +1,32 @@
+import { Grid, GridItem } from "@aivenio/aquarium";
+import React, { useRef } from "react";
+import Header from "src/app/layout/header/Header";
+import SkipLink from "src/app/layout/skip-link/SkipLink";
+
+function LayoutWithoutNav({ children }: React.PropsWithChildren) {
+  const ref = useRef<HTMLDivElement>(null);
+  return (
+    <>
+      <SkipLink mainContent={ref} />
+      <Grid
+        colGap={"l1"}
+        rowGap={"l2"}
+        minHeight={"screen"}
+        style={{
+          gridTemplateColumns: "auto",
+          gridTemplateRows: "auto 1fr",
+          isolation: "isolate",
+        }}
+      >
+        <GridItem height={"l5"} backgroundColor={"primary-80"} paddingX={"l2"}>
+          <Header />
+        </GridItem>
+        <GridItem justifySelf={"center"} width={"1/2"}>
+          <div ref={ref}>{children}</div>
+        </GridItem>
+      </Grid>
+    </>
+  );
+}
+
+export default LayoutWithoutNav;

--- a/coral/src/app/pages/approvals/index.tsx
+++ b/coral/src/app/pages/approvals/index.tsx
@@ -2,10 +2,9 @@ import { PageHeader } from "@aivenio/aquarium";
 import { Navigate, useMatches } from "react-router-dom";
 import AuthenticationRequiredBoundary from "src/app/components/AuthenticationRequiredBoundary";
 import ApprovalResourceTabs from "src/app/features/approvals/components/ApprovalResourceTabs";
-import Layout from "src/app/layout/Layout";
 import {
-  ApprovalsTabEnum,
   APPROVALS_TAB_ID_INTO_PATH,
+  ApprovalsTabEnum,
   isApprovalsTabEnum,
 } from "src/app/router_utils";
 
@@ -18,10 +17,10 @@ const ApprovalsPage = () => {
   }
   return (
     <AuthenticationRequiredBoundary>
-      <Layout>
+      <>
         <PageHeader title={"Approve requests"} />
         <ApprovalResourceTabs currentTab={currentTab} />
-      </Layout>
+      </>
     </AuthenticationRequiredBoundary>
   );
 

--- a/coral/src/app/pages/connectors/index.tsx
+++ b/coral/src/app/pages/connectors/index.tsx
@@ -4,14 +4,13 @@ import { useNavigate } from "react-router-dom";
 import AuthenticationRequiredBoundary from "src/app/components/AuthenticationRequiredBoundary";
 import PreviewBanner from "src/app/components/PreviewBanner";
 import BrowseConnectors from "src/app/features/connectors/browse/BrowseConnectors";
-import Layout from "src/app/layout/Layout";
 
 const ConnectorsPage = () => {
   const navigate = useNavigate();
 
   return (
     <AuthenticationRequiredBoundary>
-      <Layout>
+      <>
         <PreviewBanner linkTarget={"/kafkaConnectors"} />
         <PageHeader
           title={"All Kafka Connectors"}
@@ -22,7 +21,7 @@ const ConnectorsPage = () => {
           }}
         />
         <BrowseConnectors />
-      </Layout>
+      </>
     </AuthenticationRequiredBoundary>
   );
 };

--- a/coral/src/app/pages/connectors/request.tsx
+++ b/coral/src/app/pages/connectors/request.tsx
@@ -1,15 +1,14 @@
 import { PageHeader } from "@aivenio/aquarium";
 import AuthenticationRequiredBoundary from "src/app/components/AuthenticationRequiredBoundary";
 import ConnectorRequest from "src/app/features/connectors/request/ConnectorRequest";
-import Layout from "src/app/layout/Layout";
 
 const RequestConnector = () => {
   return (
     <AuthenticationRequiredBoundary>
-      <Layout>
+      <>
         <PageHeader title={"Request connector"} />
         <ConnectorRequest />
-      </Layout>
+      </>
     </AuthenticationRequiredBoundary>
   );
 };

--- a/coral/src/app/pages/connectors/request.tsx
+++ b/coral/src/app/pages/connectors/request.tsx
@@ -1,14 +1,15 @@
 import { PageHeader } from "@aivenio/aquarium";
 import AuthenticationRequiredBoundary from "src/app/components/AuthenticationRequiredBoundary";
 import ConnectorRequest from "src/app/features/connectors/request/ConnectorRequest";
+import LayoutWithoutNav from "src/app/layout/LayoutWithoutNav";
 
 const RequestConnector = () => {
   return (
     <AuthenticationRequiredBoundary>
-      <>
+      <LayoutWithoutNav>
         <PageHeader title={"Request connector"} />
         <ConnectorRequest />
-      </>
+      </LayoutWithoutNav>
     </AuthenticationRequiredBoundary>
   );
 };

--- a/coral/src/app/pages/index.tsx
+++ b/coral/src/app/pages/index.tsx
@@ -1,12 +1,11 @@
-import Layout from "src/app/layout/Layout";
 import { PageHeader } from "@aivenio/aquarium";
 
 const HomePage = () => {
   return (
-    <Layout>
+    <>
       <PageHeader title={"Homepage"} />
       <h1>Index</h1>
-    </Layout>
+    </>
   );
 };
 

--- a/coral/src/app/pages/not-found/index.tsx
+++ b/coral/src/app/pages/not-found/index.tsx
@@ -1,11 +1,10 @@
 import { Box, Typography } from "@aivenio/aquarium";
 import AuthenticationRequiredBoundary from "src/app/components/AuthenticationRequiredBoundary";
-import Layout from "src/app/layout/Layout";
 
 const NotFound = () => {
   return (
     <AuthenticationRequiredBoundary>
-      <Layout>
+      <>
         <Box role="main" display={"flex"} flexDirection={"column"} gap={"5"}>
           <Typography.Heading color={"secondary-100"}>
             Page not found
@@ -19,7 +18,7 @@ const NotFound = () => {
             <a href={"/index"}>Return to the old interface.</a>
           </Typography.MediumText>
         </Box>
-      </Layout>
+      </>
     </AuthenticationRequiredBoundary>
   );
 };

--- a/coral/src/app/pages/requests/index.tsx
+++ b/coral/src/app/pages/requests/index.tsx
@@ -2,10 +2,9 @@ import { PageHeader } from "@aivenio/aquarium";
 import { Navigate, useMatches } from "react-router-dom";
 import AuthenticationRequiredBoundary from "src/app/components/AuthenticationRequiredBoundary";
 import RequestsResourceTabs from "src/app/features/requests/RequestsResourceTabs";
-import Layout from "src/app/layout/Layout";
 import {
-  RequestsTabEnum,
   REQUESTS_TAB_ID_INTO_PATH,
+  RequestsTabEnum,
   isRequestsTabEnum,
 } from "src/app/router_utils";
 
@@ -18,10 +17,10 @@ const RequestsPage = () => {
   }
   return (
     <AuthenticationRequiredBoundary>
-      <Layout>
+      <>
         <PageHeader title={"My team's requests"} />
         <RequestsResourceTabs currentTab={currentTab} />
-      </Layout>
+      </>
     </AuthenticationRequiredBoundary>
   );
 

--- a/coral/src/app/pages/topics/acl-request.tsx
+++ b/coral/src/app/pages/topics/acl-request.tsx
@@ -3,14 +3,13 @@ import { useParams } from "react-router-dom";
 import AuthenticationRequiredBoundary from "src/app/components/AuthenticationRequiredBoundary";
 import PreviewBanner from "src/app/components/PreviewBanner";
 import TopicAclRequest from "src/app/features/topics/acl-request/TopicAclRequest";
-import Layout from "src/app/layout/Layout";
 
 const AclRequest = () => {
   const { topicName } = useParams();
 
   return (
     <AuthenticationRequiredBoundary>
-      <Layout>
+      <>
         <PreviewBanner
           linkTarget={`/requestAcls${
             topicName !== undefined ? `?topicName=${topicName}` : ""
@@ -18,7 +17,7 @@ const AclRequest = () => {
         />
         <PageHeader title={"ACL (Access Control) Request"} />
         <TopicAclRequest />
-      </Layout>
+      </>
     </AuthenticationRequiredBoundary>
   );
 };

--- a/coral/src/app/pages/topics/index.tsx
+++ b/coral/src/app/pages/topics/index.tsx
@@ -4,13 +4,12 @@ import { useNavigate } from "react-router-dom";
 import AuthenticationRequiredBoundary from "src/app/components/AuthenticationRequiredBoundary";
 import PreviewBanner from "src/app/components/PreviewBanner";
 import BrowseTopics from "src/app/features/topics/browse/BrowseTopics";
-import Layout from "src/app/layout/Layout";
 
 const Topics = () => {
   const navigate = useNavigate();
   return (
     <AuthenticationRequiredBoundary>
-      <Layout>
+      <>
         <PreviewBanner linkTarget={"/browseTopics"} />
         <PageHeader
           title={"All topics"}
@@ -21,7 +20,7 @@ const Topics = () => {
           }}
         />
         <BrowseTopics />
-      </Layout>
+      </>
     </AuthenticationRequiredBoundary>
   );
 };

--- a/coral/src/app/pages/topics/request.tsx
+++ b/coral/src/app/pages/topics/request.tsx
@@ -2,16 +2,15 @@ import { PageHeader } from "@aivenio/aquarium";
 import AuthenticationRequiredBoundary from "src/app/components/AuthenticationRequiredBoundary";
 import PreviewBanner from "src/app/components/PreviewBanner";
 import TopicRequest from "src/app/features/topics/request/TopicRequest";
-import Layout from "src/app/layout/Layout";
 
 const RequestTopic = () => {
   return (
     <AuthenticationRequiredBoundary>
-      <Layout>
+      <>
         <PreviewBanner linkTarget={"/requestTopics"} />
         <PageHeader title={"Request topic"} />
         <TopicRequest />
-      </Layout>
+      </>
     </AuthenticationRequiredBoundary>
   );
 };

--- a/coral/src/app/pages/topics/schema-request.tsx
+++ b/coral/src/app/pages/topics/schema-request.tsx
@@ -1,9 +1,8 @@
 import { PageHeader } from "@aivenio/aquarium";
+import { useParams } from "react-router-dom";
 import AuthenticationRequiredBoundary from "src/app/components/AuthenticationRequiredBoundary";
 import PreviewBanner from "src/app/components/PreviewBanner";
-import Layout from "src/app/layout/Layout";
 import { TopicSchemaRequest } from "src/app/features/topics/schema-request/TopicSchemaRequest";
-import { useParams } from "react-router-dom";
 
 const SchemaRequest = () => {
   // @TODO: should we add verification that this is a real topic name?
@@ -11,7 +10,7 @@ const SchemaRequest = () => {
 
   return (
     <AuthenticationRequiredBoundary>
-      <Layout>
+      <>
         {topicName && (
           <>
             <PreviewBanner
@@ -21,7 +20,7 @@ const SchemaRequest = () => {
             <TopicSchemaRequest topicName={topicName} />
           </>
         )}
-      </Layout>
+      </>
     </AuthenticationRequiredBoundary>
   );
 };

--- a/coral/src/app/router.tsx
+++ b/coral/src/app/router.tsx
@@ -1,4 +1,5 @@
 import { createBrowserRouter, RouteObject } from "react-router-dom";
+import Layout from "src/app/layout/Layout";
 import ApprovalsPage from "src/app/pages/approvals";
 import AclApprovalsPage from "src/app/pages/approvals/acls";
 import ConnectorApprovalsPage from "src/app/pages/approvals/connectors";
@@ -32,84 +33,90 @@ const routes: Array<RouteObject> = [
   //   path: "/login",
   // },
   {
-    path: Routes.TOPICS,
-    element: <Topics />,
-  },
-  {
-    path: Routes.CONNECTORS,
-    element: <ConnectorsPage />,
-  },
-  {
-    path: Routes.CONNECTOR_REQUEST,
-    element: <RequestConnector />,
-  },
-  {
-    path: Routes.TOPIC_REQUEST,
-    element: <RequestTopic />,
-  },
-  {
-    path: Routes.TOPIC_ACL_REQUEST,
-    element: <AclRequest />,
-  },
-  {
-    path: Routes.TOPIC_SCHEMA_REQUEST,
-    element: <SchemaRequest />,
-  },
-  {
-    path: Routes.REQUESTS,
-    element: <RequestsPage />,
+    path: "/",
+    element: <Layout />,
     children: [
       {
-        path: REQUESTS_TAB_ID_INTO_PATH[RequestsTabEnum.TOPICS],
-        element: <TopicRequestsPage />,
-        id: RequestsTabEnum.TOPICS,
+        path: Routes.TOPICS,
+        element: <Topics />,
       },
       {
-        path: REQUESTS_TAB_ID_INTO_PATH[RequestsTabEnum.ACLS],
-        element: <AclRequestsPage />,
-        id: RequestsTabEnum.ACLS,
+        path: Routes.CONNECTORS,
+        element: <ConnectorsPage />,
       },
       {
-        path: REQUESTS_TAB_ID_INTO_PATH[RequestsTabEnum.SCHEMAS],
-        element: <SchemaRequestsPage />,
-        id: RequestsTabEnum.SCHEMAS,
+        path: Routes.CONNECTOR_REQUEST,
+        element: <RequestConnector />,
       },
       {
-        path: REQUESTS_TAB_ID_INTO_PATH[RequestsTabEnum.CONNECTORS],
-        element: <ConnectorRequestsPage />,
-        id: RequestsTabEnum.CONNECTORS,
+        path: Routes.TOPIC_REQUEST,
+        element: <RequestTopic />,
+      },
+      {
+        path: Routes.TOPIC_ACL_REQUEST,
+        element: <AclRequest />,
+      },
+      {
+        path: Routes.TOPIC_SCHEMA_REQUEST,
+        element: <SchemaRequest />,
+      },
+      {
+        path: Routes.REQUESTS,
+        element: <RequestsPage />,
+        children: [
+          {
+            path: REQUESTS_TAB_ID_INTO_PATH[RequestsTabEnum.TOPICS],
+            element: <TopicRequestsPage />,
+            id: RequestsTabEnum.TOPICS,
+          },
+          {
+            path: REQUESTS_TAB_ID_INTO_PATH[RequestsTabEnum.ACLS],
+            element: <AclRequestsPage />,
+            id: RequestsTabEnum.ACLS,
+          },
+          {
+            path: REQUESTS_TAB_ID_INTO_PATH[RequestsTabEnum.SCHEMAS],
+            element: <SchemaRequestsPage />,
+            id: RequestsTabEnum.SCHEMAS,
+          },
+          {
+            path: REQUESTS_TAB_ID_INTO_PATH[RequestsTabEnum.CONNECTORS],
+            element: <ConnectorRequestsPage />,
+            id: RequestsTabEnum.CONNECTORS,
+          },
+        ],
+      },
+      {
+        path: Routes.APPROVALS,
+        element: <ApprovalsPage />,
+        children: [
+          {
+            path: APPROVALS_TAB_ID_INTO_PATH[ApprovalsTabEnum.TOPICS],
+            element: <TopicApprovalsPage />,
+            id: ApprovalsTabEnum.TOPICS,
+          },
+          {
+            path: APPROVALS_TAB_ID_INTO_PATH[ApprovalsTabEnum.ACLS],
+            element: <AclApprovalsPage />,
+            id: ApprovalsTabEnum.ACLS,
+          },
+          {
+            path: APPROVALS_TAB_ID_INTO_PATH[ApprovalsTabEnum.SCHEMAS],
+            element: <SchemaApprovalsPage />,
+            id: ApprovalsTabEnum.SCHEMAS,
+          },
+          {
+            path: APPROVALS_TAB_ID_INTO_PATH[ApprovalsTabEnum.CONNECTORS],
+            element: <ConnectorApprovalsPage />,
+            id: ApprovalsTabEnum.CONNECTORS,
+          },
+        ],
+      },
+      {
+        path: "*",
+        element: <NotFound />,
       },
     ],
-  },
-  {
-    path: Routes.APPROVALS,
-    element: <ApprovalsPage />,
-    children: [
-      {
-        path: APPROVALS_TAB_ID_INTO_PATH[ApprovalsTabEnum.TOPICS],
-        element: <TopicApprovalsPage />,
-        id: ApprovalsTabEnum.TOPICS,
-      },
-      {
-        path: APPROVALS_TAB_ID_INTO_PATH[ApprovalsTabEnum.ACLS],
-        element: <AclApprovalsPage />,
-        id: ApprovalsTabEnum.ACLS,
-      },
-      {
-        path: APPROVALS_TAB_ID_INTO_PATH[ApprovalsTabEnum.SCHEMAS],
-        element: <SchemaApprovalsPage />,
-        id: ApprovalsTabEnum.SCHEMAS,
-      },
-      {
-        path: APPROVALS_TAB_ID_INTO_PATH[ApprovalsTabEnum.CONNECTORS],
-        element: <ConnectorApprovalsPage />,
-        id: ApprovalsTabEnum.CONNECTORS,
-      },
-    ],
-  },
-  {
-    path: "*",
-    element: <NotFound />,
   },
 ];
 

--- a/coral/src/app/router.tsx
+++ b/coral/src/app/router.tsx
@@ -1,5 +1,6 @@
 import { createBrowserRouter, RouteObject } from "react-router-dom";
 import Layout from "src/app/layout/Layout";
+import LayoutWithoutNav from "src/app/layout/LayoutWithoutNav";
 import ApprovalsPage from "src/app/pages/approvals";
 import AclApprovalsPage from "src/app/pages/approvals/acls";
 import ConnectorApprovalsPage from "src/app/pages/approvals/connectors";
@@ -43,10 +44,6 @@ const routes: Array<RouteObject> = [
       {
         path: Routes.CONNECTORS,
         element: <ConnectorsPage />,
-      },
-      {
-        path: Routes.CONNECTOR_REQUEST,
-        element: <RequestConnector />,
       },
       {
         path: Routes.TOPIC_REQUEST,
@@ -117,6 +114,10 @@ const routes: Array<RouteObject> = [
         element: <NotFound />,
       },
     ],
+  },
+  {
+    path: Routes.CONNECTOR_REQUEST,
+    element: <RequestConnector />,
   },
 ];
 


### PR DESCRIPTION
Proposal to use `Layout` as `element` for the root route, and have all routes be children of that route so we don't have to add `Layout` manually in all `page` index components.