### PR TITLE
feat(coral): Topic overview, subscriptions - Add Subscriptions table component

### DIFF
--- a/coral/src/app/features/topics/details/subscriptions/TopicSubscriptions.test.tsx
+++ b/coral/src/app/features/topics/details/subscriptions/TopicSubscriptions.test.tsx
@@ -1,0 +1,255 @@
+import {
+  cleanup,
+  screen,
+  waitForElementToBeRemoved,
+} from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import TopicSubscriptions from "src/app/features/topics/details/subscriptions/TopicSubscriptions";
+import { getTopicOverview } from "src/domain/topic/topic-api";
+import { TopicOvervieApiResponse } from "src/domain/topic/topic-types";
+import { mockIntersectionObserver } from "src/services/test-utils/mock-intersection-observer";
+import { customRender } from "src/services/test-utils/render-with-wrappers";
+
+jest.mock("src/domain/topic/topic-api.ts");
+
+const mockGetTopicOverview = getTopicOverview as jest.MockedFunction<
+  typeof getTopicOverview
+>;
+
+jest.mock("react-router-dom", () => ({
+  ...jest.requireActual("react-router-dom"),
+  useOutletContext: () => ({ topicName: "aiventopic1" }),
+}));
+
+const mockGetTopicOverviewResponse: TopicOvervieApiResponse = {
+  topicExists: true,
+  schemaExists: false,
+  prefixAclsExists: false,
+  txnAclsExists: false,
+  topicInfoList: [
+    {
+      noOfPartitions: 1,
+      noOfReplicas: "1",
+      teamname: "Ospo",
+      teamId: 0,
+      envId: "1",
+      showEditTopic: true,
+      showDeleteTopic: false,
+      topicDeletable: false,
+      envName: "DEV",
+      topicName: "aiventopic1",
+    },
+  ],
+  aclInfoList: [
+    {
+      req_no: "1006",
+      acl_ssl: "aivtopic3user",
+      topicname: "aivtopic3",
+      topictype: "Producer",
+      consumergroup: "-na-",
+      environment: "1",
+      environmentName: "DEV",
+      teamname: "Ospo",
+      teamid: 0,
+      aclPatternType: "LITERAL",
+      showDeleteAcl: true,
+      kafkaFlavorType: "AIVEN_FOR_APACHE_KAFKA",
+    },
+    {
+      req_no: "1011",
+      acl_ssl: "declineme",
+      topicname: "aivtopic3",
+      topictype: "Producer",
+      consumergroup: "-na-",
+      environment: "1",
+      environmentName: "DEV",
+      teamname: "Ospo",
+      teamid: 0,
+      aclPatternType: "LITERAL",
+      showDeleteAcl: true,
+      kafkaFlavorType: "AIVEN_FOR_APACHE_KAFKA",
+    },
+    {
+      req_no: "1060",
+      acl_ssl: "amathieu",
+      topicname: "aivtopic3",
+      topictype: "Producer",
+      consumergroup: "-na-",
+      environment: "1",
+      environmentName: "DEV",
+      teamname: "Ospo",
+      teamid: 0,
+      aclPatternType: "LITERAL",
+      showDeleteAcl: true,
+      kafkaFlavorType: "AIVEN_FOR_APACHE_KAFKA",
+    },
+  ],
+  prefixedAclInfoList: [
+    {
+      req_no: "1063",
+      aclPatternType: "PREFIXED",
+      environment: "2",
+      environmentName: "TST",
+      kafkaFlavorType: "APACHE_KAFKA",
+      showDeleteAcl: true,
+      teamid: 1003,
+      teamname: "Ospo",
+      topicname: "aivendemot",
+      topictype: "Producer",
+      acl_ssl: "CN=myhosttest,OU=IS,OU=OU,OU=Services,O=Org",
+    },
+  ],
+  transactionalAclInfoList: [
+    {
+      req_no: "1064",
+      aclPatternType: "LITERAL",
+      environment: "2",
+      environmentName: "TST",
+      kafkaFlavorType: "APACHE_KAFKA",
+      showDeleteAcl: true,
+      teamid: 1003,
+      teamname: "Ospo",
+      topicname: "aivendemotopic",
+      topictype: "Producer",
+      acl_ip: "32.121.67.2",
+      acl_ssl: "User:*",
+      transactionalId: "tsttxnid",
+    },
+  ],
+  topicHistoryList: [
+    {
+      environmentName: "DEV",
+      teamName: "Ospo",
+      requestedBy: "muralibasani",
+      requestedTime: "2022-Nov-04 14:41:18",
+      approvedBy: "josepprat",
+      approvedTime: "2022-Nov-04 14:48:38",
+      remarks: "Create",
+    },
+  ],
+  topicPromotionDetails: {
+    topicName: "aivtopic3",
+    status: "NO_PROMOTION",
+  },
+  availableEnvironments: [
+    {
+      id: "1",
+      name: "DEV",
+    },
+    {
+      id: "2",
+      name: "TST",
+    },
+  ],
+  topicIdForDocumentation: 1015,
+};
+
+describe("TopicSubscriptions.tsx", () => {
+  beforeAll(async () => {
+    mockIntersectionObserver();
+    mockGetTopicOverview.mockResolvedValue(mockGetTopicOverviewResponse);
+    customRender(<TopicSubscriptions />, {
+      memoryRouter: true,
+      queryClient: true,
+    });
+    await waitForElementToBeRemoved(screen.getByTestId("skeleton-table"));
+  });
+
+  afterAll(() => {
+    cleanup();
+    jest.clearAllMocks();
+  });
+
+  describe("should render a table and radios to switch between different kind of subscriptions", () => {
+    it("should render a Table", () => {
+      const table = screen.getByRole("table", {
+        name: "Topic subscriptions",
+      });
+      expect(table).toBeVisible();
+    });
+    it("should render enabled and checked User subscriptions radio, ", () => {
+      const radio = screen.getByRole("radio", {
+        name: "User subs",
+      });
+      expect(radio).toBeVisible();
+      expect(radio).toBeEnabled();
+      expect(radio).toBeChecked();
+    });
+    it("should render enabled  Prefixed subs radio, ", () => {
+      const radio = screen.getByRole("radio", {
+        name: "Prefixed subs",
+      });
+      expect(radio).toBeVisible();
+      expect(radio).toBeEnabled();
+    });
+    it("should render enabled Transactional subs radio, ", () => {
+      const radio = screen.getByRole("radio", {
+        name: "Transactional subs",
+      });
+      expect(radio).toBeVisible();
+      expect(radio).toBeEnabled();
+    });
+  });
+
+  describe("should render the correct data in Table when sub radio are clicked", () => {
+    it("should render User subscriptions in Table, ", () => {
+      const radio = screen.getByRole("radio", {
+        name: "User subs",
+      });
+      const rows = screen.getAllByRole("row");
+      const rowOne = screen.getByText("aivtopic3user");
+      const rowTwo = screen.getByText("declineme");
+      const rowThree = screen.getByText("amathieu");
+      const prefixedRow = screen.queryByText("aivendemot");
+      const transactionalRow = screen.queryByText("tsttxnid");
+
+      expect(radio).toBeChecked();
+      expect(rows).toHaveLength(4);
+      expect(rowOne).toBeVisible();
+      expect(rowTwo).toBeVisible();
+      expect(rowThree).toBeVisible();
+      expect(prefixedRow).toBeNull();
+      expect(transactionalRow).toBeNull();
+    });
+
+    it("should render Prefixed subscriptions in Table, ", async () => {
+      const radio = screen.getByRole("radio", {
+        name: "Prefixed subs",
+      });
+
+      await userEvent.click(radio);
+
+      expect(radio).toBeChecked();
+
+      const rows = screen.getAllByRole("row");
+      const rowOne = screen.getByText("aivendemot");
+      const userRow = screen.queryByText("amathieu");
+      const transactionalRow = screen.queryByText("tsttxnid");
+
+      expect(rows).toHaveLength(2);
+      expect(rowOne).toBeVisible();
+      expect(userRow).toBeNull();
+      expect(transactionalRow).toBeNull();
+    });
+
+    it("should render Prefixed subscriptions in Table, ", async () => {
+      const radio = screen.getByRole("radio", {
+        name: "Transactional subs",
+      });
+
+      await userEvent.click(radio);
+
+      expect(radio).toBeChecked();
+
+      const rows = screen.getAllByRole("row");
+      const rowOne = screen.getByText("tsttxnid");
+      const prefixedRow = screen.queryByText("aivendemot");
+      const userRow = screen.queryByText("amathieu");
+
+      expect(rows).toHaveLength(2);
+      expect(rowOne).toBeVisible();
+      expect(userRow).toBeNull();
+      expect(prefixedRow).toBeNull();
+    });
+  });
+});

