### PR TITLE
Issue disable obsolete config

### DIFF
--- a/core/src/main/java/io/aiven/klaw/dao/KwProperties.java
+++ b/core/src/main/java/io/aiven/klaw/dao/KwProperties.java
@@ -33,4 +33,7 @@ public class KwProperties implements Serializable {
 
   @Column(name = "kwdesc")
   private String kwDesc;
+
+  @Column(name = "enabled")
+  private boolean enabled;
 }

--- a/core/src/main/java/io/aiven/klaw/dao/migration/MigrateData2x4x0.java
+++ b/core/src/main/java/io/aiven/klaw/dao/migration/MigrateData2x4x0.java
@@ -54,8 +54,9 @@ public class MigrateData2x4x0 {
 
     try {
 
-      //Setting for every property as this is the first introduction of the new column with eanbled true/false.
-      //In the future an if statement to only change the property being deprecated should be used.
+      // Setting for every property as this is the first introduction of the new column with eanbled
+      // true/false.
+      // In the future an if statement to only change the property being deprecated should be used.
       properties.forEach(
           property -> property.setEnabled(!deprecatedKwProperties().contains(property.getKwKey())));
       insertDataJdbc.insertDefaultKwProperties(properties);

--- a/core/src/main/java/io/aiven/klaw/dao/migration/MigrateData2x4x0.java
+++ b/core/src/main/java/io/aiven/klaw/dao/migration/MigrateData2x4x0.java
@@ -1,0 +1,72 @@
+package io.aiven.klaw.dao.migration;
+
+import io.aiven.klaw.config.ManageDatabase;
+import io.aiven.klaw.dao.KwProperties;
+import io.aiven.klaw.dao.UserInfo;
+import io.aiven.klaw.helpers.db.rdbms.InsertDataJdbc;
+import io.aiven.klaw.helpers.db.rdbms.SelectDataJdbc;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Configuration;
+
+@DataMigration(version = "2.4.0", order = 2)
+@Slf4j
+@Configuration // Spring will automatically scan and instantiate this class for retrieval.
+public class MigrateData2x4x0 {
+
+  @Autowired private SelectDataJdbc selectDataJdbc;
+
+  @Autowired private InsertDataJdbc insertDataJdbc;
+
+  @Autowired private ManageDatabase manageDatabase;
+
+  public MigrateData2x4x0() {}
+
+  public MigrateData2x4x0(
+      SelectDataJdbc selectDataJdbc, InsertDataJdbc insertDataJdbc, ManageDatabase manageDatabase) {
+    this.selectDataJdbc = selectDataJdbc;
+    this.insertDataJdbc = insertDataJdbc;
+    this.manageDatabase = manageDatabase;
+  }
+
+  @MigrationRunner()
+  public boolean migrate() {
+    log.info("Start to migrate 2.4.0 data");
+    List<UserInfo> allUserInfo = selectDataJdbc.selectAllUsersAllTenants();
+    Set<Integer> tenantIds =
+        allUserInfo.stream().map(UserInfo::getTenantId).collect(Collectors.toSet());
+
+    for (int tenantId : tenantIds) {
+      migrateKwProperties(tenantId);
+      manageDatabase.loadEnvMapForOneTenant(tenantId);
+    }
+
+    return true;
+  }
+
+  private void migrateKwProperties(Integer tenantId) {
+    log.info("Migrate KwProperties for tenant {}", tenantId);
+    List<KwProperties> properties = selectDataJdbc.selectAllKwPropertiesPerTenant(tenantId);
+
+    try {
+
+      //Setting for every property as this is the first introduction of the new column with eanbled true/false.
+      //In the future an if statement to only change the property being deprecated should be used.
+      properties.forEach(
+          property -> property.setEnabled(!deprecatedKwProperties().contains(property.getKwKey())));
+      insertDataJdbc.insertDefaultKwProperties(properties);
+    } catch (Exception ex) {
+      log.error("Exception caught: ", ex);
+    }
+  }
+
+  private static List<String> deprecatedKwProperties() {
+
+    // When removing properties ensure it's also removed from DefaultDataService
+    return Arrays.asList("klaw.superuser.mailid");
+  }
+}

--- a/core/src/main/java/io/aiven/klaw/helpers/db/rdbms/SelectDataJdbc.java
+++ b/core/src/main/java/io/aiven/klaw/helpers/db/rdbms/SelectDataJdbc.java
@@ -1262,16 +1262,17 @@ public class SelectDataJdbc {
     List<KwTenants> tenants = getTenants();
 
     for (KwTenants tenant : tenants) {
-      List<KwProperties> kwProps = kwPropertiesRepo.findAllByTenantId(tenant.getTenantId());
-
+      List<KwProperties> kwProps =
+          kwPropertiesRepo.findAllByTenantIdAndEnabledTrue(tenant.getTenantId());
+      log.info("Kw Props output : {}", kwProps);
       Map<String, Map<String, String>> fullMap = new HashMap<>();
       for (KwProperties kwProp : kwProps) {
         mapProps = new HashMap<>();
         mapProps.put("kwkey", kwProp.getKwKey());
         mapProps.put("kwvalue", kwProp.getKwValue());
         mapProps.put("kwdesc", kwProp.getKwDesc());
-        mapProps.put("kwtenantid", kwProp.getTenantId() + "");
-
+        mapProps.put("kwtenantid", String.valueOf(kwProp.getTenantId()));
+        mapProps.put("enabled", String.valueOf(kwProp.isEnabled()));
         fullMap.put(kwProp.getKwKey(), mapProps);
       }
       tenantProps.put(tenant.getTenantId(), fullMap);
@@ -1281,7 +1282,7 @@ public class SelectDataJdbc {
   }
 
   public List<KwProperties> selectAllKwPropertiesPerTenant(int tenantId) {
-    return kwPropertiesRepo.findAllByTenantId(tenantId);
+    return kwPropertiesRepo.findAllByTenantIdAndEnabledTrue(tenantId);
   }
 
   public Integer getNextTopicRequestId(String idType, int tenantId) {

--- a/core/src/main/java/io/aiven/klaw/repository/KwPropertiesRepo.java
+++ b/core/src/main/java/io/aiven/klaw/repository/KwPropertiesRepo.java
@@ -9,4 +9,6 @@ public interface KwPropertiesRepo extends CrudRepository<KwProperties, KwPropert
   List<KwProperties> findAllByKwKeyAndTenantId(String kwKey, int tenantId);
 
   List<KwProperties> findAllByTenantId(int tenantId);
+
+  List<KwProperties> findAllByTenantIdAndEnabledTrue(int tenantId);
 }

--- a/core/src/main/java/io/aiven/klaw/service/DefaultDataService.java
+++ b/core/src/main/java/io/aiven/klaw/service/DefaultDataService.java
@@ -75,7 +75,8 @@ public class DefaultDataService {
             "klaw.mail.topicrequest.content",
             tenantId,
             KwConstants.MAIL_TOPICREQUEST_CONTENT,
-            "Email notification body for a new Topic request");
+            "Email notification body for a new Topic request",
+            true);
     kwPropertiesList.add(kwProperties1);
 
     KwProperties kwProperties2 =
@@ -83,7 +84,8 @@ public class DefaultDataService {
             "klaw.mail.topicdeleterequest.content",
             tenantId,
             KwConstants.MAIL_TOPICDELETEREQUEST_CONTENT,
-            "Email notification body for Topic delete request");
+            "Email notification body for Topic delete request",
+            true);
     kwPropertiesList.add(kwProperties2);
 
     KwProperties kwProperties3 =
@@ -91,7 +93,8 @@ public class DefaultDataService {
             "klaw.mail.topicclaimrequest.content",
             tenantId,
             KwConstants.MAIL_TOPICCLAIMREQUEST_CONTENT,
-            "Email notification body for a new claim request");
+            "Email notification body for a new claim request",
+            true);
     kwPropertiesList.add(kwProperties3);
 
     KwProperties kwProperties4 =
@@ -99,7 +102,8 @@ public class DefaultDataService {
             "klaw.mail.topicrequestapproval.content",
             tenantId,
             KwConstants.MAIL_TOPICREQUESTAPPROVAL_CONTENT,
-            "Email notification body for Topic request approval");
+            "Email notification body for Topic request approval",
+            true);
     kwPropertiesList.add(kwProperties4);
 
     KwProperties kwProperties5 =
