### PR TITLE
Remove CC of team on password resets.

### DIFF
--- a/core/src/main/java/io/aiven/klaw/service/MailUtils.java
+++ b/core/src/main/java/io/aiven/klaw/service/MailUtils.java
@@ -3,6 +3,7 @@ package io.aiven.klaw.service;
 import io.aiven.klaw.config.ManageDatabase;
 import io.aiven.klaw.dao.RegisterUserInfo;
 import io.aiven.klaw.dao.Team;
+import io.aiven.klaw.dao.UserInfo;
 import io.aiven.klaw.helpers.HandleDbRequests;
 import io.aiven.klaw.helpers.KwConstants;
 import io.aiven.klaw.helpers.UtilMethods;
@@ -10,6 +11,7 @@ import io.aiven.klaw.model.enums.ApiResultStatus;
 import io.aiven.klaw.model.enums.MailType;
 import java.util.List;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import lombok.extern.slf4j.Slf4j;
@@ -333,7 +335,7 @@ public class MailUtils {
             if (registrationRequest) {
               emailId = otherMailId;
             } else {
-              emailId = dbHandle.getUsersInfo(username).getMailid();
+              emailId = getEmailAddressFromUsername(username);
             }
 
             try {
@@ -370,7 +372,7 @@ public class MailUtils {
           String emailId;
 
           try {
-            emailId = dbHandle.getUsersInfo(username).getMailid();
+            emailId = getEmailAddressFromUsername(username);
 
             if (emailId != null) {
               emailService.sendSimpleMessage(
@@ -382,6 +384,19 @@ public class MailUtils {
             log.error("Email id not found. Notification not sent !! ", e);
           }
         });
+  }
+
+  public String getEmailAddressFromUsername(String username) {
+
+    Optional<UserInfo> user =
+        manageDatabase.selectAllCachedUserInfo().stream()
+            .filter(u -> u.getUsername().equals(username))
+            .findFirst();
+    if (user.isPresent()) {
+      return user.get().getMailid();
+    } else {
+      return null;
+    }
   }
 
   public String sendMailToSaasAdmin(int tenantId, String userName, String period, String loginUrl) {

--- a/core/src/main/java/io/aiven/klaw/service/MailUtils.java
+++ b/core/src/main/java/io/aiven/klaw/service/MailUtils.java
@@ -178,7 +178,7 @@ public class MailUtils {
     formattedStr = String.format(passwordReset, username, pwd);
     subject = KLAW_ACCESS_PASSWORD_RESET_REQUESTED;
 
-    sendMail(username, dbHandle, formattedStr, subject, false, null, tenantId, loginUrl);
+    sendPwdResetMail(username, dbHandle, formattedStr, subject, false, null, tenantId, loginUrl);
   }
 
   void sendMailRegisteredUserSaas(
@@ -346,6 +346,35 @@ public class MailUtils {
             if (emailId != null) {
               emailService.sendSimpleMessage(
                   emailId, emailIdTeam, subject, formattedStr, tenantId, loginUrl);
+            } else {
+              log.error("Email id not found. Notification not sent !!");
+            }
+          } catch (Exception e) {
+            log.error("Email id not found. Notification not sent !! ", e);
+          }
+        });
+  }
+
+  private void sendPwdResetMail(
+      String username,
+      HandleDbRequests dbHandle,
+      String formattedStr,
+      String subject,
+      boolean registrationRequest,
+      String otherMailId,
+      int tenantId,
+      String loginUrl) {
+
+    CompletableFuture.runAsync(
+        () -> {
+          String emailId;
+
+          try {
+            emailId = dbHandle.getUsersInfo(username).getMailid();
+
+            if (emailId != null) {
+              emailService.sendSimpleMessage(
+                  emailId, null, subject, formattedStr, tenantId, loginUrl);
             } else {
               log.error("Email id not found. Notification not sent !!");
             }

--- a/core/src/test/java/io/aiven/klaw/service/MailUtilsTest.java
+++ b/core/src/test/java/io/aiven/klaw/service/MailUtilsTest.java
@@ -1,24 +1,63 @@
 package io.aiven.klaw.service;
 
+import io.aiven.klaw.config.ManageDatabase;
+import io.aiven.klaw.dao.UserInfo;
+import io.aiven.klaw.helpers.HandleDbRequests;
+import io.aiven.klaw.helpers.KwConstants;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
 import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.when;
 
 @ExtendWith(SpringExtension.class)
 public class MailUtilsTest {
 
+  public static final String LOGIN_URL = "https://localhost:9097";
   @Mock UserDetails userDetails;
 
+  @Mock
+  HandleDbRequests handleDbRequests;
+
+  @Mock
+  EmailService emailService;
+
+  @Mock
+  ManageDatabase manageDatabase;
+
+  @InjectMocks
   private MailUtils mailService;
+
 
   @BeforeEach
   public void setUp() throws Exception {
-    mailService = new MailUtils();
+//    mailService = new MailUtils();
   }
 
   @Test
   public void getUserDetails() {}
+
+
+  @Test
+  public void resetPasswordEmail_noCCTeam() {
+
+    String username = "Octopus";
+    UserInfo info = new UserInfo();
+    info.setUsername(username);
+    info.setMailid("Octopus.klaw@mailid");
+    when(handleDbRequests.getUsersInfo(username)).thenReturn(info);
+    when(manageDatabase.getKwPropertyValue(eq("klaw.mail.passwordreset.content"),eq(101))).thenReturn(KwConstants.MAIL_PASSWORDRESET_CONTENT);
+    mailService.sendMailResetPwd(username,"KlawPassword",handleDbRequests ,101, LOGIN_URL);
+    Mockito.verify(emailService,times(1)).sendSimpleMessage(eq(info.getMailid()),eq(null),anyString(),anyString(),eq(101),eq(LOGIN_URL));
+
+  }
 }

--- a/core/src/test/java/io/aiven/klaw/service/MailUtilsTest.java
+++ b/core/src/test/java/io/aiven/klaw/service/MailUtilsTest.java
@@ -1,23 +1,23 @@
 package io.aiven.klaw.service;
 
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.timeout;
+import static org.mockito.Mockito.when;
+
 import io.aiven.klaw.config.ManageDatabase;
 import io.aiven.klaw.dao.UserInfo;
 import io.aiven.klaw.helpers.HandleDbRequests;
 import io.aiven.klaw.helpers.KwConstants;
+import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Mockito;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
-
-import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.when;
 
 @ExtendWith(SpringExtension.class)
 public class MailUtilsTest {
@@ -25,39 +25,53 @@ public class MailUtilsTest {
   public static final String LOGIN_URL = "https://localhost:9097";
   @Mock UserDetails userDetails;
 
-  @Mock
-  HandleDbRequests handleDbRequests;
+  @Mock HandleDbRequests handleDbRequests;
 
-  @Mock
-  EmailService emailService;
+  @Mock EmailService emailService;
 
-  @Mock
-  ManageDatabase manageDatabase;
+  @Mock ManageDatabase manageDatabase;
 
-  @InjectMocks
-  private MailUtils mailService;
-
+  @InjectMocks private MailUtils mailService;
 
   @BeforeEach
   public void setUp() throws Exception {
-//    mailService = new MailUtils();
+    //    mailService = new MailUtils();
   }
 
   @Test
   public void getUserDetails() {}
 
-
   @Test
-  public void resetPasswordEmail_noCCTeam() {
+  public void resetPasswordEmail_noCCTeam() throws InterruptedException {
 
     String username = "Octopus";
     UserInfo info = new UserInfo();
     info.setUsername(username);
     info.setMailid("Octopus.klaw@mailid");
-    when(handleDbRequests.getUsersInfo(username)).thenReturn(info);
-    when(manageDatabase.getKwPropertyValue(eq("klaw.mail.passwordreset.content"),eq(101))).thenReturn(KwConstants.MAIL_PASSWORDRESET_CONTENT);
-    mailService.sendMailResetPwd(username,"KlawPassword",handleDbRequests ,101, LOGIN_URL);
-    Mockito.verify(emailService,times(1)).sendSimpleMessage(eq(info.getMailid()),eq(null),anyString(),anyString(),eq(101),eq(LOGIN_URL));
+    when(manageDatabase.selectAllCachedUserInfo()).thenReturn(List.of(info));
+    when(manageDatabase.getKwPropertyValue(eq("klaw.mail.passwordreset.content"), eq(101)))
+        .thenReturn(KwConstants.MAIL_PASSWORDRESET_CONTENT);
+    mailService.sendMailResetPwd(username, "KlawPassword", handleDbRequests, 101, LOGIN_URL);
 
+    Thread.sleep(1000);
+    Mockito.verify(emailService, timeout(1000).times(1))
+        .sendSimpleMessage(
+            eq(info.getMailid()), eq(null), anyString(), anyString(), eq(101), eq(LOGIN_URL));
+  }
+
+  @Test
+  public void resetPasswordEmail_noSuchUser() {
+
+    String username = "Octopus";
+    UserInfo info = new UserInfo();
+    info.setUsername("Octi");
+    info.setMailid("Octi.klaw@mailid");
+    when(manageDatabase.selectAllCachedUserInfo()).thenReturn(List.of(info));
+    when(manageDatabase.getKwPropertyValue(eq("klaw.mail.passwordreset.content"), eq(101)))
+        .thenReturn(KwConstants.MAIL_PASSWORDRESET_CONTENT);
+    mailService.sendMailResetPwd(username, "KlawPassword", handleDbRequests, 101, LOGIN_URL);
+    Mockito.verify(emailService, timeout(1000).times(0))
+        .sendSimpleMessage(
+            eq(info.getMailid()), eq(null), anyString(), anyString(), eq(101), eq(LOGIN_URL));
   }
 }


### PR DESCRIPTION
About this change - What it does
This change removes the team being CC'd on password resets.
Resolves: #xxxxx
Why this way
This is a security concern and needs to be rectified to ensure others can not access Klaw while pretending to be another party.