--- a/coral/src/app/features/topics/details/subscriptions/TopicSubscriptions.tsx
+++ b/coral/src/app/features/topics/details/subscriptions/TopicSubscriptions.tsx
@@ -1,0 +1,96 @@
+import { RadioButton, RadioButtonGroup } from "@aivenio/aquarium";
+import { useQuery } from "@tanstack/react-query";
+import { useMemo, useState } from "react";
+import { TableLayout } from "src/app/features/components/layouts/TableLayout";
+import { useTopicDetails } from "src/app/features/topics/details/TopicDetails";
+import { TopicSubscriptionsTable } from "src/app/features/topics/details/subscriptions/TopicSubscriptionsTable";
+import { getTopicOverview } from "src/domain/topic/topic-api";
+import { AclOverviewInfo } from "src/domain/topic/topic-types";
+
+// eslint-disable-next-line import/exports-last
+type SubscriptionOptions =
+  | "aclInfoList"
+  | "prefixedAclInfoList"
+  | "transactionalAclInfoList";
+const isSubscriptionsOption = (value: string): value is SubscriptionOptions => {
+  return [
+    "aclInfoList",
+    "prefixedAclInfoList",
+    "transactionalAclInfoList",
+  ].includes(value);
+};
+
+const TopicSubscriptions = () => {
+  // @ TODO get environment from useTopicDetails too when it is implemented
+  const { topicName } = useTopicDetails();
+  const {
+    data,
+    isLoading: dataIsLoading,
+    isError,
+    error,
+  } = useQuery(["topic-overview"], {
+    queryFn: () => getTopicOverview({ topicName, environmentId: "2" }),
+  });
+
+  const [selectedSubs, setSelectedSubs] = useState<
+    "aclInfoList" | "prefixedAclInfoList" | "transactionalAclInfoList"
+  >("aclInfoList");
+
+  const filteredData: AclOverviewInfo[] = useMemo(() => {
+    if (data === undefined) {
+      return [];
+    }
+
+    const subs = data[selectedSubs];
+
+    if (subs === undefined) {
+      return [];
+    }
+
+    return subs;
+  }, [selectedSubs, data]);
+
+  return (
+    <TableLayout
+      filters={[
+        <RadioButtonGroup
+          name="Subscription options"
+          key="subscription-options"
+          onChange={(value: string) => {
+            if (isSubscriptionsOption(value)) {
+              setSelectedSubs(value);
+            }
+          }}
+          value={selectedSubs}
+        >
+          <RadioButton name="User subscriptions" value="aclInfoList">
+            User subs
+          </RadioButton>
+          <RadioButton
+            name="Prefixed subscriptions"
+            value="prefixedAclInfoList"
+          >
+            Prefixed subs
+          </RadioButton>
+          <RadioButton
+            name="Transactional subscriptions"
+            value="transactionalAclInfoList"
+          >
+            Transactional subs
+          </RadioButton>
+        </RadioButtonGroup>,
+      ]}
+      table={
+        <TopicSubscriptionsTable
+          selectedSubs={selectedSubs}
+          filteredData={filteredData}
+        />
+      }
+      isLoading={dataIsLoading}
+      isErrorLoading={isError}
+      errorMessage={error}
+    />
+  );
+};
+
+export default TopicSubscriptions;

