### PR TITLE
refactor(coral): Only use regex for topic name validation if it should be applied

### DIFF
--- a/coral/src/app/features/topics/request/TopicRequest.test.tsx
+++ b/coral/src/app/features/topics/request/TopicRequest.test.tsx
@@ -476,7 +476,8 @@ describe("<TopicRequest />", () => {
       });
 
       it("validates that topic name starts with environment topic prefix", async () => {
-        const expectedErrorMsg = 'Topic name must start with "test-".';
+        const expectedErrorMsg =
+          'Topic name must start with "test-". It must contain at least 3 characters after the prefix.';
         const select = await screen.findByRole("combobox", {
           name: "Environment *",
         });
@@ -558,7 +559,8 @@ describe("<TopicRequest />", () => {
       });
 
       it("validates that topic name ends with environment topic suffix", async () => {
-        const expectedErrorMsg = 'Topic name must end with "-test".';
+        const expectedErrorMsg =
+          'Topic name must end with "-test". It must contain at least 3 characters before the suffix.';
         const select = await screen.findByRole("combobox", {
           name: "Environment *",
         });

--- a/coral/src/app/features/topics/request/TopicRequest.tsx
+++ b/coral/src/app/features/topics/request/TopicRequest.tsx
@@ -138,7 +138,6 @@ function TopicRequest() {
               )}
               required={true}
             />
-            <span>Please enter a topic name</span>
             <Box component={Flexbox} gap={"l1"}>
               <Box component={FlexboxItem} grow={1} width={"1/2"}>
                 <SelectOrNumberInput

--- a/coral/src/app/features/topics/request/form-schemas/topic-request-form.ts
+++ b/coral/src/app/features/topics/request/form-schemas/topic-request-form.ts
@@ -19,6 +19,7 @@ const environmentParams = z.object({
   maxPartitions: z.number().optional(),
   defaultPartitions: z.number().optional(),
   defaultRepFactor: z.number().optional(),
+  applyRegex: z.boolean().optional(),
   topicPrefix: z.array(z.string()).optional(),
   topicSuffix: z.array(z.string()).optional(),
 });
@@ -128,48 +129,52 @@ function validateTopicName(
     return;
   }
 
-  const topicPrefix = environment.params?.topicPrefix;
-  if (
-    topicPrefix !== undefined &&
-    topicPrefix.length > 0 &&
-    !topicPrefix.some((prefix) => {
-      return (
-        topicname.startsWith(prefix) &&
-        topicname.slice(prefix.length).length > 0 &&
-        defaultTopicNamePattern.test(topicname.slice(prefix.length))
-      );
-    })
-  ) {
-    ctx.addIssue({
-      code: z.ZodIssueCode.custom,
-      fatal: true,
-      message: `Topic name must start with ${generateNamePatternString(
-        topicPrefix
-      )}.`,
-      path: ["topicname"],
-    });
-  }
+  // if a topic name has a regex format, it can't have a
+  // prefix or suffix
+  if (!environment.params?.applyRegex) {
+    const topicPrefix = environment.params?.topicPrefix;
+    if (
+      topicPrefix !== undefined &&
+      topicPrefix.length > 0 &&
+      !topicPrefix.some((prefix) => {
+        return (
+          topicname.startsWith(prefix) &&
+          topicname.slice(prefix.length).length > 0 &&
+          defaultTopicNamePattern.test(topicname.slice(prefix.length))
+        );
+      })
+    ) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        fatal: true,
+        message: `Topic name must start with ${generateNamePatternString(
+          topicPrefix
+        )}.`,
+        path: ["topicname"],
+      });
+    }
 
-  const topicSuffix = environment.params?.topicSuffix;
-  if (
-    topicSuffix !== undefined &&
-    topicSuffix.length > 0 &&
-    !topicSuffix.some((prefix) => {
-      return (
-        topicname.endsWith(prefix) &&
-        topicname.slice(prefix.length).length > 0 &&
-        defaultTopicNamePattern.test(topicname.slice(prefix.length))
-      );
-    })
-  ) {
-    ctx.addIssue({
-      code: z.ZodIssueCode.custom,
-      fatal: true,
-      message: `Topic name must end with ${generateNamePatternString(
-        topicSuffix
-      )}.`,
-      path: ["topicname"],
-    });
+    const topicSuffix = environment.params?.topicSuffix;
+    if (
+      topicSuffix !== undefined &&
+      topicSuffix.length > 0 &&
+      !topicSuffix.some((prefix) => {
+        return (
+          topicname.endsWith(prefix) &&
+          topicname.slice(prefix.length).length > 0 &&
+          defaultTopicNamePattern.test(topicname.slice(prefix.length))
+        );
+      })
+    ) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        fatal: true,
+        message: `Topic name must end with ${generateNamePatternString(
+          topicSuffix
+        )}.`,
+        path: ["topicname"],
+      });
+    }
   }
 }
 

