### PR TITLE
Fix acls sync delete from other clstr

### DIFF
--- a/coral/types/api.d.ts
+++ b/coral/types/api.d.ts
@@ -592,6 +592,7 @@ export type components = {
       aclSsl?: string;
       aclType?: string;
       envSelected?: string;
+      aclId?: string;
     };
     KwRolesPermissionsModel: {
       /** Format: int32 */
@@ -1027,8 +1028,8 @@ export type components = {
       options?: components["schemas"]["Options"];
       series?: (string)[];
       titleForReport?: string;
-      xaxisLabel?: string;
       yaxisLabel?: string;
+      xaxisLabel?: string;
     };
     Options: {
       title?: components["schemas"]["Title"];
@@ -1174,6 +1175,7 @@ export type components = {
       permission?: string;
       transactionalId?: string;
       aclPatternType?: string;
+      aclId?: string;
       totalNoPages?: string;
       allPageNos?: (string)[];
       possibleTeams?: (string)[];

--- a/core/src/main/java/io/aiven/klaw/model/AclInfo.java
+++ b/core/src/main/java/io/aiven/klaw/model/AclInfo.java
@@ -25,6 +25,7 @@ public class AclInfo {
   private String permission;
   private String transactionalId;
   private String aclPatternType;
+  private String aclId; // aiven acl id
   private String totalNoPages;
   private List<String> allPageNos;
   private List<String> possibleTeams;

--- a/core/src/main/java/io/aiven/klaw/model/SyncAclUpdates.java
+++ b/core/src/main/java/io/aiven/klaw/model/SyncAclUpdates.java
@@ -13,4 +13,5 @@ public class SyncAclUpdates {
   private String aclSsl;
   private String aclType;
   private String envSelected;
+  private String aclId; // aiven acl id
 }

--- a/core/src/main/java/io/aiven/klaw/service/AclSyncControllerService.java
+++ b/core/src/main/java/io/aiven/klaw/service/AclSyncControllerService.java
@@ -524,6 +524,7 @@ public class AclSyncControllerService {
             && Objects.equals(aclListItem.get("principle"), acl_ssl)
             && Objects.equals(aclSotItem.getAclType(), mp.getTopictype())) {
           mp.setTeamname(manageDatabase.getTeamNameFromTeamId(tenantId, aclSotItem.getTeamId()));
+          mp.setTeamid(aclSotItem.getTeamId());
           mp.setReq_no(aclSotItem.getReq_no() + "");
           break;
         }
@@ -531,6 +532,10 @@ public class AclSyncControllerService {
 
       if (mp.getTeamname() == null) {
         mp.setTeamname("Unknown");
+      }
+
+      if (!verifyIfTopicExists(aclListItem, aclsFromSOT)) {
+        continue;
       }
 
       if (isReconciliation) {
@@ -545,6 +550,19 @@ public class AclSyncControllerService {
       }
     }
     return aclListMap;
+  }
+
+  private boolean verifyIfTopicExists(
+      Map<String, String> aclListItemFromCluster, List<Acl> aclsFromLocalMetadata) {
+    String topicName;
+    if ("topic".equalsIgnoreCase(aclListItemFromCluster.get("resourceType"))) {
+      topicName = aclListItemFromCluster.get("resourceName");
+      String finalTopicName = topicName;
+      return aclsFromLocalMetadata.stream()
+          .anyMatch(acl -> acl.getTopicname().equals(finalTopicName));
+    }
+
+    return false;
   }
 
   private List<String> tenantFiltering(List<String> teamList) {

--- a/core/src/main/java/io/aiven/klaw/service/AclSyncControllerService.java
+++ b/core/src/main/java/io/aiven/klaw/service/AclSyncControllerService.java
@@ -45,6 +45,7 @@ import org.springframework.stereotype.Service;
 @Slf4j
 public class AclSyncControllerService {
 
+  public static final String TOPIC_RESOURCE = "topic";
   private int TOPIC_COUNTER = 0;
 
   private static String AIVEN_ACL_ID_KEY = "aivenaclid";
@@ -500,7 +501,7 @@ public class AclSyncControllerService {
         }
       }
 
-      if ("topic".equalsIgnoreCase(aclListItem.get("resourceType"))) {
+      if (TOPIC_RESOURCE.equalsIgnoreCase(aclListItem.get("resourceType"))) {
         mp.setTopicname(aclListItem.get("resourceName"));
       }
 
@@ -562,7 +563,7 @@ public class AclSyncControllerService {
   private boolean verifyIfTopicExists(
       Map<String, String> aclListItemFromCluster, List<String> topicListInSelectedEnv) {
     String topicName;
-    if ("topic".equalsIgnoreCase(aclListItemFromCluster.get("resourceType"))) {
+    if (TOPIC_RESOURCE.equalsIgnoreCase(aclListItemFromCluster.get("resourceType"))) {
       topicName = aclListItemFromCluster.get("resourceName");
       return topicListInSelectedEnv.contains(topicName);
     }

--- a/core/src/main/resources/static/js/synchronizeAcls.js
+++ b/core/src/main/resources/static/js/synchronizeAcls.js
@@ -201,7 +201,7 @@ app.controller("synchronizeAclsCtrl", function($scope, $http, $location, $window
                 }
 
         $scope.updatedSyncArray = [];
-        $scope.getDetails = function(sequence, req_no, teamselected, topic, consumergroup, acl_ip, acl_ssl, acltype) {
+        $scope.getDetails = function(sequence, req_no, teamselected, topic, consumergroup, acl_ip, acl_ssl, acltype, aclId) {
 
             var serviceInput = {};
 
@@ -214,6 +214,7 @@ app.controller("synchronizeAclsCtrl", function($scope, $http, $location, $window
             serviceInput['aclSsl'] = acl_ssl;
             serviceInput['aclType'] = acltype;
             serviceInput['envSelected'] = $scope.getAcls.envName;
+            serviceInput['aclId'] = aclId;
 
             $scope.updatedSyncArray.push(serviceInput);
         }

--- a/core/src/main/resources/templates/synchronizeAcls.html
+++ b/core/src/main/resources/templates/synchronizeAcls.html
@@ -559,7 +559,7 @@
 									<td ng-show="resultBrowset.teamname == ''">
 										<select class="form-control custom-select" ng-change="getDetails(resultBrowset.sequence, resultBrowset.req_no,
 										 resultBrowset.teamname,resultBrowset.topicname,resultBrowset.consumergroup,resultBrowset.acl_ip,
-										 resultBrowset.acl_ssl,resultBrowset.topictype)"
+										 resultBrowset.acl_ssl,resultBrowset.topictype, resultBrowset.aclId)"
 												ng-model="resultBrowset.teamname" ng-value="resultBrowset.teamname"
 												ng-options="possibleTeams as possibleTeams for possibleTeams in resultBrowset.possibleTeams">
 											<option value="" selected="selected">

--- a/core/src/test/java/io/aiven/klaw/TopicAclControllerIT.java
+++ b/core/src/test/java/io/aiven/klaw/TopicAclControllerIT.java
@@ -835,7 +835,7 @@ public class TopicAclControllerIT {
   @Order(25)
   @Test
   public void getAclsToBeSynced() throws Exception {
-    List<Map<String, String>> aclInfo = utilMethods.getClusterAcls();
+    List<Map<String, String>> aclInfo = utilMethods.getClusterSyncAcls();
 
     when(clusterApiService.getAcls(
             anyString(), any(), eq(KafkaSupportedProtocol.PLAINTEXT), anyInt()))

--- a/core/src/test/java/io/aiven/klaw/UtilMethods.java
+++ b/core/src/test/java/io/aiven/klaw/UtilMethods.java
@@ -254,6 +254,32 @@ public class UtilMethods {
     return allTopicReqs;
   }
 
+  public List<Map<String, String>> getClusterSyncAcls() {
+    Set<Map<String, String>> acls = new HashSet<>();
+
+    HashMap<String, String> aclbindingMap;
+
+    aclbindingMap = new HashMap<>();
+    aclbindingMap.put("host", "2.1.2.2");
+    aclbindingMap.put("principle", "User:*");
+    aclbindingMap.put("operation", AclPermissionType.READ.value);
+    aclbindingMap.put("permissionType", "ALLOW");
+    aclbindingMap.put("resourceType", "TOPIC");
+    aclbindingMap.put("resourceName", "testtopic1001");
+    acls.add(aclbindingMap);
+
+    aclbindingMap = new HashMap<>();
+    aclbindingMap.put("host", "2.1.2.2");
+    aclbindingMap.put("principle", "User:*");
+    aclbindingMap.put("operation", AclPermissionType.READ.value);
+    aclbindingMap.put("permissionType", "ALLOW");
+    aclbindingMap.put("resourceType", "GROUP");
+    aclbindingMap.put("resourceName", "mygrp2");
+    acls.add(aclbindingMap);
+
+    return new ArrayList<>(acls);
+  }
+
   public List<Map<String, String>> getClusterAcls() {
     Set<Map<String, String>> acls = new HashSet<>();
 
@@ -283,6 +309,26 @@ public class UtilMethods {
     aclbindingMap.put("permissionType", "ALLOW");
     aclbindingMap.put("resourceType", "GROUP");
     aclbindingMap.put("resourceName", "mygrp1");
+    acls.add(aclbindingMap);
+
+    return new ArrayList<>(acls);
+  }
+
+  public List<Map<String, String>> getClusterAclsNonApacheKafka() {
+    Set<Map<String, String>> acls = new HashSet<>();
+
+    HashMap<String, String> aclbindingMap;
+
+    aclbindingMap = new HashMap<>();
+    aclbindingMap.put("host", "*");
+    aclbindingMap.put("principle", "testuser1234");
+    aclbindingMap.put("consumerGroup", "-na-");
+    aclbindingMap.put("operation", AclPermissionType.READ.value);
+    aclbindingMap.put("permissionType", "ALLOW");
+    aclbindingMap.put("resourceType", "TOPIC");
+    aclbindingMap.put("resourceName", "testtopic1");
+    aclbindingMap.put("aivenaclid", "aclid12345");
+
     acls.add(aclbindingMap);
 
     return new ArrayList<>(acls);
@@ -744,6 +790,7 @@ public class UtilMethods {
     syncAclUpdates.setAclIp("12.2.4.55");
     syncAclUpdates.setTeamSelected("Team2");
     syncAclUpdates.setEnvSelected("DEV");
+    syncAclUpdates.setAclId("aclid12345");
 
     SyncAclUpdates syncAclUpdates1 = new SyncAclUpdates();
     syncAclUpdates1.setTopicName("testtopic1");
@@ -752,6 +799,7 @@ public class UtilMethods {
     syncAclUpdates1.setAclIp("12.2.4.55");
     syncAclUpdates1.setTeamSelected("Team2");
     syncAclUpdates1.setEnvSelected("1");
+    syncAclUpdates1.setAclId("aclid12346");
 
     syncUpdatesList.add(syncAclUpdates);
     syncUpdatesList.add(syncAclUpdates1);

--- a/core/src/test/java/io/aiven/klaw/service/AclSyncControllerServiceTest.java
+++ b/core/src/test/java/io/aiven/klaw/service/AclSyncControllerServiceTest.java
@@ -14,6 +14,7 @@ import io.aiven.klaw.dao.Acl;
 import io.aiven.klaw.dao.Env;
 import io.aiven.klaw.dao.KwClusters;
 import io.aiven.klaw.dao.Team;
+import io.aiven.klaw.dao.Topic;
 import io.aiven.klaw.dao.UserInfo;
 import io.aiven.klaw.error.KlawException;
 import io.aiven.klaw.helpers.db.rdbms.HandleDbRequestsJdbc;
@@ -170,6 +171,10 @@ public class AclSyncControllerServiceTest {
         .thenReturn(utilMethods.getClusterAcls());
     when(handleDbRequests.getAllTeamsOfUsers(anyString(), anyInt()))
         .thenReturn(getAvailableTeams());
+    Topic t1 = new Topic();
+    t1.setTopicname("testtopic1");
+    t1.setEnvironment(envSelected);
+    when(manageDatabase.getTopicsForTenant(anyInt())).thenReturn(List.of(t1));
     when(handleDbRequests.getSyncAcls(anyString(), anyInt())).thenReturn(getAclsSOT0());
     when(manageDatabase.getClusters(any(KafkaClustersType.class), anyInt()))
         .thenReturn(clustersHashMap);
@@ -196,6 +201,10 @@ public class AclSyncControllerServiceTest {
         .thenReturn(utilMethods.getClusterAclsNonApacheKafka());
     when(handleDbRequests.getAllTeamsOfUsers(anyString(), anyInt()))
         .thenReturn(getAvailableTeams());
+    Topic t1 = new Topic();
+    t1.setTopicname("testtopic1");
+    t1.setEnvironment(envSelected);
+    when(manageDatabase.getTopicsForTenant(anyInt())).thenReturn(List.of(t1));
     when(handleDbRequests.getSyncAcls(anyString(), anyInt()))
         .thenReturn(getAclsSOT0NonApacheKafka());
     when(manageDatabase.getClusters(any(KafkaClustersType.class), anyInt()))
@@ -316,6 +325,7 @@ public class AclSyncControllerServiceTest {
     aclReq.setAclssl(null);
     aclReq.setConsumergroup("mygrp1");
     aclReq.setAclType(AclType.CONSUMER.value);
+    aclReq.setEnvironment("1");
 
     aclList.add(aclReq);
 

--- a/core/src/test/java/io/aiven/klaw/service/AclSyncControllerServiceTest.java
+++ b/core/src/test/java/io/aiven/klaw/service/AclSyncControllerServiceTest.java
@@ -166,7 +166,7 @@ public class AclSyncControllerServiceTest {
     when(manageDatabase.getTeamsAndAllowedEnvs(anyInt(), anyInt()))
         .thenReturn(Collections.singletonList("1"));
     when(manageDatabase.getKafkaEnvList(anyInt())).thenReturn(utilMethods.getEnvLists());
-    when(clusterApiService.getAcls(anyString(), any(), any(KafkaSupportedProtocol.class), anyInt()))
+    when(clusterApiService.getAcls(anyString(), any(), any(), anyInt()))
         .thenReturn(utilMethods.getClusterAcls());
     when(handleDbRequests.getAllTeamsOfUsers(anyString(), anyInt()))
         .thenReturn(getAvailableTeams());
@@ -180,11 +180,38 @@ public class AclSyncControllerServiceTest {
     List<AclInfo> aclList =
         aclSyncControllerService.getSyncAcls(envSelected, pageNo, "", topicNameSearch, "");
 
-    assertThat(aclList).isEmpty();
+    assertThat(aclList.size()).isEqualTo(1);
   }
 
   @Test
   @Order(7)
+  public void getAclsSyncTrueNonApacheKafka() throws KlawException {
+    String envSelected = "1", pageNo = "1", topicNameSearch = "testtopic1";
+
+    stubUserInfo();
+    when(manageDatabase.getTeamsAndAllowedEnvs(anyInt(), anyInt()))
+        .thenReturn(Collections.singletonList("1"));
+    when(manageDatabase.getKafkaEnvList(anyInt())).thenReturn(utilMethods.getEnvLists());
+    when(clusterApiService.getAcls(anyString(), any(), any(), anyInt()))
+        .thenReturn(utilMethods.getClusterAclsNonApacheKafka());
+    when(handleDbRequests.getAllTeamsOfUsers(anyString(), anyInt()))
+        .thenReturn(getAvailableTeams());
+    when(handleDbRequests.getSyncAcls(anyString(), anyInt()))
+        .thenReturn(getAclsSOT0NonApacheKafka());
+    when(manageDatabase.getClusters(any(KafkaClustersType.class), anyInt()))
+        .thenReturn(clustersHashMap);
+    when(clustersHashMap.get(any())).thenReturn(kwClusters);
+    when(kwClusters.getBootstrapServers()).thenReturn("clusters");
+    when(commonUtilsService.deriveCurrentPage(anyString(), anyString(), anyInt())).thenReturn("1");
+
+    List<AclInfo> aclList =
+        aclSyncControllerService.getSyncAcls(envSelected, pageNo, "", topicNameSearch, "");
+
+    assertThat(aclList.size()).isEqualTo(1);
+  }
+
+  @Test
+  @Order(8)
   public void getAclsSyncTrue2() throws KlawException {
     String envSelected = "1", pageNo = "1", topicNameSearch = "test";
 
@@ -210,7 +237,7 @@ public class AclSyncControllerServiceTest {
   }
 
   @Test
-  @Order(8)
+  @Order(9)
   public void updateSyncBackAcls() throws KlawException {
     String envSelected = "1";
     Map<String, String> aivenAclId = new HashMap<>();
@@ -288,6 +315,23 @@ public class AclSyncControllerServiceTest {
     aclReq.setAclip("2.1.2.1");
     aclReq.setAclssl(null);
     aclReq.setConsumergroup("mygrp1");
+    aclReq.setAclType(AclType.CONSUMER.value);
+
+    aclList.add(aclReq);
+
+    return aclList;
+  }
+
+  private List<Acl> getAclsSOT0NonApacheKafka() {
+    List<Acl> aclList = new ArrayList();
+
+    Acl aclReq = new Acl();
+    aclReq.setReq_no(1001);
+    aclReq.setTopicname("testtopic1");
+    aclReq.setTeamId(1);
+    aclReq.setAclip("*");
+    aclReq.setAclssl(null);
+    aclReq.setConsumergroup("-na-");
     aclReq.setAclType(AclType.CONSUMER.value);
 
     aclList.add(aclReq);

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -5329,6 +5329,9 @@
           },
           "envSelected" : {
             "type" : "string"
+          },
+          "aclId" : {
+            "type" : "string"
           }
         }
       },
@@ -6623,10 +6626,10 @@
           "titleForReport" : {
             "type" : "string"
           },
-          "xaxisLabel" : {
+          "yaxisLabel" : {
             "type" : "string"
           },
-          "yaxisLabel" : {
+          "xaxisLabel" : {
             "type" : "string"
           }
         }
@@ -7052,6 +7055,9 @@
             "type" : "string"
           },
           "aclPatternType" : {
+            "type" : "string"
+          },
+          "aclId" : {
             "type" : "string"
           },
           "totalNoPages" : {


### PR DESCRIPTION
About this change - What it does

when aiven acls are synced with klaw, aclid is captured so that deletion is possible

Resolves: #1244 
Why this way
It is now possible to delete acls which are synced from other clustr