--- a/coral/src/app/features/topics/details/subscriptions/TopicSubscriptions.tsx
+++ b/coral/src/app/features/topics/details/subscriptions/TopicSubscriptions.tsx
@@ -7,7 +7,6 @@ import { TopicSubscriptionsTable } from "src/app/features/topics/details/subscri
 import { getTopicOverview } from "src/domain/topic/topic-api";
 import { AclOverviewInfo } from "src/domain/topic/topic-types";
 
-// eslint-disable-next-line import/exports-last
 type SubscriptionOptions =
   | "aclInfoList"
   | "prefixedAclInfoList"
@@ -32,9 +31,8 @@ const TopicSubscriptions = () => {
     queryFn: () => getTopicOverview({ topicName, environmentId: "2" }),
   });
 
-  const [selectedSubs, setSelectedSubs] = useState<
-    "aclInfoList" | "prefixedAclInfoList" | "transactionalAclInfoList"
-  >("aclInfoList");
+  const [selectedSubs, setSelectedSubs] =
+    useState<SubscriptionOptions>("aclInfoList");
 
   const filteredData: AclOverviewInfo[] = useMemo(() => {
     if (data === undefined) {

--- a/coral/src/app/features/topics/details/subscriptions/TopicSubscriptionsTable.test.tsx
+++ b/coral/src/app/features/topics/details/subscriptions/TopicSubscriptionsTable.test.tsx
@@ -1,0 +1,174 @@
+import { cleanup, render, screen } from "@testing-library/react";
+import { AclOverviewInfo } from "src/domain/topic/topic-types";
+import { mockIntersectionObserver } from "src/services/test-utils/mock-intersection-observer";
+import { TopicSubscriptionsTable } from "src/app/features/topics/details/subscriptions/TopicSubscriptionsTable";
+
+const mockUserSubs: AclOverviewInfo[] = [
+  {
+    req_no: "1006",
+    acl_ssl: "aivtopic3user",
+    topicname: "aivtopic3",
+    topictype: "Producer",
+    consumergroup: "-na-",
+    environment: "1",
+    environmentName: "DEV",
+    teamname: "Ospo",
+    teamid: 0,
+    aclPatternType: "LITERAL",
+    showDeleteAcl: true,
+    kafkaFlavorType: "AIVEN_FOR_APACHE_KAFKA",
+  },
+  {
+    req_no: "1011",
+    acl_ssl: "declineme",
+    topicname: "aivtopic3",
+    topictype: "Producer",
+    consumergroup: "-na-",
+    environment: "1",
+    environmentName: "DEV",
+    teamname: "Ospo",
+    teamid: 0,
+    aclPatternType: "LITERAL",
+    showDeleteAcl: true,
+    kafkaFlavorType: "AIVEN_FOR_APACHE_KAFKA",
+  },
+  {
+    req_no: "1060",
+    acl_ssl: "amathieu",
+    topicname: "aivtopic3",
+    topictype: "Producer",
+    consumergroup: "-na-",
+    environment: "1",
+    environmentName: "DEV",
+    teamname: "Ospo",
+    teamid: 0,
+    aclPatternType: "LITERAL",
+    showDeleteAcl: true,
+    kafkaFlavorType: "AIVEN_FOR_APACHE_KAFKA",
+  },
+];
+const mockedPrefixedSubs: AclOverviewInfo[] = [
+  {
+    req_no: "1063",
+    aclPatternType: "PREFIXED",
+    environment: "2",
+    environmentName: "TST",
+    kafkaFlavorType: "APACHE_KAFKA",
+    showDeleteAcl: true,
+    teamid: 1003,
+    teamname: "Ospo",
+    topicname: "aivendemot",
+    topictype: "Producer",
+    acl_ssl: "CN=myhosttest,OU=IS,OU=OU,OU=Services,O=Org",
+  },
+];
+const mockedTransactionalSubs: AclOverviewInfo[] = [
+  {
+    req_no: "1064",
+    aclPatternType: "LITERAL",
+    environment: "2",
+    environmentName: "TST",
+    kafkaFlavorType: "APACHE_KAFKA",
+    showDeleteAcl: true,
+    teamid: 1003,
+    teamname: "Ospo",
+    topicname: "aivendemotopic",
+    topictype: "Producer",
+    acl_ip: "32.121.67.2",
+    acl_ssl: "User:*",
+    transactionalId: "tsttxnid",
+  },
+];
+
+const userSubsColumnNames = [
+  "Principals/Usernames",
+  "IP addresses",
+  "ACL type",
+  "Team",
+  "Requested on",
+  "Delete",
+];
+
+const prefixedSubsColumnNames = [
+  "Prefix",
+  "Principals/Usernames",
+  "IP addresses",
+  "ACL type",
+  "Team",
+  "Requested on",
+  "Delete",
+];
+const transactionalSubsColumnNames = [
+  "Transactional ID",
+  "Principals/Usernames",
+  "IP addresses",
+  "ACL type",
+  "Team",
+  "Requested on",
+  "Delete",
+];
+
+describe("TopicSubscriptionsTable.tsx", () => {
+  beforeAll(() => {
+    mockIntersectionObserver();
+  });
+
+  afterAll(() => {
+    cleanup();
+  });
+
+  describe("should render empty state when no data is passed", () => {
+    it("renders empty state when passed empty data", () => {
+      render(
+        <TopicSubscriptionsTable filteredData={[]} selectedSubs="aclInfoList" />
+      );
+      const emptyStateMessage = screen.getByText(
+        "No subscription matched your criteria."
+      );
+      expect(emptyStateMessage).toBeVisible();
+    });
+  });
+
+  describe("should render correct columns according to the type of subscription passed", () => {
+    afterEach(cleanup);
+    it("renders correct columns for User subscriptions", () => {
+      render(
+        <TopicSubscriptionsTable
+          filteredData={mockUserSubs}
+          selectedSubs="aclInfoList"
+        />
+      );
+      const columns = userSubsColumnNames.map((name) =>
+        screen.getByRole("columnheader", { name })
+      );
+      expect(columns).toHaveLength(userSubsColumnNames.length);
+    });
+
+    it("renders correct columns for Prefixed subscriptions", () => {
+      render(
+        <TopicSubscriptionsTable
+          filteredData={mockedPrefixedSubs}
+          selectedSubs="prefixedAclInfoList"
+        />
+      );
+      const columns = prefixedSubsColumnNames.map((name) =>
+        screen.getByRole("columnheader", { name })
+      );
+      expect(columns).toHaveLength(prefixedSubsColumnNames.length);
+    });
+
+    it("renders correct columns for Transactional subscriptions", () => {
+      render(
+        <TopicSubscriptionsTable
+          filteredData={mockedTransactionalSubs}
+          selectedSubs="transactionalAclInfoList"
+        />
+      );
+
+      const columns = transactionalSubsColumnNames.map((name) =>
+        screen.getByRole("columnheader", { name })
+      );
+      expect(columns).toHaveLength(transactionalSubsColumnNames.length);
+    });
+  });
+});

--- a/coral/src/app/features/topics/details/subscriptions/TopicSubscriptionsTable.tsx
+++ b/coral/src/app/features/topics/details/subscriptions/TopicSubscriptionsTable.tsx
@@ -1,0 +1,205 @@
+import {
+  Box,
+  DataTable,
+  DataTableColumn,
+  EmptyState,
+  StatusChip,
+} from "@aivenio/aquarium";
+import deleteIcon from "@aivenio/aquarium/dist/src/icons/delete";
+import { AclOverviewInfo } from "src/domain/topic/topic-types";
+
+type SubscriptionOptions =
+  | "aclInfoList"
+  | "prefixedAclInfoList"
+  | "transactionalAclInfoList";
+
+interface TopicSubscriptionsTableProps {
+  selectedSubs: SubscriptionOptions;
+  filteredData: AclOverviewInfo[];
+}
+
+interface AclInfoListRow {
+  id: AclOverviewInfo["req_no"];
+  principals: string[];
+  ips: string[];
+  aclType: AclOverviewInfo["topictype"];
+  team: AclOverviewInfo["teamname"];
+  requestedOn: string;
+  showDeleteAcl: AclOverviewInfo["showDeleteAcl"];
+  topicname?: AclOverviewInfo["topicname"];
+  transactionalId?: AclOverviewInfo["transactionalId"];
+}
+
+const getRows = (
+  selectedSubs: SubscriptionOptions,
+  data: AclOverviewInfo[]
+): AclInfoListRow[] => {
+  return data.map(
+    ({
+      req_no,
+      acl_ssl,
+      acl_ip,
+      topictype,
+      teamname,
+      showDeleteAcl,
+      topicname,
+      transactionalId,
+    }) => {
+      const row: AclInfoListRow = {
+        id: req_no,
+        principals: acl_ssl ? [acl_ssl] : [],
+        ips: acl_ip ? [acl_ip] : [],
+        aclType: topictype,
+        team: teamname,
+        requestedOn: "Not yet in API",
+        showDeleteAcl,
+      };
+
+      if (selectedSubs === "prefixedAclInfoList") {
+        row.topicname = topicname;
+      }
+
+      if (selectedSubs === "transactionalAclInfoList") {
+        row.transactionalId = transactionalId || "Not found";
+      }
+
+      return row;
+    }
+  );
+};
+
+const getColumns = (
+  selectedSubs: SubscriptionOptions
+): Array<DataTableColumn<AclInfoListRow>> => {
+  const additionalColumns: {
+    [key in
+      | "prefixedAclInfoList"
+      | "transactionalAclInfoList"]: DataTableColumn<AclInfoListRow>;
+  } = {
+    prefixedAclInfoList: {
+      type: "text",
+      field: "topicname",
+      headerName: "Prefix",
+    },
+    transactionalAclInfoList: {
+      type: "text",
+      field: "transactionalId",
+      headerName: "Transactional ID",
+    },
+  };
+
+  const columns: Array<DataTableColumn<AclInfoListRow>> = [
+    {
+      type: "custom",
+      field: "principals",
+      headerName: "Principals/Usernames",
+      UNSAFE_render: ({ principals }: AclInfoListRow) => {
+        return (
+          <Box display="flex" wrap={"wrap"} gap={"2"}>
+            {principals.map((principal, index) => (
+              <StatusChip
+                dense
+                status="neutral"
+                key={`${principal}-${index}`}
+                // We need to add a space after text value
+                // Otherwise a list of values would be rendered as value1value2value3 for screen readers
+                // Instead of value1 value2 value3
+                text={`${principal} `}
+              />
+            ))}
+          </Box>
+        );
+      },
+    },
+    {
+      type: "custom",
+      field: "ips",
+      headerName: "IP addresses",
+      UNSAFE_render: ({ ips }: AclInfoListRow) => {
+        if (ips.length === 0) {
+          return "*";
+        }
+        return (
+          <Box display="flex" wrap={"wrap"} gap={"2"}>
+            {ips.map((ip, index) => (
+              <StatusChip
+                dense
+                status="neutral"
+                key={`${ip}-${index}`}
+                // We need to add a space after text value
+                // Otherwise a list of values would be rendered as value1value2value3 for screen readers
+                // Instead of value1 value2 value3
+                text={`${ip} `}
+              />
+            ))}
+          </Box>
+        );
+      },
+    },
+    {
+      type: "status",
+      field: "aclType",
+      headerName: "ACL type",
+      status: ({ aclType }) => ({
+        status: aclType === "Consumer" ? "success" : "info",
+        text: aclType.toUpperCase(),
+      }),
+    },
+    {
+      type: "text",
+      field: "team",
+      headerName: "Team",
+    },
+    {
+      type: "text",
+      field: "requestedOn",
+      headerName: "Requested on",
+    },
+    {
+      type: "action",
+      headerName: "Delete",
+      headerInvisible: true,
+      width: 30,
+      action: ({ id, showDeleteAcl }) => ({
+        text: "Delete",
+        icon: deleteIcon,
+        onClick: () => console.log("Delete", id),
+        disabled: !showDeleteAcl,
+        "aria-label": `Delete ACL request`,
+      }),
+    },
+  ];
+
+  if (
+    selectedSubs === "prefixedAclInfoList" ||
+    selectedSubs === "transactionalAclInfoList"
+  ) {
+    columns.unshift(additionalColumns[selectedSubs]);
+  }
+
+  return columns;
+};
+
+export const TopicSubscriptionsTable = ({
+  selectedSubs,
+  filteredData,
+}: TopicSubscriptionsTableProps) => {
+  const rows = getRows(selectedSubs, filteredData);
+  const columns = getColumns(selectedSubs);
+
+  return rows.length === 0 ? (
+    <EmptyState title="No subscriptions">
+      No subscription matched your criteria.
+    </EmptyState>
+  ) : (
+    <>
+      Number of rows: {rows.length}
+      <DataTable
+        ariaLabel={"Topic subscriptions"}
+        columns={columns}
+        rows={rows}
+        noWrap={false}
+      />
+    </>
+  );
+};

--- a/coral/src/app/features/topics/details/subscriptions/TopicSubscriptionsTable.tsx
+++ b/coral/src/app/features/topics/details/subscriptions/TopicSubscriptionsTable.tsx
@@ -192,14 +192,11 @@ export const TopicSubscriptionsTable = ({
       No subscription matched your criteria.
     </EmptyState>
   ) : (
-    <>
-      Number of rows: {rows.length}
-      <DataTable
-        ariaLabel={"Topic subscriptions"}
-        columns={columns}
-        rows={rows}
-        noWrap={false}
-      />
-    </>
+    <DataTable
+      ariaLabel={"Topic subscriptions"}
+      columns={columns}
+      rows={rows}
+      noWrap={false}
+    />
   );
 };

--- a/coral/src/app/router.tsx
+++ b/coral/src/app/router.tsx
@@ -1,4 +1,6 @@
 import { createBrowserRouter, RouteObject } from "react-router-dom";
+import { TopicOverview } from "src/app/features/topics/details/overview";
+import TopicSubscriptions from "src/app/features/topics/details/subscriptions/TopicSubscriptions";
 import Layout from "src/app/layout/Layout";
 import LayoutWithoutNav from "src/app/layout/LayoutWithoutNav";
 import ApprovalsPage from "src/app/pages/approvals";
@@ -16,6 +18,7 @@ import SchemaRequestsPage from "src/app/pages/requests/schemas";
 import TopicRequestsPage from "src/app/pages/requests/topics";
 import Topics from "src/app/pages/topics";
 import AclRequest from "src/app/pages/topics/acl-request";
+import { TopicDetailsPage } from "src/app/pages/topics/details";
 import RequestTopic from "src/app/pages/topics/request";
 import SchemaRequest from "src/app/pages/topics/schema-request";
 import {
@@ -28,10 +31,8 @@ import {
   TopicOverviewTabEnum,
 } from "src/app/router_utils";
 import { getRouterBasename } from "src/config";
-import { TopicDetailsPage } from "src/app/pages/topics/details";
 import { createRouteBehindFeatureFlag } from "src/services/feature-flags/route-utils";
 import { FeatureFlag } from "src/services/feature-flags/types";
-import { TopicOverview } from "src/app/features/topics/details/overview";
 
 const routes: Array<RouteObject> = [
   // Login is currently the responsibility of the
@@ -62,7 +63,7 @@ const routes: Array<RouteObject> = [
           },
           {
             path: TOPIC_OVERVIEW_TAB_ID_INTO_PATH[TopicOverviewTabEnum.ACLS],
-            element: <div>ACLS</div>,
+            element: <TopicSubscriptions />,
             id: TopicOverviewTabEnum.ACLS,
           },
           {

--- a/coral/src/domain/topic/topic-types.ts
+++ b/coral/src/domain/topic/topic-types.ts
@@ -33,6 +33,9 @@ type TopicRequestApiResponse = ResolveIntersectionTypes<
   Paginated<TopicRequest[]>
 >;
 
+type AclOverviewInfo = KlawApiModel<"AclOverviewInfo">;
+type TopicOvervieApiResponse = KlawApiResponse<"getTopicOverview">;
+
 export type {
   Topic,
   TopicNames,
@@ -43,4 +46,6 @@ export type {
   TopicRequestOperationTypes,
   TopicRequestStatus,
   TopicRequestApiResponse,
+  TopicOvervieApiResponse,
+  AclOverviewInfo,
 };


### PR DESCRIPTION
## About this change - What it does

Add Table rendering Topic subscriptions. The Table can render each of the three types of subscriptions:
- user subscriptions
- prefixed subscriptions
- transactional subscriptions

The Table takes a `filteredData` prop because we will filter the data we get from the `getTopicOverview` call further in the PR implementing the filter #[1230](https://github.com/aiven/klaw/issues/1230)


https://github.com/aiven/klaw/assets/20607294/fc5d13a3-7f77-4853-9cf4-f694fec82688


## Followups

- The UI to switch between subscription types is tabs in the design, but there are no such tabs in `aqaurium`, so radio button were implemented
- The data fetched currently has a hardcoded `environment` param, as this value will be picked from the outlet context once it is implemented

Resolves: #1229