@@ -107,7 +111,8 @@ public class DefaultDataService {
             "klaw.mail.topicrequestdenial.content",
             tenantId,
             KwConstants.MAIL_TOPICREQUESTDENIAL_CONTENT,
-            "Email notification body for Topic request decline");
+            "Email notification body for Topic request decline",
+            true);
     kwPropertiesList.add(kwProperties5);
 
     KwProperties kwProperties6 =
@@ -115,7 +120,8 @@ public class DefaultDataService {
             "klaw.mail.aclrequest.content",
             tenantId,
             KwConstants.MAIL_ACLREQUEST_CONTENT,
-            "Email notification body for new Acl request");
+            "Email notification body for new Acl request",
+            true);
     kwPropertiesList.add(kwProperties6);
 
     KwProperties kwProperties7 =
@@ -123,7 +129,8 @@ public class DefaultDataService {
             "klaw.mail.aclrequestdelete.content",
             tenantId,
             KwConstants.MAIL_ACLREQUESTDELETE_CONTENT,
-            "Email notification body for Acl delete request");
+            "Email notification body for Acl delete request",
+            true);
     kwPropertiesList.add(kwProperties7);
 
     KwProperties kwProperties8 =
@@ -131,7 +138,8 @@ public class DefaultDataService {
             "klaw.mail.aclrequestapproval.content",
             tenantId,
             KwConstants.MAIL_ACLREQUESTAPPROVAL_CONTENT,
-            "Email notification body for Acl request approval");
+            "Email notification body for Acl request approval",
+            true);
     kwPropertiesList.add(kwProperties8);
 
     KwProperties kwProperties9 =
