### PR TITLE
Update query with created state

### DIFF
--- a/core/src/main/java/io/aiven/klaw/repository/AclRequestsRepo.java
+++ b/core/src/main/java/io/aiven/klaw/repository/AclRequestsRepo.java
@@ -29,7 +29,7 @@ public interface AclRequestsRepo
 
   @Query(
       value =
-          "select count(*) from kwaclrequests where (requestor = :userId or approver = :userId) and tenantid = :tenantId",
+          "select count(*) from kwaclrequests where (requestor = :userId or approver = :userId) and tenantid = :tenantId and topicstatus='created'",
       nativeQuery = true)
   List<Object[]> findAllRecordsCountForUserId(
       @Param("userId") String userId, @Param("tenantId") Integer tenantId);

--- a/core/src/main/java/io/aiven/klaw/repository/AclRequestsRepo.java
+++ b/core/src/main/java/io/aiven/klaw/repository/AclRequestsRepo.java
@@ -29,7 +29,7 @@ public interface AclRequestsRepo
 
   @Query(
       value =
-          "select count(*) from kwaclrequests where (requestor = :userId or approver = :userId) and tenantid = :tenantId and topicstatus='created'",
+          "select count(*) from kwaclrequests where (requestor = :userId) and tenantid = :tenantId and topicstatus='created'",
       nativeQuery = true)
   List<Object[]> findAllRecordsCountForUserId(
       @Param("userId") String userId, @Param("tenantId") Integer tenantId);

--- a/core/src/main/java/io/aiven/klaw/repository/KwKafkaConnectorRequestsRepo.java
+++ b/core/src/main/java/io/aiven/klaw/repository/KwKafkaConnectorRequestsRepo.java
@@ -40,7 +40,7 @@ public interface KwKafkaConnectorRequestsRepo
 
   @Query(
       value =
-          "select count(*) from kwkafkaconnectorrequests where (requestor = :userId or approver = :userId) and tenantid = :tenantId and connectorstatus='created'",
+          "select count(*) from kwkafkaconnectorrequests where (requestor = :userId) and tenantid = :tenantId and connectorstatus='created'",
       nativeQuery = true)
   List<Object[]> findAllRecordsCountForUserId(
       @Param("userId") String userId, @Param("tenantId") Integer tenantId);

--- a/core/src/main/java/io/aiven/klaw/repository/KwKafkaConnectorRequestsRepo.java
+++ b/core/src/main/java/io/aiven/klaw/repository/KwKafkaConnectorRequestsRepo.java
@@ -40,7 +40,7 @@ public interface KwKafkaConnectorRequestsRepo
 
   @Query(
       value =
-          "select count(*) from kwkafkaconnectorrequests where (requestor = :userId or approver = :userId) and tenantid = :tenantId",
+          "select count(*) from kwkafkaconnectorrequests where (requestor = :userId or approver = :userId) and tenantid = :tenantId and connectorstatus='created'",
       nativeQuery = true)
   List<Object[]> findAllRecordsCountForUserId(
       @Param("userId") String userId, @Param("tenantId") Integer tenantId);

--- a/core/src/main/java/io/aiven/klaw/repository/SchemaRequestRepo.java
+++ b/core/src/main/java/io/aiven/klaw/repository/SchemaRequestRepo.java
@@ -33,7 +33,7 @@ public interface SchemaRequestRepo
 
   @Query(
       value =
-          "select count(*) from kwschemarequests where (requestor = :userId or approver = :userId) and tenantid = :tenantId and topicstatus='created'",
+          "select count(*) from kwschemarequests where (requestor = :userId) and tenantid = :tenantId and topicstatus='created'",
       nativeQuery = true)
   List<Object[]> findAllRecordsCountForUserId(
       @Param("userId") String userId, @Param("tenantId") Integer tenantId);

--- a/core/src/main/java/io/aiven/klaw/repository/SchemaRequestRepo.java
+++ b/core/src/main/java/io/aiven/klaw/repository/SchemaRequestRepo.java
@@ -33,7 +33,7 @@ public interface SchemaRequestRepo
 
   @Query(
       value =
-          "select count(*) from kwschemarequests where (requestor = :userId or approver = :userId) and tenantid = :tenantId",
+          "select count(*) from kwschemarequests where (requestor = :userId or approver = :userId) and tenantid = :tenantId and topicstatus='created'",
       nativeQuery = true)
   List<Object[]> findAllRecordsCountForUserId(
       @Param("userId") String userId, @Param("tenantId") Integer tenantId);

--- a/core/src/main/java/io/aiven/klaw/repository/TopicRequestsRepo.java
+++ b/core/src/main/java/io/aiven/klaw/repository/TopicRequestsRepo.java
@@ -33,7 +33,7 @@ public interface TopicRequestsRepo
 
   @Query(
       value =
-          "select count(*) from kwtopicrequests where (requestor = :userId or approver = :userId) and tenantid = :tenantId and topicstatus='created'",
+          "select count(*) from kwtopicrequests where (requestor = :userId) and tenantid = :tenantId and topicstatus='created'",
       nativeQuery = true)
   List<Object[]> findAllRecordsCountForUserId(
       @Param("userId") String userId, @Param("tenantId") Integer tenantId);

