### PR TITLE
fix(coral): Remove superfluous `defaultValue` in `TopicSchemaRequest`

### DIFF
--- a/coral/src/app/features/topics/schema-request/TopicSchemaRequest.tsx
+++ b/coral/src/app/features/topics/schema-request/TopicSchemaRequest.tsx
@@ -150,7 +150,6 @@ function TopicSchemaRequest(props: TopicSchemaRequestProps) {
               name={"topicname"}
               labelText={"Topic name"}
               readOnly={topicName !== undefined}
-              defaultValue={topicName}
             >
               {topicNames.map((topic) => {
                 return (


### PR DESCRIPTION
## About this change - What it does

Navigating to `/topic/aivtopic1/request-schema` will return this warning in the browser's console:

```
Warning: Select elements must be either controlled or uncontrolled (specify either the value prop, or the defaultValue prop, but not both). Decide between using a controlled or uncontrolled select element and remove one of these props. More info: https://reactjs.org/link/controlled-components
  ```
  
This is because we set a `defaultValue` for the Topic name's `NativeSelect`, when none is needed: its `value` is already set by the `useForm`'s `defaultValues` option.

We can therefore safely delete it and solve the conflict.

