### PR TITLE
Return Schema Promotion button using new TopicOverview button

### DIFF
--- a/core/src/main/java/io/aiven/klaw/service/SchemaOverviewService.java
+++ b/core/src/main/java/io/aiven/klaw/service/SchemaOverviewService.java
@@ -163,8 +163,13 @@ public class SchemaOverviewService extends BaseOverviewService {
             // A team owns a topic across all environments so we can assume if the search returned
             // one or more topics it is owned by this users team.
             if (topics.size() > 0) {
+
               // Set Promotion Details
-              processSchemaPromotionDetails(schemaOverview, tenantId, schemaEnv, kafkaEnvIds);
+              processSchemaPromotionDetails(
+                  schemaOverview,
+                  tenantId,
+                  schemaEnv,
+                  topics.stream().map(topic -> topic.getEnvironment()).toList());
               log.info("Getting schema details for: " + topicNameSearch);
             }
           }
@@ -182,7 +187,7 @@ public class SchemaOverviewService extends BaseOverviewService {
 
   private void processSchemaPromotionDetails(
       SchemaOverview schemaOverview, int tenantId, Env schemaEnv, List<String> kafkaEnvIds) {
-    log.info("SchemaEnv Id {}", schemaEnv.getId());
+    log.debug("SchemaEnv Id {} KafkaEnvIds {}", schemaEnv.getId(), kafkaEnvIds);
     Map<String, String> promotionDetails = new HashMap<>();
     generatePromotionDetails(
         tenantId,

--- a/core/src/test/java/io/aiven/klaw/service/SchemaOverviewServiceTest.java
+++ b/core/src/test/java/io/aiven/klaw/service/SchemaOverviewServiceTest.java
@@ -117,9 +117,9 @@ public class SchemaOverviewServiceTest {
     when(commonUtilsService.getTeamId(anyString())).thenReturn(10);
     when(handleDbRequests.getAllTopicsByTopicNameAndTeamIdAndTenantId(
             eq(TESTTOPIC), eq(10), eq(101)))
-        .thenReturn(List.of(createTopic(TESTTOPIC, "1")));
+        .thenReturn(List.of(createTopic(TESTTOPIC, "1"), createTopic(TESTTOPIC, "2")));
     SchemaOverview returnedValue =
-        schemaOverviewService.getSchemaOfTopic(TESTTOPIC, "1", List.of("1", "2"));
+        schemaOverviewService.getSchemaOfTopic(TESTTOPIC, "1", List.of("1"));
 
     assertThat(returnedValue.getSchemaPromotionDetails()).isNotNull();
     assertThat(returnedValue.getSchemaPromotionDetails().get("DEV").containsKey("status")).isTrue();

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -10,7 +10,7 @@
       "name" : "Apache 2.0",
       "url" : "https://www.apache.org/licenses/LICENSE-2.0.html"
     },
-    "version" : "2.2.0"
+    "version" : "2.3.0"
   },
   "externalDocs" : {
     "description" : "Klaw documentation",


### PR DESCRIPTION
Change in API requires finding the environments a topic is provisioned on by a different look up.

About this change - What it does
This change makes a list of the Kafka environments that the topic is provisioned on using existing information instead of information passed in through the API.
Resolves: #xxxxx
Why this way
This means we do not rely on the api to pass the information but it allows us to do a look up using information we already have from a verified source, straight from the db.