--- a/core/src/main/java/io/aiven/klaw/repository/TopicRequestsRepo.java
+++ b/core/src/main/java/io/aiven/klaw/repository/TopicRequestsRepo.java
@@ -33,7 +33,7 @@ public interface TopicRequestsRepo
 
   @Query(
       value =
-          "select count(*) from kwtopicrequests where (requestor = :userId or approver = :userId) and tenantid = :tenantId",
+          "select count(*) from kwtopicrequests where (requestor = :userId or approver = :userId) and tenantid = :tenantId and topicstatus='created'",
       nativeQuery = true)
   List<Object[]> findAllRecordsCountForUserId(
       @Param("userId") String userId, @Param("tenantId") Integer tenantId);

--- a/core/src/test/java/io/aiven/klaw/helpers/db/rdbms/AclRequestsIntegrationTest.java
+++ b/core/src/test/java/io/aiven/klaw/helpers/db/rdbms/AclRequestsIntegrationTest.java
@@ -134,7 +134,8 @@ public class AclRequestsIntegrationTest {
     utilMethods = new UtilMethods();
     ReflectionTestUtils.setField(selectDataJdbc, "aclRequestsRepo", repo);
     ReflectionTestUtils.setField(selectDataJdbc, "schemaRequestRepo", schemaRequestRepo);
-    ReflectionTestUtils.setField(selectDataJdbc, "kafkaConnectorRequestsRepo", kafkaConnectorRequestsRepo);
+    ReflectionTestUtils.setField(
+        selectDataJdbc, "kafkaConnectorRequestsRepo", kafkaConnectorRequestsRepo);
     ReflectionTestUtils.setField(selectDataJdbc, "topicRequestsRepo", topicRequestsRepo);
     ReflectionTestUtils.setField(selectDataJdbc, "userInfoRepo", userInfoRepo);
     loadData();
@@ -626,7 +627,7 @@ public class AclRequestsIntegrationTest {
 
   @Test
   @Order(24)
-  public void getRequestsCountForCreatedStatus(){
+  public void getRequestsCountForCreatedStatus() {
     int count = selectDataJdbc.findAllComponentsCountForUser("Jackie", 101);
     assertThat(count).isEqualTo(21);
     count = selectDataJdbc.findAllComponentsCountForUser("Jackie", 103);

--- a/core/src/test/java/io/aiven/klaw/helpers/db/rdbms/AclRequestsIntegrationTest.java
+++ b/core/src/test/java/io/aiven/klaw/helpers/db/rdbms/AclRequestsIntegrationTest.java
@@ -11,6 +11,9 @@ import io.aiven.klaw.model.enums.RequestMode;
 import io.aiven.klaw.model.enums.RequestOperationType;
 import io.aiven.klaw.model.enums.RequestStatus;
 import io.aiven.klaw.repository.AclRequestsRepo;
+import io.aiven.klaw.repository.KwKafkaConnectorRequestsRepo;
+import io.aiven.klaw.repository.SchemaRequestRepo;
+import io.aiven.klaw.repository.TopicRequestsRepo;
 import io.aiven.klaw.repository.UserInfoRepo;
 import java.util.List;
 import java.util.Map;
@@ -34,6 +37,13 @@ import org.springframework.test.util.ReflectionTestUtils;
 public class AclRequestsIntegrationTest {
 
   @Autowired private AclRequestsRepo repo;
+
+  @Autowired private SchemaRequestRepo schemaRequestRepo;
+
+  @Autowired private KwKafkaConnectorRequestsRepo kafkaConnectorRequestsRepo;
+
+  @Autowired private TopicRequestsRepo topicRequestsRepo;
+
   @Autowired private UserInfoRepo userInfoRepo;
 
   @Autowired TestEntityManager entityManager;
@@ -123,6 +133,9 @@ public class AclRequestsIntegrationTest {
     selectDataJdbc = new SelectDataJdbc();
     utilMethods = new UtilMethods();
     ReflectionTestUtils.setField(selectDataJdbc, "aclRequestsRepo", repo);
+    ReflectionTestUtils.setField(selectDataJdbc, "schemaRequestRepo", schemaRequestRepo);
+    ReflectionTestUtils.setField(selectDataJdbc, "kafkaConnectorRequestsRepo", kafkaConnectorRequestsRepo);
+    ReflectionTestUtils.setField(selectDataJdbc, "topicRequestsRepo", topicRequestsRepo);
     ReflectionTestUtils.setField(selectDataJdbc, "userInfoRepo", userInfoRepo);
     loadData();
   }
@@ -609,6 +622,15 @@ public class AclRequestsIntegrationTest {
     assertThat(statsCount.get(RequestStatus.DELETED.value)).isEqualTo(0L);
     assertThat(operationTypeCount.get(RequestOperationType.CREATE.value)).isEqualTo(20L);
     assertThat(operationTypeCount.get(RequestOperationType.DELETE.value)).isEqualTo(0L);
+  }
+
+  @Test
+  @Order(24)
+  public void getRequestsCountForCreatedStatus(){
+    int count = selectDataJdbc.findAllComponentsCountForUser("Jackie", 101);
+    assertThat(count).isEqualTo(21);
+    count = selectDataJdbc.findAllComponentsCountForUser("Jackie", 103);
+    assertThat(count).isEqualTo(10);
   }
 
   @Order(24)


### PR DESCRIPTION
About this change - What it does

When a user is deleted, look for existing requests with only created state

Resolves: #1219  
Why this way
Helps in removing stale data like inactive users