### PR TITLE
feat(coral): Implement layout for request creation forms (no side nav)

### DIFF
--- a/coral/src/app/features/connectors/request/ConnectorRequest.tsx
+++ b/coral/src/app/features/connectors/request/ConnectorRequest.tsx
@@ -87,7 +87,7 @@ function ConnectorRequest() {
         </Dialog>
       )}
 
-      <Box maxWidth={"7xl"}>
+      <Box>
         {connectorRequestMutation.isError && (
           <Box marginBottom={"l1"} role="alert">
             <Alert type="error">

--- a/coral/src/app/features/topics/acl-request/TopicAclRequest.tsx
+++ b/coral/src/app/features/topics/acl-request/TopicAclRequest.tsx
@@ -129,7 +129,7 @@ const TopicAclRequest = () => {
       : selectedEnvironment?.topicNames;
 
   return (
-    <Box maxWidth={"7xl"}>
+    <Box>
       {aclType === "CONSUMER" ? (
         <TopicConsumerForm
           renderAclTypeField={() => (

--- a/coral/src/app/features/topics/acl-request/forms/SkeletonForm.tsx
+++ b/coral/src/app/features/topics/acl-request/forms/SkeletonForm.tsx
@@ -15,7 +15,7 @@ import {
 
 const SkeletonForm = () => {
   return (
-    <Box data-testid={"skeleton"} maxWidth={"7xl"}>
+    <Box data-testid={"skeleton"}>
       <Grid cols="2" minWidth={"fit"} colGap={"9"}>
         <GridItem>
           <Flexbox gap={"4"}>

--- a/coral/src/app/features/topics/request/TopicRequest.tsx
+++ b/coral/src/app/features/topics/request/TopicRequest.tsx
@@ -99,7 +99,7 @@ function TopicRequest() {
           &quot;Continue&quot; for an immediate redirect.
         </Dialog>
       )}
-      <Box maxWidth={"7xl"}>
+      <Box>
         {isError && (
           <Box marginBottom={"l1"} role="alert">
             <Alert type="error">{parseErrorMsg(error)}</Alert>

--- a/coral/src/app/features/topics/schema-request/TopicSchemaRequest.tsx
+++ b/coral/src/app/features/topics/schema-request/TopicSchemaRequest.tsx
@@ -128,7 +128,7 @@ function TopicSchemaRequest(props: TopicSchemaRequestProps) {
           &quot;Continue&quot; for an immediate redirect.
         </Dialog>
       )}
-      <Box maxWidth={"7xl"}>
+      <Box>
         {schemaRequestMutation.isError && (
           <Box marginBottom={"l1"} role="alert">
             <Alert type="error">

--- a/coral/src/app/layout/Layout.test.tsx
+++ b/coral/src/app/layout/Layout.test.tsx
@@ -1,5 +1,5 @@
-import Layout from "src/app/layout/Layout";
 import { cleanup, screen, within } from "@testing-library/react";
+import Layout from "src/app/layout/Layout";
 import { customRender } from "src/services/test-utils/render-with-wrappers";
 import { tabThroughForward } from "src/services/test-utils/tabbing";
 
@@ -9,15 +9,13 @@ jest.mock("src/services/feature-flags/utils", () => ({
   isFeatureFlagActive: () => isFeatureFlagActiveMock(),
 }));
 
-const testChildren = <div data-testid={"test-children"}></div>;
-
 describe("Layout.tsx", () => {
   isFeatureFlagActiveMock.mockReturnValue(true);
 
   describe("renders the layout component with all needed elements", () => {
     beforeAll(() => {
-      customRender(<Layout>{testChildren}</Layout>, {
-        memoryRouter: true,
+      customRender(<Layout />, {
+        browserRouter: true,
         queryClient: true,
       });
     });
@@ -41,19 +39,11 @@ describe("Layout.tsx", () => {
       const nav = screen.getByRole("navigation", { name: "Main navigation" });
       expect(nav).toBeVisible();
     });
-
-    it("renders its children in the main section", () => {
-      const main = screen.getByRole("main");
-      const child = within(main).getByTestId("test-children");
-
-      expect(main).toBeVisible();
-      expect(child).toBeVisible();
-    });
   });
 
   describe("enables user to navigate all navigation element with keyboard", () => {
     beforeEach(() => {
-      customRender(<Layout>{testChildren}</Layout>, {
+      customRender(<Layout />, {
         memoryRouter: true,
         queryClient: true,
       });

--- a/coral/src/app/layout/Layout.tsx
+++ b/coral/src/app/layout/Layout.tsx
@@ -1,10 +1,11 @@
-import MainNavigation from "src/app/layout/main-navigation/MainNavigation";
+import { useRef } from "react";
+import { Outlet } from "react-router-dom";
 import HeaderNavigation from "src/app/layout/header/HeaderNavigation";
-import SkipLink from "src/app/layout/skip-link/SkipLink";
-import { ReactNode, useRef } from "react";
+import MainNavigation from "src/app/layout/main-navigation/MainNavigation";
 import { BasePage } from "src/app/layout/page/BasePage";
+import SkipLink from "src/app/layout/skip-link/SkipLink";
 
-function Layout({ children }: { children: ReactNode }) {
+function Layout() {
   const ref = useRef<HTMLDivElement>(null);
 
   return (
@@ -12,7 +13,11 @@ function Layout({ children }: { children: ReactNode }) {
       <SkipLink mainContent={ref} />
       <BasePage
         headerContent={<HeaderNavigation />}
-        content={<div ref={ref}>{children}</div>}
+        content={
+          <div ref={ref}>
+            <Outlet />
+          </div>
+        }
         sidebar={<MainNavigation />}
       />
     </>

--- a/coral/src/app/layout/LayoutWithoutNav.test.tsx
+++ b/coral/src/app/layout/LayoutWithoutNav.test.tsx
@@ -1,0 +1,97 @@
+import { cleanup, screen, within } from "@testing-library/react";
+import LayoutWithoutNav from "src/app/layout/LayoutWithoutNav";
+import { customRender } from "src/services/test-utils/render-with-wrappers";
+import { tabThroughForward } from "src/services/test-utils/tabbing";
+
+const isFeatureFlagActiveMock = jest.fn();
+
+jest.mock("src/services/feature-flags/utils", () => ({
+  isFeatureFlagActive: () => isFeatureFlagActiveMock(),
+}));
+
+describe("LayoutWithoutNav.tsx", () => {
+  isFeatureFlagActiveMock.mockReturnValue(true);
+
+  describe("renders the layout component with all needed elements", () => {
+    beforeAll(() => {
+      customRender(<LayoutWithoutNav />, {
+        browserRouter: true,
+        queryClient: true,
+      });
+    });
+
+    afterAll(cleanup);
+
+    it("renders a button to skip to main content for assistive technology", () => {
+      const skipLink = screen.getByRole("button", {
+        name: "Skip to main content",
+      });
+
+      expect(skipLink).toBeEnabled();
+    });
+
+    it("renders the header", () => {
+      const header = screen.getByRole("banner");
+      expect(header).toBeVisible();
+    });
+
+    it("does not render the main navigation", () => {
+      const nav = screen.queryByRole("navigation", { name: "Main navigation" });
+      expect(nav).not.toBeInTheDocument();
+    });
+  });
+
+  describe("enables user to navigate all navigation element with keyboard", () => {
+    beforeEach(() => {
+      customRender(<LayoutWithoutNav />, {
+        memoryRouter: true,
+        queryClient: true,
+      });
+    });
+
+    afterEach(cleanup);
+
+    it("sets focus on the skip link when user tabs the first time", async () => {
+      const skipLink = screen.getByRole("button", {
+        name: "Skip to main content",
+      });
+
+      expect(skipLink).not.toHaveFocus();
+      await tabThroughForward(1);
+
+      expect(skipLink).toHaveFocus();
+    });
+
+    it("sets focus on the link to the Klaw homepage if user tabs 2 times", async () => {
+      const homeLink = screen.getByRole("link", { name: "Klaw homepage" });
+      expect(homeLink).not.toHaveFocus();
+
+      await tabThroughForward(2);
+
+      expect(homeLink).toHaveFocus();
+    });
+
+    it("sets focus on the Create a new entity dropdown of the quick link navigation if user tabs 3 times", async () => {
+      const dropdown = screen.getByRole("button", {
+        name: "Request a new",
+      });
+
+      expect(dropdown).not.toHaveFocus();
+      await tabThroughForward(3);
+
+      expect(dropdown).toHaveFocus();
+    });
+
+    it("sets focus on the first element of the quick link navigation if user tabs 4 times", async () => {
+      const quickLinks = screen.getByRole("navigation", {
+        name: "Quick links",
+      });
+      const link = within(quickLinks).getAllByRole("link")[0];
+
+      expect(link).not.toHaveFocus();
+      await tabThroughForward(4);
+
+      expect(link).toHaveFocus();
+    });
+  });
+});

--- a/coral/src/app/layout/LayoutWithoutNav.tsx
+++ b/coral/src/app/layout/LayoutWithoutNav.tsx
@@ -1,0 +1,24 @@
+import { useRef } from "react";
+import { Outlet } from "react-router-dom";
+import HeaderNavigation from "src/app/layout/header/HeaderNavigation";
+import { BasePageWithoutNav } from "src/app/layout/page/BasePageWithoutNav";
+import SkipLink from "src/app/layout/skip-link/SkipLink";
+
+function LayoutWithoutNav() {
+  const ref = useRef<HTMLDivElement>(null);
+  return (
+    <>
+      <SkipLink mainContent={ref} />
+      <BasePageWithoutNav
+        headerContent={<HeaderNavigation />}
+        content={
+          <div ref={ref}>
+            <Outlet />
+          </div>
+        }
+      />
+    </>
+  );
+}
+
+export default LayoutWithoutNav;

--- a/coral/src/app/layout/page/BasePageWithoutNav.test.tsx
+++ b/coral/src/app/layout/page/BasePageWithoutNav.test.tsx
@@ -1,0 +1,63 @@
+import { cleanup, render, screen, within } from "@testing-library/react";
+import { BasePageWithoutNav } from "src/app/layout/page/BasePageWithoutNav";
+
+describe("BasePageWithoutNav.tsx", () => {
+  const contentElement = <div data-testid={"content-element"} />;
+  const headerContentElement = <div data-testid={"header-content-element"} />;
+
+  describe("renders a basic page layout with dedicated, required slots", () => {
+    beforeAll(() => {
+      render(<BasePageWithoutNav content={contentElement} />);
+    });
+
+    afterAll(cleanup);
+
+    it("renders a header element", () => {
+      const heading = screen.getByRole("banner");
+
+      expect(heading).toBeVisible();
+    });
+
+    it("renders a link to the Klaw homepage", () => {
+      const link = screen.getByRole("link", { name: "Klaw homepage" });
+
+      expect(link).toBeVisible();
+    });
+
+    it("renders the Klaw logo inside link hidden from assistive technology", () => {
+      const link = screen.getByRole("link", { name: "Klaw homepage" });
+      const logo = link.querySelector("img");
+
+      expect(logo).toHaveAttribute("src");
+      expect(logo).toHaveAttribute("aria-hidden", "true");
+    });
+
+    it("does not render sidebar content", () => {
+      const sidebar = screen.queryByTestId("sidebar-element");
+
+      expect(sidebar).not.toBeInTheDocument();
+    });
+  });
+
+  describe("renders additional elements as slots based on props", () => {
+    beforeAll(() => {
+      render(
+        <BasePageWithoutNav
+          headerContent={headerContentElement}
+          content={contentElement}
+        />
+      );
+    });
+
+    afterAll(cleanup);
+
+    it("renders a given component as header content inside the header", () => {
+      const header = screen.getByRole("banner");
+      const headerContent = within(header).getByTestId(
+        "header-content-element"
+      );
+
+      expect(headerContent).toBeVisible();
+    });
+  });
+});

--- a/coral/src/app/layout/page/BasePageWithoutNav.tsx
+++ b/coral/src/app/layout/page/BasePageWithoutNav.tsx
@@ -1,0 +1,56 @@
+import { Box, Grid, GridItem } from "@aivenio/aquarium";
+import logo from "/src/app/layout/header/klaw_logo.png";
+
+type BasePageWithoutNavProps = {
+  headerContent?: JSX.Element;
+  content: JSX.Element;
+};
+function BasePageWithoutNav({
+  headerContent,
+  content,
+}: BasePageWithoutNavProps) {
+  return (
+    <Grid
+      minHeight={"screen"}
+      style={{
+        gridTemplateColumns: "1fr",
+        gridTemplateRows: "auto 1fr",
+      }}
+    >
+      <GridItem height={"l5"} backgroundColor={"primary-80"} paddingX={"l2"}>
+        <Box
+          component={"header"}
+          display={"flex"}
+          height={"full"}
+          justifyContent={"space-between"}
+          alignItems={"center"}
+          alignContent={"center"}
+        >
+          <a href={"/"}>
+            <span style={{ color: "white" }} className={"visually-hidden"}>
+              Klaw homepage
+            </span>
+            <img aria-hidden="true" alt="" src={logo} height={50} width={150} />
+          </a>
+          {headerContent}
+        </Box>
+      </GridItem>
+      <GridItem>
+        <Box
+          component={"main"}
+          display={"flex"}
+          flexDirection={"column"}
+          padding={"l2"}
+          style={{ isolation: "isolate" }}
+          justifyContent={"center"}
+          width={"3/5"}
+          margin={"auto"}
+        >
+          {content}
+        </Box>
+      </GridItem>
+    </Grid>
+  );
+}
+
+export { BasePageWithoutNav };

--- a/coral/src/app/pages/approvals/index.tsx
+++ b/coral/src/app/pages/approvals/index.tsx
@@ -2,11 +2,10 @@ import { PageHeader } from "@aivenio/aquarium";
 import { Navigate, useMatches } from "react-router-dom";
 import ApprovalResourceTabs from "src/app/features/approvals/components/ApprovalResourceTabs";
 import {
-  ApprovalsTabEnum,
   APPROVALS_TAB_ID_INTO_PATH,
+  ApprovalsTabEnum,
   isApprovalsTabEnum,
 } from "src/app/router_utils";
-import Layout from "src/app/layout/Layout";
 
 const ApprovalsPage = () => {
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
@@ -16,10 +15,10 @@ const ApprovalsPage = () => {
     return <Navigate to={`/approvals/topics`} replace={true} />;
   }
   return (
-    <Layout>
+    <>
       <PageHeader title={"Approve requests"} />
       <ApprovalResourceTabs currentTab={currentTab} />
-    </Layout>
+    </>
   );
 
   function findMatchingTab(

--- a/coral/src/app/pages/connectors/index.tsx
+++ b/coral/src/app/pages/connectors/index.tsx
@@ -3,13 +3,12 @@ import add from "@aivenio/aquarium/dist/src/icons/add";
 import { useNavigate } from "react-router-dom";
 import PreviewBanner from "src/app/components/PreviewBanner";
 import BrowseConnectors from "src/app/features/connectors/browse/BrowseConnectors";
-import Layout from "src/app/layout/Layout";
 
 const ConnectorsPage = () => {
   const navigate = useNavigate();
 
   return (
-    <Layout>
+    <>
       <PreviewBanner linkTarget={"/kafkaConnectors"} />
       <PageHeader
         title={"All Connectors"}
@@ -20,7 +19,7 @@ const ConnectorsPage = () => {
         }}
       />
       <BrowseConnectors />
-    </Layout>
+    </>
   );
 };
 

--- a/coral/src/app/pages/connectors/request.tsx
+++ b/coral/src/app/pages/connectors/request.tsx
@@ -1,13 +1,12 @@
 import { PageHeader } from "@aivenio/aquarium";
 import ConnectorRequest from "src/app/features/connectors/request/ConnectorRequest";
-import Layout from "src/app/layout/Layout";
 
 const RequestConnector = () => {
   return (
-    <Layout>
+    <>
       <PageHeader title={"Request connector"} />
       <ConnectorRequest />
-    </Layout>
+    </>
   );
 };
 

--- a/coral/src/app/pages/index.tsx
+++ b/coral/src/app/pages/index.tsx
@@ -1,12 +1,11 @@
-import Layout from "src/app/layout/Layout";
 import { PageHeader } from "@aivenio/aquarium";
 
 const HomePage = () => {
   return (
-    <Layout>
+    <>
       <PageHeader title={"Homepage"} />
       <h1>Index</h1>
-    </Layout>
+    </>
   );
 };
 

--- a/coral/src/app/pages/not-found/index.tsx
+++ b/coral/src/app/pages/not-found/index.tsx
@@ -1,9 +1,8 @@
 import { Box, Typography } from "@aivenio/aquarium";
-import Layout from "src/app/layout/Layout";
 
 const NotFound = () => {
   return (
-    <Layout>
+    <>
       <Box role="main" display={"flex"} flexDirection={"column"} gap={"5"}>
         <Typography.Heading color={"secondary-100"}>
           Page not found
@@ -17,7 +16,7 @@ const NotFound = () => {
           <a href={"/index"}>Return to the old interface.</a>
         </Typography.MediumText>
       </Box>
-    </Layout>
+    </>
   );
 };
 

--- a/coral/src/app/pages/requests/index.tsx
+++ b/coral/src/app/pages/requests/index.tsx
@@ -1,10 +1,9 @@
 import { PageHeader } from "@aivenio/aquarium";
 import { Navigate, useMatches } from "react-router-dom";
 import RequestsResourceTabs from "src/app/features/requests/RequestsResourceTabs";
-import Layout from "src/app/layout/Layout";
 import {
-  RequestsTabEnum,
   REQUESTS_TAB_ID_INTO_PATH,
+  RequestsTabEnum,
   isRequestsTabEnum,
 } from "src/app/router_utils";
 
@@ -16,10 +15,10 @@ const RequestsPage = () => {
     return <Navigate to={`/requests/topics`} replace={true} />;
   }
   return (
-    <Layout>
+    <>
       <PageHeader title={"My team's requests"} />
       <RequestsResourceTabs currentTab={currentTab} />
-    </Layout>
+    </>
   );
 
   function findMatchingTab(

--- a/coral/src/app/pages/topics/acl-request.tsx
+++ b/coral/src/app/pages/topics/acl-request.tsx
@@ -2,13 +2,12 @@ import { PageHeader } from "@aivenio/aquarium";
 import { useParams } from "react-router-dom";
 import PreviewBanner from "src/app/components/PreviewBanner";
 import TopicAclRequest from "src/app/features/topics/acl-request/TopicAclRequest";
-import Layout from "src/app/layout/Layout";
 
 const AclRequest = () => {
   const { topicName } = useParams();
 
   return (
-    <Layout>
+    <>
       <PreviewBanner
         linkTarget={`/requestAcls${
           topicName !== undefined ? `?topicName=${topicName}` : ""
@@ -16,7 +15,7 @@ const AclRequest = () => {
       />
       <PageHeader title={"ACL (Access Control) Request"} />
       <TopicAclRequest />
-    </Layout>
+    </>
   );
 };
 

--- a/coral/src/app/pages/topics/index.tsx
+++ b/coral/src/app/pages/topics/index.tsx
@@ -3,12 +3,11 @@ import add from "@aivenio/aquarium/dist/src/icons/add";
 import { useNavigate } from "react-router-dom";
 import PreviewBanner from "src/app/components/PreviewBanner";
 import BrowseTopics from "src/app/features/topics/browse/BrowseTopics";
-import Layout from "src/app/layout/Layout";
 
 const Topics = () => {
   const navigate = useNavigate();
   return (
-    <Layout>
+    <>
       <PreviewBanner linkTarget={"/browseTopics"} />
       <PageHeader
         title={"All topics"}
@@ -19,7 +18,7 @@ const Topics = () => {
         }}
       />
       <BrowseTopics />
-    </Layout>
+    </>
   );
 };
 

--- a/coral/src/app/pages/topics/request.tsx
+++ b/coral/src/app/pages/topics/request.tsx
@@ -1,15 +1,14 @@
 import { PageHeader } from "@aivenio/aquarium";
 import PreviewBanner from "src/app/components/PreviewBanner";
 import TopicRequest from "src/app/features/topics/request/TopicRequest";
-import Layout from "src/app/layout/Layout";
 
 const RequestTopic = () => {
   return (
-    <Layout>
+    <>
       <PreviewBanner linkTarget={"/requestTopics"} />
       <PageHeader title={"Request topic"} />
       <TopicRequest />
-    </Layout>
+    </>
   );
 };
 

--- a/coral/src/app/pages/topics/schema-request.tsx
+++ b/coral/src/app/pages/topics/schema-request.tsx
@@ -1,15 +1,14 @@
 import { PageHeader } from "@aivenio/aquarium";
-import PreviewBanner from "src/app/components/PreviewBanner";
-import Layout from "src/app/layout/Layout";
-import { TopicSchemaRequest } from "src/app/features/topics/schema-request/TopicSchemaRequest";
 import { useParams } from "react-router-dom";
+import PreviewBanner from "src/app/components/PreviewBanner";
+import { TopicSchemaRequest } from "src/app/features/topics/schema-request/TopicSchemaRequest";
 
 const SchemaRequest = () => {
   // @TODO: should we add verification that this is a real topic name?
   const { topicName } = useParams();
 
   return (
-    <Layout>
+    <>
       <PreviewBanner
         linkTarget={
           topicName === undefined
@@ -25,7 +24,7 @@ const SchemaRequest = () => {
         }
       />
       <TopicSchemaRequest topicName={topicName} />
-    </Layout>
+    </>
   );
 };
 

--- a/coral/src/app/router.tsx
+++ b/coral/src/app/router.tsx
@@ -1,4 +1,6 @@
 import { createBrowserRouter, RouteObject } from "react-router-dom";
+import Layout from "src/app/layout/Layout";
+import LayoutWithoutNav from "src/app/layout/LayoutWithoutNav";
 import ApprovalsPage from "src/app/pages/approvals";
 import AclApprovalsPage from "src/app/pages/approvals/acls";
 import ConnectorApprovalsPage from "src/app/pages/approvals/connectors";
@@ -32,92 +34,106 @@ const routes: Array<RouteObject> = [
   //   path: "/login",
   // },
   {
-    path: Routes.TOPICS,
-    element: <Topics />,
-  },
-  {
-    path: Routes.CONNECTORS,
-    element: <ConnectorsPage />,
-  },
-  {
-    path: Routes.CONNECTOR_REQUEST,
-    element: <RequestConnector />,
-  },
-  {
-    path: Routes.TOPIC_REQUEST,
-    element: <RequestTopic />,
-  },
-  {
-    path: Routes.TOPIC_ACL_REQUEST,
-    element: <AclRequest />,
-  },
-  {
-    path: Routes.SCHEMA_REQUEST,
-    element: <SchemaRequest />,
-  },
-  {
-    path: Routes.ACL_REQUEST,
-    element: <AclRequest />,
-  },
-  {
-    path: Routes.TOPIC_SCHEMA_REQUEST,
-    element: <SchemaRequest />,
-  },
-  {
-    path: Routes.REQUESTS,
-    element: <RequestsPage />,
+    path: "/",
+    element: <Layout />,
     children: [
       {
-        path: REQUESTS_TAB_ID_INTO_PATH[RequestsTabEnum.TOPICS],
-        element: <TopicRequestsPage />,
-        id: RequestsTabEnum.TOPICS,
+        path: Routes.TOPICS,
+        element: <Topics />,
       },
       {
-        path: REQUESTS_TAB_ID_INTO_PATH[RequestsTabEnum.ACLS],
-        element: <AclRequestsPage />,
-        id: RequestsTabEnum.ACLS,
+        path: Routes.CONNECTORS,
+        element: <ConnectorsPage />,
       },
       {
-        path: REQUESTS_TAB_ID_INTO_PATH[RequestsTabEnum.SCHEMAS],
-        element: <SchemaRequestsPage />,
-        id: RequestsTabEnum.SCHEMAS,
+        path: Routes.REQUESTS,
+        element: <RequestsPage />,
+        children: [
+          {
+            path: REQUESTS_TAB_ID_INTO_PATH[RequestsTabEnum.TOPICS],
+            element: <TopicRequestsPage />,
+            id: RequestsTabEnum.TOPICS,
+          },
+          {
+            path: REQUESTS_TAB_ID_INTO_PATH[RequestsTabEnum.ACLS],
+            element: <AclRequestsPage />,
+            id: RequestsTabEnum.ACLS,
+          },
+          {
+            path: REQUESTS_TAB_ID_INTO_PATH[RequestsTabEnum.SCHEMAS],
+            element: <SchemaRequestsPage />,
+            id: RequestsTabEnum.SCHEMAS,
+          },
+          {
+            path: REQUESTS_TAB_ID_INTO_PATH[RequestsTabEnum.CONNECTORS],
+            element: <ConnectorRequestsPage />,
+            id: RequestsTabEnum.CONNECTORS,
+          },
+        ],
       },
       {
-        path: REQUESTS_TAB_ID_INTO_PATH[RequestsTabEnum.CONNECTORS],
-        element: <ConnectorRequestsPage />,
-        id: RequestsTabEnum.CONNECTORS,
+        path: Routes.APPROVALS,
+        element: <ApprovalsPage />,
+        children: [
+          {
+            path: APPROVALS_TAB_ID_INTO_PATH[ApprovalsTabEnum.TOPICS],
+            element: <TopicApprovalsPage />,
+            id: ApprovalsTabEnum.TOPICS,
+          },
+          {
+            path: APPROVALS_TAB_ID_INTO_PATH[ApprovalsTabEnum.ACLS],
+            element: <AclApprovalsPage />,
+            id: ApprovalsTabEnum.ACLS,
+          },
+          {
+            path: APPROVALS_TAB_ID_INTO_PATH[ApprovalsTabEnum.SCHEMAS],
+            element: <SchemaApprovalsPage />,
+            id: ApprovalsTabEnum.SCHEMAS,
+          },
+          {
+            path: APPROVALS_TAB_ID_INTO_PATH[ApprovalsTabEnum.CONNECTORS],
+            element: <ConnectorApprovalsPage />,
+            id: ApprovalsTabEnum.CONNECTORS,
+          },
+        ],
       },
     ],
   },
   {
-    path: Routes.APPROVALS,
-    element: <ApprovalsPage />,
+    path: "/",
+    element: <LayoutWithoutNav />,
     children: [
       {
-        path: APPROVALS_TAB_ID_INTO_PATH[ApprovalsTabEnum.TOPICS],
-        element: <TopicApprovalsPage />,
-        id: ApprovalsTabEnum.TOPICS,
+        path: Routes.ACL_REQUEST,
+        element: <AclRequest />,
       },
       {
-        path: APPROVALS_TAB_ID_INTO_PATH[ApprovalsTabEnum.ACLS],
-        element: <AclApprovalsPage />,
-        id: ApprovalsTabEnum.ACLS,
+        path: Routes.SCHEMA_REQUEST,
+        element: <SchemaRequest />,
       },
       {
-        path: APPROVALS_TAB_ID_INTO_PATH[ApprovalsTabEnum.SCHEMAS],
-        element: <SchemaApprovalsPage />,
-        id: ApprovalsTabEnum.SCHEMAS,
+        path: Routes.CONNECTOR_REQUEST,
+        element: <RequestConnector />,
       },
       {
-        path: APPROVALS_TAB_ID_INTO_PATH[ApprovalsTabEnum.CONNECTORS],
-        element: <ConnectorApprovalsPage />,
-        id: ApprovalsTabEnum.CONNECTORS,
+        path: Routes.TOPIC_REQUEST,
+        element: <RequestTopic />,
+      },
+
+      {
+        path: Routes.TOPIC_ACL_REQUEST,
+        element: <AclRequest />,
+      },
+      {
+        path: Routes.TOPIC_SCHEMA_REQUEST,
+        element: <SchemaRequest />,
       },
     ],
   },
   {
     path: "*",
-    element: <NotFound />,
+    element: <Layout />,
+    children: [{ path: "*", element: <NotFound /> }],
   },
 ];
 


### PR DESCRIPTION
## About this change - What it does

- Add `LayoutWithoutNav` and `BasePageWithoutNav`
- Use `Layout` and `LayoutWithoutNav` as parent `element` in `router.tsx` for relevant routes
- Remove inline `Layout` usage in pages
- Fix layout styles

All forms are now rendered without side nav, as per design specs.


https://github.com/aiven/klaw/assets/20607294/c58666fc-923c-4195-a9ea-7b251a756e2e



Resolves: #1141

