### PR TITLE
fix(coral): Make all env available when using prefix in ACL request

### DIFF
--- a/coral/src/app/features/topics/acl-request/fields/EnvironmentField.tsx
+++ b/coral/src/app/features/topics/acl-request/fields/EnvironmentField.tsx
@@ -5,13 +5,23 @@ import { ExtendedEnvironment } from "src/app/features/topics/acl-request/queries
 interface EnvironmentFieldProps {
   environments: ExtendedEnvironment[];
   selectedTopic?: string;
+  prefixed?: boolean;
 }
 
 const getOptions = (
   environments: ExtendedEnvironment[],
+  prefixed: boolean,
   topicName?: string
 ) => {
   return environments.map((env) => {
+    if (prefixed) {
+      return (
+        <Option key={env.id} value={env.id}>
+          {env.name}
+        </Option>
+      );
+    }
+
     if (env.topicNames.length === 0) {
       return (
         <Option key={env.id} value={env.id} disabled>
@@ -39,6 +49,7 @@ const getOptions = (
 const EnvironmentField = ({
   environments,
   selectedTopic,
+  prefixed = false,
 }: EnvironmentFieldProps) => {
   return (
     <NativeSelect
@@ -47,7 +58,7 @@ const EnvironmentField = ({
       placeholder={"-- Please select --"}
       required
     >
-      {getOptions(environments, selectedTopic)}
+      {getOptions(environments, prefixed, selectedTopic)}
     </NativeSelect>
   );
 };

--- a/coral/src/app/features/topics/acl-request/forms/TopicProducerForm.tsx
+++ b/coral/src/app/features/topics/acl-request/forms/TopicProducerForm.tsx
@@ -141,6 +141,7 @@ const TopicProducerForm = ({
             <EnvironmentField
               environments={environments}
               selectedTopic={topicname}
+              prefixed={aclPatternType === "PREFIXED"}
             />
           </GridItem>
 


### PR DESCRIPTION
## About this change - What it does

https://github.com/aiven/klaw/pull/1119 introduced a "smarter" environment Select input in ACL forms. The available environments will be enabled or disabled depending on the topic chosen. However, when choosing the `PREFIXED` pattern type, all environments would be disabled and render a wrong state, because the prefix may not be === an existing topic name.


https://github.com/aiven/klaw/assets/20607294/e43e9e57-0f0d-431a-8fef-c9ae9d8d7574



## The fix

In regards to how the `PREFIXED` option is used, we should allow all environments to be chosen in this case.

https://github.com/aiven/klaw/assets/20607294/ab6b12b1-e897-486b-b9fc-3e5bb62f5242



