### PR TITLE
Issue connector promotion

### DIFF
--- a/core/src/main/java/io/aiven/klaw/service/ClusterApiService.java
+++ b/core/src/main/java/io/aiven/klaw/service/ClusterApiService.java
@@ -411,7 +411,8 @@ public class ClusterApiService {
 
       String uri;
 
-      if (RequestOperationType.CREATE.value.equals(connectorType)) {
+      if (RequestOperationType.CREATE.value.equals(connectorType)
+          || RequestOperationType.PROMOTE.value.equals(connectorType)) {
         uri = clusterConnUrl + URI_POST_CONNECTOR;
       } else if (RequestOperationType.UPDATE.value.equals(connectorType)) {
         uri = clusterConnUrl + URI_UPDATE_CONNECTOR;

--- a/core/src/main/resources/static/js/connectorOverview.js
+++ b/core/src/main/resources/static/js/connectorOverview.js
@@ -352,7 +352,8 @@ app.controller("connectorOverviewCtrl", function($scope, $http, $location, $wind
                 serviceInput['teamName'] = $scope.teamname;
                 serviceInput['remarks'] = "Connector promotion."
                 serviceInput['connectortype'] = 'Create';
-                serviceInput['description'] = $scope.topicSelectedParam + " connector."
+                serviceInput['description'] = $scope.topicSelectedParam + " connector.";
+                serviceInput['requestOperationType'] = "PROMOTE";
 
                 swal({
                         title: "Are you sure?",


### PR DESCRIPTION
About this change - What it does
This sends the requestOperationType with the request on creation allowing it to correctly create the request and it also ensures that the requestOperationType is handled correctly on approval
Resolves: #1070 
Why this way