@@ -139,7 +147,8 @@ public class DefaultDataService {
             "klaw.mail.aclrequestdenial.content",
             tenantId,
             KwConstants.MAIL_ACLREQUESTDENIAL_CONTENT,
-            "Email notification body for Acl request decline");
+            "Email notification body for Acl request decline",
+            true);
     kwPropertiesList.add(kwProperties9);
 
     KwProperties kwProperties10 =
@@ -147,7 +156,8 @@ public class DefaultDataService {
             "klaw.mail.registeruser.content",
             tenantId,
             KwConstants.MAIL_REGISTERUSER_CONTENT,
-            "Email notification body for new user request to be approved.");
+            "Email notification body for new user request to be approved.",
+            true);
     kwPropertiesList.add(kwProperties10);
 
     KwProperties kwProperties11 =
@@ -155,7 +165,8 @@ public class DefaultDataService {
             "klaw.mail.registeruser.saas.content",
             tenantId,
             KwConstants.MAIL_REGISTERUSER_SAAS_CONTENT,
-            "Email notification body for new user request");
+            "Email notification body for new user request",
+            true);
     kwPropertiesList.add(kwProperties11);
 
     KwProperties kwProperties12 =
@@ -163,7 +174,8 @@ public class DefaultDataService {
             "klaw.mail.registerusertouser.content",
             tenantId,
             KwConstants.MAIL_REGISTERUSERTOUSER_CONTENT,
-            "Email notification body for new user request to actual user.");
+            "Email notification body for new user request to actual user.",
+            true);
     kwPropertiesList.add(kwProperties12);
 
     KwProperties kwProperties13 =
@@ -171,7 +183,8 @@ public class DefaultDataService {
             "klaw.mail.registerusertouser.saas.content",
             tenantId,
             KwConstants.MAIL_REGISTERUSERTOUSER_SAAS_CONTENT,
-            "Email notification body for new SaaS user request to actual user.");
+            "Email notification body for new SaaS user request to actual user.",
+            true);
     kwPropertiesList.add(kwProperties13);
 
     KwProperties kwProperties14 =
