### PR TITLE
feat(coral): Add paginated option for filters

### DIFF
--- a/coral/src/app/features/components/filters/AclTypeFilter.test.tsx
+++ b/coral/src/app/features/components/filters/AclTypeFilter.test.tsx
@@ -105,7 +105,7 @@ describe("AclTypeFilter.tsx", () => {
     });
   });
 
-  describe("updates the search param to preserve ACL type in url", () => {
+  describe("updates the search param to preserve ACL type in url (paginated)", () => {
     const consumerAcl = "CONSUMER";
 
     beforeEach(async () => {
@@ -140,6 +140,42 @@ describe("AclTypeFilter.tsx", () => {
         expect(window.location.search).toEqual(
           `?aclType=${consumerAcl}&page=1`
         );
+      });
+    });
+  });
+  describe("updates the search param to preserve ACL type in url (not paginated)", () => {
+    const consumerAcl = "CONSUMER";
+
+    beforeEach(async () => {
+      customRender(<AclTypeFilter paginated={false} />, {
+        queryClient: true,
+        browserRouter: true,
+      });
+    });
+
+    afterEach(() => {
+      // resets url to get to clean state again
+      window.history.pushState({}, "No page title", "/");
+      cleanup();
+    });
+
+    it("shows no search param by default", async () => {
+      expect(window.location.search).toEqual("");
+    });
+
+    it(`sets "?aclType=${consumerAcl}" as search param when user selected it`, async () => {
+      const select = screen.getByRole("combobox", {
+        name: filterLabel,
+      });
+
+      const option = screen.getByRole("option", {
+        name: consumerAcl,
+      });
+
+      await userEvent.selectOptions(select, option);
+
+      await waitFor(() => {
+        expect(window.location.search).toEqual(`?aclType=${consumerAcl}`);
       });
     });
   });

--- a/coral/src/app/features/components/filters/AclTypeFilter.tsx
+++ b/coral/src/app/features/components/filters/AclTypeFilter.tsx
@@ -5,7 +5,11 @@ import { AclType } from "src/domain/acl";
 type AclTypeForFilter = AclType | "ALL";
 const aclTypesForFilter: AclTypeForFilter[] = ["ALL", "CONSUMER", "PRODUCER"];
 
-function AclTypeFilter() {
+interface AclTypeFilterProps {
+  paginated?: boolean;
+}
+
+function AclTypeFilter({ paginated }: AclTypeFilterProps) {
   const { aclType, setFilterValue } = useFiltersValues();
 
   return (
@@ -15,7 +19,11 @@ function AclTypeFilter() {
       defaultValue={aclType}
       onChange={(e) => {
         const selectedType = e.target.value as AclTypeForFilter;
-        return setFilterValue({ name: "aclType", value: selectedType });
+        return setFilterValue({
+          name: "aclType",
+          value: selectedType,
+          paginated,
+        });
       }}
     >
       {aclTypesForFilter.map((type) => {

--- a/coral/src/app/features/components/filters/EnvironmentFilter.test.tsx
+++ b/coral/src/app/features/components/filters/EnvironmentFilter.test.tsx
@@ -234,7 +234,7 @@ describe("EnvironmentFilter.tsx", () => {
     });
   });
 
-  describe("updates the search param to preserve environment in url", () => {
+  describe("updates the search param to preserve environment in url (paginated)", () => {
     beforeEach(async () => {
       mockGetEnvironments.mockResolvedValue(mockEnvironments);
       mockGetSchemaRegistryEnvironments.mockResolvedValue([]);
@@ -294,6 +294,71 @@ describe("EnvironmentFilter.tsx", () => {
 
       await waitFor(() => {
         expect(window.location.search).toEqual("?page=1");
+      });
+    });
+  });
+
+  describe("updates the search param to preserve environment in url (not paginated)", () => {
+    beforeEach(async () => {
+      mockGetEnvironments.mockResolvedValue(mockEnvironments);
+      mockGetSchemaRegistryEnvironments.mockResolvedValue([]);
+      mockGetSyncConnectorsEnvironments.mockResolvedValue([]);
+
+      customRender(
+        <EnvironmentFilter
+          environmentEndpoint={"getAllEnvironmentsForTopicAndAcl"}
+          paginated={false}
+        />,
+        {
+          queryClient: true,
+          browserRouter: true,
+        }
+      );
+      await waitForElementToBeRemoved(
+        screen.getByTestId("select-environment-loading")
+      );
+    });
+
+    afterEach(() => {
+      // resets url to get to clean state again
+      window.history.pushState({}, "No page title", "/");
+      jest.resetAllMocks();
+      cleanup();
+    });
+
+    it("shows no search param by default", async () => {
+      expect(window.location.search).toEqual("");
+    });
+
+    it(`sets "${mockEnvironments[1].name}" as search param when user selected it`, async () => {
+      const select = screen.getByRole("combobox", {
+        name: filterLabel,
+      });
+
+      const option = screen.getByRole("option", {
+        name: mockEnvironments[1].name,
+      });
+
+      await userEvent.selectOptions(select, option);
+
+      await waitFor(() => {
+        expect(window.location.search).toEqual(
+          `?environment=${mockEnvironments[1].id}`
+        );
+      });
+    });
+
+    it("removes environment search param when user chooses All environment", async () => {
+      const select = screen.getByRole("combobox", {
+        name: filterLabel,
+      });
+
+      const option = screen.getByRole("option", { name: "All Environments" });
+
+      await userEvent.selectOptions(select, option);
+
+      await waitFor(() => {
+        expect(window.location.search).toEqual("");
       });
     });
   });

--- a/coral/src/app/features/components/filters/EnvironmentFilter.tsx
+++ b/coral/src/app/features/components/filters/EnvironmentFilter.tsx
@@ -16,6 +16,7 @@ type EnvironmentEndpoint =
 interface EnvironmentFilterProps {
   isSchemaRegistryEnvironments?: boolean;
   environmentEndpoint: EnvironmentEndpoint;
+  paginated?: boolean;
 }
 
 const environmentEndpointMap: {
@@ -26,7 +27,10 @@ const environmentEndpointMap: {
   getAllEnvironmentsForConnector: getAllEnvironmentsForConnector,
 };
 
-function EnvironmentFilter({ environmentEndpoint }: EnvironmentFilterProps) {
+function EnvironmentFilter({
+  environmentEndpoint,
+  paginated,
+}: EnvironmentFilterProps) {
   const { environment, setFilterValue } = useFiltersValues();
 
   const { data: environments } = useQuery<Environment[], HTTPError>(
@@ -48,7 +52,11 @@ function EnvironmentFilter({ environmentEndpoint }: EnvironmentFilterProps) {
         labelText="Filter by Environment"
         value={environment}
         onChange={(event) =>
-          setFilterValue({ name: "environment", value: event.target.value })
+          setFilterValue({
+            name: "environment",
+            value: event.target.value,
+            paginated,
+          })
         }
       >
         <Option key={"ALL"} value={"ALL"}>

--- a/coral/src/app/features/components/filters/MyRequestsFilter.test.tsx
+++ b/coral/src/app/features/components/filters/MyRequestsFilter.test.tsx
@@ -43,7 +43,7 @@ describe("MyRequestsFilter", () => {
     });
   });
 
-  it("sets the showOnlyMyRequests and page search parameter when user toggles the switch", async () => {
+  it("sets the showOnlyMyRequests and page search parameter when user toggles the switch (paginated)", async () => {
     window.history.replaceState(null, "", "/");
     customRender(<MyRequestsFilter />, {
       browserRouter: true,
@@ -59,7 +59,7 @@ describe("MyRequestsFilter", () => {
     );
   });
 
-  it("unsets the showOnlyMyRequests and page search parameter when user untoggles the switch", async () => {
+  it("unsets the showOnlyMyRequests and page search parameter when user untoggles the switch (paginated)", async () => {
     window.history.replaceState(null, "", "/?showOnlyMyRequests=true");
     customRender(<MyRequestsFilter />, {
       browserRouter: true,
@@ -73,5 +73,37 @@ describe("MyRequestsFilter", () => {
     await userEvent.click(showMyRequests);
     await waitFor(() => expect(showMyRequests).not.toBeChecked());
     await waitFor(() => expect(window.location.search).toEqual("?page=1"));
+  });
+
+  it("sets the showOnlyMyRequests and page search parameter when user toggles the switch (not paginated)", async () => {
+    window.history.replaceState(null, "", "/");
+    customRender(<MyRequestsFilter paginated={false} />, {
+      browserRouter: true,
+    });
+    await waitFor(() => expect(window.location.search).toEqual(""));
+    const showMyRequests = screen.getByRole("checkbox", {
+      name: "Show only my requests",
+    });
+    await userEvent.click(showMyRequests);
+    await waitFor(() => expect(showMyRequests).toBeChecked());
+    await waitFor(() =>
+      expect(window.location.search).toEqual("?showOnlyMyRequests=true")
+    );
+  });
+
+  it("unsets the showOnlyMyRequests and page search parameter when user untoggles the switch", async () => {
+    window.history.replaceState(null, "", "/?showOnlyMyRequests=true");
+    customRender(<MyRequestsFilter paginated={false} />, {
+      browserRouter: true,
+    });
+    await waitFor(() =>
+      expect(window.location.search).toEqual("?showOnlyMyRequests=true")
+    );
+    const showMyRequests = screen.getByRole("checkbox", {
+      name: "Show only my requests",
+    });
+    await userEvent.click(showMyRequests);
+    await waitFor(() => expect(showMyRequests).not.toBeChecked());
+    await waitFor(() => expect(window.location.search).toEqual(""));
   });
 });

--- a/coral/src/app/features/components/filters/MyRequestsFilter.tsx
+++ b/coral/src/app/features/components/filters/MyRequestsFilter.tsx
@@ -1,13 +1,21 @@
 import { Switch } from "@aivenio/aquarium";
 import { useFiltersValues } from "src/app/features/components/filters/useFiltersValues";
 
-function MyRequestsFilter() {
+interface MyRequestsFilterProps {
+  paginated?: boolean;
+}
+
+function MyRequestsFilter({ paginated }: MyRequestsFilterProps) {
   const { showOnlyMyRequests, setFilterValue } = useFiltersValues();
 
   const handleChangeIsMyRequest = (
     event: React.ChangeEvent<HTMLInputElement>
   ) => {
-    setFilterValue({ name: "showOnlyMyRequests", value: event.target.checked });
+    setFilterValue({
+      name: "showOnlyMyRequests",
+      value: event.target.checked,
+      paginated,
+    });
   };
 
   return (

--- a/coral/src/app/features/components/filters/RequestTypeFilter.test.tsx
+++ b/coral/src/app/features/components/filters/RequestTypeFilter.test.tsx
@@ -106,7 +106,7 @@ describe("RequestTypeFilter.tsx", () => {
     });
   });
 
-  describe("updates the search param to preserve request type in url", () => {
+  describe("updates the search param to preserve request type in url (paginated)", () => {
     const defaultRequestType = "DELETE";
     const deleteName = requestOperationTypeNameMap[defaultRequestType];
 
@@ -158,6 +158,62 @@ describe("RequestTypeFilter.tsx", () => {
 
       await waitFor(() => {
         expect(window.location.search).toEqual(`?page=1`);
+      });
+    });
+  });
+
+  describe("updates the search param to preserve request type in url (not paginated)", () => {
+    const defaultRequestType = "DELETE";
+    const deleteName = requestOperationTypeNameMap[defaultRequestType];
+
+    beforeEach(async () => {
+      customRender(<RequestTypeFilter paginated={false} />, {
+        queryClient: true,
+        browserRouter: true,
+      });
+    });
+
+    afterEach(() => {
+      // resets url to get to clean state again
+      window.history.pushState({}, "No page title", "/");
+      cleanup();
+    });
+
+    it("shows no search param by default", async () => {
+      expect(window.location.search).toEqual("");
+    });
+
+    it(`sets "?requestType=${defaultRequestType}" as search param when user selected it`, async () => {
+      const select = screen.getByRole("combobox", {
+        name: filterLabel,
+      });
+
+      const option = screen.getByRole("option", {
+        name: deleteName,
+      });
+
+      await userEvent.selectOptions(select, option);
+
+      await waitFor(() => {
+        expect(window.location.search).toEqual(
+          `?requestType=${defaultRequestType}`
+        );
+      });
+    });
+
+    it(`unsets "?requestType" as search param when user selects All request types`, async () => {
+      const select = screen.getByRole("combobox", {
+        name: filterLabel,
+      });
+
+      const allOption = screen.getByRole("option", {
+        name: "All request types",
+      });
+
+      await userEvent.selectOptions(select, allOption);
+
+      await waitFor(() => {
+        expect(window.location.search).toEqual(``);
       });
     });
   });

--- a/coral/src/app/features/components/filters/RequestTypeFilter.tsx
+++ b/coral/src/app/features/components/filters/RequestTypeFilter.tsx
@@ -12,13 +12,21 @@ type RequestOperationTypeOptions = ResolveIntersectionTypes<
   RequestOperationType | "ALL"
 >;
 
-function RequestTypeFilter() {
+interface RequestTypeFilterProps {
+  paginated?: boolean;
+}
+
+function RequestTypeFilter({ paginated }: RequestTypeFilterProps) {
   const { requestType, setFilterValue } = useFiltersValues();
 
   const handleChangeRequestType = (e: ChangeEvent<HTMLSelectElement>) => {
     const nextOperationType = e.target.value as RequestOperationTypeOptions;
 
-    setFilterValue({ name: "requestType", value: nextOperationType });
+    setFilterValue({
+      name: "requestType",
+      value: nextOperationType,
+      paginated,
+    });
   };
 
   return (

--- a/coral/src/app/features/components/filters/SearchFilter.test.tsx
+++ b/coral/src/app/features/components/filters/SearchFilter.test.tsx
@@ -94,7 +94,7 @@ describe("SearchFilter.tsx", () => {
     });
   });
 
-  describe("updates the search param to preserve topic in url", () => {
+  describe("updates the search param to preserve topic in url (paginated)", () => {
     beforeEach(async () => {
       customRender(
         <SearchFilter placeholder={placeholder} description={description} />,
@@ -124,6 +124,44 @@ describe("SearchFilter.tsx", () => {
 
       await waitFor(() => {
         expect(window.location.search).toEqual(`?search=testing&page=1`);
+      });
+    });
+  });
+
+  describe("updates the search param to preserve topic in url (not paginated)", () => {
+    beforeEach(async () => {
+      customRender(
+        <SearchFilter
+          placeholder={placeholder}
+          description={description}
+          paginated={false}
+        />,
+        {
+          browserRouter: true,
+        }
+      );
+    });
+
+    afterEach(() => {
+      // resets url to get to clean state again
+      window.history.pushState({}, "No page title", "/");
+      jest.resetAllMocks();
+      cleanup();
+    });
+
+    it("shows no search param by default", async () => {
+      expect(window.location.search).toEqual("");
+    });
+
+    it("sets `testing` as search param when user types in search input", async () => {
+      const searchInput = screen.getByRole("search", { name: placeholder });
+
+      await userEvent.type(searchInput, "testing");
+
+      expect(searchInput).toHaveValue("testing");
+
+      await waitFor(() => {
+        expect(window.location.search).toEqual(`?search=testing`);
       });
     });
   });

--- a/coral/src/app/features/components/filters/SearchFilter.tsx
+++ b/coral/src/app/features/components/filters/SearchFilter.tsx
@@ -6,9 +6,14 @@ import type { ChangeEvent } from "react";
 type SearchFilterProps = {
   placeholder: string;
   description: string;
+  paginated?: boolean;
 };
 
-function SearchFilter({ placeholder, description }: SearchFilterProps) {
+function SearchFilter({
+  placeholder,
+  description,
+  paginated,
+}: SearchFilterProps) {
   const { search, setFilterValue } = useFiltersValues();
   return (
     <>
@@ -24,6 +29,7 @@ function SearchFilter({ placeholder, description }: SearchFilterProps) {
             setFilterValue({
               name: "search",
               value: String(event.target.value).trim(),
+              paginated,
             }),
           500
         )}

--- a/coral/src/app/features/components/filters/StatusFilter.test.tsx
+++ b/coral/src/app/features/components/filters/StatusFilter.test.tsx
@@ -118,7 +118,7 @@ describe("StatusFilter.tsx", () => {
     });
   });
 
-  describe("updates the search param to preserve status in url", () => {
+  describe("updates the search param to preserve status in url (paginated)", () => {
     const deletedStatus = "DELETED";
     const deletedName = requestStatusNameMap["DELETED"];
 
@@ -154,6 +154,47 @@ describe("StatusFilter.tsx", () => {
         expect(window.location.search).toEqual(
           `?status=${deletedStatus}&page=1`
         );
+      });
+    });
+  });
+
+  describe("updates the search param to preserve status in url (not paginated)", () => {
+    const deletedStatus = "DELETED";
+    const deletedName = requestStatusNameMap["DELETED"];
+
+    beforeEach(async () => {
+      customRender(
+        <StatusFilter defaultStatus={"CREATED"} paginated={false} />,
+        {
+          queryClient: true,
+          browserRouter: true,
+        }
+      );
+    });
+
+    afterEach(() => {
+      // resets url to get to clean state again
+      window.history.pushState({}, "No page title", "/");
+      cleanup();
+    });
+
+    it("shows no search param by default", async () => {
+      expect(window.location.search).toEqual("");
+    });
+
+    it(`sets "?status=${deletedStatus}" as search param when user selected it`, async () => {
+      const select = screen.getByRole("combobox", {
+        name: filterLabel,
+      });
+
+      const option = screen.getByRole("option", {
+        name: deletedName,
+      });
+
+      await userEvent.selectOptions(select, option);
+
+      await waitFor(() => {
+        expect(window.location.search).toEqual(`?status=${deletedStatus}`);
       });
     });
   });

--- a/coral/src/app/features/components/filters/StatusFilter.tsx
+++ b/coral/src/app/features/components/filters/StatusFilter.tsx
@@ -8,10 +8,11 @@ import { RequestStatus } from "src/domain/requests/requests-types";
 
 type StatusFilterProps = {
   defaultStatus: RequestStatus;
+  paginated?: boolean;
 };
 
 function StatusFilter(props: StatusFilterProps) {
-  const { defaultStatus } = props;
+  const { defaultStatus, paginated } = props;
 
   const { status, setFilterValue } = useFiltersValues({ defaultStatus });
 
@@ -22,7 +23,7 @@ function StatusFilter(props: StatusFilterProps) {
       defaultValue={status}
       onChange={(e) => {
         const status = e.target.value as RequestStatus;
-        return setFilterValue({ name: "status", value: status });
+        return setFilterValue({ name: "status", value: status, paginated });
       }}
     >
       {statusList.map((status) => {

--- a/coral/src/app/features/components/filters/TeamFilter.test.tsx
+++ b/coral/src/app/features/components/filters/TeamFilter.test.tsx
@@ -149,7 +149,7 @@ describe("TeamFilter.tsx", () => {
     });
   });
 
-  describe("updates the search param to preserve team in url", () => {
+  describe("updates the search param to preserve team in url (paginated)", () => {
     const optionToSelect = "DevRel";
     const optionId = "1004";
 
@@ -186,6 +186,47 @@ describe("TeamFilter.tsx", () => {
 
       await waitFor(() => {
         expect(window.location.search).toEqual(`?teamId=${optionId}&page=1`);
+      });
+    });
+  });
+
+  describe("updates the search param to preserve team in url (not paginated)", () => {
+    const optionToSelect = "DevRel";
+    const optionId = "1004";
+
+    beforeEach(async () => {
+      mockGetTeams.mockResolvedValue(mockedTeamsResponse);
+      customRender(<TeamFilter paginated={false} />, {
+        queryClient: true,
+        browserRouter: true,
+      });
+      await waitFor(() => {
+        expect(screen.getByRole("combobox")).toBeVisible();
+      });
+    });
+
+    afterEach(() => {
+      // resets url to get to clean state again
+      window.history.pushState({}, "No page title", "/");
+      jest.resetAllMocks();
+      cleanup();
+    });
+
+    it("shows no search param by default", async () => {
+      expect(window.location.search).toEqual("");
+    });
+
+    it("sets `teamId=1` as search param when user selected it", async () => {
+      const select = screen.getByRole("combobox", {
+        name: filterLabel,
+      });
+
+      const option = screen.getByRole("option", { name: optionToSelect });
+
+      await userEvent.selectOptions(select, option);
+
+      await waitFor(() => {
+        expect(window.location.search).toEqual(`?teamId=${optionId}`);
       });
     });
   });

--- a/coral/src/app/features/components/filters/TeamFilter.tsx
+++ b/coral/src/app/features/components/filters/TeamFilter.tsx
@@ -3,7 +3,11 @@ import { useQuery } from "@tanstack/react-query";
 import { useFiltersValues } from "src/app/features/components/filters/useFiltersValues";
 import { getTeams } from "src/domain/team/team-api";
 
-function TeamFilter() {
+interface TeamFilterProps {
+  paginated?: boolean;
+}
+
+function TeamFilter({ paginated = true }: TeamFilterProps) {
   const { data: topicTeams } = useQuery(["topic-get-teams"], {
     queryFn: () => getTeams(),
   });
@@ -22,7 +26,11 @@ function TeamFilter() {
         labelText="Filter by team"
         value={teamId}
         onChange={(event) =>
-          setFilterValue({ name: "teamId", value: event.target.value })
+          setFilterValue({
+            name: "teamId",
+            value: event.target.value,
+            paginated,
+          })
         }
       >
         <Option key={"ALL"} value={"ALL"}>

--- a/coral/src/app/features/components/filters/useFiltersValues.test.tsx
+++ b/coral/src/app/features/components/filters/useFiltersValues.test.tsx
@@ -183,7 +183,7 @@ describe("useFiltersValues.tsx", () => {
       });
     });
   });
-  describe("should set correct filter values when using setFilterValue", () => {
+  describe("should set correct filter values when using setFilterValue (paginated)", () => {
     afterEach(() => {
       window.history.pushState({}, "", "/");
       cleanup();
@@ -286,6 +286,118 @@ describe("useFiltersValues.tsx", () => {
       });
 
       expect(window.location.search).toBe("?search=abc&page=1");
+    });
+  });
+  describe("should set correct filter values when using setFilterValue (not paginated)", () => {
+    afterEach(() => {
+      window.history.pushState({}, "", "/");
+      cleanup();
+    });
+
+    it("sets the correct environment filter value", () => {
+      const {
+        result: { current },
+      } = renderHook(() => useFiltersValues(), {
+        wrapper: ({ children }) => <BrowserRouter>{children}</BrowserRouter>,
+      });
+
+      current.setFilterValue({
+        name: "environment",
+        value: "1",
+        paginated: false,
+      });
+
+      expect(window.location.search).toBe("?environment=1");
+    });
+    it("sets the correct aclType filter value", () => {
+      const {
+        result: { current },
+      } = renderHook(() => useFiltersValues(), {
+        wrapper: ({ children }) => <BrowserRouter>{children}</BrowserRouter>,
+      });
+
+      current.setFilterValue({
+        name: "aclType",
+        value: "PRODUCER",
+        paginated: false,
+      });
+
+      expect(window.location.search).toBe("?aclType=PRODUCER");
+    });
+    it("sets the correct status filter value", () => {
+      const {
+        result: { current },
+      } = renderHook(() => useFiltersValues(), {
+        wrapper: ({ children }) => <BrowserRouter>{children}</BrowserRouter>,
+      });
+
+      current.setFilterValue({
+        name: "status",
+        value: "CREATED",
+        paginated: false,
+      });
+
+      expect(window.location.search).toBe("?status=CREATED");
+    });
+    it("sets the correct team filter value", () => {
+      const {
+        result: { current },
+      } = renderHook(() => useFiltersValues(), {
+        wrapper: ({ children }) => <BrowserRouter>{children}</BrowserRouter>,
+      });
+
+      current.setFilterValue({
+        name: "teamId",
+        value: "2",
+        paginated: false,
+      });
+
+      expect(window.location.search).toBe("?teamId=2");
+    });
+    it("sets the correct showOnlyMyRequests filter value", () => {
+      const {
+        result: { current },
+      } = renderHook(() => useFiltersValues(), {
+        wrapper: ({ children }) => <BrowserRouter>{children}</BrowserRouter>,
+      });
+
+      current.setFilterValue({
+        name: "showOnlyMyRequests",
+        value: true,
+        paginated: false,
+      });
+
+      expect(window.location.search).toBe("?showOnlyMyRequests=true");
+    });
+    it("sets the correct operationType filter value", () => {
+      const {
+        result: { current },
+      } = renderHook(() => useFiltersValues(), {
+        wrapper: ({ children }) => <BrowserRouter>{children}</BrowserRouter>,
+      });
+
+      current.setFilterValue({
+        name: "requestType",
+        value: "CREATE",
+        paginated: false,
+      });
+
+      expect(window.location.search).toBe("?requestType=CREATE");
+    });
+    it("sets the correct search filter value", () => {
+      const {
+        result: { current },
+      } = renderHook(() => useFiltersValues(), {
+        wrapper: ({ children }) => <BrowserRouter>{children}</BrowserRouter>,
+      });
+
+      current.setFilterValue({
+        name: "search",
+        value: "abc",
+        paginated: false,
+      });
+
+      expect(window.location.search).toBe("?search=abc");
     });
   });
 });

--- a/coral/src/app/features/components/filters/useFiltersValues.tsx
+++ b/coral/src/app/features/components/filters/useFiltersValues.tsx
@@ -6,13 +6,17 @@ import {
 } from "src/domain/requests/requests-types";
 
 type SetFiltersParams =
-  | { name: "environment"; value: string }
-  | { name: "aclType"; value: AclType | "ALL" }
-  | { name: "status"; value: RequestStatus }
-  | { name: "teamId"; value: string }
-  | { name: "showOnlyMyRequests"; value: boolean }
-  | { name: "requestType"; value: RequestOperationType | "ALL" }
-  | { name: "search"; value: string };
+  | { name: "environment"; value: string; paginated?: boolean }
+  | { name: "aclType"; value: AclType | "ALL"; paginated?: boolean }
+  | { name: "status"; value: RequestStatus; paginated?: boolean }
+  | { name: "teamId"; value: string; paginated?: boolean }
+  | { name: "showOnlyMyRequests"; value: boolean; paginated?: boolean }
+  | {
+      name: "requestType";
+      value: RequestOperationType | "ALL";
+      paginated?: boolean;
+    }
+  | { name: "search"; value: string; paginated?: boolean };
 
 type UseFiltersValuesParams =
   | {
@@ -34,8 +38,9 @@ type UseFilterValuesReturn = {
   showOnlyMyRequests: boolean;
   requestType: RequestOperationType | "ALL";
   search: string;
-  setFilterValue: ({ name, value }: SetFiltersParams) => void;
+  setFilterValue: ({ name, value, paginated }: SetFiltersParams) => void;
 };
+
 const useFiltersValues = (
   defaultValues: UseFiltersValuesParams = {}
 ): UseFilterValuesReturn => {
@@ -64,21 +69,27 @@ const useFiltersValues = (
     defaultRequestType;
   const search = searchParams.get("search") ?? defaultSearch;
 
-  const setFilterValue = ({ name, value }: SetFiltersParams) => {
+  const setFilterValue = ({
+    name,
+    value,
+    paginated = true,
+  }: SetFiltersParams) => {
+    const parsedValue = typeof value === "boolean" ? String(value) : value;
+    searchParams.set(name, parsedValue);
+
     if (
       (value === "ALL" && name !== "status") ||
       value === "" ||
       value === false
     ) {
       searchParams.delete(name);
-      searchParams.set("page", "1");
-      setSearchParams(searchParams);
-    } else {
-      const parsedValue = typeof value === "boolean" ? String(value) : value;
-      searchParams.set(name, parsedValue);
-      searchParams.set("page", "1");
-      setSearchParams(searchParams);
     }
+
+    if (paginated) {
+      searchParams.set("page", "1");
+    }
+
+    setSearchParams(searchParams);
   };
 
   return {


### PR DESCRIPTION
## About this change - What it does

In the Topic overview subscriptions tab, we render a Table. We want to filter the data in this table. We therefore want to be able to use `useTableFilterValues`. However, the current way this hook is set up assumes that the data we filter will always be paginated, which is not correct in this case (and others we might encounter later.

This means we always set a `page=1` search param when applying a filter, to ensure that the data is correctly rendered, even when it doesn't make sense:

https://github.com/aiven/klaw/assets/20607294/a28680fb-9c6d-484f-8573-9e278852c4fb


This PR add a `paginated` prop which can be passed to all our `[entity]Filter` copmponents:
- it is `true` by default, as filtering paginated data is currently our most common usecase
- if `false` is passed, we do not set the `page=1` search param

This will allow more flexibility in the use of these filters in non paginated contexts.
