### PR TITLE
Save schemas with versions in db

### DIFF
--- a/cluster-api/src/main/java/io/aiven/klaw/clusterapi/controller/ClusterApiController.java
+++ b/cluster-api/src/main/java/io/aiven/klaw/clusterapi/controller/ClusterApiController.java
@@ -200,7 +200,9 @@ public class ClusterApiController {
     return new ResponseEntity<>(consumerOffsetDetails, HttpStatus.OK);
   }
 
-  @PostMapping(value = "/createTopics")
+  @PostMapping(
+      value = "/createTopics",
+      produces = {MediaType.APPLICATION_JSON_VALUE})
   public ResponseEntity<ApiResponse> createTopics(
       @RequestBody @Valid ClusterTopicRequest clusterTopicRequest) {
     try {
@@ -218,7 +220,9 @@ public class ClusterApiController {
     }
   }
 
-  @PostMapping(value = "/updateTopics")
+  @PostMapping(
+      value = "/updateTopics",
+      produces = {MediaType.APPLICATION_JSON_VALUE})
   public ResponseEntity<ApiResponse> updateTopics(
       @RequestBody @Valid ClusterTopicRequest clusterTopicRequest) {
     try {
@@ -235,7 +239,9 @@ public class ClusterApiController {
     }
   }
 
-  @PostMapping(value = "/deleteTopics")
+  @PostMapping(
+      value = "/deleteTopics",
+      produces = {MediaType.APPLICATION_JSON_VALUE})
   public ResponseEntity<ApiResponse> deleteTopics(
       @RequestBody @Valid ClusterTopicRequest clusterTopicRequest) {
     try {
@@ -251,7 +257,9 @@ public class ClusterApiController {
     }
   }
 
-  @PostMapping(value = "/createAcls")
+  @PostMapping(
+      value = "/createAcls",
+      produces = {MediaType.APPLICATION_JSON_VALUE})
   public ResponseEntity<ApiResponse> createAcls(
       @RequestBody @Valid ClusterAclRequest clusterAclRequest) {
 
@@ -305,7 +313,9 @@ public class ClusterApiController {
         HttpStatus.INTERNAL_SERVER_ERROR);
   }
 
-  @PostMapping(value = "/deleteAcls")
+  @PostMapping(
+      value = "/deleteAcls",
+      produces = {MediaType.APPLICATION_JSON_VALUE})
   public ResponseEntity<ApiResponse> deleteAcls(
       @RequestBody @Valid ClusterAclRequest clusterAclRequest) {
     String result;
@@ -360,7 +370,9 @@ public class ClusterApiController {
    * compatibility is NOT_SET, get global compatibility - Apply global compatibility on subject
    * level If force register is not enabled - Register schema
    */
-  @PostMapping(value = "/postSchema")
+  @PostMapping(
+      value = "/postSchema",
+      produces = {MediaType.APPLICATION_JSON_VALUE})
   public ResponseEntity<ApiResponse> postSchema(
       @RequestBody @Valid ClusterSchemaRequest clusterSchemaRequest) {
     try {
@@ -371,7 +383,9 @@ public class ClusterApiController {
     }
   }
 
-  @PostMapping(value = "/schema/validate/compatibility")
+  @PostMapping(
+      value = "/schema/validate/compatibility",
+      produces = {MediaType.APPLICATION_JSON_VALUE})
   public ResponseEntity<ApiResponse> schemaCompatibilityValidation(
       @RequestBody @Valid ClusterSchemaRequest clusterSchemaRequest) {
     try {

--- a/cluster-api/src/main/java/io/aiven/klaw/clusterapi/models/RegisterSchemaCustomResponse.java
+++ b/cluster-api/src/main/java/io/aiven/klaw/clusterapi/models/RegisterSchemaCustomResponse.java
@@ -1,0 +1,13 @@
+package io.aiven.klaw.clusterapi.models;
+
+import java.io.Serializable;
+import lombok.Data;
+import lombok.ToString;
+
+@Data
+@ToString
+public class RegisterSchemaCustomResponse implements Serializable {
+  Integer id;
+  Integer version;
+  boolean schemaRegistered;
+}

--- a/cluster-api/src/main/java/io/aiven/klaw/clusterapi/models/RegisterSchemaResponse.java
+++ b/cluster-api/src/main/java/io/aiven/klaw/clusterapi/models/RegisterSchemaResponse.java
@@ -1,0 +1,13 @@
+package io.aiven.klaw.clusterapi.models;
+
+import java.io.Serializable;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.ToString;
+
+@Getter
+@Setter
+@ToString
+public class RegisterSchemaResponse implements Serializable {
+  Integer id;
+}

--- a/cluster-api/src/main/java/io/aiven/klaw/clusterapi/services/SchemaService.java
+++ b/cluster-api/src/main/java/io/aiven/klaw/clusterapi/services/SchemaService.java
@@ -159,7 +159,7 @@ public class SchemaService {
   }
 
   private RegisterSchemaCustomResponse registerSchemaPostCall(
-      ClusterSchemaRequest clusterSchemaRequest) {
+      ClusterSchemaRequest clusterSchemaRequest) throws Exception {
     String suffixUrl =
         clusterSchemaRequest.getEnv()
             + "/"
@@ -190,8 +190,11 @@ public class SchemaService {
 
     RegisterSchemaResponse registerSchemaResponse = schemaResponseResponseEntity.getBody();
     RegisterSchemaCustomResponse registerSchemaCustomResponse = new RegisterSchemaCustomResponse();
-    registerSchemaCustomResponse.setId(
-        registerSchemaResponse != null ? registerSchemaResponse.getId() : -1);
+    if (registerSchemaResponse != null) {
+      registerSchemaCustomResponse.setId(registerSchemaResponse.getId());
+    } else {
+      throw new Exception("Failure in registering schema.");
+    }
 
     registerSchemaCustomResponse.setVersion(
         versionsListAfter.get(versionsListAfter.size() - 1)); // set the last element of array

--- a/cluster-api/src/main/java/io/aiven/klaw/clusterapi/services/SchemaService.java
+++ b/cluster-api/src/main/java/io/aiven/klaw/clusterapi/services/SchemaService.java
@@ -3,12 +3,15 @@ package io.aiven.klaw.clusterapi.services;
 import io.aiven.klaw.clusterapi.models.ApiResponse;
 import io.aiven.klaw.clusterapi.models.ClusterSchemaRequest;
 import io.aiven.klaw.clusterapi.models.ClusterTopicRequest;
+import io.aiven.klaw.clusterapi.models.RegisterSchemaCustomResponse;
+import io.aiven.klaw.clusterapi.models.RegisterSchemaResponse;
 import io.aiven.klaw.clusterapi.models.SchemaCompatibilityCheckResponse;
 import io.aiven.klaw.clusterapi.models.enums.ApiResultStatus;
 import io.aiven.klaw.clusterapi.models.enums.ClusterStatus;
 import io.aiven.klaw.clusterapi.models.enums.KafkaClustersType;
 import io.aiven.klaw.clusterapi.models.enums.KafkaSupportedProtocol;
 import io.aiven.klaw.clusterapi.utils.ClusterApiUtils;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -96,36 +99,27 @@ public class SchemaService {
         }
       }
 
-      String suffixUrl =
-          clusterSchemaRequest.getEnv()
-              + "/"
-              + SCHEMA_SUBJECTS_URI
-              + "/"
-              + clusterSchemaRequest.getTopicName()
-              + SCHEMA_VALUE_URI
-              + "/versions";
-      Pair<String, RestTemplate> reqDetails =
-          clusterApiUtils.getRequestDetails(suffixUrl, clusterSchemaRequest.getProtocol());
+      RegisterSchemaCustomResponse registerSchemaCustomResponse =
+          registerSchemaPostCall(clusterSchemaRequest);
 
-      HttpEntity<Map<String, String>> request =
-          buildSchemaEntity(
-              clusterSchemaRequest.getFullSchema(),
-              clusterSchemaRequest.getClusterIdentification());
-      ResponseEntity<String> responseNew =
-          reqDetails.getRight().postForEntity(reqDetails.getLeft(), request, String.class);
-
-      String updateTopicReqStatus = registerSchemaPostCall(clusterSchemaRequest);
-
-      return ApiResponse.builder().success(true).message(updateTopicReqStatus).build();
+      return ApiResponse.builder()
+          .success(true)
+          .message(ApiResultStatus.SUCCESS.value)
+          .data(registerSchemaCustomResponse)
+          .build();
     } catch (Exception e) {
       log.error("Exception:", e);
       if (e instanceof HttpClientErrorException
           && ((HttpClientErrorException.Conflict) e).getStatusCode().value() == 409) {
         return ApiResponse.builder()
+            .success(false)
             .message("Schema being registered is incompatible with an earlier schema")
             .build();
       }
-      return ApiResponse.builder().success(false).message("Failure in registering schema.").build();
+      return ApiResponse.builder()
+          .success(false)
+          .message("Failure in registering schema." + e.getMessage())
+          .build();
     } finally {
       // Ensure the Schema compatibility is returned to previous setting before the force update.
       resetCompatibilityOnSubject(
@@ -164,24 +158,47 @@ public class SchemaService {
     }
   }
 
-  private String registerSchemaPostCall(ClusterSchemaRequest clusterSchemaRequest) {
+  private RegisterSchemaCustomResponse registerSchemaPostCall(
+      ClusterSchemaRequest clusterSchemaRequest) {
     String suffixUrl =
         clusterSchemaRequest.getEnv()
-            + "/subjects/"
+            + "/"
+            + SCHEMA_SUBJECTS_URI
+            + "/"
             + clusterSchemaRequest.getTopicName()
-            + "-value/versions";
+            + SCHEMA_VALUE_URI
+            + "/versions";
     Pair<String, RestTemplate> reqDetails =
         clusterApiUtils.getRequestDetails(suffixUrl, clusterSchemaRequest.getProtocol());
 
     HttpEntity<Map<String, String>> request =
         buildSchemaEntity(
             clusterSchemaRequest.getFullSchema(), clusterSchemaRequest.getClusterIdentification());
-    ResponseEntity<String> responseNew =
-        reqDetails.getRight().postForEntity(reqDetails.getLeft(), request, String.class);
 
-    String updateTopicReqStatus = responseNew.getBody();
-    log.info("SchemaRequest response body {}", responseNew.getBody());
-    return updateTopicReqStatus;
+    ResponseEntity<RegisterSchemaResponse> schemaResponseResponseEntity =
+        reqDetails
+            .getRight()
+            .postForEntity(reqDetails.getLeft(), request, RegisterSchemaResponse.class);
+    List<Integer> versionsListAfter =
+        new ArrayList<>(
+            Objects.requireNonNull(
+                getSchemaVersions(
+                    clusterSchemaRequest.getEnv(),
+                    clusterSchemaRequest.getTopicName(),
+                    clusterSchemaRequest.getProtocol(),
+                    clusterSchemaRequest.getClusterIdentification())));
+
+    RegisterSchemaResponse registerSchemaResponse = schemaResponseResponseEntity.getBody();
+    RegisterSchemaCustomResponse registerSchemaCustomResponse = new RegisterSchemaCustomResponse();
+    registerSchemaCustomResponse.setId(
+        registerSchemaResponse != null ? registerSchemaResponse.getId() : -1);
+
+    registerSchemaCustomResponse.setVersion(
+        versionsListAfter.get(versionsListAfter.size() - 1)); // set the last element of array
+    registerSchemaCustomResponse.setSchemaRegistered(true);
+
+    log.info("SchemaRequest response body {}", schemaResponseResponseEntity.getBody());
+    return registerSchemaCustomResponse;
   }
 
   public Map<Integer, Map<String, Object>> getSchema(

--- a/cluster-api/src/main/java/io/aiven/klaw/clusterapi/services/SchemaService.java
+++ b/cluster-api/src/main/java/io/aiven/klaw/clusterapi/services/SchemaService.java
@@ -197,7 +197,7 @@ public class SchemaService {
         versionsListAfter.get(versionsListAfter.size() - 1)); // set the last element of array
     registerSchemaCustomResponse.setSchemaRegistered(true);
 
-    log.info("SchemaRequest response body {}", schemaResponseResponseEntity.getBody());
+    log.debug("SchemaRequest response body {}", schemaResponseResponseEntity.getBody());
     return registerSchemaCustomResponse;
   }
 

--- a/cluster-api/src/test/java/io/aiven/klaw/clusterapi/services/SchemaServiceRegisterSchemaTest.java
+++ b/cluster-api/src/test/java/io/aiven/klaw/clusterapi/services/SchemaServiceRegisterSchemaTest.java
@@ -412,12 +412,18 @@ class SchemaServiceRegisterSchemaTest {
             any(HashMap.class)))
         .thenReturn(createErrorCompatibilityResponseEntity(HttpStatus.NOT_FOUND))
         .thenReturn(createErrorCompatibilityResponseEntity(HttpStatus.NOT_FOUND));
+    when(restTemplate.exchange(
+            eq(REGISTRY_URL),
+            any(HttpMethod.class),
+            any(HttpEntity.class),
+            eq(new ParameterizedTypeReference<Map<String, String>>() {}),
+            any(HashMap.class)))
+        .thenReturn(createErrorCompatibilityResponseEntity(HttpStatus.NOT_FOUND))
+        .thenReturn(createErrorCompatibilityResponseEntity(HttpStatus.NOT_FOUND));
     schemaService.registerSchema(schemaReq);
     // change schema compatibility to NONE, once
     verify(restTemplate, times(1)).put(any(), any(), eq(String.class));
 
-    verify(restTemplate, times(2))
-        .postForEntity(anyString(), any(HttpEntity.class), eq(String.class));
     // 2 calls to get the current SchemaCompatibility (subject, global) as isForce==false
     verify(restTemplate, times(2))
         .exchange(

--- a/core/src/main/java/io/aiven/klaw/helpers/KwConstants.java
+++ b/core/src/main/java/io/aiven/klaw/helpers/KwConstants.java
@@ -7,7 +7,6 @@ public class KwConstants {
   public static final List<String> allowConfigForAdmins =
       Arrays.asList(
           "klaw.adduser.roles",
-          "klaw.superuser.mailid",
           "klaw.tenant.config",
           "klaw.envs.standardnames",
           "klaw.broadcast.text",
@@ -26,9 +25,6 @@ public class KwConstants {
 
   public static final String INFRATEAM = "INFRATEAM";
   public static final String STAGINGTEAM = "STAGINGTEAM";
-
-  public static final String INVALID_KEY_MESSAGE =
-      "Invalid License !! Please request from https://klaw-project.io for a license key.";
   public static final String MAIL_TOPICREQUEST_CONTENT =
       "Dear User, \\nA request for a create topic %s has been requested in Klaw.";
   public static final String MAIL_TOPICDELETEREQUEST_CONTENT =

--- a/core/src/main/java/io/aiven/klaw/helpers/KwConstants.java
+++ b/core/src/main/java/io/aiven/klaw/helpers/KwConstants.java
@@ -67,7 +67,7 @@ public class KwConstants {
   public static final String TENANT_CONFIG = "{}";
   public static final String ADDUSER_ROLES = "USER";
   public static final String ENVS_STANDARDNAMES =
-      "DEV,TST,SIT,STG,QAE,ACC,E2E,IOE,DRE,PEE,PRD,PRE,UAT";
+      "DEV,TST,SIT,STG,QAE,ACC,E2E,IOE,DRE,PEE,PRD,PRE,UAT,TEST,PROD";
   public static final String MAIL_PROTOCOL = "smtp";
   public static final String MAIL_HOST = "smtphost";
   public static final String MAIL_PORT = "22";

--- a/core/src/main/java/io/aiven/klaw/helpers/db/rdbms/DeleteDataJdbc.java
+++ b/core/src/main/java/io/aiven/klaw/helpers/db/rdbms/DeleteDataJdbc.java
@@ -326,7 +326,7 @@ public class DeleteDataJdbc {
 
   public void deleteSchemas(Topic topicObj) {
     messageSchemaRepo.deleteAll(
-        messageSchemaRepo.findAllByTenantIdAndTopicname(
-            topicObj.getTenantId(), topicObj.getTopicname()));
+        messageSchemaRepo.findAllByTenantIdAndTopicnameAndEnvironment(
+            topicObj.getTenantId(), topicObj.getTopicname(), topicObj.getEnvironment()));
   }
 }

--- a/core/src/main/java/io/aiven/klaw/helpers/db/rdbms/DeleteDataJdbc.java
+++ b/core/src/main/java/io/aiven/klaw/helpers/db/rdbms/DeleteDataJdbc.java
@@ -323,4 +323,10 @@ public class DeleteDataJdbc {
 
     return ApiResultStatus.SUCCESS.value;
   }
+
+  public void deleteSchemas(Topic topicObj) {
+    messageSchemaRepo.deleteAll(
+        messageSchemaRepo.findAllByTenantIdAndTopicname(
+            topicObj.getTenantId(), topicObj.getTopicname()));
+  }
 }

--- a/core/src/main/java/io/aiven/klaw/helpers/db/rdbms/UpdateDataJdbc.java
+++ b/core/src/main/java/io/aiven/klaw/helpers/db/rdbms/UpdateDataJdbc.java
@@ -348,8 +348,11 @@ public class UpdateDataJdbc {
     schemas.add(schemaObj);
 
     List<MessageSchema> messageSchemaList =
-        messageSchemaRepo.findAllByTenantIdAndTopicnameAndSchemaversion(
-            schemaObj.getTenantId(), schemaObj.getTopicname(), schemaObj.getSchemaversion());
+        messageSchemaRepo.findAllByTenantIdAndTopicnameAndSchemaversionAndEnvironment(
+            schemaObj.getTenantId(),
+            schemaObj.getTopicname(),
+            schemaObj.getSchemaversion(),
+            schemaObj.getEnvironment());
     if (messageSchemaList.isEmpty()) {
       insertDataJdbcHelper.insertIntoMessageSchemaSOT(schemas);
     }

--- a/core/src/main/java/io/aiven/klaw/model/cluster/RegisterSchemaCustomResponse.java
+++ b/core/src/main/java/io/aiven/klaw/model/cluster/RegisterSchemaCustomResponse.java
@@ -1,0 +1,13 @@
+package io.aiven.klaw.model.cluster;
+
+import java.io.Serializable;
+import lombok.Data;
+import lombok.ToString;
+
+@Data
+@ToString
+public class RegisterSchemaCustomResponse implements Serializable {
+  Integer id;
+  Integer version;
+  boolean newSchemaRegistered;
+}

--- a/core/src/main/java/io/aiven/klaw/repository/MessageSchemaRepo.java
+++ b/core/src/main/java/io/aiven/klaw/repository/MessageSchemaRepo.java
@@ -13,6 +13,11 @@ public interface MessageSchemaRepo extends CrudRepository<MessageSchema, Message
 
   List<MessageSchema> findAllByTenantId(int tenantId);
 
+  List<MessageSchema> findAllByTenantIdAndTopicname(int tenantId, String topicName);
+
+  List<MessageSchema> findAllByTenantIdAndTopicnameAndSchemaversion(
+      int tenantId, String topicName, String schemaVersion);
+
   @Query(
       value = "select count(*) from kwavroschemas where env = :envId and tenantid = :tenantId",
       nativeQuery = true)

--- a/core/src/main/java/io/aiven/klaw/repository/MessageSchemaRepo.java
+++ b/core/src/main/java/io/aiven/klaw/repository/MessageSchemaRepo.java
@@ -13,10 +13,11 @@ public interface MessageSchemaRepo extends CrudRepository<MessageSchema, Message
 
   List<MessageSchema> findAllByTenantId(int tenantId);
 
-  List<MessageSchema> findAllByTenantIdAndTopicname(int tenantId, String topicName);
+  List<MessageSchema> findAllByTenantIdAndTopicnameAndEnvironment(
+      int tenantId, String topicName, String environmentId);
 
-  List<MessageSchema> findAllByTenantIdAndTopicnameAndSchemaversion(
-      int tenantId, String topicName, String schemaVersion);
+  List<MessageSchema> findAllByTenantIdAndTopicnameAndSchemaversionAndEnvironment(
+      int tenantId, String topicName, String schemaVersion, String environmentId);
 
   @Query(
       value = "select count(*) from kwavroschemas where env = :envId and tenantid = :tenantId",

--- a/core/src/main/java/io/aiven/klaw/service/CommonUtilsService.java
+++ b/core/src/main/java/io/aiven/klaw/service/CommonUtilsService.java
@@ -1,6 +1,7 @@
 package io.aiven.klaw.service;
 
 import static io.aiven.klaw.helpers.KwConstants.ORDER_OF_TOPIC_ENVS;
+import static io.aiven.klaw.helpers.KwConstants.REQUEST_TOPICS_OF_ENVS;
 
 import io.aiven.klaw.config.ManageDatabase;
 import io.aiven.klaw.dao.Env;
@@ -475,14 +476,14 @@ public class CommonUtilsService {
       List<Integer> intOrderEnvsList = new ArrayList<>();
 
       switch (envPropertyType) {
-        case "ORDER_OF_ENVS" -> {
+        case ORDER_OF_TOPIC_ENVS -> {
           List<String> orderOfTopicPromotionEnvsList =
               tenantModel.getOrderOfTopicPromotionEnvsList();
           if (null != orderOfTopicPromotionEnvsList && !orderOfTopicPromotionEnvsList.isEmpty()) {
             orderOfTopicPromotionEnvsList.forEach(a -> intOrderEnvsList.add(Integer.parseInt(a)));
           }
         }
-        case "REQUEST_TOPICS_OF_ENVS" -> {
+        case REQUEST_TOPICS_OF_ENVS -> {
           List<String> requestTopics = tenantModel.getRequestTopicsEnvironmentsList();
           if (requestTopics != null && !requestTopics.isEmpty()) {
             requestTopics.forEach(a -> intOrderEnvsList.add(Integer.parseInt(a)));

--- a/core/src/main/java/io/aiven/klaw/service/DefaultDataService.java
+++ b/core/src/main/java/io/aiven/klaw/service/DefaultDataService.java
@@ -198,11 +198,6 @@ public class DefaultDataService {
             "Email notification body for password reset");
     kwPropertiesList.add(kwProperties16);
 
-    KwProperties kwProperties17 =
-        new KwProperties(
-            "klaw.superuser.mailid", tenantId, mailId, "Email id of Super user or Super Admin");
-    kwPropertiesList.add(kwProperties17);
-
     KwProperties kwProperties18 =
         new KwProperties(
             "klaw.reports.location",

--- a/core/src/main/java/io/aiven/klaw/service/EnvsClustersTenantsControllerService.java
+++ b/core/src/main/java/io/aiven/klaw/service/EnvsClustersTenantsControllerService.java
@@ -13,6 +13,8 @@ import static io.aiven.klaw.error.KlawErrorMessages.ENV_CLUSTER_TNT_ERR_108;
 import static io.aiven.klaw.helpers.KwConstants.DAYS_EXPIRY_DEFAULT_TENANT;
 import static io.aiven.klaw.helpers.KwConstants.DAYS_TRIAL_PERIOD;
 import static io.aiven.klaw.helpers.KwConstants.DEFAULT_TENANT_ID;
+import static io.aiven.klaw.helpers.KwConstants.ORDER_OF_TOPIC_ENVS;
+import static io.aiven.klaw.helpers.KwConstants.REQUEST_TOPICS_OF_ENVS;
 import static io.aiven.klaw.helpers.KwConstants.SUPERADMIN_ROLE;
 import static io.aiven.klaw.model.enums.RolesType.SUPERADMIN;
 import static io.aiven.klaw.service.UsersTeamsControllerService.MASKED_PWD;
@@ -314,12 +316,11 @@ public class EnvsClustersTenantsControllerService {
   public List<EnvModelResponse> getEnvsForRequestTopicsCluster() {
     int tenantId = getUserDetails(getUserName()).getTenantId();
 
-    String requestTopicsEnvs =
-        commonUtilsService.getEnvProperty(tenantId, "REQUEST_TOPICS_OF_ENVS");
+    String requestTopicsEnvs = commonUtilsService.getEnvProperty(tenantId, REQUEST_TOPICS_OF_ENVS);
     if (requestTopicsEnvs == null) {
       return new ArrayList<>();
     }
-    String orderOfEnvs = commonUtilsService.getEnvProperty(tenantId, "ORDER_OF_ENVS");
+    String orderOfEnvs = commonUtilsService.getEnvProperty(tenantId, ORDER_OF_TOPIC_ENVS);
     String[] reqTopicsEnvs = requestTopicsEnvs.split(",");
     List<Env> listEnvs = manageDatabase.getKafkaEnvList(tenantId);
     List<EnvModelResponse> envModelList = getEnvModels(listEnvs, KafkaClustersType.KAFKA, tenantId);
@@ -338,7 +339,7 @@ public class EnvsClustersTenantsControllerService {
 
   public List<EnvModelResponse> getKafkaEnvs() {
     int tenantId = getUserDetails(getUserName()).getTenantId();
-    String orderOfEnvs = commonUtilsService.getEnvProperty(tenantId, "ORDER_OF_ENVS");
+    String orderOfEnvs = commonUtilsService.getEnvProperty(tenantId, ORDER_OF_TOPIC_ENVS);
     List<Env> listEnvs = manageDatabase.getKafkaEnvList(tenantId);
     List<EnvModelResponse> envModelList = getEnvModels(listEnvs, KafkaClustersType.KAFKA, tenantId);
     envModelList.forEach(
@@ -364,7 +365,7 @@ public class EnvsClustersTenantsControllerService {
 
   public List<EnvModelResponse> getConnectorEnvs() {
     int tenantId = getUserDetails(getUserName()).getTenantId();
-    String orderOfEnvs = commonUtilsService.getEnvProperty(tenantId, "ORDER_OF_ENVS");
+    String orderOfEnvs = commonUtilsService.getEnvProperty(tenantId, ORDER_OF_TOPIC_ENVS);
     List<Env> listEnvs = manageDatabase.getKafkaConnectEnvList(tenantId);
     List<EnvModelResponse> envModelList =
         getEnvModels(listEnvs, KafkaClustersType.KAFKA_CONNECT, tenantId);

--- a/core/src/main/java/io/aiven/klaw/service/MailUtils.java
+++ b/core/src/main/java/io/aiven/klaw/service/MailUtils.java
@@ -29,12 +29,11 @@ public class MailUtils {
   public static final String KLAW_REGISTRATION_REQUEST = "Klaw Registration request";
 
   @Value("${klaw.admin.mailid}")
-  private String kwSaasAdminMailId;
+  private String kwAdminMailId;
 
   @Value("${klaw.ad.username.attribute:preferred_username}")
   private String preferredUsername;
 
-  private static final String SUPERUSER_MAILID_KEY = "klaw.superuser.mailid";
   private static final String TOPIC_REQ_KEY = "klaw.mail.topicrequest.content";
   private static final String TOPIC_REQ_DEL_KEY = "klaw.mail.topicdeleterequest.content";
   private static final String TOPIC_REQ_CLAIM_KEY = "klaw.mail.topicclaimrequest.content";
@@ -54,8 +53,6 @@ public class MailUtils {
   private static final String REGISTER_USER_SAASADMIN_TOUSER_KEY =
       "klaw.mail.registerusertouser.saasadmin.content";
   private static final String RECONCILIATION_TOPICS_KEY = "klaw.mail.recontopics.content";
-
-  private String superUserMailId;
   private String topicRequestMail;
   private String topicDeleteRequestMail;
   private String topicClaimRequestMail;
@@ -201,9 +198,7 @@ public class MailUtils {
             registrationRequest, registerUserInfo.getUsername(), registerUserInfo.getFullname());
 
     subject = NEW_USER_REGISTRATION_REQUEST;
-    if (!Objects.equals(
-        registerUserInfo.getMailid(),
-        manageDatabase.getKwPropertyValue(SUPERUSER_MAILID_KEY, tenantId)))
+    if (!Objects.equals(registerUserInfo.getMailid(), kwAdminMailId))
       sendMailToAdmin(subject, formattedStr, tenantId, loginUrl);
 
     // Sending to user
@@ -261,9 +256,7 @@ public class MailUtils {
               registerUserInfo.getRole());
 
       subject = NEW_USER_REGISTRATION_REQUEST;
-      if (!Objects.equals(
-          registerUserInfo.getMailid(),
-          manageDatabase.getKwPropertyValue(SUPERUSER_MAILID_KEY, tenantId)))
+      if (!Objects.equals(registerUserInfo.getMailid(), kwAdminMailId))
         sendMailToAdmin(subject, formattedStr, tenantId, loginUrl);
 
       // Sending to user
@@ -293,7 +286,6 @@ public class MailUtils {
 
   public void sendReconMailToAdmin(
       String subject, String reconTopicsContent, String tenantName, int tenantId, String loginUrl) {
-    this.superUserMailId = manageDatabase.getKwPropertyValue(SUPERUSER_MAILID_KEY, tenantId);
     String reconMailContent =
         manageDatabase.getKwPropertyValue(RECONCILIATION_TOPICS_KEY, tenantId);
     String formattedStr = String.format(reconMailContent, tenantName);
@@ -301,9 +293,9 @@ public class MailUtils {
     try {
       CompletableFuture.runAsync(
               () -> {
-                if (superUserMailId != null) {
+                if (kwAdminMailId != null) {
                   emailService.sendSimpleMessage(
-                      superUserMailId, null, subject, formattedStr, tenantId, loginUrl);
+                      kwAdminMailId, null, subject, formattedStr, tenantId, loginUrl);
                 }
               })
           .get();
@@ -313,12 +305,11 @@ public class MailUtils {
   }
 
   public void sendMailToAdmin(String subject, String mailContent, int tenantId, String loginUrl) {
-    this.superUserMailId = manageDatabase.getKwPropertyValue(SUPERUSER_MAILID_KEY, tenantId);
     CompletableFuture.runAsync(
         () -> {
-          if (superUserMailId != null) {
+          if (kwAdminMailId != null) {
             emailService.sendSimpleMessage(
-                superUserMailId, null, subject, mailContent, tenantId, loginUrl);
+                kwAdminMailId, null, subject, mailContent, tenantId, loginUrl);
           }
         });
   }
@@ -332,7 +323,6 @@ public class MailUtils {
       String otherMailId,
       int tenantId,
       String loginUrl) {
-    this.superUserMailId = manageDatabase.getKwPropertyValue(SUPERUSER_MAILID_KEY, tenantId);
 
     CompletableFuture.runAsync(
         () -> {
@@ -369,7 +359,7 @@ public class MailUtils {
     String mailtext =
         "Tenant extension : Tenant " + tenantId + " username " + userName + " period " + period;
     emailService.sendSimpleMessage(
-        userName, kwSaasAdminMailId, "Tenant Extension", mailtext, tenantId, loginUrl);
+        userName, kwAdminMailId, "Tenant Extension", mailtext, tenantId, loginUrl);
     return ApiResultStatus.SUCCESS.value;
   }
 }

--- a/core/src/main/java/io/aiven/klaw/service/SchemaRegistryControllerService.java
+++ b/core/src/main/java/io/aiven/klaw/service/SchemaRegistryControllerService.java
@@ -273,9 +273,20 @@ public class SchemaRegistryControllerService {
         clusterApiService.postSchema(
             schemaRequest, schemaRequest.getEnvironment(), schemaRequest.getTopicname(), tenantId);
     HandleDbRequests dbHandle = manageDatabase.getHandleDbRequests();
-    if (Objects.requireNonNull(Objects.requireNonNull(response.getBody()).getMessage())
-        .contains("id\":")) {
+    ApiResponse apiResponse = response.getBody();
+    Map<String, Object> registerSchemaCustomResponse = null;
+    boolean schemaRegistered = false;
+    if (apiResponse != null
+        && apiResponse.getData() != null
+        && apiResponse.getData() instanceof Map<?, ?>) {
+      registerSchemaCustomResponse = (Map) apiResponse.getData();
+      schemaRegistered = (Boolean) registerSchemaCustomResponse.get("schemaRegistered");
+    }
+    if (registerSchemaCustomResponse != null && (registerSchemaCustomResponse.containsKey("id"))) {
       try {
+        if (schemaRegistered) {
+          schemaRequest.setSchemaversion(registerSchemaCustomResponse.get("version") + "");
+        }
         String responseDb = dbHandle.updateSchemaRequest(schemaRequest, userDetails);
         mailService.sendMail(
             schemaRequest.getTopicname(),

--- a/core/src/main/java/io/aiven/klaw/service/TopicControllerService.java
+++ b/core/src/main/java/io/aiven/klaw/service/TopicControllerService.java
@@ -15,6 +15,7 @@ import static io.aiven.klaw.error.KlawErrorMessages.TOPICS_ERR_111;
 import static io.aiven.klaw.error.KlawErrorMessages.TOPICS_ERR_112;
 import static io.aiven.klaw.error.KlawErrorMessages.TOPICS_ERR_113;
 import static io.aiven.klaw.error.KlawErrorMessages.TOPICS_ERR_114;
+import static io.aiven.klaw.helpers.KwConstants.ORDER_OF_TOPIC_ENVS;
 import static io.aiven.klaw.model.enums.MailType.*;
 import static org.springframework.beans.BeanUtils.copyProperties;
 
@@ -1086,7 +1087,7 @@ public class TopicControllerService {
 
     // tenant filtering
     List<Env> listAllEnvs = manageDatabase.getKafkaEnvList(tenantId);
-    String orderOfEnvs = commonUtilsService.getEnvProperty(tenantId, "ORDER_OF_ENVS");
+    String orderOfEnvs = commonUtilsService.getEnvProperty(tenantId, ORDER_OF_TOPIC_ENVS);
 
     topicsFromSOT = commonUtilsService.groupTopicsByEnv(topicsFromSOT);
     List<Topic> filterProducerConsumerList = new ArrayList<>();

--- a/core/src/main/java/io/aiven/klaw/service/TopicSyncControllerService.java
+++ b/core/src/main/java/io/aiven/klaw/service/TopicSyncControllerService.java
@@ -6,6 +6,7 @@ import static io.aiven.klaw.error.KlawErrorMessages.TOPICS_SYNC_ERR_101;
 import static io.aiven.klaw.error.KlawErrorMessages.TOPICS_SYNC_ERR_102;
 import static io.aiven.klaw.error.KlawErrorMessages.TOPICS_SYNC_ERR_103;
 import static io.aiven.klaw.error.KlawErrorMessages.TOPICS_SYNC_ERR_104;
+import static io.aiven.klaw.helpers.KwConstants.ORDER_OF_TOPIC_ENVS;
 import static org.springframework.beans.BeanUtils.copyProperties;
 
 import io.aiven.klaw.config.ManageDatabase;
@@ -629,7 +630,7 @@ public class TopicSyncControllerService {
 
     // tenant filtering
     List<Env> listAllEnvs = manageDatabase.getKafkaEnvList(tenantId);
-    String orderOfEnvs = commonUtilsService.getEnvProperty(tenantId, "ORDER_OF_ENVS");
+    String orderOfEnvs = commonUtilsService.getEnvProperty(tenantId, ORDER_OF_TOPIC_ENVS);
 
     topicsFromSOT = commonUtilsService.groupTopicsByEnv(topicsFromSOT);
     List<Topic> filterProducerConsumerList = new ArrayList<>();
@@ -924,7 +925,7 @@ public class TopicSyncControllerService {
     // tenant filtering
     int tenantId = commonUtilsService.getTenantId(getUserName());
     String syncCluster = manageDatabase.getTenantConfig().get(tenantId).getBaseSyncEnvironment();
-    String orderOfEnvs = commonUtilsService.getEnvProperty(tenantId, "ORDER_OF_ENVS");
+    String orderOfEnvs = commonUtilsService.getEnvProperty(tenantId, ORDER_OF_TOPIC_ENVS);
 
     List<Topic> existingTopics;
     List<Topic> listTopics = new ArrayList<>();

--- a/core/src/main/java/io/aiven/klaw/validation/TopicRequestValidatorImpl.java
+++ b/core/src/main/java/io/aiven/klaw/validation/TopicRequestValidatorImpl.java
@@ -18,6 +18,7 @@ import static io.aiven.klaw.error.KlawErrorMessages.TOPICS_VLD_ERR_115;
 import static io.aiven.klaw.error.KlawErrorMessages.TOPICS_VLD_ERR_116;
 import static io.aiven.klaw.error.KlawErrorMessages.TOPICS_VLD_ERR_117;
 import static io.aiven.klaw.error.KlawErrorMessages.TOPICS_VLD_ERR_118;
+import static io.aiven.klaw.helpers.KwConstants.ORDER_OF_TOPIC_ENVS;
 
 import io.aiven.klaw.dao.Topic;
 import io.aiven.klaw.model.enums.ApiResultStatus;
@@ -175,7 +176,7 @@ public class TopicRequestValidatorImpl
       TopicRequestModel topicRequestModel,
       String syncCluster,
       ConstraintValidatorContext constraintValidatorContext) {
-    String orderOfEnvs = commonUtilsService.getEnvProperty(tenantId, "ORDER_OF_ENVS");
+    String orderOfEnvs = commonUtilsService.getEnvProperty(tenantId, ORDER_OF_TOPIC_ENVS);
     boolean promotionOrderCheck = false;
     if (null != orderOfEnvs) {
       promotionOrderCheck = checkInPromotionOrder(topicRequestModel.getEnvironment(), orderOfEnvs);

--- a/core/src/test/java/io/aiven/klaw/helpers/db/rdbms/UpdateDataJdbcTest.java
+++ b/core/src/test/java/io/aiven/klaw/helpers/db/rdbms/UpdateDataJdbcTest.java
@@ -157,8 +157,8 @@ public class UpdateDataJdbcTest {
 
   @Test
   public void updateSchemaRequest() {
-    when(messageSchemaRepo.findAllByTenantIdAndTopicnameAndSchemaversion(
-            anyInt(), anyString(), anyString()))
+    when(messageSchemaRepo.findAllByTenantIdAndTopicnameAndSchemaversionAndEnvironment(
+            anyInt(), anyString(), anyString(), anyString()))
         .thenReturn(Collections.emptyList());
     String result =
         updateData.updateSchemaRequest(utilMethods.getSchemaRequestsDao().get(0), "uiuser1");

--- a/core/src/test/java/io/aiven/klaw/service/SchemaRegistryControllerServiceTest.java
+++ b/core/src/test/java/io/aiven/klaw/service/SchemaRegistryControllerServiceTest.java
@@ -193,8 +193,16 @@ public class SchemaRegistryControllerServiceTest {
   @Order(4)
   public void execSchemaRequestsSuccess() throws KlawException {
     int schemaReqId = 1001;
+    Map<String, Object> registerSchemaCustomResponse = new HashMap<>();
+    registerSchemaCustomResponse.put("schemaRegistered", true);
+    registerSchemaCustomResponse.put("version", 1);
+    registerSchemaCustomResponse.put("id", 1);
 
-    ApiResponse apiResponse = ApiResponse.builder().message("Schema registered id\": 215").build();
+    ApiResponse apiResponse =
+        ApiResponse.builder()
+            .message("Schema registered id\": 215")
+            .data(registerSchemaCustomResponse)
+            .build();
 
     ResponseEntity<ApiResponse> response = new ResponseEntity<>(apiResponse, HttpStatus.OK);
     SchemaRequest schemaRequest = new SchemaRequest();

--- a/core/src/test/java/io/aiven/klaw/service/TopicOverviewServiceTest.java
+++ b/core/src/test/java/io/aiven/klaw/service/TopicOverviewServiceTest.java
@@ -1,6 +1,7 @@
 package io.aiven.klaw.service;
 
 import static io.aiven.klaw.helpers.KwConstants.ORDER_OF_TOPIC_ENVS;
+import static io.aiven.klaw.helpers.KwConstants.REQUEST_TOPICS_OF_ENVS;
 import static io.aiven.klaw.service.BaseOverviewService.NO_PROMOTION;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
@@ -125,7 +126,7 @@ public class TopicOverviewServiceTest {
 
     when(manageDatabase.getAllEnvList(anyInt()))
         .thenReturn(createListOfEnvs(KafkaClustersType.SCHEMA_REGISTRY, 5));
-    when(commonUtilsService.getEnvProperty(eq(101), eq("REQUEST_TOPICS_OF_ENVS"))).thenReturn("1");
+    when(commonUtilsService.getEnvProperty(eq(101), eq(REQUEST_TOPICS_OF_ENVS))).thenReturn("1");
     mockTenantConfig();
     List<AclInfo> aclList =
         topicOverviewService.getTopicOverview(TESTTOPIC, "1", AclGroupBy.NONE).getAclInfoList();
@@ -161,7 +162,7 @@ public class TopicOverviewServiceTest {
 
     when(manageDatabase.getAllEnvList(anyInt()))
         .thenReturn(createListOfEnvs(KafkaClustersType.SCHEMA_REGISTRY, 5));
-    when(commonUtilsService.getEnvProperty(eq(101), eq("REQUEST_TOPICS_OF_ENVS"))).thenReturn("1");
+    when(commonUtilsService.getEnvProperty(eq(101), eq(REQUEST_TOPICS_OF_ENVS))).thenReturn("1");
     mockTenantConfig();
 
     List<AclInfo> aclList =
@@ -184,8 +185,8 @@ public class TopicOverviewServiceTest {
     stubSchemaPromotionInfo(TESTTOPIC, KafkaClustersType.KAFKA, 15);
     when(commonUtilsService.getTopicsForTopicName(TESTTOPIC, 101))
         .thenReturn(List.of(createTopic(TESTTOPIC)));
-    when(commonUtilsService.getEnvProperty(eq(101), eq("REQUEST_TOPICS_OF_ENVS"))).thenReturn("1");
-    when(commonUtilsService.getEnvProperty(eq(101), eq("ORDER_OF_ENVS"))).thenReturn("1");
+    when(commonUtilsService.getEnvProperty(eq(101), eq(REQUEST_TOPICS_OF_ENVS))).thenReturn("1");
+    when(commonUtilsService.getEnvProperty(eq(101), eq(ORDER_OF_TOPIC_ENVS))).thenReturn("1");
 
     TopicOverview returnedValue =
         topicOverviewService.getTopicOverview(TESTTOPIC, "1", AclGroupBy.NONE);
@@ -201,10 +202,10 @@ public class TopicOverviewServiceTest {
     stubKafkaPromotion(TESTTOPIC, 15);
     stubSchemaPromotionInfo(TESTTOPIC, KafkaClustersType.KAFKA, 15);
     when(commonUtilsService.getTopicsForTopicName(TESTTOPIC, 101))
-        .thenReturn(Arrays.asList(createTopic(TESTTOPIC)));
-    when(commonUtilsService.getEnvProperty(eq(101), eq("REQUEST_TOPICS_OF_ENVS")))
+        .thenReturn(List.of(createTopic(TESTTOPIC)));
+    when(commonUtilsService.getEnvProperty(eq(101), eq(REQUEST_TOPICS_OF_ENVS)))
         .thenReturn("1,2,3,4,5,6,7,8,9,10,11,12,13,14,15");
-    when(commonUtilsService.getEnvProperty(eq(101), eq("ORDER_OF_ENVS")))
+    when(commonUtilsService.getEnvProperty(eq(101), eq(ORDER_OF_TOPIC_ENVS)))
         .thenReturn("1,2,3,4,5,6,7,8,9,10,11,12,13,14,15");
 
     TopicOverview returnedValue =
@@ -224,7 +225,7 @@ public class TopicOverviewServiceTest {
     stubKafkaPromotion(TESTTOPIC, 1);
     stubSchemaPromotionInfo(TESTTOPIC, KafkaClustersType.KAFKA, 15);
 
-    when(commonUtilsService.getEnvProperty(eq(101), eq("ORDER_OF_ENVS"))).thenReturn("1");
+    when(commonUtilsService.getEnvProperty(eq(101), eq(ORDER_OF_TOPIC_ENVS))).thenReturn("1");
 
     TopicOverview returnedValue =
         topicOverviewService.getTopicOverview(TESTTOPIC, "1", AclGroupBy.NONE);
@@ -258,7 +259,7 @@ public class TopicOverviewServiceTest {
 
     when(manageDatabase.getAllEnvList(anyInt()))
         .thenReturn(createListOfEnvs(KafkaClustersType.SCHEMA_REGISTRY, 5));
-    when(commonUtilsService.getEnvProperty(eq(101), eq("REQUEST_TOPICS_OF_ENVS"))).thenReturn("1");
+    when(commonUtilsService.getEnvProperty(eq(101), eq(REQUEST_TOPICS_OF_ENVS))).thenReturn("1");
     mockTenantConfig();
     List<AclInfo> aclList =
         topicOverviewService.getTopicOverview(TESTTOPIC, "1", AclGroupBy.NONE).getAclInfoList();
@@ -280,7 +281,7 @@ public class TopicOverviewServiceTest {
     stubKafkaPromotion(TESTTOPIC, 1);
     stubSchemaPromotionInfo(TESTTOPIC, KafkaClustersType.KAFKA, 15);
 
-    when(commonUtilsService.getEnvProperty(eq(101), eq("ORDER_OF_ENVS"))).thenReturn("1");
+    when(commonUtilsService.getEnvProperty(eq(101), eq(ORDER_OF_TOPIC_ENVS))).thenReturn("1");
     when(commonUtilsService.getTopicsForTopicName(eq(TESTTOPIC), eq(101)))
         .thenReturn(List.of(createTopic(TESTTOPIC)));
     when(handleDbRequests.getSyncAcls(anyString(), eq(TESTTOPIC), eq(101)))

--- a/core/src/test/java/io/aiven/klaw/service/UiConfigControllerServiceTest.java
+++ b/core/src/test/java/io/aiven/klaw/service/UiConfigControllerServiceTest.java
@@ -1,5 +1,6 @@
 package io.aiven.klaw.service;
 
+import static io.aiven.klaw.helpers.KwConstants.ORDER_OF_TOPIC_ENVS;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
@@ -136,7 +137,7 @@ public class UiConfigControllerServiceTest {
   public void getRequestSchemaEnvs_IsEmpty() {
     stubUserInfo();
     when(commonUtilsService.isNotAuthorizedUser(any(), any())).thenReturn(false);
-    when(commonUtilsService.getEnvProperty(eq(101), eq("ORDER_OF_ENVS"))).thenReturn("DEV,TST");
+    when(commonUtilsService.getEnvProperty(eq(101), eq(ORDER_OF_TOPIC_ENVS))).thenReturn("DEV,TST");
     when(commonUtilsService.getEnvProperty(eq(101), eq("REQUEST_SCHEMA_OF_ENVS"))).thenReturn("");
     when(handleDbRequests.getAllSchemaRegEnvs(1)).thenReturn(getAllSchemaEnvs());
     when(manageDatabase.getSchemaRegEnvList(eq(101))).thenReturn(getAllSchemaEnvs());
@@ -152,7 +153,7 @@ public class UiConfigControllerServiceTest {
 
     stubUserInfo();
     when(commonUtilsService.isNotAuthorizedUser(any(), any())).thenReturn(false);
-    when(commonUtilsService.getEnvProperty(eq(101), eq("ORDER_OF_ENVS"))).thenReturn("DEV,TST");
+    when(commonUtilsService.getEnvProperty(eq(101), eq(ORDER_OF_TOPIC_ENVS))).thenReturn("DEV,TST");
     when(commonUtilsService.getEnvProperty(eq(101), eq("REQUEST_SCHEMA_OF_ENVS")))
         .thenReturn("DEV");
     when(handleDbRequests.getAllSchemaRegEnvs(1)).thenReturn(getAllSchemaEnvs());
@@ -172,7 +173,7 @@ public class UiConfigControllerServiceTest {
     // sTT is a misspelt env one tht does not exist and so should not be returned.
     stubUserInfo();
     when(commonUtilsService.isNotAuthorizedUser(any(), any())).thenReturn(false);
-    when(commonUtilsService.getEnvProperty(eq(101), eq("ORDER_OF_ENVS"))).thenReturn("DEV,TST");
+    when(commonUtilsService.getEnvProperty(eq(101), eq(ORDER_OF_TOPIC_ENVS))).thenReturn("DEV,TST");
     when(commonUtilsService.getEnvProperty(eq(101), eq("REQUEST_SCHEMA_OF_ENVS")))
         .thenReturn("DEV,sTT");
     when(handleDbRequests.getAllSchemaRegEnvs(1)).thenReturn(getAllSchemaEnvs());
@@ -192,7 +193,7 @@ public class UiConfigControllerServiceTest {
     // DEV and TSTS are both spelt correctly and configured so both should be returned.
     stubUserInfo();
     when(commonUtilsService.isNotAuthorizedUser(any(), any())).thenReturn(false);
-    when(commonUtilsService.getEnvProperty(eq(101), eq("ORDER_OF_ENVS"))).thenReturn("DEV,TST");
+    when(commonUtilsService.getEnvProperty(eq(101), eq(ORDER_OF_TOPIC_ENVS))).thenReturn("DEV,TST");
     when(commonUtilsService.getEnvProperty(eq(101), eq("REQUEST_SCHEMA_OF_ENVS")))
         .thenReturn("DEV,TST");
     when(handleDbRequests.getAllSchemaRegEnvs(1)).thenReturn(getAllSchemaEnvs());
@@ -213,7 +214,8 @@ public class UiConfigControllerServiceTest {
     // only two kWclusters are configured DEV and TST so UAT should not return.
     stubUserInfo();
     when(commonUtilsService.isNotAuthorizedUser(any(), any())).thenReturn(false);
-    when(commonUtilsService.getEnvProperty(eq(101), eq("ORDER_OF_ENVS"))).thenReturn("DEV,TST,UAT");
+    when(commonUtilsService.getEnvProperty(eq(101), eq(ORDER_OF_TOPIC_ENVS)))
+        .thenReturn("DEV,TST,UAT");
     when(commonUtilsService.getEnvProperty(eq(101), eq("REQUEST_SCHEMA_OF_ENVS")))
         .thenReturn("DEV,TST,UAT");
     when(handleDbRequests.getAllSchemaRegEnvs(1)).thenReturn(getAllSchemaEnvs());


### PR DESCRIPTION
About this change - What it does

- When a new schema is requested, it is stored in db together with its version. Cluster api is updated to return version together with id
- there is a superuser mailid which is now removed and using klaw admin mail id from application.properties.

Resolves: #1102 
Resolves: #1111 
Why this way

- Schemas can now be searched through