--- a/coral/src/app/features/topics/request/utils.test.ts
+++ b/coral/src/app/features/topics/request/utils.test.ts
@@ -100,19 +100,6 @@ describe("TopicRequest utils", () => {
       );
     });
 
-    it("generates the description for an env with one topic prefix", () => {
-      const envWithoutExtras: Environment["params"] = {
-        applyRegex: false,
-        topicPrefix: ["prefix_"],
-        topicRegex: undefined,
-        topicSuffix: undefined,
-      };
-
-      expect(generateTopicNameDescription(envWithoutExtras)).toEqual(
-        'Prefix name with: "prefix_". Allowed characters: letter, digit, period, underscore, and hyphen.'
-      );
-    });
-
     it("generates the description for an env with two topic prefixes", () => {
       const envWithoutExtras: Environment["params"] = {
         applyRegex: false,
@@ -221,6 +208,34 @@ describe("TopicRequest utils", () => {
         'Follow name pattern: ".*Dev*.", ".*Dev2*." or ".*Dev3*.". Allowed characters: letter, digit, period,' +
           " underscore, and" +
           " hyphen."
+      );
+    });
+
+    // if a topic name has a regex format, it can't have a
+    // prefix or suffix
+    it("generates the description for an env with one regex and a prefix", () => {
+      const envWithoutExtras: Environment["params"] = {
+        applyRegex: true,
+        topicPrefix: ["prefix_"],
+        topicRegex: [".*Dev*."],
+        topicSuffix: undefined,
+      };
+
+      expect(generateTopicNameDescription(envWithoutExtras)).toEqual(
+        'Follow name pattern: ".*Dev*.". Allowed characters: letter, digit, period, underscore, and hyphen.'
+      );
+    });
+
+    it("generates the description for an env with one prefix and two suffix", () => {
+      const envWithoutExtras: Environment["params"] = {
+        applyRegex: undefined,
+        topicPrefix: ["prefix_"],
+        topicRegex: undefined,
+        topicSuffix: ["_suffix, _suffix"],
+      };
+
+      expect(generateTopicNameDescription(envWithoutExtras)).toEqual(
+        'Suffix name with: "_suffix, _suffix". Prefix name with: "prefix_". Allowed characters: letter, digit, period, underscore, and hyphen.'
       );
     });
   });

--- a/coral/src/app/features/topics/request/utils.test.ts
+++ b/coral/src/app/features/topics/request/utils.test.ts
@@ -2,6 +2,9 @@ import {
   generateNamePatternString,
   generateTopicNameDescription,
   transformAdvancedConfigEntries,
+  isValidTopicNameWithPrefixAndSuffix,
+  isValidTopicNameWithPrefix,
+  isValidTopicNameWithSuffix,
 } from "src/app/features/topics/request/utils";
 import { Environment } from "src/domain/environment";
 
