### PR TITLE
fix(coral): Add z-index to skip link for focus-visible

### DIFF
--- a/coral/src/app/layout/page/BasePage.tsx
+++ b/coral/src/app/layout/page/BasePage.tsx
@@ -14,7 +14,6 @@ function BasePage({ headerContent, content, sidebar }: BasePageProps) {
       style={{
         gridTemplateColumns: "245px 1fr",
         gridTemplateRows: "auto 1fr",
-        isolation: "isolate",
       }}
     >
       <GridItem
@@ -53,6 +52,7 @@ function BasePage({ headerContent, content, sidebar }: BasePageProps) {
           flexDirection={"column"}
           padding={"l2"}
           width={"full"}
+          style={{ isolation: "isolate" }}
         >
           {content}
         </Box>


### PR DESCRIPTION
# About this change - What it does

Adds a high z-index to skip link for `focus-visible` (so only when it's in focus due to keyboard navigation) which is needed now for it to show up. 

Resolves: #1117

### works again 🎉 

https://github.com/aiven/klaw/assets/943800/7c05a43c-e72f-4436-9a7e-1e3724c88558


