### PR TITLE
fix(coral): Update payload and typing in schema request

### DIFF
--- a/coral/src/domain/schema-request/schema-request-api.ts
+++ b/coral/src/domain/schema-request/schema-request-api.ts
@@ -26,16 +26,17 @@ type CreateSchemaRequestPayload = ResolveIntersectionTypes<
 const createSchemaRequest = (
   params: CreateSchemaRequestPayload
 ): Promise<KlawApiResponse<"uploadSchema">> => {
-  const payload = {
+  const payload: KlawApiRequest<"uploadSchema"> = {
     ...params,
     schemaversion: "1.0",
     appname: "App",
+    requestOperationType: "CREATE",
   };
 
-  return api.post<KlawApiResponse<"uploadSchema">, CreateSchemaRequestPayload>(
-    API_PATHS.uploadSchema,
-    payload
-  );
+  return api.post<
+    KlawApiResponse<"uploadSchema">,
+    KlawApiRequest<"uploadSchema">
+  >(API_PATHS.uploadSchema, payload);
 };
 
 type GetSchemaRequestsForApproverQueryParams = ResolveIntersectionTypes<


### PR DESCRIPTION
# About this change - What it does

- `uploadSchema` does not require the `requestOperationType` to be in the payload
- typing for the api call did not use the ` KlawApiRequest<"uploadSchema">` type to define payload, which is why the TS compiler didn't catch it. 

It's now updated to:

```api.post<
    KlawApiResponse<"uploadSchema">,
    KlawApiRequest<"uploadSchema">
  >(API_PATHS.uploadSchema, payload);
 ```
 
 this made `pnpm tsc` fail and surfaced that bug. 
 
 We're now passing the `requestOperationType`
 
 
 Note: We should check other APIs too for this pattern. 

Resolves: #xxxxx
Why this way