@@ -179,7 +192,8 @@ public class DefaultDataService {
             "klaw.mail.recontopics.content",
             tenantId,
             KwConstants.MAIL_RECONTOPICS_CONTENT,
-            "Email notification body for reconciliation of topics.");
+            "Email notification body for reconciliation of topics.",
+            true);
     kwPropertiesList.add(kwProperties14);
 
     KwProperties kwProperties15 =
@@ -187,7 +201,8 @@ public class DefaultDataService {
             "klaw.mail.newuseradded.content",
             tenantId,
             KwConstants.MAIL_NEWUSERADDED_CONTENT,
-            "Email notification body after a new user is added");
+            "Email notification body after a new user is added",
+            true);
     kwPropertiesList.add(kwProperties15);
 
     KwProperties kwProperties16 =
@@ -195,7 +210,8 @@ public class DefaultDataService {
             "klaw.mail.passwordreset.content",
             tenantId,
             KwConstants.MAIL_PASSWORDRESET_CONTENT,
-            "Email notification body for password reset");
+            "Email notification body for password reset",
+            true);
     kwPropertiesList.add(kwProperties16);
 
     KwProperties kwProperties18 =
@@ -203,7 +219,8 @@ public class DefaultDataService {
             "klaw.reports.location",
             tenantId,
             KwConstants.REPORTS_LOCATION,
-            "Temporary location of reports");
+            "Temporary location of reports",
+            true);
     kwPropertiesList.add(kwProperties18);
 
     KwProperties kwProperties20 =
@@ -211,12 +228,13 @@ public class DefaultDataService {
             "klaw.getschemas.enable",
             tenantId,
             KwConstants.GETSCHEMAS_ENABLE,
-            "Enable View or retrieve schemas");
+            "Enable View or retrieve schemas",
+            true);
     kwPropertiesList.add(kwProperties20);
 
     KwProperties kwProperties21 =
         new KwProperties(
-            "klaw.clusterapi.url", tenantId, KwConstants.CLUSTERAPI_URL, "Cluster Api URL");
+            "klaw.clusterapi.url", tenantId, KwConstants.CLUSTERAPI_URL, "Cluster Api URL", true);
     kwPropertiesList.add(kwProperties21);
 
     KwProperties kwProperties22 =
@@ -224,7 +242,8 @@ public class DefaultDataService {
             "klaw.tenant.config",
             tenantId,
             KwConstants.TENANT_CONFIG,
-            "Base sync cluster, order of topic promotion environments, topic request envs");
+            "Base sync cluster, order of topic promotion environments, topic request envs",
+            true);
     kwPropertiesList.add(kwProperties22);
 
     KwProperties kwProperties23 =
@@ -232,7 +251,8 @@ public class DefaultDataService {
             "klaw.adduser.roles",
             tenantId,
             KwConstants.ADDUSER_ROLES,
-            "Allowed roles when adding a new user.");
+            "Allowed roles when adding a new user.",
+            true);
     kwPropertiesList.add(kwProperties23);
 
     KwProperties kwProperties24 =
@@ -240,7 +260,8 @@ public class DefaultDataService {
             "klaw.envs.standardnames",
             tenantId,
             KwConstants.ENVS_STANDARDNAMES,
-            "Standard names of environments");
+            "Standard names of environments",
+            true);
     kwPropertiesList.add(kwProperties24);
 
     KwProperties kwProperties19 =
@@ -248,12 +269,13 @@ public class DefaultDataService {
             "klaw.mail.notifications.enable",
             tenantId,
             KwConstants.MAIL_NOTIFICATIONS_ENABLE,
-            "Smtp Config Enable email notifications");
+            "Smtp Config Enable email notifications",
+            true);
     kwPropertiesList.add(kwProperties19);
 
     KwProperties kwProperties33 =
         new KwProperties(
-            "klaw.broadcast.text", tenantId, "", "Broadcast text to all your tenant users");
+            "klaw.broadcast.text", tenantId, "", "Broadcast text to all your tenant users", true);
     kwPropertiesList.add(kwProperties33);
 
     KwProperties kwProperties34 =
