### PR TITLE
chore(coral): Update aquarium -> 1.20.0

### DIFF
--- a/coral/package.json
+++ b/coral/package.json
@@ -42,7 +42,7 @@
     ]
   },
   "dependencies": {
-    "@aivenio/aquarium": "^1.17.1",
+    "@aivenio/aquarium": "^1.20.0",
     "@hookform/resolvers": "^2.9.10",
     "@monaco-editor/react": "^4.5.0",
     "@tanstack/react-query": "^4.29.5",

--- a/coral/pnpm-lock.yaml
+++ b/coral/pnpm-lock.yaml
@@ -1,7 +1,7 @@
 lockfileVersion: 5.4
 
 specifiers:
-  '@aivenio/aquarium': ^1.17.1
+  '@aivenio/aquarium': ^1.20.0
   '@hookform/resolvers': ^2.9.10
   '@monaco-editor/react': ^4.5.0
   '@tanstack/react-query': ^4.29.5
@@ -51,7 +51,7 @@ specifiers:
   zod: ^3.19.1
 
 dependencies:
-  '@aivenio/aquarium': 1.17.1_pvnihi4muhoy7kenlmiyxwzuqy
+  '@aivenio/aquarium': 1.20.0_pvnihi4muhoy7kenlmiyxwzuqy
   '@hookform/resolvers': 2.9.10_react-hook-form@7.43.9
   '@monaco-editor/react': 4.5.0_bp43pgihi2cxclx2bm2cvm6q7a
   '@tanstack/react-query': 4.29.5_biqbaboplfbrettd7655fr4n2y
@@ -108,8 +108,8 @@ packages:
     resolution: {integrity: sha512-+u76oB43nOHrF4DDWRLWDCtci7f3QJoEBigemIdIeTi1ODqjx6Tad9NCVnPRwewWlKkVab5PlK8DCtPTyX7S8g==}
     dev: true
 
-  /@aivenio/aquarium/1.17.1_pvnihi4muhoy7kenlmiyxwzuqy:
-    resolution: {integrity: sha512-qg5Sw9VbGlDRrDYsmbGa1uvOwSFYqZC563cZemiUH5Mberv67J/Yo5ShqAcgHZsmqZMzDI3pPWkWqSBvpVQqGQ==}
+  /@aivenio/aquarium/1.20.0_pvnihi4muhoy7kenlmiyxwzuqy:
+    resolution: {integrity: sha512-4DC0kC1DAaDXxGuVPuN5CXWAuweBSVM2TDRCXMRSPDjU0dLWL4dyUcCnllUEHjFqBQMovySif4IC5wVNoxtqAw==}
     peerDependencies:
       lodash: 4.x
       react: 16.x || 17.x
@@ -118,6 +118,7 @@ packages:
       '@iconify/react': 3.2.2_react@18.2.0
       '@iconify/types': 1.1.0
       '@popperjs/core': 2.11.6
+      '@react-spring/web': 9.7.2_biqbaboplfbrettd7655fr4n2y
       classnames: 2.3.2
       downshift: 7.1.0_react@18.2.0
       lodash: 4.17.21
@@ -126,7 +127,10 @@ packages:
       react-aria: 3.23.1_biqbaboplfbrettd7655fr4n2y
       react-dom: 18.2.0_react@18.2.0
       react-popper: 2.3.0_r6q5zrenym2zg7je7hgi674bti
-      react-stately: 3.21.0_react@18.2.0
+      react-stately: 3.22.0_react@18.2.0
+      recharts: 2.6.2_biqbaboplfbrettd7655fr4n2y
+    transitivePeerDependencies:
+      - prop-types
     dev: false
 
   /@ampproject/remapping/2.2.0:
@@ -920,6 +924,12 @@ packages:
       '@swc/helpers': 0.4.14
     dev: false
 
+  /@internationalized/date/3.2.0:
+    resolution: {integrity: sha512-VDMHN1m33L4eqPs5BaihzgQJXyaORbMoHOtrapFxx179J8ucY5CRIHYsq5RRLKPHZWgjNfa5v6amWWDkkMFywA==}
+    dependencies:
+      '@swc/helpers': 0.4.14
+    dev: false
+
   /@internationalized/message/3.1.0:
     resolution: {integrity: sha512-Oo5m70FcBdADf7G8NkUffVSfuCdeAYVfsvNjZDi9ELpjvkc4YNJVTHt/NyTI9K7FgAVoELxiP9YmN0sJ+HNHYQ==}
     dependencies:
@@ -1476,17 +1486,17 @@ packages:
       react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
     dependencies:
       '@react-aria/focus': 3.11.0_react@18.2.0
-      '@react-aria/i18n': 3.7.0_react@18.2.0
+      '@react-aria/i18n': 3.7.1_react@18.2.0
       '@react-aria/interactions': 3.14.0_react@18.2.0
       '@react-aria/live-announcer': 3.2.0
       '@react-aria/selection': 3.13.1_react@18.2.0
-      '@react-aria/utils': 3.15.0_react@18.2.0
+      '@react-aria/utils': 3.16.0_react@18.2.0
       '@react-stately/grid': 3.5.0_react@18.2.0
-      '@react-stately/selection': 3.12.0_react@18.2.0
+      '@react-stately/selection': 3.13.0_react@18.2.0
       '@react-stately/virtualizer': 3.5.0_react@18.2.0
-      '@react-types/checkbox': 3.4.2_react@18.2.0
+      '@react-types/checkbox': 3.4.3_react@18.2.0
       '@react-types/grid': 3.1.6_react@18.2.0
-      '@react-types/shared': 3.17.0_react@18.2.0
+      '@react-types/shared': 3.18.0_react@18.2.0
       '@swc/helpers': 0.4.14
       react: 18.2.0
       react-dom: 18.2.0_react@18.2.0
@@ -1503,9 +1513,9 @@ packages:
       '@react-aria/interactions': 3.14.0_react@18.2.0
       '@react-aria/selection': 3.13.1_react@18.2.0
       '@react-aria/utils': 3.15.0_react@18.2.0
-      '@react-stately/list': 3.7.0_react@18.2.0
+      '@react-stately/list': 3.8.0_react@18.2.0
       '@react-types/checkbox': 3.4.2_react@18.2.0
-      '@react-types/shared': 3.17.0_react@18.2.0
+      '@react-types/shared': 3.18.0_react@18.2.0
       '@swc/helpers': 0.4.14
       react: 18.2.0
     transitivePeerDependencies:
@@ -1523,7 +1533,23 @@ packages:
       '@internationalized/string': 3.1.0
       '@react-aria/ssr': 3.5.0_react@18.2.0
       '@react-aria/utils': 3.15.0_react@18.2.0
-      '@react-types/shared': 3.17.0_react@18.2.0
+      '@react-types/shared': 3.18.0_react@18.2.0
+      '@swc/helpers': 0.4.14
+      react: 18.2.0
+    dev: false
+
+  /@react-aria/i18n/3.7.1_react@18.2.0:
+    resolution: {integrity: sha512-2fu1cv8yD3V+rlhOqstTdGAubadoMFuPE7lA1FfYdaJNxXa09iWqvpipUPlxYJrahW0eazkesOPDKFwOEMF1iA==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
+    dependencies:
+      '@internationalized/date': 3.2.0
+      '@internationalized/message': 3.1.0
+      '@internationalized/number': 3.2.0
+      '@internationalized/string': 3.1.0
+      '@react-aria/ssr': 3.6.0_react@18.2.0
+      '@react-aria/utils': 3.16.0_react@18.2.0
+      '@react-types/shared': 3.18.0_react@18.2.0
       '@swc/helpers': 0.4.14
       react: 18.2.0
     dev: false
@@ -1534,7 +1560,7 @@ packages:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
     dependencies:
       '@react-aria/utils': 3.15.0_react@18.2.0
-      '@react-types/shared': 3.17.0_react@18.2.0
+      '@react-types/shared': 3.18.0_react@18.2.0
       '@swc/helpers': 0.4.14
       react: 18.2.0
     dev: false
@@ -1546,7 +1572,7 @@ packages:
     dependencies:
       '@react-aria/utils': 3.15.0_react@18.2.0
       '@react-types/label': 3.7.2_react@18.2.0
-      '@react-types/shared': 3.17.0_react@18.2.0
+      '@react-types/shared': 3.18.0_react@18.2.0
       '@swc/helpers': 0.4.14
       react: 18.2.0
     dev: false
@@ -1560,7 +1586,7 @@ packages:
       '@react-aria/interactions': 3.14.0_react@18.2.0
       '@react-aria/utils': 3.15.0_react@18.2.0
       '@react-types/link': 3.4.0_react@18.2.0
-      '@react-types/shared': 3.17.0_react@18.2.0
+      '@react-types/shared': 3.18.0_react@18.2.0
       '@swc/helpers': 0.4.14
       react: 18.2.0
     dev: false
@@ -1575,10 +1601,10 @@ packages:
       '@react-aria/label': 3.5.0_react@18.2.0
       '@react-aria/selection': 3.13.1_react@18.2.0
       '@react-aria/utils': 3.15.0_react@18.2.0
-      '@react-stately/collections': 3.6.0_react@18.2.0
-      '@react-stately/list': 3.7.0_react@18.2.0
+      '@react-stately/collections': 3.7.0_react@18.2.0
+      '@react-stately/list': 3.8.0_react@18.2.0
       '@react-types/listbox': 3.4.0_react@18.2.0
-      '@react-types/shared': 3.17.0_react@18.2.0
+      '@react-types/shared': 3.18.0_react@18.2.0
       '@swc/helpers': 0.4.14
       react: 18.2.0
     dev: false
@@ -1600,12 +1626,12 @@ packages:
       '@react-aria/overlays': 3.13.0_biqbaboplfbrettd7655fr4n2y
       '@react-aria/selection': 3.13.1_react@18.2.0
       '@react-aria/utils': 3.15.0_react@18.2.0
-      '@react-stately/collections': 3.6.0_react@18.2.0
-      '@react-stately/menu': 3.5.0_react@18.2.0
-      '@react-stately/tree': 3.5.0_react@18.2.0
+      '@react-stately/collections': 3.7.0_react@18.2.0
+      '@react-stately/menu': 3.5.1_react@18.2.0
+      '@react-stately/tree': 3.6.0_react@18.2.0
       '@react-types/button': 3.7.1_react@18.2.0
       '@react-types/menu': 3.8.0_react@18.2.0
-      '@react-types/shared': 3.17.0_react@18.2.0
+      '@react-types/shared': 3.18.0_react@18.2.0
       '@swc/helpers': 0.4.14
       react: 18.2.0
       react-dom: 18.2.0_react@18.2.0
@@ -1618,7 +1644,7 @@ packages:
     dependencies:
       '@react-aria/progress': 3.4.0_react@18.2.0
       '@react-types/meter': 3.3.0_react@18.2.0
-      '@react-types/shared': 3.17.0_react@18.2.0
+      '@react-types/shared': 3.18.0_react@18.2.0
       '@swc/helpers': 0.4.14
       react: 18.2.0
     dev: false
@@ -1635,10 +1661,10 @@ packages:
       '@react-aria/spinbutton': 3.3.0_biqbaboplfbrettd7655fr4n2y
       '@react-aria/textfield': 3.9.0_react@18.2.0
       '@react-aria/utils': 3.15.0_react@18.2.0
-      '@react-stately/numberfield': 3.4.0_react@18.2.0
+      '@react-stately/numberfield': 3.4.1_react@18.2.0
       '@react-types/button': 3.7.1_react@18.2.0
       '@react-types/numberfield': 3.4.0_react@18.2.0
-      '@react-types/shared': 3.17.0_react@18.2.0
+      '@react-types/shared': 3.18.0_react@18.2.0
       '@react-types/textfield': 3.7.0_react@18.2.0
       '@swc/helpers': 0.4.14
       react: 18.2.0
@@ -1657,10 +1683,10 @@ packages:
       '@react-aria/ssr': 3.5.0_react@18.2.0
       '@react-aria/utils': 3.15.0_react@18.2.0
       '@react-aria/visually-hidden': 3.7.0_react@18.2.0
-      '@react-stately/overlays': 3.5.0_react@18.2.0
+      '@react-stately/overlays': 3.5.1_react@18.2.0
       '@react-types/button': 3.7.1_react@18.2.0
       '@react-types/overlays': 3.7.0_react@18.2.0
-      '@react-types/shared': 3.17.0_react@18.2.0
+      '@react-types/shared': 3.18.0_react@18.2.0
       '@swc/helpers': 0.4.14
       react: 18.2.0
       react-dom: 18.2.0_react@18.2.0
@@ -1675,7 +1701,7 @@ packages:
       '@react-aria/label': 3.5.0_react@18.2.0
       '@react-aria/utils': 3.15.0_react@18.2.0
       '@react-types/progress': 3.3.0_react@18.2.0
-      '@react-types/shared': 3.17.0_react@18.2.0
+      '@react-types/shared': 3.18.0_react@18.2.0
       '@swc/helpers': 0.4.14
       react: 18.2.0
     dev: false
@@ -1690,9 +1716,9 @@ packages:
       '@react-aria/interactions': 3.14.0_react@18.2.0
       '@react-aria/label': 3.5.0_react@18.2.0
       '@react-aria/utils': 3.15.0_react@18.2.0
-      '@react-stately/radio': 3.7.0_react@18.2.0
+      '@react-stately/radio': 3.8.0_react@18.2.0
       '@react-types/radio': 3.4.0_react@18.2.0
-      '@react-types/shared': 3.17.0_react@18.2.0
+      '@react-types/shared': 3.18.0_react@18.2.0
       '@swc/helpers': 0.4.14
       react: 18.2.0
     dev: false
@@ -1706,10 +1732,10 @@ packages:
       '@react-aria/interactions': 3.14.0_react@18.2.0
       '@react-aria/textfield': 3.9.0_react@18.2.0
       '@react-aria/utils': 3.15.0_react@18.2.0
-      '@react-stately/searchfield': 3.4.0_react@18.2.0
+      '@react-stately/searchfield': 3.4.1_react@18.2.0
       '@react-types/button': 3.7.1_react@18.2.0
       '@react-types/searchfield': 3.4.0_react@18.2.0
-      '@react-types/shared': 3.17.0_react@18.2.0
+      '@react-types/shared': 3.18.0_react@18.2.0
       '@swc/helpers': 0.4.14
       react: 18.2.0
     dev: false
@@ -1728,10 +1754,10 @@ packages:
       '@react-aria/selection': 3.13.1_react@18.2.0
       '@react-aria/utils': 3.15.0_react@18.2.0
       '@react-aria/visually-hidden': 3.7.0_react@18.2.0
-      '@react-stately/select': 3.4.0_react@18.2.0
+      '@react-stately/select': 3.5.0_react@18.2.0
       '@react-types/button': 3.7.1_react@18.2.0
       '@react-types/select': 3.7.0_react@18.2.0
-      '@react-types/shared': 3.17.0_react@18.2.0
+      '@react-types/shared': 3.18.0_react@18.2.0
       '@swc/helpers': 0.4.14
       react: 18.2.0
       react-dom: 18.2.0_react@18.2.0
@@ -1746,9 +1772,9 @@ packages:
       '@react-aria/i18n': 3.7.0_react@18.2.0
       '@react-aria/interactions': 3.14.0_react@18.2.0
       '@react-aria/utils': 3.15.0_react@18.2.0
-      '@react-stately/collections': 3.6.0_react@18.2.0
-      '@react-stately/selection': 3.12.0_react@18.2.0
-      '@react-types/shared': 3.17.0_react@18.2.0
+      '@react-stately/collections': 3.7.0_react@18.2.0
+      '@react-stately/selection': 3.13.0_react@18.2.0
+      '@react-types/shared': 3.18.0_react@18.2.0
       '@swc/helpers': 0.4.14
       react: 18.2.0
     dev: false
@@ -1759,7 +1785,7 @@ packages:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
     dependencies:
       '@react-aria/utils': 3.15.0_react@18.2.0
-      '@react-types/shared': 3.17.0_react@18.2.0
+      '@react-types/shared': 3.18.0_react@18.2.0
       '@swc/helpers': 0.4.14
       react: 18.2.0
     dev: false
@@ -1774,10 +1800,10 @@ packages:
       '@react-aria/interactions': 3.14.0_react@18.2.0
       '@react-aria/label': 3.5.0_react@18.2.0
       '@react-aria/utils': 3.15.0_react@18.2.0
-      '@react-stately/radio': 3.7.0_react@18.2.0
-      '@react-stately/slider': 3.3.0_react@18.2.0
+      '@react-stately/radio': 3.8.0_react@18.2.0
+      '@react-stately/slider': 3.3.1_react@18.2.0
       '@react-types/radio': 3.4.0_react@18.2.0
-      '@react-types/shared': 3.17.0_react@18.2.0
+      '@react-types/shared': 3.18.0_react@18.2.0
       '@react-types/slider': 3.4.0_react@18.2.0
       '@swc/helpers': 0.4.14
       react: 18.2.0
@@ -1789,11 +1815,11 @@ packages:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
       react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
     dependencies:
-      '@react-aria/i18n': 3.7.0_react@18.2.0
+      '@react-aria/i18n': 3.7.1_react@18.2.0
       '@react-aria/live-announcer': 3.2.0
-      '@react-aria/utils': 3.15.0_react@18.2.0
+      '@react-aria/utils': 3.16.0_react@18.2.0
       '@react-types/button': 3.7.1_react@18.2.0
-      '@react-types/shared': 3.17.0_react@18.2.0
+      '@react-types/shared': 3.18.0_react@18.2.0
       '@swc/helpers': 0.4.14
       react: 18.2.0
       react-dom: 18.2.0_react@18.2.0
@@ -1808,13 +1834,22 @@ packages:
       react: 18.2.0
     dev: false
 
+  /@react-aria/ssr/3.6.0_react@18.2.0:
+    resolution: {integrity: sha512-OFiYQdv+Yk7AO7IsQu/fAEPijbeTwrrEYvdNoJ3sblBBedD5j5fBTNWrUPNVlwC4XWWnWTCMaRIVsJujsFiWXg==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
+    dependencies:
+      '@swc/helpers': 0.4.14
+      react: 18.2.0
+    dev: false
+
   /@react-aria/switch/3.4.0_react@18.2.0:
     resolution: {integrity: sha512-FWbjqNcY+fAjRNXVQTvOx93udhaySgXLsMNLRAVUcFm45FqTaxAhHhNGtRnVhDvzHTJY/Y+kpcGzCcW2rXzPxg==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
     dependencies:
       '@react-aria/toggle': 3.5.0_react@18.2.0
-      '@react-stately/toggle': 3.5.0_react@18.2.0
+      '@react-stately/toggle': 3.5.1_react@18.2.0
       '@react-types/switch': 3.3.0_react@18.2.0
       '@swc/helpers': 0.4.14
       react: 18.2.0
@@ -1833,11 +1868,11 @@ packages:
       '@react-aria/live-announcer': 3.2.0
       '@react-aria/selection': 3.13.1_react@18.2.0
       '@react-aria/utils': 3.15.0_react@18.2.0
-      '@react-stately/table': 3.8.0_react@18.2.0
+      '@react-stately/table': 3.9.0_react@18.2.0
       '@react-stately/virtualizer': 3.5.0_react@18.2.0
       '@react-types/checkbox': 3.4.2_react@18.2.0
       '@react-types/grid': 3.1.6_react@18.2.0
-      '@react-types/shared': 3.17.0_react@18.2.0
+      '@react-types/shared': 3.18.0_react@18.2.0
       '@react-types/table': 3.5.0_react@18.2.0
       '@swc/helpers': 0.4.14
       react: 18.2.0
@@ -1854,9 +1889,9 @@ packages:
       '@react-aria/interactions': 3.14.0_react@18.2.0
       '@react-aria/selection': 3.13.1_react@18.2.0
       '@react-aria/utils': 3.15.0_react@18.2.0
-      '@react-stately/list': 3.7.0_react@18.2.0
-      '@react-stately/tabs': 3.3.0_react@18.2.0
-      '@react-types/shared': 3.17.0_react@18.2.0
+      '@react-stately/list': 3.8.0_react@18.2.0
+      '@react-stately/tabs': 3.4.0_react@18.2.0
+      '@react-types/shared': 3.18.0_react@18.2.0
       '@react-types/tabs': 3.2.0_react@18.2.0
       '@swc/helpers': 0.4.14
       react: 18.2.0
@@ -1870,7 +1905,7 @@ packages:
       '@react-aria/focus': 3.11.0_react@18.2.0
       '@react-aria/label': 3.5.0_react@18.2.0
       '@react-aria/utils': 3.15.0_react@18.2.0
-      '@react-types/shared': 3.17.0_react@18.2.0
+      '@react-types/shared': 3.18.0_react@18.2.0
       '@react-types/textfield': 3.7.0_react@18.2.0
       '@swc/helpers': 0.4.14
       react: 18.2.0
@@ -1883,10 +1918,10 @@ packages:
     dependencies:
       '@react-aria/focus': 3.11.0_react@18.2.0
       '@react-aria/interactions': 3.14.0_react@18.2.0
-      '@react-aria/utils': 3.15.0_react@18.2.0
-      '@react-stately/toggle': 3.5.0_react@18.2.0
-      '@react-types/checkbox': 3.4.2_react@18.2.0
-      '@react-types/shared': 3.17.0_react@18.2.0
+      '@react-aria/utils': 3.16.0_react@18.2.0
+      '@react-stately/toggle': 3.5.1_react@18.2.0
+      '@react-types/checkbox': 3.4.3_react@18.2.0
+      '@react-types/shared': 3.18.0_react@18.2.0
       '@react-types/switch': 3.3.0_react@18.2.0
       '@swc/helpers': 0.4.14
       react: 18.2.0
@@ -1900,8 +1935,8 @@ packages:
       '@react-aria/focus': 3.11.0_react@18.2.0
       '@react-aria/interactions': 3.14.0_react@18.2.0
       '@react-aria/utils': 3.15.0_react@18.2.0
-      '@react-stately/tooltip': 3.3.0_react@18.2.0
-      '@react-types/shared': 3.17.0_react@18.2.0
+      '@react-stately/tooltip': 3.4.0_react@18.2.0
+      '@react-types/shared': 3.18.0_react@18.2.0
       '@react-types/tooltip': 3.3.0_react@18.2.0
       '@swc/helpers': 0.4.14
       react: 18.2.0
@@ -1914,7 +1949,20 @@ packages:
     dependencies:
       '@react-aria/ssr': 3.5.0_react@18.2.0
       '@react-stately/utils': 3.6.0_react@18.2.0
-      '@react-types/shared': 3.17.0_react@18.2.0
+      '@react-types/shared': 3.18.0_react@18.2.0
+      '@swc/helpers': 0.4.14
+      clsx: 1.2.1
+      react: 18.2.0
+    dev: false
+
+  /@react-aria/utils/3.16.0_react@18.2.0:
+    resolution: {integrity: sha512-BumpgENDlXuoRPQm1OfVUYRcxY9vwuXw1AmUpwF61v55gAZT3LvJWsfF8jgfQNzLJr5jtr7xvUx7pXuEyFpJMA==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
+    dependencies:
+      '@react-aria/ssr': 3.6.0_react@18.2.0
+      '@react-stately/utils': 3.6.0_react@18.2.0
+      '@react-types/shared': 3.18.0_react@18.2.0
       '@swc/helpers': 0.4.14
       clsx: 1.2.1
       react: 18.2.0
@@ -1927,10 +1975,64 @@ packages:
     dependencies:
       '@react-aria/interactions': 3.14.0_react@18.2.0
       '@react-aria/utils': 3.15.0_react@18.2.0
-      '@react-types/shared': 3.17.0_react@18.2.0
+      '@react-types/shared': 3.18.0_react@18.2.0
       '@swc/helpers': 0.4.14
       clsx: 1.2.1
       react: 18.2.0
+    dev: false
+
+  /@react-spring/animated/9.7.2_react@18.2.0:
+    resolution: {integrity: sha512-ipvleJ99ipqlnHkz5qhSsgf/ny5aW0ZG8Q+/2Oj9cI7LCc7COdnrSO6V/v8MAX3JOoQNzfz6dye2s5Pt5jGaIA==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0
+    dependencies:
+      '@react-spring/shared': 9.7.2_react@18.2.0
+      '@react-spring/types': 9.7.2
+      react: 18.2.0
+    dev: false
+
+  /@react-spring/core/9.7.2_react@18.2.0:
+    resolution: {integrity: sha512-fF512edZT/gKVCA90ZRxfw1DmELeVwiL4OC2J6bMUlNr707C0h4QRoec6DjzG27uLX2MvS1CEatf9KRjwZR9/w==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0
+    dependencies:
+      '@react-spring/animated': 9.7.2_react@18.2.0
+      '@react-spring/rafz': 9.7.2
+      '@react-spring/shared': 9.7.2_react@18.2.0
+      '@react-spring/types': 9.7.2
+      react: 18.2.0
+    dev: false
+
+  /@react-spring/rafz/9.7.2:
+    resolution: {integrity: sha512-kDWMYDQto3+flkrX3vy6DU/l9pxQ4TVW91DglQEc11iDc7shF4+WVDRJvOVLX+xoMP7zyag1dMvlIgvQ+dvA/A==}
+    dev: false
+
+  /@react-spring/shared/9.7.2_react@18.2.0:
+    resolution: {integrity: sha512-6U9qkno+9DxlH5nSltnPs+kU6tYKf0bPLURX2te13aGel8YqgcpFYp5Av8DcN2x3sukinAsmzHUS/FRsdZMMBA==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0
+    dependencies:
+      '@react-spring/rafz': 9.7.2
+      '@react-spring/types': 9.7.2
+      react: 18.2.0
+    dev: false
+
+  /@react-spring/types/9.7.2:
+    resolution: {integrity: sha512-GEflx2Ex/TKVMHq5g5MxQDNNPNhqg+4Db9m7+vGTm8ttZiyga7YQUF24shgRNebKIjahqCuei16SZga8h1pe4g==}
+    dev: false
+
+  /@react-spring/web/9.7.2_biqbaboplfbrettd7655fr4n2y:
+    resolution: {integrity: sha512-7qNc7/5KShu2D05x7o2Ols2nUE7mCKfKLaY2Ix70xPMfTle1sZisoQMBFgV9w/fSLZlHZHV9P0uWJqEXQnbV4Q==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0
+      react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0
+    dependencies:
+      '@react-spring/animated': 9.7.2_react@18.2.0
+      '@react-spring/core': 9.7.2_react@18.2.0
+      '@react-spring/shared': 9.7.2_react@18.2.0
+      '@react-spring/types': 9.7.2
+      react: 18.2.0
+      react-dom: 18.2.0_react@18.2.0
     dev: false
 
   /@react-stately/calendar/3.1.0_react@18.2.0:
@@ -1938,11 +2040,25 @@ packages:
     peerDependencies:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
     dependencies:
-      '@internationalized/date': 3.1.0
+      '@internationalized/date': 3.2.0
       '@react-stately/utils': 3.6.0_react@18.2.0
-      '@react-types/calendar': 3.1.0_react@18.2.0
-      '@react-types/datepicker': 3.2.0_react@18.2.0
-      '@react-types/shared': 3.17.0_react@18.2.0
+      '@react-types/calendar': 3.2.0_react@18.2.0
+      '@react-types/datepicker': 3.3.0_react@18.2.0
+      '@react-types/shared': 3.18.0_react@18.2.0
+      '@swc/helpers': 0.4.14
+      react: 18.2.0
+    dev: false
+
+  /@react-stately/calendar/3.2.0_react@18.2.0:
+    resolution: {integrity: sha512-A13QSmlzLI5rtpIu2QIkij4ST29MWkCJd1kM6WFDS/1if8lSzfPL3kI4tdFDaFzFCwmv2Hb2cIfv9soIG8KASQ==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
+    dependencies:
+      '@internationalized/date': 3.2.0
+      '@react-stately/utils': 3.6.0_react@18.2.0
+      '@react-types/calendar': 3.2.0_react@18.2.0
+      '@react-types/datepicker': 3.3.0_react@18.2.0
+      '@react-types/shared': 3.18.0_react@18.2.0
       '@swc/helpers': 0.4.14
       react: 18.2.0
     dev: false
@@ -1952,10 +2068,23 @@ packages:
     peerDependencies:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
     dependencies:
-      '@react-stately/toggle': 3.5.0_react@18.2.0
+      '@react-stately/toggle': 3.5.1_react@18.2.0
       '@react-stately/utils': 3.6.0_react@18.2.0
-      '@react-types/checkbox': 3.4.2_react@18.2.0
-      '@react-types/shared': 3.17.0_react@18.2.0
+      '@react-types/checkbox': 3.4.3_react@18.2.0
+      '@react-types/shared': 3.18.0_react@18.2.0
+      '@swc/helpers': 0.4.14
+      react: 18.2.0
+    dev: false
+
+  /@react-stately/checkbox/3.4.1_react@18.2.0:
+    resolution: {integrity: sha512-Ju1EBuIE/JJbuhd8xMkgqf3KuSNpRrwXsgtI+Ur42F+lAedZH7vqy+5bZPo0Q3u0yHcNJzexZXOxHZNqq1ij8w==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
+    dependencies:
+      '@react-stately/toggle': 3.5.1_react@18.2.0
+      '@react-stately/utils': 3.6.0_react@18.2.0
+      '@react-types/checkbox': 3.4.3_react@18.2.0
+      '@react-types/shared': 3.18.0_react@18.2.0
       '@swc/helpers': 0.4.14
       react: 18.2.0
     dev: false
@@ -1965,7 +2094,17 @@ packages:
     peerDependencies:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
     dependencies:
-      '@react-types/shared': 3.17.0_react@18.2.0
+      '@react-types/shared': 3.18.0_react@18.2.0
+      '@swc/helpers': 0.4.14
+      react: 18.2.0
+    dev: false
+
+  /@react-stately/collections/3.7.0_react@18.2.0:
+    resolution: {integrity: sha512-xZHJxjGXFe3LUbuNgR1yATBVSIQnm+ItLq2DJZo3JzTtRu3gEwLoRRoapPsBQnC5VsjcaimgoqvT05P0AlvCTQ==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
+    dependencies:
+      '@react-types/shared': 3.18.0_react@18.2.0
       '@swc/helpers': 0.4.14
       react: 18.2.0
     dev: false
@@ -1975,22 +2114,38 @@ packages:
     peerDependencies:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
     dependencies:
-      '@react-stately/list': 3.7.0_react@18.2.0
-      '@react-stately/menu': 3.5.0_react@18.2.0
-      '@react-stately/select': 3.4.0_react@18.2.0
+      '@react-stately/list': 3.8.0_react@18.2.0
+      '@react-stately/menu': 3.5.1_react@18.2.0
+      '@react-stately/select': 3.5.0_react@18.2.0
       '@react-stately/utils': 3.6.0_react@18.2.0
-      '@react-types/combobox': 3.6.0_react@18.2.0
-      '@react-types/shared': 3.17.0_react@18.2.0
+      '@react-types/combobox': 3.6.1_react@18.2.0
+      '@react-types/shared': 3.18.0_react@18.2.0
       '@swc/helpers': 0.4.14
       react: 18.2.0
     dev: false
 
-  /@react-stately/data/3.9.0_react@18.2.0:
-    resolution: {integrity: sha512-67zP/QkVInsU9wtKVj1b0MwaogDCC15eEe9/ULRf6xmaw0m6VOfm/Rz4Y9OvR8cQd5o+ImuAeRYEorRJ59yK5w==}
+  /@react-stately/combobox/3.5.0_react@18.2.0:
+    resolution: {integrity: sha512-1klrkm1q1awoPUIXt0kKRrUu+rISLQkHRkStjLupXgGOnJUyYP0XWPYHCnRV+IR2K2RnWYiEY5kOi7TEp/F7Fw==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
     dependencies:
-      '@react-types/shared': 3.17.0_react@18.2.0
+      '@react-stately/collections': 3.7.0_react@18.2.0
+      '@react-stately/list': 3.8.0_react@18.2.0
+      '@react-stately/menu': 3.5.1_react@18.2.0
+      '@react-stately/select': 3.5.0_react@18.2.0
+      '@react-stately/utils': 3.6.0_react@18.2.0
+      '@react-types/combobox': 3.6.1_react@18.2.0
+      '@react-types/shared': 3.18.0_react@18.2.0
+      '@swc/helpers': 0.4.14
+      react: 18.2.0
+    dev: false
+
+  /@react-stately/data/3.9.1_react@18.2.0:
+    resolution: {integrity: sha512-UClgI8jQTF3hVR/WLa2ht7Gjd2x2PRnYycDmfY+mfbd+ONBD7rX/m3KWGgrR8AvO05qSpQoSlab8D+cfLXvgWA==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
+    dependencies:
+      '@react-types/shared': 3.18.0_react@18.2.0
       '@swc/helpers': 0.4.14
       react: 18.2.0
     dev: false
@@ -2000,12 +2155,27 @@ packages:
     peerDependencies:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
     dependencies:
-      '@internationalized/date': 3.1.0
+      '@internationalized/date': 3.2.0
       '@internationalized/string': 3.1.0
-      '@react-stately/overlays': 3.5.0_react@18.2.0
+      '@react-stately/overlays': 3.5.1_react@18.2.0
       '@react-stately/utils': 3.6.0_react@18.2.0
-      '@react-types/datepicker': 3.2.0_react@18.2.0
-      '@react-types/shared': 3.17.0_react@18.2.0
+      '@react-types/datepicker': 3.3.0_react@18.2.0
+      '@react-types/shared': 3.18.0_react@18.2.0
+      '@swc/helpers': 0.4.14
+      react: 18.2.0
+    dev: false
+
+  /@react-stately/datepicker/3.4.0_react@18.2.0:
+    resolution: {integrity: sha512-JiRQBQYDXOQDdJl5YUGob10aVYp2N/F5rSSkRt7MrBJhC87bkDW0ARfs83gnl398WOJ6d9rJp0f+CJa1mjtzUw==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
+    dependencies:
+      '@internationalized/date': 3.2.0
+      '@internationalized/string': 3.1.0
+      '@react-stately/overlays': 3.5.1_react@18.2.0
+      '@react-stately/utils': 3.6.0_react@18.2.0
+      '@react-types/datepicker': 3.3.0_react@18.2.0
+      '@react-types/shared': 3.18.0_react@18.2.0
       '@swc/helpers': 0.4.14
       react: 18.2.0
     dev: false
@@ -2015,8 +2185,19 @@ packages:
     peerDependencies:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
     dependencies:
-      '@react-stately/selection': 3.12.0_react@18.2.0
-      '@react-types/shared': 3.17.0_react@18.2.0
+      '@react-stately/selection': 3.13.0_react@18.2.0
+      '@react-types/shared': 3.18.0_react@18.2.0
+      '@swc/helpers': 0.4.14
+      react: 18.2.0
+    dev: false
+
+  /@react-stately/dnd/3.2.0_react@18.2.0:
+    resolution: {integrity: sha512-e+f5lBiBBHmgqwcKKPxJBpCSx08iuNacNUFQ5/yIWm/enpjwTQhCMyfOFCLM1DfSllM/19GlqV/GiDRM7xjEAQ==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
+    dependencies:
+      '@react-stately/selection': 3.13.0_react@18.2.0
+      '@react-types/shared': 3.18.0_react@18.2.0
       '@swc/helpers': 0.4.14
       react: 18.2.0
     dev: false
@@ -2026,9 +2207,22 @@ packages:
     peerDependencies:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
     dependencies:
-      '@react-stately/selection': 3.12.0_react@18.2.0
-      '@react-types/grid': 3.1.6_react@18.2.0
-      '@react-types/shared': 3.17.0_react@18.2.0
+      '@react-stately/selection': 3.13.0_react@18.2.0
+      '@react-types/grid': 3.1.7_react@18.2.0
+      '@react-types/shared': 3.18.0_react@18.2.0
+      '@swc/helpers': 0.4.14
+      react: 18.2.0
+    dev: false
+
+  /@react-stately/grid/3.6.0_react@18.2.0:
+    resolution: {integrity: sha512-Sq/ivfq9Kskghoe6rYh2PfhB9/jBGfoj8wUZ4bqHcalTrBjfUvkcWMSFosibYPNZFDkA7r00bbJPDJVf1VLhuw==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
+    dependencies:
+      '@react-stately/collections': 3.7.0_react@18.2.0
+      '@react-stately/selection': 3.13.0_react@18.2.0
+      '@react-types/grid': 3.1.7_react@18.2.0
+      '@react-types/shared': 3.18.0_react@18.2.0
       '@swc/helpers': 0.4.14
       react: 18.2.0
     dev: false
@@ -2038,50 +2232,50 @@ packages:
     peerDependencies:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
     dependencies:
-      '@react-stately/table': 3.8.0_react@18.2.0
+      '@react-stately/table': 3.9.0_react@18.2.0
       '@react-stately/virtualizer': 3.5.0_react@18.2.0
       '@react-types/grid': 3.1.6_react@18.2.0
-      '@react-types/shared': 3.17.0_react@18.2.0
+      '@react-types/shared': 3.18.0_react@18.2.0
       '@react-types/table': 3.5.0_react@18.2.0
       '@swc/helpers': 0.4.14
       react: 18.2.0
     dev: false
 
-  /@react-stately/list/3.7.0_react@18.2.0:
-    resolution: {integrity: sha512-/BxCqXFjX9P+OJWjIYmUWaOGJ2hlZHUdymVwZPkIWdO9K7069LWckdYFXRqLFMwIGLUcXVfw4jR0BIQqWlR4eA==}
+  /@react-stately/list/3.8.0_react@18.2.0:
+    resolution: {integrity: sha512-eJ1iUFnXPZi5MGW2h/RdNTrKtq4HLoAlFAQbC4eSPlET6VDeFsX9NkKhE/A111ia24DnWCqJB5zH20EvNbOxxA==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
     dependencies:
-      '@react-stately/collections': 3.6.0_react@18.2.0
-      '@react-stately/selection': 3.12.0_react@18.2.0
+      '@react-stately/collections': 3.7.0_react@18.2.0
+      '@react-stately/selection': 3.13.0_react@18.2.0
       '@react-stately/utils': 3.6.0_react@18.2.0
-      '@react-types/shared': 3.17.0_react@18.2.0
+      '@react-types/shared': 3.18.0_react@18.2.0
       '@swc/helpers': 0.4.14
       react: 18.2.0
     dev: false
 
-  /@react-stately/menu/3.5.0_react@18.2.0:
-    resolution: {integrity: sha512-JL6TcT+SbYdlxNLOS84SXp6njDNZuXfkt05o4rS51evmjM2+hlYaB9+yUMqrCb/J2nW7vVAg51TDAhLgmGTYKg==}
+  /@react-stately/menu/3.5.1_react@18.2.0:
+    resolution: {integrity: sha512-nnuZlDBFIc3gB34kofbKDStFg9r8rijY+7ez2VWQmss72I9D7+JTn7OXJxV0oQt2lBYmNfS5W6bC9uXk3Z4dLg==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
     dependencies:
-      '@react-stately/overlays': 3.5.0_react@18.2.0
+      '@react-stately/overlays': 3.5.1_react@18.2.0
       '@react-stately/utils': 3.6.0_react@18.2.0
-      '@react-types/menu': 3.8.0_react@18.2.0
-      '@react-types/shared': 3.17.0_react@18.2.0
+      '@react-types/menu': 3.9.0_react@18.2.0
+      '@react-types/shared': 3.18.0_react@18.2.0
       '@swc/helpers': 0.4.14
       react: 18.2.0
     dev: false
 
-  /@react-stately/numberfield/3.4.0_react@18.2.0:
-    resolution: {integrity: sha512-R+LjwRpspttiO0tZ8KikXu184D3HZJG37jVcp/yM1jyMURmQHWfjjR6PHuD66PSV5PtM2KQlBj6PGvDLg1UwlQ==}
+  /@react-stately/numberfield/3.4.1_react@18.2.0:
+    resolution: {integrity: sha512-fpIyk3Wf9HN/fY/T2y4q9mA/9z4no8QMY4tEIn/tkumjU6QGzxCSRO0qb3RFE8sU0etsVAZOkPi+97DeQVLExw==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
     dependencies:
       '@internationalized/number': 3.2.0
       '@react-stately/utils': 3.6.0_react@18.2.0
-      '@react-types/numberfield': 3.4.0_react@18.2.0
-      '@react-types/shared': 3.17.0_react@18.2.0
+      '@react-types/numberfield': 3.4.1_react@18.2.0
+      '@react-types/shared': 3.18.0_react@18.2.0
       '@swc/helpers': 0.4.14
       react: 18.2.0
     dev: false
@@ -2092,100 +2286,112 @@ packages:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
     dependencies:
       '@react-stately/utils': 3.6.0_react@18.2.0
-      '@react-types/overlays': 3.7.0_react@18.2.0
+      '@react-types/overlays': 3.7.1_react@18.2.0
       '@swc/helpers': 0.4.14
       react: 18.2.0
     dev: false
 
-  /@react-stately/radio/3.7.0_react@18.2.0:
-    resolution: {integrity: sha512-TKyR6RfX1qZRPAxVWIKMTt2s3J+IlxFZHykiEl85gHBmABSWW4JO4RjkgcmbaAGLAhu1pJU8ktJOyi+MyndpHA==}
+  /@react-stately/overlays/3.5.1_react@18.2.0:
+    resolution: {integrity: sha512-lDKqqpdaIQdJb8DS4+tT7p0TLyCeaUaFpEtWZNjyv1/nguoqYtSeRwnyPR4p/YM4AW7SJspNiTJSLQxkTMIa8w==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
     dependencies:
       '@react-stately/utils': 3.6.0_react@18.2.0
-      '@react-types/radio': 3.4.0_react@18.2.0
-      '@react-types/shared': 3.17.0_react@18.2.0
+      '@react-types/overlays': 3.7.1_react@18.2.0
       '@swc/helpers': 0.4.14
       react: 18.2.0
     dev: false
 
-  /@react-stately/searchfield/3.4.0_react@18.2.0:
-    resolution: {integrity: sha512-aaQLczPUIJwTGlllALT49RSvWY55oqmJWhLL7j3hnL1cNV0WmkmoSdAo7drDaux5vkgkurxuwMEZ8ymFYeZ+Nw==}
+  /@react-stately/radio/3.8.0_react@18.2.0:
+    resolution: {integrity: sha512-3xNocZ8jlS8JcQtlS+pGhGLmrTA/P6zWs7Xi3Cx/I6ialFVL7IE0W37Z0XTYrvpNhE9hmG4+j63ZqQDNj2nu6A==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
     dependencies:
       '@react-stately/utils': 3.6.0_react@18.2.0
-      '@react-types/searchfield': 3.4.0_react@18.2.0
-      '@react-types/shared': 3.17.0_react@18.2.0
+      '@react-types/radio': 3.4.1_react@18.2.0
+      '@react-types/shared': 3.18.0_react@18.2.0
       '@swc/helpers': 0.4.14
       react: 18.2.0
     dev: false
 
-  /@react-stately/select/3.4.0_react@18.2.0:
-    resolution: {integrity: sha512-thSqD3apMCSgZgKtqHKGVIQRyvG8l0supIuzJicBwq6xg+J8X5muPCZgchCSNmU6im/l81XXE8LGuHGgMilORA==}
+  /@react-stately/searchfield/3.4.1_react@18.2.0:
+    resolution: {integrity: sha512-iEMcT2hH15TSoONi6FyFa9mh+H/UyNneYFzaUgl7kEClfL38Dq/y0zF18N9T8PJ0GvXN2Yj9Fc0AvycNy3DQ8g==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
     dependencies:
-      '@react-stately/collections': 3.6.0_react@18.2.0
-      '@react-stately/list': 3.7.0_react@18.2.0
-      '@react-stately/menu': 3.5.0_react@18.2.0
-      '@react-stately/selection': 3.12.0_react@18.2.0
       '@react-stately/utils': 3.6.0_react@18.2.0
-      '@react-types/select': 3.7.0_react@18.2.0
-      '@react-types/shared': 3.17.0_react@18.2.0
+      '@react-types/searchfield': 3.4.1_react@18.2.0
+      '@react-types/shared': 3.18.0_react@18.2.0
       '@swc/helpers': 0.4.14
       react: 18.2.0
     dev: false
 
-  /@react-stately/selection/3.12.0_react@18.2.0:
-    resolution: {integrity: sha512-qgUaPwqtAl7YaZxxGdb55ZaVuMB1rG+Vr+9fgG8dPtDYCNaPeIlg7ndC4ylzDhCWIx8D5qZotcrqCA4+93TwdA==}
+  /@react-stately/select/3.5.0_react@18.2.0:
+    resolution: {integrity: sha512-65gCPkIcyhGBDlWKYQY+Xvx38r7dtZ/GMp09LFZqqZTYSe29EgY45Owv4+EQ2ZSoZxb3cEvG/sv+hLL0VSGjgQ==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
     dependencies:
-      '@react-stately/collections': 3.6.0_react@18.2.0
+      '@react-stately/collections': 3.7.0_react@18.2.0
+      '@react-stately/list': 3.8.0_react@18.2.0
+      '@react-stately/menu': 3.5.1_react@18.2.0
+      '@react-stately/selection': 3.13.0_react@18.2.0
       '@react-stately/utils': 3.6.0_react@18.2.0
-      '@react-types/shared': 3.17.0_react@18.2.0
+      '@react-types/select': 3.8.0_react@18.2.0
+      '@react-types/shared': 3.18.0_react@18.2.0
       '@swc/helpers': 0.4.14
       react: 18.2.0
     dev: false
 
-  /@react-stately/slider/3.3.0_react@18.2.0:
-    resolution: {integrity: sha512-17aGJYHBRY3g4ZeiIgCNOvYl3HBARvSJhUKoNxZMRa2pqREW+WmBRRAXv5KTymW/KfcGb0RCq1ytYsderEgZAQ==}
+  /@react-stately/selection/3.13.0_react@18.2.0:
+    resolution: {integrity: sha512-F6FiB5GIS6wdmDDJtD2ofr+y6ysLHcvHVyUZHm00aEup2hcNjtNx3x4MlFIc3tO1LvxDSIIWXJhPXdB4sb32uw==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
     dependencies:
-      '@react-aria/i18n': 3.7.0_react@18.2.0
-      '@react-aria/utils': 3.15.0_react@18.2.0
+      '@react-stately/collections': 3.7.0_react@18.2.0
       '@react-stately/utils': 3.6.0_react@18.2.0
-      '@react-types/shared': 3.17.0_react@18.2.0
-      '@react-types/slider': 3.4.0_react@18.2.0
+      '@react-types/shared': 3.18.0_react@18.2.0
       '@swc/helpers': 0.4.14
       react: 18.2.0
     dev: false
 
-  /@react-stately/table/3.8.0_react@18.2.0:
-    resolution: {integrity: sha512-WmOcW9+4zm6MQZxYEC77u5HMxTcvcotkFptohHd0YtHXx+z5iwClCVKKFG2mc5lE+K4iQE41Q56nVKLjAu+TsA==}
+  /@react-stately/slider/3.3.1_react@18.2.0:
+    resolution: {integrity: sha512-d38VY/jAvDzohYvqsdwsegcRCmzO1Ed4N3cdSGqYNTkr/nLTye/NZGpzt8kGbPUsc4UzOH7GoycqG6x6hFlyuw==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
     dependencies:
-      '@react-stately/collections': 3.6.0_react@18.2.0
-      '@react-stately/grid': 3.5.0_react@18.2.0
-      '@react-stately/selection': 3.12.0_react@18.2.0
-      '@react-types/grid': 3.1.6_react@18.2.0
-      '@react-types/shared': 3.17.0_react@18.2.0
-      '@react-types/table': 3.5.0_react@18.2.0
-      '@swc/helpers': 0.4.14
-      react: 18.2.0
-    dev: false
-
-  /@react-stately/tabs/3.3.0_react@18.2.0:
-    resolution: {integrity: sha512-Kf47+aXGf4NvnREMDqH+uuTa0QsYCxOp0poywR8lRPmYsL7V8yrTS2wXQnDL7cq8PXbL5v+ew0xmrV+BiUlNRg==}
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
-    dependencies:
-      '@react-stately/list': 3.7.0_react@18.2.0
+      '@react-aria/i18n': 3.7.1_react@18.2.0
+      '@react-aria/utils': 3.16.0_react@18.2.0
       '@react-stately/utils': 3.6.0_react@18.2.0
-      '@react-types/tabs': 3.2.0_react@18.2.0
+      '@react-types/shared': 3.18.0_react@18.2.0
+      '@react-types/slider': 3.5.0_react@18.2.0
+      '@swc/helpers': 0.4.14
+      react: 18.2.0
+    dev: false
+
+  /@react-stately/table/3.9.0_react@18.2.0:
+    resolution: {integrity: sha512-Cl0jmC5eCEhWBAhCjhGklsgYluziNZHF34lHnc99T/DPP+OxwrgwS9rJKTW7L6UOvHU/ADKjEwkE/fZuqVBohg==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
+    dependencies:
+      '@react-stately/collections': 3.7.0_react@18.2.0
+      '@react-stately/grid': 3.6.0_react@18.2.0
+      '@react-stately/selection': 3.13.0_react@18.2.0
+      '@react-types/grid': 3.1.7_react@18.2.0
+      '@react-types/shared': 3.18.0_react@18.2.0
+      '@react-types/table': 3.6.0_react@18.2.0
+      '@swc/helpers': 0.4.14
+      react: 18.2.0
+    dev: false
+
+  /@react-stately/tabs/3.4.0_react@18.2.0:
+    resolution: {integrity: sha512-GeU0cykAEsyTf2tWC7JZqqLrgxPT1WriCmu9QAswJ7Dev1PkPvwDy3CEhJ3QDklTlhiLXLZOooyHh37lZTjRdg==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
+    dependencies:
+      '@react-stately/list': 3.8.0_react@18.2.0
+      '@react-stately/utils': 3.6.0_react@18.2.0
+      '@react-types/shared': 3.18.0_react@18.2.0
+      '@react-types/tabs': 3.2.1_react@18.2.0
       '@swc/helpers': 0.4.14
       react: 18.2.0
     dev: false
@@ -2196,33 +2402,45 @@ packages:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
     dependencies:
       '@react-stately/utils': 3.6.0_react@18.2.0
-      '@react-types/checkbox': 3.4.2_react@18.2.0
-      '@react-types/shared': 3.17.0_react@18.2.0
+      '@react-types/checkbox': 3.4.3_react@18.2.0
+      '@react-types/shared': 3.18.0_react@18.2.0
       '@swc/helpers': 0.4.14
       react: 18.2.0
     dev: false
 
-  /@react-stately/tooltip/3.3.0_react@18.2.0:
-    resolution: {integrity: sha512-cYg4zKUc0y71L5OO5DyaCoh248A7wvXAU6VGMhppPGx+iPoWJMLBBdEJjf8Oa12NGxNv9SC5lTcv6js2k4+WwQ==}
+  /@react-stately/toggle/3.5.1_react@18.2.0:
+    resolution: {integrity: sha512-PF4ZaATpXWu7DkneGSZ2/PA6LJ1MrhKNiaENTZlbojXMRr5kK33wPzaDW7I8O25IUm0+rvQicv7A6QkEOxgOPg==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
     dependencies:
-      '@react-stately/overlays': 3.5.0_react@18.2.0
       '@react-stately/utils': 3.6.0_react@18.2.0
-      '@react-types/tooltip': 3.3.0_react@18.2.0
+      '@react-types/checkbox': 3.4.3_react@18.2.0
+      '@react-types/shared': 3.18.0_react@18.2.0
       '@swc/helpers': 0.4.14
       react: 18.2.0
     dev: false
 
-  /@react-stately/tree/3.5.0_react@18.2.0:
-    resolution: {integrity: sha512-5+MzMQUFq3+lbGkZC0SlcIDrYmPvxBKuC8xL5W6SuFekbrrxrS6IJexRe4QulaaAliDpX2/9DVZTt38eVfyf0A==}
+  /@react-stately/tooltip/3.4.0_react@18.2.0:
+    resolution: {integrity: sha512-TQyDIcugRah4eGmbK6UsyrtJrKJKte+xKv8X7kgdiGVMWiENiMG5h+3pGa8OT07FJzg7FvQHkMH+hrIuAqXT2g==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
     dependencies:
-      '@react-stately/collections': 3.6.0_react@18.2.0
-      '@react-stately/selection': 3.12.0_react@18.2.0
+      '@react-stately/overlays': 3.5.1_react@18.2.0
       '@react-stately/utils': 3.6.0_react@18.2.0
-      '@react-types/shared': 3.17.0_react@18.2.0
+      '@react-types/tooltip': 3.4.0_react@18.2.0
+      '@swc/helpers': 0.4.14
+      react: 18.2.0
+    dev: false
+
+  /@react-stately/tree/3.6.0_react@18.2.0:
+    resolution: {integrity: sha512-9ekYGaebgMmd2p6PGRzsvr8KsDsDnrJF2uLV1GMq9hBaMxOLN5/dpxgfZGdHWoF3MXgeHeLloqrleMNfO6g64Q==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
+    dependencies:
+      '@react-stately/collections': 3.7.0_react@18.2.0
+      '@react-stately/selection': 3.13.0_react@18.2.0
+      '@react-stately/utils': 3.6.0_react@18.2.0
+      '@react-types/shared': 3.18.0_react@18.2.0
       '@swc/helpers': 0.4.14
       react: 18.2.0
     dev: false
@@ -2241,8 +2459,8 @@ packages:
     peerDependencies:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
     dependencies:
-      '@react-aria/utils': 3.15.0_react@18.2.0
-      '@react-types/shared': 3.17.0_react@18.2.0
+      '@react-aria/utils': 3.16.0_react@18.2.0
+      '@react-types/shared': 3.18.0_react@18.2.0
       '@swc/helpers': 0.4.14
       react: 18.2.0
     dev: false
@@ -2253,7 +2471,7 @@ packages:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
     dependencies:
       '@react-types/link': 3.4.0_react@18.2.0
-      '@react-types/shared': 3.17.0_react@18.2.0
+      '@react-types/shared': 3.18.0_react@18.2.0
       react: 18.2.0
     dev: false
 
@@ -2262,7 +2480,7 @@ packages:
     peerDependencies:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
     dependencies:
-      '@react-types/shared': 3.17.0_react@18.2.0
+      '@react-types/shared': 3.18.0_react@18.2.0
       react: 18.2.0
     dev: false
 
@@ -2271,8 +2489,18 @@ packages:
     peerDependencies:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
     dependencies:
-      '@internationalized/date': 3.1.0
-      '@react-types/shared': 3.17.0_react@18.2.0
+      '@internationalized/date': 3.2.0
+      '@react-types/shared': 3.18.0_react@18.2.0
+      react: 18.2.0
+    dev: false
+
+  /@react-types/calendar/3.2.0_react@18.2.0:
+    resolution: {integrity: sha512-MunGx/lQgf/Lf9v2MrWoqKTZhJJcyAhUno2MewytdMQNXwtY2FB1X4fUufMMrKHwhVnFVkGfEQJCh4FAm5P9JA==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
+    dependencies:
+      '@internationalized/date': 3.2.0
+      '@react-types/shared': 3.18.0_react@18.2.0
       react: 18.2.0
     dev: false
 
@@ -2281,7 +2509,16 @@ packages:
     peerDependencies:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
     dependencies:
-      '@react-types/shared': 3.17.0_react@18.2.0
+      '@react-types/shared': 3.18.0_react@18.2.0
+      react: 18.2.0
+    dev: false
+
+  /@react-types/checkbox/3.4.3_react@18.2.0:
+    resolution: {integrity: sha512-kn2f8mK88yvRrCfh8jYCDL2xpPhSApFWk9+qjWGsX/bnGGob7D5n71YYQ4cS58117YK2nrLc/AyQJXcZnJiA7Q==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
+    dependencies:
+      '@react-types/shared': 3.18.0_react@18.2.0
       react: 18.2.0
     dev: false
 
@@ -2290,7 +2527,16 @@ packages:
     peerDependencies:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
     dependencies:
-      '@react-types/shared': 3.17.0_react@18.2.0
+      '@react-types/shared': 3.18.0_react@18.2.0
+      react: 18.2.0
+    dev: false
+
+  /@react-types/combobox/3.6.1_react@18.2.0:
+    resolution: {integrity: sha512-CydRYMc80d4Wi6HeXUhmVPrVUnvQm60WJUaX2hM71tkKFo9ZOM6oW02YuOicjkNr7gpM7PLUxvM4Poc9EvDQTw==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
+    dependencies:
+      '@react-types/shared': 3.18.0_react@18.2.0
       react: 18.2.0
     dev: false
 
@@ -2299,9 +2545,20 @@ packages:
     peerDependencies:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
     dependencies:
-      '@internationalized/date': 3.1.0
-      '@react-types/overlays': 3.7.0_react@18.2.0
-      '@react-types/shared': 3.17.0_react@18.2.0
+      '@internationalized/date': 3.2.0
+      '@react-types/overlays': 3.7.1_react@18.2.0
+      '@react-types/shared': 3.18.0_react@18.2.0
+      react: 18.2.0
+    dev: false
+
+  /@react-types/datepicker/3.3.0_react@18.2.0:
+    resolution: {integrity: sha512-dKhkpG3UhdwYqdpVjg5dCQgMefpr7sa4a6Ep6fvbyD/q7gv9+h0/1J5F3FJynW+CBL6uYhcZjNev2vjYVTDbEg==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
+    dependencies:
+      '@internationalized/date': 3.2.0
+      '@react-types/overlays': 3.7.1_react@18.2.0
+      '@react-types/shared': 3.18.0_react@18.2.0
       react: 18.2.0
     dev: false
 
@@ -2310,8 +2567,8 @@ packages:
     peerDependencies:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
     dependencies:
-      '@react-types/overlays': 3.7.0_react@18.2.0
-      '@react-types/shared': 3.17.0_react@18.2.0
+      '@react-types/overlays': 3.7.1_react@18.2.0
+      '@react-types/shared': 3.18.0_react@18.2.0
       react: 18.2.0
     dev: false
 
@@ -2320,7 +2577,16 @@ packages:
     peerDependencies:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
     dependencies:
-      '@react-types/shared': 3.17.0_react@18.2.0
+      '@react-types/shared': 3.18.0_react@18.2.0
+      react: 18.2.0
+    dev: false
+
+  /@react-types/grid/3.1.7_react@18.2.0:
+    resolution: {integrity: sha512-YKo/AbJrgWErPmr5y0K4o6Ts9ModFv5+2FVujecIydu3zLuHsVcx//6uVeHSy2W+uTV9vU/dpMP+GGgg+vWQhw==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
+    dependencies:
+      '@react-types/shared': 3.18.0_react@18.2.0
       react: 18.2.0
     dev: false
 
@@ -2329,7 +2595,7 @@ packages:
     peerDependencies:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
     dependencies:
-      '@react-types/shared': 3.17.0_react@18.2.0
+      '@react-types/shared': 3.18.0_react@18.2.0
       react: 18.2.0
     dev: false
 
@@ -2339,7 +2605,7 @@ packages:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
     dependencies:
       '@react-aria/interactions': 3.14.0_react@18.2.0
-      '@react-types/shared': 3.17.0_react@18.2.0
+      '@react-types/shared': 3.18.0_react@18.2.0
       react: 18.2.0
     dev: false
 
@@ -2348,7 +2614,7 @@ packages:
     peerDependencies:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
     dependencies:
-      '@react-types/shared': 3.17.0_react@18.2.0
+      '@react-types/shared': 3.18.0_react@18.2.0
       react: 18.2.0
     dev: false
 
@@ -2357,8 +2623,18 @@ packages:
     peerDependencies:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
     dependencies:
-      '@react-types/overlays': 3.7.0_react@18.2.0
-      '@react-types/shared': 3.17.0_react@18.2.0
+      '@react-types/overlays': 3.7.1_react@18.2.0
+      '@react-types/shared': 3.18.0_react@18.2.0
+      react: 18.2.0
+    dev: false
+
+  /@react-types/menu/3.9.0_react@18.2.0:
+    resolution: {integrity: sha512-aalUYwOkzcHn8X59vllgtH96YLqZvAr4mTj5GEs8chv5JVlmArUzcDiOymNrYZ0p9JzshzSUqxxXyCFpnnxghw==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
+    dependencies:
+      '@react-types/overlays': 3.7.1_react@18.2.0
+      '@react-types/shared': 3.18.0_react@18.2.0
       react: 18.2.0
     dev: false
 
@@ -2368,7 +2644,7 @@ packages:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
     dependencies:
       '@react-types/progress': 3.3.0_react@18.2.0
-      '@react-types/shared': 3.17.0_react@18.2.0
+      '@react-types/shared': 3.18.0_react@18.2.0
       react: 18.2.0
     dev: false
 
@@ -2377,7 +2653,16 @@ packages:
     peerDependencies:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
     dependencies:
-      '@react-types/shared': 3.17.0_react@18.2.0
+      '@react-types/shared': 3.18.0_react@18.2.0
+      react: 18.2.0
+    dev: false
+
+  /@react-types/numberfield/3.4.1_react@18.2.0:
+    resolution: {integrity: sha512-iS+s2BgOWUxYnMt+LG1OxlKZWeggKMBs55/NzVF5I2MCe1ju8ZUgM27g9A/gvUTdjt+fqx6VZu0MCipw0rVkIQ==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
+    dependencies:
+      '@react-types/shared': 3.18.0_react@18.2.0
       react: 18.2.0
     dev: false
 
@@ -2386,7 +2671,16 @@ packages:
     peerDependencies:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
     dependencies:
-      '@react-types/shared': 3.17.0_react@18.2.0
+      '@react-types/shared': 3.18.0_react@18.2.0
+      react: 18.2.0
+    dev: false
+
+  /@react-types/overlays/3.7.1_react@18.2.0:
+    resolution: {integrity: sha512-2AwYQkelr4p1uXR1KJIGQEbubOumzM853Hsyup2y/TaMbjvBWOVyzYWSrQURex667JZmpwUb0qjkEH+4z3Q74g==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
+    dependencies:
+      '@react-types/shared': 3.18.0_react@18.2.0
       react: 18.2.0
     dev: false
 
@@ -2395,7 +2689,7 @@ packages:
     peerDependencies:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
     dependencies:
-      '@react-types/shared': 3.17.0_react@18.2.0
+      '@react-types/shared': 3.18.0_react@18.2.0
       react: 18.2.0
     dev: false
 
@@ -2404,7 +2698,16 @@ packages:
     peerDependencies:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
     dependencies:
-      '@react-types/shared': 3.17.0_react@18.2.0
+      '@react-types/shared': 3.18.0_react@18.2.0
+      react: 18.2.0
+    dev: false
+
+  /@react-types/radio/3.4.1_react@18.2.0:
+    resolution: {integrity: sha512-8r7s+Zj0JoIpYgbuHjhE/eWUHKiptaFvYXMH986yKAg969VQlQiP9Dm4oWv2d+p26WbGK7oJDQJCt8NjASWl8g==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
+    dependencies:
+      '@react-types/shared': 3.18.0_react@18.2.0
       react: 18.2.0
     dev: false
 
@@ -2413,8 +2716,18 @@ packages:
     peerDependencies:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
     dependencies:
-      '@react-types/shared': 3.17.0_react@18.2.0
+      '@react-types/shared': 3.18.0_react@18.2.0
       '@react-types/textfield': 3.7.0_react@18.2.0
+      react: 18.2.0
+    dev: false
+
+  /@react-types/searchfield/3.4.1_react@18.2.0:
+    resolution: {integrity: sha512-JmIwylx88IYrntfw7vAWCL1Ip5okJIRtC8Ne6mr2IjT4oGA9BRF5LpoPdEZlXfVPwLt7jlwGLUwKphbkds+yUA==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
+    dependencies:
+      '@react-types/shared': 3.18.0_react@18.2.0
+      '@react-types/textfield': 3.7.1_react@18.2.0
       react: 18.2.0
     dev: false
 
@@ -2423,7 +2736,16 @@ packages:
     peerDependencies:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
     dependencies:
-      '@react-types/shared': 3.17.0_react@18.2.0
+      '@react-types/shared': 3.18.0_react@18.2.0
+      react: 18.2.0
+    dev: false
+
+  /@react-types/select/3.8.0_react@18.2.0:
+    resolution: {integrity: sha512-hdaB3CzK8GSip9oGahfnlwolRqdNow85CQwf5P0oEtIDdijihrG6hyphPu5HYGK687EF+lfhnWUYUMwckEwB8Q==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
+    dependencies:
+      '@react-types/shared': 3.18.0_react@18.2.0
       react: 18.2.0
     dev: false
 
@@ -2435,12 +2757,29 @@ packages:
       react: 18.2.0
     dev: false
 
+  /@react-types/shared/3.18.0_react@18.2.0:
+    resolution: {integrity: sha512-WJj7RAPj7NLdR/VzFObgvCju9NMDktWSruSPJ3DrL5qyrrvJoyMW67L4YjNoVp2b7Y+k10E0q4fSMV0PlJoL0w==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
+    dependencies:
+      react: 18.2.0
+    dev: false
+
   /@react-types/slider/3.4.0_react@18.2.0:
     resolution: {integrity: sha512-Kj+B6njpm4ltiu3gCBOPRnbzllV21IVr0bCQdNnWcf5DX8aN4VdI8EFkTz0DSwMm2WPCwZop0MDWDoRwXJK1ng==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
     dependencies:
-      '@react-types/shared': 3.17.0_react@18.2.0
+      '@react-types/shared': 3.18.0_react@18.2.0
+      react: 18.2.0
+    dev: false
+
+  /@react-types/slider/3.5.0_react@18.2.0:
+    resolution: {integrity: sha512-ri0jGWt1x/+nWLLJmlRKaS0xyAjTE1UtsobEYotKkQjzG93WrsEZrb0tLmDnXyEfWi3NXyrReQcORveyv4EQ5g==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
+    dependencies:
+      '@react-types/shared': 3.18.0_react@18.2.0
       react: 18.2.0
     dev: false
 
@@ -2449,8 +2788,8 @@ packages:
     peerDependencies:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
     dependencies:
-      '@react-types/checkbox': 3.4.2_react@18.2.0
-      '@react-types/shared': 3.17.0_react@18.2.0
+      '@react-types/checkbox': 3.4.3_react@18.2.0
+      '@react-types/shared': 3.18.0_react@18.2.0
       react: 18.2.0
     dev: false
 
@@ -2459,8 +2798,18 @@ packages:
     peerDependencies:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
     dependencies:
-      '@react-types/grid': 3.1.6_react@18.2.0
-      '@react-types/shared': 3.17.0_react@18.2.0
+      '@react-types/grid': 3.1.7_react@18.2.0
+      '@react-types/shared': 3.18.0_react@18.2.0
+      react: 18.2.0
+    dev: false
+
+  /@react-types/table/3.6.0_react@18.2.0:
+    resolution: {integrity: sha512-jUp8yTWJuJlqpJY+EIEppgjFsZ3oj4y9zg1oUO+l1rqRWEqmAdoq42g3dTZHmnz9hQJkUeo34I1HGaB9kxNqvg==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
+    dependencies:
+      '@react-types/grid': 3.1.7_react@18.2.0
+      '@react-types/shared': 3.18.0_react@18.2.0
       react: 18.2.0
     dev: false
 
@@ -2469,7 +2818,16 @@ packages:
     peerDependencies:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
     dependencies:
-      '@react-types/shared': 3.17.0_react@18.2.0
+      '@react-types/shared': 3.18.0_react@18.2.0
+      react: 18.2.0
+    dev: false
+
+  /@react-types/tabs/3.2.1_react@18.2.0:
+    resolution: {integrity: sha512-KgvhrYvISQUq540iuNc3bRvOCfLvaeqpB5VwDYR8amG1FVWHklCW8xx8Uz63SVkOvNtExYCrlw63M/OnjRUzOw==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
+    dependencies:
+      '@react-types/shared': 3.18.0_react@18.2.0
       react: 18.2.0
     dev: false
 
@@ -2478,7 +2836,16 @@ packages:
     peerDependencies:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
     dependencies:
-      '@react-types/shared': 3.17.0_react@18.2.0
+      '@react-types/shared': 3.18.0_react@18.2.0
+      react: 18.2.0
+    dev: false
+
+  /@react-types/textfield/3.7.1_react@18.2.0:
+    resolution: {integrity: sha512-6V5+6/VgDbmgN61pyVct1VrXb2hqq7Y43BFQ+/ZhFDlVaMpC5xKWKgW/gPbGLLc27gax8t2Brt7VHJj+d+yrUw==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
+    dependencies:
+      '@react-types/shared': 3.18.0_react@18.2.0
       react: 18.2.0
     dev: false
 
@@ -2487,8 +2854,18 @@ packages:
     peerDependencies:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
     dependencies:
-      '@react-types/overlays': 3.7.0_react@18.2.0
-      '@react-types/shared': 3.17.0_react@18.2.0
+      '@react-types/overlays': 3.7.1_react@18.2.0
+      '@react-types/shared': 3.18.0_react@18.2.0
+      react: 18.2.0
+    dev: false
+
+  /@react-types/tooltip/3.4.0_react@18.2.0:
+    resolution: {integrity: sha512-dvMwX377uJAMTuditfvwWed53YjV62XWMqW29Fave4xg3A807VVK3H1iEgwCIGA9ve2XHF8cJbqSHD635qU+tQ==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
+    dependencies:
+      '@react-types/overlays': 3.7.1_react@18.2.0
+      '@react-types/shared': 3.18.0_react@18.2.0
       react: 18.2.0
     dev: false
 
@@ -2694,6 +3071,48 @@ packages:
   /@types/cookie/0.4.1:
     resolution: {integrity: sha512-XW/Aa8APYr6jSVVA1y/DEIZX0/GMKLEVekNG727R8cs56ahETkRAy/3DR7+fJyh7oUgGwNQaRfXCun0+KbWY7Q==}
     dev: true
+
+  /@types/d3-array/3.0.4:
+    resolution: {integrity: sha512-nwvEkG9vYOc0Ic7G7kwgviY4AQlTfYGIZ0fqB7CQHXGyYM6nO7kJh5EguSNA3jfh4rq7Sb7eMVq8isuvg2/miQ==}
+    dev: false
+
+  /@types/d3-color/3.1.0:
+    resolution: {integrity: sha512-HKuicPHJuvPgCD+np6Se9MQvS6OCbJmOjGvylzMJRlDwUXjKTTXs6Pwgk79O09Vj/ho3u1ofXnhFOaEWWPrlwA==}
+    dev: false
+
+  /@types/d3-ease/3.0.0:
+    resolution: {integrity: sha512-aMo4eaAOijJjA6uU+GIeW018dvy9+oH5Y2VPPzjjfxevvGQ/oRDs+tfYC9b50Q4BygRR8yE2QCLsrT0WtAVseA==}
+    dev: false
+
+  /@types/d3-interpolate/3.0.1:
+    resolution: {integrity: sha512-jx5leotSeac3jr0RePOH1KdR9rISG91QIE4Q2PYTu4OymLTZfA3SrnURSLzKH48HmXVUru50b8nje4E79oQSQw==}
+    dependencies:
+      '@types/d3-color': 3.1.0
+    dev: false
+
+  /@types/d3-path/3.0.0:
+    resolution: {integrity: sha512-0g/A+mZXgFkQxN3HniRDbXMN79K3CdTpLsevj+PXiTcb2hVyvkZUBg37StmgCQkaD84cUJ4uaDAWq7UJOQy2Tg==}
+    dev: false
+
+  /@types/d3-scale/4.0.3:
+    resolution: {integrity: sha512-PATBiMCpvHJSMtZAMEhc2WyL+hnzarKzI6wAHYjhsonjWJYGq5BXTzQjv4l8m2jO183/4wZ90rKvSeT7o72xNQ==}
+    dependencies:
+      '@types/d3-time': 3.0.0
+    dev: false
+
+  /@types/d3-shape/3.1.1:
+    resolution: {integrity: sha512-6Uh86YFF7LGg4PQkuO2oG6EMBRLuW9cbavUW46zkIO5kuS2PfTqo2o9SkgtQzguBHbLgNnU90UNsITpsX1My+A==}
+    dependencies:
+      '@types/d3-path': 3.0.0
+    dev: false
+
+  /@types/d3-time/3.0.0:
+    resolution: {integrity: sha512-sZLCdHvBUcNby1cB6Fd3ZBrABbjz3v1Vm90nysCQ6Vt7vd6e/h9Lt7SiJUoEX0l4Dzc7P5llKyhqSi1ycSf1Hg==}
+    dev: false
+
+  /@types/d3-timer/3.0.0:
+    resolution: {integrity: sha512-HNB/9GHqu7Fo8AQiugyJbv6ZxYz58wef0esl4Mv828w1ZKpAshw/uFWVDUcIB9KKFeFKoxS3cHY07FFgtTRZ1g==}
+    dev: false
 
   /@types/debug/4.1.7:
     resolution: {integrity: sha512-9AonUzyTjXXhEOa0DnqpzZi6VHlqKMswga9EXjpXnnqxwLtdvPPtlO8evrI5D9S6asFRCQ6v+wpiUKbw+vKqyg==}
@@ -3553,6 +3972,10 @@ packages:
       which: 2.0.2
     dev: true
 
+  /css-unit-converter/1.1.2:
+    resolution: {integrity: sha512-IiJwMC8rdZE0+xiEZHeru6YoONC4rfPMqGm2W85jMIbkFvv5nFTwJVFHam2eFrN6txmoUYFAFXiv8ICVeTO0MA==}
+    dev: false
+
   /css.escape/1.5.1:
     resolution: {integrity: sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==}
     dev: true
@@ -3575,6 +3998,77 @@ packages:
   /csstype/3.1.1:
     resolution: {integrity: sha512-DJR/VvkAvSZW9bTouZue2sSxDwdTN92uHjqeKVm+0dAqdfNykRzQ95tay8aXMBAAPpUiq4Qcug2L7neoRh2Egw==}
     dev: true
+
+  /d3-array/3.2.3:
+    resolution: {integrity: sha512-JRHwbQQ84XuAESWhvIPaUV4/1UYTBOLiOPGWqgFDHZS1D5QN9c57FbH3QpEnQMYiOXNzKUQyGTZf+EVO7RT5TQ==}
+    engines: {node: '>=12'}
+    dependencies:
+      internmap: 2.0.3
+    dev: false
+
+  /d3-color/3.1.0:
+    resolution: {integrity: sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==}
+    engines: {node: '>=12'}
+    dev: false
+
+  /d3-ease/3.0.1:
+    resolution: {integrity: sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==}
+    engines: {node: '>=12'}
+    dev: false
+
+  /d3-format/3.1.0:
+    resolution: {integrity: sha512-YyUI6AEuY/Wpt8KWLgZHsIU86atmikuoOmCfommt0LYHiQSPjvX2AcFc38PX0CBpr2RCyZhjex+NS/LPOv6YqA==}
+    engines: {node: '>=12'}
+    dev: false
+
+  /d3-interpolate/3.0.1:
+    resolution: {integrity: sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==}
+    engines: {node: '>=12'}
+    dependencies:
+      d3-color: 3.1.0
+    dev: false
+
+  /d3-path/3.1.0:
+    resolution: {integrity: sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==}
+    engines: {node: '>=12'}
+    dev: false
+
+  /d3-scale/4.0.2:
+    resolution: {integrity: sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==}
+    engines: {node: '>=12'}
+    dependencies:
+      d3-array: 3.2.3
+      d3-format: 3.1.0
+      d3-interpolate: 3.0.1
+      d3-time: 3.1.0
+      d3-time-format: 4.1.0
+    dev: false
+
+  /d3-shape/3.2.0:
+    resolution: {integrity: sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==}
+    engines: {node: '>=12'}
+    dependencies:
+      d3-path: 3.1.0
+    dev: false
+
+  /d3-time-format/4.1.0:
+    resolution: {integrity: sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==}
+    engines: {node: '>=12'}
+    dependencies:
+      d3-time: 3.1.0
+    dev: false
+
+  /d3-time/3.1.0:
+    resolution: {integrity: sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==}
+    engines: {node: '>=12'}
+    dependencies:
+      d3-array: 3.2.3
+    dev: false
+
+  /d3-timer/3.0.1:
+    resolution: {integrity: sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==}
+    engines: {node: '>=12'}
+    dev: false
 
   /data-urls/3.0.2:
     resolution: {integrity: sha512-Jy/tj3ldjZJo63sVAvg6LHt2mHvl4V6AgRAmNDtLdm7faqtsx+aJG42rsyCo9JCoRVKwPFzKlIPx3DIibwSIaQ==}
@@ -3607,6 +4101,10 @@ packages:
     dependencies:
       ms: 2.1.2
     dev: true
+
+  /decimal.js-light/2.5.1:
+    resolution: {integrity: sha512-qIMFpTMZmny+MMIitAB6D7iVPEorVw6YQRWkvarTkT4tBeSLLiHzcwj6q0MmYSFCiVpiqPJTJEYIrpcPzVEIvg==}
+    dev: false
 
   /decimal.js/10.4.2:
     resolution: {integrity: sha512-ic1yEvwT6GuvaYwBLLY6/aFFgjZdySKTE8en/fkU3QICTmRtgtSlFn0u0BXN06InZwtfCelR7j8LRiDI/02iGA==}
@@ -3689,6 +4187,12 @@ packages:
     resolution: {integrity: sha512-NMt+m9zFMPZe0JcY9gN224Qvk6qLIdqex29clBvc/y75ZBX9YA9wNK3frsYvu2DI1xcCIwxwnX+TlsJ2DSOADg==}
     dev: true
 
+  /dom-helpers/3.4.0:
+    resolution: {integrity: sha512-LnuPJ+dwqKDIyotW1VzmOZ5TONUN7CwkCR5hrgawTUbkBGYdeoNLZo6nNfGkCrjtE1nXXaj7iMMpDa8/d9WoIA==}
+    dependencies:
+      '@babel/runtime': 7.19.4
+    dev: false
+
   /domexception/4.0.0:
     resolution: {integrity: sha512-A2is4PLG+eeSfoTMA95/s4pvAoSo2mKtiM5jlHkAVewmiO8ISFTFKZjH7UAM1Atli/OT/7JHOrJRJiMKUZKYBw==}
     engines: {node: '>=12'}
@@ -3706,7 +4210,7 @@ packages:
       prop-types: 15.8.1
       react: 18.2.0
       react-is: 17.0.2
-      tslib: 2.4.0
+      tslib: 2.5.0
     dev: false
 
   /eastasianwidth/0.2.0:
@@ -4140,6 +4644,10 @@ packages:
     engines: {node: '>=0.10.0'}
     dev: true
 
+  /eventemitter3/4.0.7:
+    resolution: {integrity: sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==}
+    dev: false
+
   /events/3.3.0:
     resolution: {integrity: sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==}
     engines: {node: '>=0.8.x'}
@@ -4203,6 +4711,11 @@ packages:
   /fast-deep-equal/3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
     dev: true
+
+  /fast-equals/5.0.1:
+    resolution: {integrity: sha512-WF1Wi8PwwSY7/6Kx0vKXtw8RwuSGoM1bvDaJbu7MxDlR1vovZjIAKrnzyrThgAjm6JDTu0fVgWXDlMGspodfoQ==}
+    engines: {node: '>=6.0.0'}
+    dev: false
 
   /fast-glob/3.2.12:
     resolution: {integrity: sha512-DVj4CQIYYow0BlaelwK1pHl5n5cRSJfM60UA0zK891sVInoPri2Ekj7+e1CT3/3qxXenpI+nBBmQAcJPJgaj4w==}
@@ -4635,6 +5148,11 @@ packages:
       has: 1.0.3
       side-channel: 1.0.4
     dev: true
+
+  /internmap/2.0.3:
+    resolution: {integrity: sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==}
+    engines: {node: '>=12'}
+    dev: false
 
   /intl-messageformat/10.2.5:
     resolution: {integrity: sha512-AievYMN6WLLHwBeCTv4aRKG+w3ZNyZtkObwgsKk3Q7GNTq8zDRvDbJSBQkb2OPeVCcAKcIXvak9FF/bRNavoww==}
@@ -6022,6 +6540,10 @@ packages:
       find-up: 4.1.0
     dev: true
 
+  /postcss-value-parser/3.3.1:
+    resolution: {integrity: sha512-pISE66AbVkp4fDQ7VHBwRNXzAAKJjw4Vw7nWI/+Q3vuly7SNfgYXvm6i5IgFylHGK5sP/xHAbB7N49OS4gWNyQ==}
+    dev: false
+
   /postcss/8.4.23:
     resolution: {integrity: sha512-bQ3qMcpF6A/YjR55xtoTr0jGOlnPOKAIMdOWiv0EIT6HVPEaJiJB4NLljSbiHoC2RX7DN5Uvjtpbg1NPdwv1oA==}
     engines: {node: ^10 || ^12 || >=14}
@@ -6186,6 +6708,10 @@ packages:
     resolution: {integrity: sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w==}
     dev: true
 
+  /react-lifecycles-compat/3.0.4:
+    resolution: {integrity: sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA==}
+    dev: false
+
   /react-popper/2.3.0_r6q5zrenym2zg7je7hgi674bti:
     resolution: {integrity: sha512-e1hj8lL3uM+sgSR4Lxzn5h1GxBlpa4CQz0XLF8kx4MDrDRWY0Ena4c97PUeSX9i5W3UAfDP0z0FXCTQkoXUl3Q==}
     peerDependencies:
@@ -6204,6 +6730,17 @@ packages:
     resolution: {integrity: sha512-wViHqhAd8OHeLS/IRMJjTSDHF3U9eWi62F/MledQGPdJGDhodXJ9PBLNGr6WWL7qlH12Mt3TyTpbS+hGXMjCzQ==}
     engines: {node: '>=0.10.0'}
     dev: true
+
+  /react-resize-detector/8.1.0_biqbaboplfbrettd7655fr4n2y:
+    resolution: {integrity: sha512-S7szxlaIuiy5UqLhLL1KY3aoyGHbZzsTpYal9eYMwCyKqoqoVLCmIgAgNyIM1FhnP2KyBygASJxdhejrzjMb+w==}
+    peerDependencies:
+      react: ^16.0.0 || ^17.0.0 || ^18.0.0
+      react-dom: ^16.0.0 || ^17.0.0 || ^18.0.0
+    dependencies:
+      lodash: 4.17.21
+      react: 18.2.0
+      react-dom: 18.2.0_react@18.2.0
+    dev: false
 
   /react-router-dom/6.10.0_biqbaboplfbrettd7655fr4n2y:
     resolution: {integrity: sha512-E5dfxRPuXKJqzwSe/qGcqdwa18QiWC6f3H3cWXM24qj4N0/beCIf/CWTipop2xm7mR0RCS99NnaqPNjHtrAzCg==}
@@ -6238,33 +6775,46 @@ packages:
       react-is: 18.2.0
     dev: true
 
-  /react-stately/3.21.0_react@18.2.0:
-    resolution: {integrity: sha512-nnGkuRAoq9auj5SYRwxM6eVYvkS9WhxH9iKuzlqE1Gverp3JDFMFgKSaG/DFWG/m1TPlGvwYUwdVjyhINsFUqA==}
+  /react-smooth/2.0.3_biqbaboplfbrettd7655fr4n2y:
+    resolution: {integrity: sha512-yl4y3XiMorss7ayF5QnBiSprig0+qFHui8uh7Hgg46QX5O+aRMRKlfGGNGLHno35JkQSvSYY8eCWkBfHfrSHfg==}
+    peerDependencies:
+      prop-types: ^15.6.0
+      react: ^15.0.0 || ^16.0.0 || ^17.0.0 || ^18.0.0
+      react-dom: ^15.0.0 || ^16.0.0 || ^17.0.0 || ^18.0.0
+    dependencies:
+      fast-equals: 5.0.1
+      react: 18.2.0
+      react-dom: 18.2.0_react@18.2.0
+      react-transition-group: 2.9.0_biqbaboplfbrettd7655fr4n2y
+    dev: false
+
+  /react-stately/3.22.0_react@18.2.0:
+    resolution: {integrity: sha512-w5itlPtjfUpxy+195LxRbaCNaGN1NVfPHelhYXuoPoKNgUvmy54uKXvP1Ek1ETZ9e55BaXuMs83yXv94wIMdpQ==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
     dependencies:
-      '@react-stately/calendar': 3.1.0_react@18.2.0
-      '@react-stately/checkbox': 3.4.0_react@18.2.0
-      '@react-stately/collections': 3.6.0_react@18.2.0
-      '@react-stately/combobox': 3.4.0_react@18.2.0
-      '@react-stately/data': 3.9.0_react@18.2.0
-      '@react-stately/datepicker': 3.3.0_react@18.2.0
-      '@react-stately/dnd': 3.1.0_react@18.2.0
-      '@react-stately/list': 3.7.0_react@18.2.0
-      '@react-stately/menu': 3.5.0_react@18.2.0
-      '@react-stately/numberfield': 3.4.0_react@18.2.0
-      '@react-stately/overlays': 3.5.0_react@18.2.0
-      '@react-stately/radio': 3.7.0_react@18.2.0
-      '@react-stately/searchfield': 3.4.0_react@18.2.0
-      '@react-stately/select': 3.4.0_react@18.2.0
-      '@react-stately/selection': 3.12.0_react@18.2.0
-      '@react-stately/slider': 3.3.0_react@18.2.0
-      '@react-stately/table': 3.8.0_react@18.2.0
-      '@react-stately/tabs': 3.3.0_react@18.2.0
-      '@react-stately/toggle': 3.5.0_react@18.2.0
-      '@react-stately/tooltip': 3.3.0_react@18.2.0
-      '@react-stately/tree': 3.5.0_react@18.2.0
-      '@react-types/shared': 3.17.0_react@18.2.0
+      '@react-stately/calendar': 3.2.0_react@18.2.0
+      '@react-stately/checkbox': 3.4.1_react@18.2.0
+      '@react-stately/collections': 3.7.0_react@18.2.0
+      '@react-stately/combobox': 3.5.0_react@18.2.0
+      '@react-stately/data': 3.9.1_react@18.2.0
+      '@react-stately/datepicker': 3.4.0_react@18.2.0
+      '@react-stately/dnd': 3.2.0_react@18.2.0
+      '@react-stately/list': 3.8.0_react@18.2.0
+      '@react-stately/menu': 3.5.1_react@18.2.0
+      '@react-stately/numberfield': 3.4.1_react@18.2.0
+      '@react-stately/overlays': 3.5.1_react@18.2.0
+      '@react-stately/radio': 3.8.0_react@18.2.0
+      '@react-stately/searchfield': 3.4.1_react@18.2.0
+      '@react-stately/select': 3.5.0_react@18.2.0
+      '@react-stately/selection': 3.13.0_react@18.2.0
+      '@react-stately/slider': 3.3.1_react@18.2.0
+      '@react-stately/table': 3.9.0_react@18.2.0
+      '@react-stately/tabs': 3.4.0_react@18.2.0
+      '@react-stately/toggle': 3.5.1_react@18.2.0
+      '@react-stately/tooltip': 3.4.0_react@18.2.0
+      '@react-stately/tree': 3.6.0_react@18.2.0
+      '@react-types/shared': 3.18.0_react@18.2.0
       react: 18.2.0
     dev: false
 
@@ -6278,6 +6828,20 @@ packages:
       react-shallow-renderer: 16.15.0_react@18.2.0
       scheduler: 0.23.0
     dev: true
+
+  /react-transition-group/2.9.0_biqbaboplfbrettd7655fr4n2y:
+    resolution: {integrity: sha512-+HzNTCHpeQyl4MJ/bdE0u6XRMe9+XG/+aL4mCxVN4DnPBQ0/5bfHWPDuOZUzYdMj94daZaZdCCc1Dzt9R/xSSg==}
+    peerDependencies:
+      react: '>=15.0.0'
+      react-dom: '>=15.0.0'
+    dependencies:
+      dom-helpers: 3.4.0
+      loose-envify: 1.4.0
+      prop-types: 15.8.1
+      react: 18.2.0
+      react-dom: 18.2.0_react@18.2.0
+      react-lifecycles-compat: 3.0.4
+    dev: false
 
   /react/18.2.0:
     resolution: {integrity: sha512-/3IjMdb2L9QbBdWiW5e3P2/npwMBaU9mHCSCUzNln0ZCYbcfTsGbTJrU/kGemdH2IWmB2ioZ+zkxtmq6g09fGQ==}
@@ -6301,6 +6865,33 @@ packages:
       picomatch: 2.3.1
     dev: true
 
+  /recharts-scale/0.4.5:
+    resolution: {integrity: sha512-kivNFO+0OcUNu7jQquLXAxz1FIwZj8nrj+YkOKc5694NbjCvcT6aSZiIzNzd2Kul4o4rTto8QVR9lMNtxD4G1w==}
+    dependencies:
+      decimal.js-light: 2.5.1
+    dev: false
+
+  /recharts/2.6.2_biqbaboplfbrettd7655fr4n2y:
+    resolution: {integrity: sha512-dVhNfgI21LlF+4AesO3mj+i+9YdAAjoGaDWIctUgH/G2iy14YVtb/DSUeic77xr19rbKCiq+pQGfeg2kJQDHig==}
+    engines: {node: '>=12'}
+    peerDependencies:
+      prop-types: ^15.6.0
+      react: ^16.0.0 || ^17.0.0 || ^18.0.0
+      react-dom: ^16.0.0 || ^17.0.0 || ^18.0.0
+    dependencies:
+      classnames: 2.3.2
+      eventemitter3: 4.0.7
+      lodash: 4.17.21
+      react: 18.2.0
+      react-dom: 18.2.0_react@18.2.0
+      react-is: 16.13.1
+      react-resize-detector: 8.1.0_biqbaboplfbrettd7655fr4n2y
+      react-smooth: 2.0.3_biqbaboplfbrettd7655fr4n2y
+      recharts-scale: 0.4.5
+      reduce-css-calc: 2.1.8
+      victory-vendor: 36.6.10
+    dev: false
+
   /redent/3.0.0:
     resolution: {integrity: sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==}
     engines: {node: '>=8'}
@@ -6308,6 +6899,13 @@ packages:
       indent-string: 4.0.0
       strip-indent: 3.0.0
     dev: true
+
+  /reduce-css-calc/2.1.8:
+    resolution: {integrity: sha512-8liAVezDmUcH+tdzoEGrhfbGcP7nOV4NkGE3a74+qqvE7nt9i4sKLGBuZNOnpI4WiGksiNPklZxva80061QiPg==}
+    dependencies:
+      css-unit-converter: 1.1.2
+      postcss-value-parser: 3.3.1
+    dev: false
 
   /regenerator-runtime/0.13.10:
     resolution: {integrity: sha512-KepLsg4dU12hryUO7bp/axHAKvwGOCV0sGloQtpagJ12ai+ojVDqkeGSiRX1zlq+kjIMZ1t7gpze+26QqtdGqw==}
@@ -6906,10 +7504,6 @@ packages:
     resolution: {integrity: sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==}
     dev: true
 
-  /tslib/2.4.0:
-    resolution: {integrity: sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==}
-    dev: false
-
   /tslib/2.5.0:
     resolution: {integrity: sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg==}
 
@@ -7041,6 +7635,25 @@ packages:
       '@types/istanbul-lib-coverage': 2.0.4
       convert-source-map: 1.9.0
     dev: true
+
+  /victory-vendor/36.6.10:
+    resolution: {integrity: sha512-7YqYGtsA4mByokBhCjk+ewwPhUfzhR1I3Da6/ZsZUv/31ceT77RKoaqrxRq5Ki+9we4uzf7+A+7aG2sfYhm7nA==}
+    dependencies:
+      '@types/d3-array': 3.0.4
+      '@types/d3-ease': 3.0.0
+      '@types/d3-interpolate': 3.0.1
+      '@types/d3-scale': 4.0.3
+      '@types/d3-shape': 3.1.1
+      '@types/d3-time': 3.0.0
+      '@types/d3-timer': 3.0.0
+      d3-array: 3.2.3
+      d3-ease: 3.0.1
+      d3-interpolate: 3.0.1
+      d3-scale: 4.0.2
+      d3-shape: 3.2.0
+      d3-time: 3.1.0
+      d3-timer: 3.0.1
+    dev: false
 
   /vite/4.3.2_@types+node@18.11.2:
     resolution: {integrity: sha512-9R53Mf+TBoXCYejcL+qFbZde+eZveQLDYd9XgULILLC1a5ZwPaqgmdVpL8/uvw2BM/1TzetWjglwm+3RO+xTyw==}

--- a/coral/src/app/components/__snapshots__/Form.test.tsx.snap
+++ b/coral/src/app/components/__snapshots__/Form.test.tsx.snap
@@ -4,6 +4,7 @@ exports[`Form <PasswordInput> should render <PasswordInput> 1`] = `
 <div>
   <form>
     <div
+      class="Aquarium-Input"
       style="display: flex; flex-direction: column;"
     >
       <label
@@ -12,12 +13,12 @@ exports[`Form <PasswordInput> should render <PasswordInput> 1`] = `
         id="input-1177-label"
       >
         <span
-          class="inline-block mb-2 typography-small-strong text-grey-60"
+          class="inline-flex items-center mb-2 typography-small-strong text-grey-60"
         >
           PasswordInput
         </span>
         <span
-          class="relative block"
+          class="Aquarium-InputBase relative block"
         >
           <input
             class="block w-full rounded-sm disabled:cursor-not-allowed disabled:border-grey-20 disabled:bg-grey-5 typography-small text-grey-70 disabled:text-grey-40 placeholder:text-grey-40 focus:outline-none px-3 py-3 border border-grey-20 hover:border-grey-50 focus:border-info-70"
@@ -34,7 +35,7 @@ exports[`Form <PasswordInput> should render <PasswordInput> 1`] = `
       </p>
     </div>
     <button
-      class="text-white bg-primary-80 active:bg-primary-90 active:ring-0 focus-visible:ring-2 focus-visible:ring-primary-100 focus-visible:ring-inset hover:bg-primary-70 disabled:bg-primary-5 inline-block border-0 rounded-sm transition whitespace-nowrap focus:outline-none relative text-center typography-default-strong py-3 px-4"
+      class="Aquarium-Button Aquarium-Button.Primary text-white bg-primary-80 active:bg-primary-90 active:ring-0 focus-visible:ring-2 focus-visible:ring-primary-100 focus-visible:ring-inset hover:bg-primary-70 disabled:bg-primary-5 inline-block border-0 rounded-sm transition whitespace-nowrap focus:outline-none relative text-center typography-default-strong py-3 px-4 icon-stroke-2"
       title="Submit"
       type="submit"
     />
@@ -46,6 +47,7 @@ exports[`Form <TextInput> should render <TextInput> 1`] = `
 <div>
   <form>
     <div
+      class="Aquarium-Input"
       style="display: flex; flex-direction: column;"
     >
       <label
@@ -54,12 +56,12 @@ exports[`Form <TextInput> should render <TextInput> 1`] = `
         id="input-21-label"
       >
         <span
-          class="inline-block mb-2 typography-small-strong text-grey-60"
+          class="inline-flex items-center mb-2 typography-small-strong text-grey-60"
         >
           TextInput
         </span>
         <span
-          class="relative block"
+          class="Aquarium-InputBase relative block"
         >
           <input
             class="block w-full rounded-sm disabled:cursor-not-allowed disabled:border-grey-20 disabled:bg-grey-5 typography-small text-grey-70 disabled:text-grey-40 placeholder:text-grey-40 focus:outline-none px-3 py-3 border border-grey-20 hover:border-grey-50 focus:border-info-70"
@@ -76,7 +78,7 @@ exports[`Form <TextInput> should render <TextInput> 1`] = `
       </p>
     </div>
     <button
-      class="text-white bg-primary-80 active:bg-primary-90 active:ring-0 focus-visible:ring-2 focus-visible:ring-primary-100 focus-visible:ring-inset hover:bg-primary-70 disabled:bg-primary-5 inline-block border-0 rounded-sm transition whitespace-nowrap focus:outline-none relative text-center typography-default-strong py-3 px-4"
+      class="Aquarium-Button Aquarium-Button.Primary text-white bg-primary-80 active:bg-primary-90 active:ring-0 focus-visible:ring-2 focus-visible:ring-primary-100 focus-visible:ring-inset hover:bg-primary-70 disabled:bg-primary-5 inline-block border-0 rounded-sm transition whitespace-nowrap focus:outline-none relative text-center typography-default-strong py-3 px-4 icon-stroke-2"
       title="Submit"
       type="submit"
     />

--- a/coral/src/app/layout/header/HeaderNavigation.tsx
+++ b/coral/src/app/layout/header/HeaderNavigation.tsx
@@ -4,7 +4,7 @@ import questionMark from "@aivenio/aquarium/dist/module/icons/questionMark";
 import user from "@aivenio/aquarium/dist/module/icons/user";
 import code from "@aivenio/aquarium/icons/code";
 import codeBlock from "@aivenio/aquarium/icons/codeBlock";
-import layoutGroupBy from "@aivenio/aquarium/icons/layoutGroupBy";
+import dataflow02 from "@aivenio/aquarium/icons/dataflow02";
 import people from "@aivenio/aquarium/icons/people";
 import { useNavigate } from "react-router-dom";
 import HeaderMenuLink from "src/app/layout/header/HeaderMenuLink";
@@ -53,7 +53,7 @@ function HeaderNavigation() {
             <DropdownMenu.Item key="schema" icon={code}>
               Schema
             </DropdownMenu.Item>
-            <DropdownMenu.Item key="connector" icon={layoutGroupBy}>
+            <DropdownMenu.Item key="connector" icon={dataflow02}>
               Kafka connector
             </DropdownMenu.Item>
           </DropdownMenu.Items>

--- a/coral/src/app/layout/main-navigation/MainNavigation.tsx
+++ b/coral/src/app/layout/main-navigation/MainNavigation.tsx
@@ -3,7 +3,7 @@ import codeBlock from "@aivenio/aquarium/dist/src/icons/codeBlock";
 import cog from "@aivenio/aquarium/dist/src/icons/cog";
 import add from "@aivenio/aquarium/dist/src/icons/add";
 import database from "@aivenio/aquarium/dist/src/icons/database";
-import layoutGroupBy from "@aivenio/aquarium/dist/src/icons/layoutGroupBy";
+import dataflow02 from "@aivenio/aquarium/dist/src/icons/dataflow02";
 import list from "@aivenio/aquarium/dist/src/icons/list";
 import people from "@aivenio/aquarium/dist/src/icons/people";
 import tickCircle from "@aivenio/aquarium/dist/src/icons/tickCircle";
@@ -52,7 +52,7 @@ function MainNavigation() {
         </li>
         <li>
           <MainNavigationLink
-            icon={layoutGroupBy}
+            icon={dataflow02}
             to={Routes.CONNECTORS}
             linkText={"Connectors"}
             active={pathname.startsWith(Routes.CONNECTORS)}


### PR DESCRIPTION
## About this change - What it does

Update `aquarium` dependency.

## Notable changes

- `Toast` is here. This issue can be tackled: https://github.com/aiven/klaw/issues/614
- The icons have been updated, and `layoutGroupBy` has beend eleted. It jas been replaced by `dataflow02`:

<img width="196" alt="Screenshot 2023-05-23 at 14 09 20" src="https://github.com/aiven/klaw/assets/20607294/03e3184f-eb82-4ca1-ada5-1a0dc0486103">
<img width="207" alt="Screenshot 2023-05-23 at 14 09 34" src="https://github.com/aiven/klaw/assets/20607294/e74d7c46-f6d9-475e-9ca9-06fecc7648db">