@@ -269,6 +272,421 @@ describe("TopicRequest utils", () => {
       expect(generateNamePatternString(input)).toEqual(
         '"_suffix1", "_suffix2", "_suffix3" or "_suffix4"'
       );
+    });
+  });
+
+  describe("isValidTopicNameWithPrefix", () => {
+    const defaultPattern = /^[a-zA-Z0-9._-]*$/;
+
+    describe("with one prefix in the list", () => {
+      const testPrefix = ["one_"];
+      it("returns false when topic name does not contain prefix", () => {
+        const result = isValidTopicNameWithPrefix({
+          topicName: "some-topic",
+          prefix: testPrefix,
+          defaultPattern,
+        });
+        expect(result).toBe(false);
+      });
+
+      it("returns false when topic name contains prefix, but has no other characters", () => {
+        const result = isValidTopicNameWithPrefix({
+          topicName: "one_",
+          prefix: testPrefix,
+          defaultPattern,
+        });
+        expect(result).toBe(false);
+      });
+
+      it("returns false when topic name contains prefix, but only has 1 character", () => {
+        const result = isValidTopicNameWithPrefix({
+          topicName: "one_1",
+          prefix: testPrefix,
+          defaultPattern,
+        });
+        expect(result).toBe(false);
+      });
+
+      it("returns false when topic name contains prefix, but only has 2 characters", () => {
+        const result = isValidTopicNameWithPrefix({
+          topicName: "one_12",
+          prefix: testPrefix,
+          defaultPattern,
+        });
+        expect(result).toBe(false);
+      });
+
+      it("returns false when the topic name contains prefix but the rest doesn't match default pattern", () => {
+        const result = isValidTopicNameWithPrefix({
+          topicName: "one_@#$%",
+          prefix: testPrefix,
+          defaultPattern,
+        });
+        expect(result).toBe(false);
+      });
+
+      it("returns true when topic name contains prefix, and only has 3 characters", () => {
+        const result = isValidTopicNameWithPrefix({
+          topicName: "one_123",
+          prefix: testPrefix,
+          defaultPattern,
+        });
+        expect(result).toBe(true);
+      });
+    });
+
+    describe("with three prefix in the list", () => {
+      const testPrefix = ["one_", "anotherone_", "prefix_"];
+
+      it("returns false when topic name contains one prefix, but has no other characters", () => {
+        const result = isValidTopicNameWithPrefix({
+          topicName: "anotherone_",
+          prefix: testPrefix,
+          defaultPattern,
+        });
+        expect(result).toBe(false);
+      });
+
+      it("returns false when topic name contains prefix, but only has 1 character", () => {
+        const result = isValidTopicNameWithPrefix({
+          topicName: "one_1",
+          prefix: testPrefix,
+          defaultPattern,
+        });
+        expect(result).toBe(false);
+      });
+
+      it("returns false when topic name contains prefix, but only has 2 characters", () => {
+        const result = isValidTopicNameWithPrefix({
+          topicName: "anotherone_12",
+          prefix: testPrefix,
+          defaultPattern,
+        });
+        expect(result).toBe(false);
+      });
+
+      it("returns false when the topic name matches but the rest doesn't match default pattern", () => {
+        const result = isValidTopicNameWithPrefix({
+          topicName: "one_@#$%",
+          prefix: testPrefix,
+          defaultPattern,
+        });
+        expect(result).toBe(false);
+      });
+
+      it("returns true when topic name contains prefix, and only has 3 characters", () => {
+        const result = isValidTopicNameWithPrefix({
+          topicName: "anotherone_123",
+          prefix: testPrefix,
+          defaultPattern,
+        });
+        expect(result).toBe(true);
+      });
+    });
+  });
+
+  describe("isValidTopicNameWithSuffix", () => {
+    const defaultPattern = /^[a-zA-Z0-9._-]*$/;
+
+    describe("with one suffix in the list", () => {
+      const testSuffix = ["_one"];
+
+      it("returns false when topic name does not contain suffix", () => {
+        const result = isValidTopicNameWithSuffix({
+          topicName: "some-topic",
+          suffix: testSuffix,
+          defaultPattern,
+        });
+        expect(result).toBe(false);
+      });
+
+      it("returns false when topic name contains suffix, but has no other characters", () => {
+        const result = isValidTopicNameWithSuffix({
+          topicName: "_one",
+          suffix: testSuffix,
+          defaultPattern,
+        });
+        expect(result).toBe(false);
+      });
+
+      it("returns false when topic name contains suffix, but only has 1 character", () => {
+        const result = isValidTopicNameWithSuffix({
+          topicName: "1_one",
+          suffix: testSuffix,
+          defaultPattern,
+        });
+        expect(result).toBe(false);
+      });
+
+      it("returns false when topic name contains suffix, but only has 2 characters", () => {
+        const result = isValidTopicNameWithSuffix({
+          topicName: "12_one",
+          suffix: testSuffix,
+          defaultPattern,
+        });
+        expect(result).toBe(false);
+      });
+
+      it("returns false when the topic name contains suffix but the rest doesn't match default pattern", () => {
+        const result = isValidTopicNameWithSuffix({
+          topicName: "@#$%_one",
+          suffix: testSuffix,
+          defaultPattern,
+        });
+        expect(result).toBe(false);
+      });
+
+      it("returns true when topic name contains suffix, and only has 3 characters", () => {
+        const result = isValidTopicNameWithSuffix({
+          topicName: "abc_one",
+          suffix: testSuffix,
+          defaultPattern,
+        });
+        expect(result).toBe(true);
+      });
+    });
+
+    describe("with three suffix in the list", () => {
+      const testSuffix = ["_suf", "_suffix", "_supersuffix"];
+
+      it("returns false when topic name contains one suffix, but has no other characters", () => {
+        const result = isValidTopicNameWithSuffix({
+          topicName: "_suf",
+          suffix: testSuffix,
+          defaultPattern,
+        });
+        expect(result).toBe(false);
+      });
+
+      it("returns false when topic name contains suffix, but only has 1 character", () => {
+        const result = isValidTopicNameWithSuffix({
+          topicName: "1_suffix",
+          suffix: testSuffix,
+          defaultPattern,
+        });
+        expect(result).toBe(false);
+      });
+
+      it("returns false when topic name contains suffix, but only has 2 characters", () => {
+        const result = isValidTopicNameWithSuffix({
+          topicName: "12_suffix",
+          suffix: testSuffix,
+          defaultPattern,
+        });
+        expect(result).toBe(false);
+      });
+
+      it("returns false when the topic name matches but the rest doesn't match default pattern", () => {
+        const result = isValidTopicNameWithSuffix({
+          topicName: "@#$%1_su",
+          suffix: testSuffix,
+          defaultPattern,
+        });
+        expect(result).toBe(false);
+      });
+
+      it("returns true when topic name contains suffix, and has 3 characters", () => {
+        const result = isValidTopicNameWithSuffix({
+          topicName: "123_suffix",
+          suffix: testSuffix,
+          defaultPattern,
+        });
+        expect(result).toBe(true);
+      });
+    });
+  });
+
+  describe("isValidTopicNameWithPrefixAndSuffix", () => {
+    const defaultPattern = /^[a-zA-Z0-9._-]*$/;
+    it("returns true if there is no prefix or suffix", () => {
+      const result = isValidTopicNameWithPrefixAndSuffix({
+        topicName: "some-topic",
+        prefix: [],
+        suffix: [],
+        defaultPattern,
+      });
+      expect(result).toBe(true);
+    });
+
+    describe("one prefix and one suffix", () => {
+      const prefix = ["one_"];
+      const suffix = ["_9one"];
+
+      it("returns false if topicName contains none of those", () => {
+        const result = isValidTopicNameWithPrefixAndSuffix({
+          topicName: "some-topic",
+          prefix,
+          suffix,
+          defaultPattern,
+        });
+        expect(result).toBe(false);
+      });
+
+      it("returns false if topicName only contains the prefix", () => {
+        const result = isValidTopicNameWithPrefixAndSuffix({
+          topicName: "one_",
+          prefix,
+          suffix,
+          defaultPattern,
+        });
+        expect(result).toBe(false);
+      });
+
+      it("returns false if topicName only contains the suffix", () => {
+        const result = isValidTopicNameWithPrefixAndSuffix({
+          topicName: "_9one",
+          prefix,
+          suffix,
+          defaultPattern,
+        });
+        expect(result).toBe(false);
+      });
+
+      it("returns false if topicName contains both, but has no character other than prefix and suffix", () => {
+        const result = isValidTopicNameWithPrefixAndSuffix({
+          topicName: "one__9one",
+          prefix,
+          suffix,
+          defaultPattern,
+        });
+        expect(result).toBe(false);
+      });
+
+      it("returns false if topicName contains both, but has only one character other than prefix and suffix", () => {
+        const result = isValidTopicNameWithPrefixAndSuffix({
+          topicName: "one_1_9one",
+          prefix,
+          suffix,
+          defaultPattern,
+        });
+        expect(result).toBe(false);
+      });
+
+      it("returns false if topicName contains both, but has only two characters other than prefix and suffix", () => {
+        const result = isValidTopicNameWithPrefixAndSuffix({
+          topicName: "one_12_9one",
+          prefix,
+          suffix,
+          defaultPattern,
+        });
+        expect(result).toBe(false);
+      });
+
+      it("returns false if topicName contains one of two similar prefixes, but has only two characters other then that", () => {
+        const result = isValidTopicNameWithPrefixAndSuffix({
+          topicName: "pre_21_su2",
+          prefix: ["pre_", "otherpre_"],
+          suffix,
+          defaultPattern,
+        });
+        expect(result).toBe(false);
+      });
+
+      it("returns false if topicName contains both, the name minus prefix and suffix have 3 characters, but they don't match the default pattern", () => {
+        const result = isValidTopicNameWithPrefixAndSuffix({
+          topicName: "one_a-su_",
+          prefix,
+          suffix,
+          defaultPattern,
+        });
+        expect(result).toBe(false);
+      });
+
+      it("returns true if topicName contains both and the part without prefix and suffix has three characters", () => {
+        const result = isValidTopicNameWithPrefixAndSuffix({
+          topicName: "one_abc_9one",
+          prefix,
+          suffix,
+          defaultPattern,
+        });
+        expect(result).toBe(true);
+      });
+    });
+
+    describe("multiple prefixes and suffixes", () => {
+      const defaultPattern = /^[a-zA-Z0-9._-]*$/;
+      const prefix = ["one_", "two_"];
+      const suffix = ["_9one", "_9two", "_9three"];
+
+      it("returns false if topicName contains none of those", () => {
+        const result = isValidTopicNameWithPrefixAndSuffix({
+          topicName: "some-topic",
+          prefix,
+          suffix,
+          defaultPattern,
+        });
+        expect(result).toBe(false);
+      });
+
+      it("returns false if topicName only contains one of the prefixes", () => {
+        const result = isValidTopicNameWithPrefixAndSuffix({
+          topicName: "one_",
+          prefix,
+          suffix,
+          defaultPattern,
+        });
+        expect(result).toBe(false);
+      });
+
+      it("returns false if topicName only contains one of the suffixes", () => {
+        const result = isValidTopicNameWithPrefixAndSuffix({
+          topicName: "_9one",
+          prefix,
+          suffix,
+          defaultPattern,
+        });
+        expect(result).toBe(false);
+      });
+
+      it("returns false if topicName contains one of both, but has only one character other than prefix and suffix", () => {
+        const result = isValidTopicNameWithPrefixAndSuffix({
+          topicName: "one__9two",
+          prefix,
+          suffix,
+          defaultPattern,
+        });
+        expect(result).toBe(false);
+      });
+
+      it("returns false if topicName contains one of both, but has only two characters other than prefix and suffix", () => {
+        const result = isValidTopicNameWithPrefixAndSuffix({
+          topicName: "one_12_9two",
+          prefix,
+          suffix,
+          defaultPattern,
+        });
+        expect(result).toBe(false);
+      });
+
+      it("returns false if topicName contains one of two similar suffixes, but has only two characters other then that", () => {
+        const result = isValidTopicNameWithPrefixAndSuffix({
+          topicName: "one_12_su2",
+          prefix,
+          suffix: ["_su", "_su2"],
+          defaultPattern,
+        });
+        expect(result).toBe(false);
+      });
+
+      it("returns false if topicName contains one of both, the name minus prefix and suffix have 3 characters, but they don't match the default pattern", () => {
+        const result = isValidTopicNameWithPrefixAndSuffix({
+          topicName: "one_$!!_9two",
+          prefix,
+          suffix,
+          defaultPattern,
+        });
+        expect(result).toBe(false);
+      });
+
+      it("returns true if topicName contains one of both and the part without prefix and suffix has three characters", () => {
+        const result = isValidTopicNameWithPrefixAndSuffix({
+          topicName: "one_abc_9two",
+          prefix,
+          suffix,
+          defaultPattern,
+        });
+        expect(result).toBe(true);
+      });
     });
   });
 });