@@ -261,7 +283,8 @@ public class DefaultDataService {
             "klaw.mail.registerusertouser.saasadmin.content",
             tenantId,
             KwConstants.MAIL_REGISTERUSERTOUSER_SAAS_ADMIN_CONTENT,
-            "Email notification body for new SaaS user request to actual user.");
+            "Email notification body for new SaaS user request to actual user.",
+            true);
     kwPropertiesList.add(kwProperties34);
 
     return kwPropertiesList;

--- a/core/src/main/java/io/aiven/klaw/service/ServerConfigService.java
+++ b/core/src/main/java/io/aiven/klaw/service/ServerConfigService.java
@@ -156,9 +156,10 @@ public class ServerConfigService {
       KwPropertiesResponse kwPropertiesResponse = new KwPropertiesResponse();
       kwKey = stringStringEntry.getKey();
       kwVal = stringStringEntry.getValue().get("kwvalue");
+      boolean kwEnabled = Boolean.parseBoolean(stringStringEntry.getValue().get("enabled"));
       kwPropertiesResponse.setKwkey(kwKey);
 
-      if (KwConstants.TENANT_CONFIG_PROPERTY.equals(kwKey)) {
+      if (KwConstants.TENANT_CONFIG_PROPERTY.equals(kwKey) && kwEnabled) {
         TenantConfig dynamicObj;
         try {
           OBJECT_MAPPER.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
@@ -176,7 +177,7 @@ public class ServerConfigService {
           kwPropertiesResponse.setKwvalue(kwVal);
           kwPropertiesResponse.setKwdesc(stringStringEntry.getValue().get("kwdesc"));
         }
-      } else {
+      } else if (kwEnabled) {
         kwPropertiesResponse.setKwvalue(kwVal);
         kwPropertiesResponse.setKwdesc(stringStringEntry.getValue().get("kwdesc"));
 

--- a/core/src/main/resources/db/changelog/changelog.yaml
+++ b/core/src/main/resources/db/changelog/changelog.yaml
@@ -1043,3 +1043,16 @@ databaseChangeLog:
                 - column:
                     name: envparams
                     type: CLOB
+    - changeSet:
+        id: 10-05-2023 Add a column to allow deprecation of unused or replaced properties
+        author: aindriu-aiven
+        changes:
+          - addColumn:
+              tableName: kwproperties
+              columns:
+                - column:
+                    constraints:
+                      nullable: false
+                    name: enabled
+                    type: boolean
+                    defaultValue: true

--- a/core/src/test/java/io/aiven/klaw/config/MigrationUtilityTest.java
+++ b/core/src/test/java/io/aiven/klaw/config/MigrationUtilityTest.java
@@ -107,7 +107,7 @@ class MigrationUtilityTest {
     Reflections reflections = new Reflections(PROD_PACKAGE_TO_SCAN);
     Set<Class<?>> classes = reflections.getTypesAnnotatedWith(DataMigration.class);
     // When adding a new package you will need to increment this by 1.
-    assertThat(classes.size()).isEqualTo(2);
+    assertThat(classes.size()).isEqualTo(3);
     Set<Integer> uniqueOrder = new HashSet<>();
     // Check Order Numbers are correctly assigned
     classes.forEach(

--- a/core/src/test/java/io/aiven/klaw/dao/migration/MigrateData2x4x0Test.java
+++ b/core/src/test/java/io/aiven/klaw/dao/migration/MigrateData2x4x0Test.java
@@ -1,0 +1,188 @@
+package io.aiven.klaw.dao.migration;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.aiven.klaw.config.ManageDatabase;
+import io.aiven.klaw.dao.Env;
+import io.aiven.klaw.dao.KwProperties;
+import io.aiven.klaw.dao.UserInfo;
+import io.aiven.klaw.dao.test.MigrationTestData2x1x0;
+import io.aiven.klaw.dao.test.MigrationTestData2x2x0;
+import io.aiven.klaw.helpers.db.rdbms.InsertDataJdbc;
+import io.aiven.klaw.helpers.db.rdbms.SelectDataJdbc;
+import io.aiven.klaw.model.enums.KafkaClustersType;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.springframework.context.annotation.Bean;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+@ExtendWith(SpringExtension.class)
+class MigrateData2x4x0Test {
+
+  private MigrateData2x4x0 migrateData2x4x0;
+
+  @Mock private SelectDataJdbc selectDataJdbc;
+
+  @Mock private InsertDataJdbc insertDataJdbc;
+
+  @Mock private ManageDatabase manageDatabase;
+
+  @Bean
+  public MigrationTestData2x1x0 MigrateTestData2x1x0() {
+    return new MigrationTestData2x1x0();
+  }
+
+  @Bean
+  public MigrationTestData2x2x0 MigrationTestData2x1x0() {
+    return new MigrationTestData2x2x0();
+  }
+
+  @Captor ArgumentCaptor<List<KwProperties>> propertiesArgumentCaptor;
+
+  @BeforeEach
+  public void setUp() {
+    migrateData2x4x0 = new MigrateData2x4x0(selectDataJdbc, insertDataJdbc, manageDatabase);
+  }
+
+  @Test
+  public void givenNoTenantsDoNotMigrateAnyData() {
+
+    when(selectDataJdbc.selectAllUsersAllTenants()).thenReturn(getUserAndTenantInfo(0));
+
+    boolean success = migrateData2x4x0.migrate();
+    verify(selectDataJdbc, times(1)).selectAllUsersAllTenants();
+    // No other calls made
+    verify(insertDataJdbc, times(0)).addNewEnv(any(Env.class));
+    verify(selectDataJdbc, times(0)).selectAllEnvs(any(KafkaClustersType.class), anyInt());
+    //    called once per tenant
+    verify(manageDatabase, times(0)).loadEnvMapForOneTenant(anyInt());
+    assertThat(success).isTrue();
+  }
+
+  @Test
+  public void givenOneTenantAndNoPropertiesMigrateEmptyListData() {
+    // Setup
+    when(selectDataJdbc.selectAllUsersAllTenants()).thenReturn(getUserAndTenantInfo(1));
+
+    when(selectDataJdbc.selectAllKwPropertiesPerTenant(anyInt()))
+        .thenReturn(Collections.EMPTY_LIST);
+
+    // Execute
+    boolean success = migrateData2x4x0.migrate();
+
+    // Verify
+    verify(selectDataJdbc, times(1)).selectAllUsersAllTenants();
+    verify(selectDataJdbc, times(1)).selectAllKwPropertiesPerTenant(anyInt());
+
+    verify(insertDataJdbc, times(1)).insertDefaultKwProperties(eq(Collections.EMPTY_LIST));
+    //    called once per tenant
+    verify(manageDatabase, times(1)).loadEnvMapForOneTenant(anyInt());
+    assertThat(success).isTrue();
+  }
+
+  @Test
+  public void givenOneTenantAndNoDisabledPropertiesMigrateData_NoDisabledProperties() {
+    // Setup
+    when(selectDataJdbc.selectAllUsersAllTenants()).thenReturn(getUserAndTenantInfo(1));
+
+    when(selectDataJdbc.selectAllKwPropertiesPerTenant(anyInt())).thenReturn(getProperties(8));
+
+    // Execute
+    boolean success = migrateData2x4x0.migrate();
+
+    // Verify
+    verify(selectDataJdbc, times(1)).selectAllUsersAllTenants();
+    verify(selectDataJdbc, times(1)).selectAllKwPropertiesPerTenant(anyInt());
+
+    verify(insertDataJdbc, times(1)).insertDefaultKwProperties(propertiesArgumentCaptor.capture());
+    //    called once per tenant
+    verify(manageDatabase, times(1)).loadEnvMapForOneTenant(anyInt());
+    assertThat(success).isTrue();
+
+    List<KwProperties> properties = propertiesArgumentCaptor.getValue();
+    assertThat(properties.size()).isEqualTo(8);
+    for (KwProperties prop : properties) {
+
+      assertThat(prop.isEnabled()).isTrue();
+    }
+  }
+
+  @Test
+  public void givenOneTenantAndMatchingDisabledPropertiesMigrateData_disabledProperties() {
+    // Setup
+    when(selectDataJdbc.selectAllUsersAllTenants()).thenReturn(getUserAndTenantInfo(1));
+    List<KwProperties> returnProperties = getProperties(8);
+    KwProperties disableProp = new KwProperties();
+    disableProp.setTenantId(101);
+    disableProp.setKwValue("added value");
+    disableProp.setKwKey("klaw.superuser.mailid");
+    returnProperties.add(disableProp);
+
+    when(selectDataJdbc.selectAllKwPropertiesPerTenant(anyInt())).thenReturn(returnProperties);
+
+    // Execute
+    boolean success = migrateData2x4x0.migrate();
+
+    // Verify
+    verify(selectDataJdbc, times(1)).selectAllUsersAllTenants();
+    verify(selectDataJdbc, times(1)).selectAllKwPropertiesPerTenant(anyInt());
+
+    verify(insertDataJdbc, times(1)).insertDefaultKwProperties(propertiesArgumentCaptor.capture());
+    //    called once per tenant
+    verify(manageDatabase, times(1)).loadEnvMapForOneTenant(anyInt());
+    assertThat(success).isTrue();
+
+    List<KwProperties> properties = propertiesArgumentCaptor.getValue();
+    assertThat(properties.size()).isEqualTo(9);
+    for (KwProperties prop : properties) {
+      if (prop.getKwKey().equalsIgnoreCase("klaw.superuser.mailid")) {
+        assertThat(prop.isEnabled()).isFalse();
+      } else {
+        assertThat(prop.isEnabled()).isTrue();
+      }
+    }
+  }
+
+  private List<UserInfo> getUserAndTenantInfo(int numberOfEntries) {
+    List<UserInfo> users = new ArrayList<>();
+    for (int i = 0; i < numberOfEntries; i++) {
+      UserInfo info = new UserInfo();
+      info.setTenantId(101 + i);
+      info.setTeamId(1 + i);
+      info.setRole("User");
+      info.setUsername("User" + i);
+      info.setFullname("User" + i + " LastName");
+      info.setSwitchTeams(false);
+      users.add(info);
+    }
+
+    return users;
+  }
+
+  private List<KwProperties> getProperties(int numberOfEntries) {
+    List<KwProperties> kwProperties = new ArrayList<>();
+    for (int i = 0; i < numberOfEntries; i++) {
+      KwProperties prop = new KwProperties();
+      prop.setTenantId(101);
+      prop.setKwKey("klaw.config.version." + i);
+      prop.setKwValue(String.valueOf(i));
+
+      kwProperties.add(prop);
+    }
+
+    return kwProperties;
+  }
+}

--- a/core/src/test/java/io/aiven/klaw/service/ServerConfigServiceTest.java
+++ b/core/src/test/java/io/aiven/klaw/service/ServerConfigServiceTest.java
@@ -342,6 +342,7 @@ public class ServerConfigServiceTest {
     map.put("kwvalue", mapper.writeValueAsString(config));
     map.put("kwkey", KLAW_TENANT_CONFIG);
     map.put("kwdes", "Desc");
+    map.put("enabled", "true");
     map.put("tenantid", "101");
     dbObject.put(KLAW_TENANT_CONFIG, map);
 
@@ -392,6 +393,7 @@ public class ServerConfigServiceTest {
     map.put("kwvalue", mapper.writeValueAsString(config));
     map.put("kwkey", KLAW_TENANT_CONFIG);
     map.put("kwdes", "Desc");
+    map.put("enabled", "true");
     map.put("tenantid", "101");
     dbObject.put(KLAW_TENANT_CONFIG, map);
 

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -10,7 +10,7 @@
       "name" : "Apache 2.0",
       "url" : "https://www.apache.org/licenses/LICENSE-2.0.html"
     },
-    "version" : "2.2.0"
+    "version" : "2.3.0"
   },
   "externalDocs" : {
     "description" : "Klaw documentation",


### PR DESCRIPTION
About this change - What it does
This change allows us to disable properties so they are not returned to the user once they are deprecated.
Resolves: #xxxxx
Why this way
This removes any confusion the user might have in terms of what options they should configure if they are configuring Klaw.