--- a/coral/src/app/features/topics/request/utils.ts
+++ b/coral/src/app/features/topics/request/utils.ts
@@ -63,22 +63,26 @@ function generateTopicNameDescription(
     const { applyRegex, topicRegex, topicPrefix, topicSuffix } =
       environmentParams;
 
-    if (applyRegex && topicRegex && topicRegex.length > 0) {
-      desc.unshift(
-        `Follow name pattern: ${generateNamePatternString(topicRegex)}.`
-      );
-    }
+    // if a topic name has a regex format, it can't have a
+    // prefix or suffix
+    if (applyRegex) {
+      if (topicRegex && topicRegex.length > 0) {
+        desc.unshift(
+          `Follow name pattern: ${generateNamePatternString(topicRegex)}.`
+        );
+      }
+    } else {
+      if (topicPrefix && topicPrefix.length > 0) {
+        desc.unshift(
+          `Prefix name with: ${generateNamePatternString(topicPrefix)}.`
+        );
+      }
 
-    if (topicPrefix && topicPrefix.length > 0) {
-      desc.unshift(
-        `Prefix name with: ${generateNamePatternString(topicPrefix)}.`
-      );
-    }
-
-    if (topicSuffix && topicSuffix.length > 0) {
-      desc.unshift(
-        `Suffix name with: ${generateNamePatternString(topicSuffix)}.`
-      );
+      if (topicSuffix && topicSuffix.length > 0) {
+        desc.unshift(
+          `Suffix name with: ${generateNamePatternString(topicSuffix)}.`
+        );
+      }
     }
   }
   return desc.join(" ");

--- a/coral/src/domain/environment/environment-test-helper.ts
+++ b/coral/src/domain/environment/environment-test-helper.ts
@@ -18,6 +18,7 @@ const defaultEnvironmentDTO: KlawApiModel<"EnvModelResponse"> = {
   associatedEnv: undefined,
   clusterType: "ALL",
   params: {
+    applyRegex: undefined,
     defaultPartitions: undefined,
     defaultRepFactor: undefined,
     maxPartitions: undefined,


### PR DESCRIPTION
# About this change - What it does

When a topic name should have a regex ( `applyRegex: true` in the environments params), then _only_ this regex is used for validation, regardless if prefix or suffix is also in the params. 

This PR updates this in form field instructions (currently the placeholder) and validation. 

It also removes a small text that was used to try out options for field instructions and sneaked itself in 🥷 through the last PR. 

It also updates test cases to confirm proper validation.

### Recording (updated after last commit)
(using a mocked environment api call)

https://user-images.githubusercontent.com/943800/236470395-da6e0751-70e0-4d35-b605-f7422d081155.mov





