### PR TITLE
feat(coral): Use SegmentedControlGroup for subscriptions options

### DIFF
--- a/coral/src/app/features/topics/details/subscriptions/TopicSubscriptions.test.tsx
+++ b/coral/src/app/features/topics/details/subscriptions/TopicSubscriptions.test.tsx
@@ -160,42 +160,38 @@ describe("TopicSubscriptions.tsx", () => {
     jest.clearAllMocks();
   });
 
-  describe("should render a table and radios to switch between different kind of subscriptions", () => {
+  describe("should render a table and buttons to switch between different kind of subscriptions", () => {
     it("should render a Table", () => {
       const table = screen.getByRole("table", {
         name: "Topic subscriptions",
       });
       expect(table).toBeVisible();
     });
-    it("should render enabled and checked User subscriptions radio, ", () => {
-      const radio = screen.getByRole("radio", {
-        name: "User subs",
+    it("should render enabled and checked User subscriptions button, ", () => {
+      const button = screen.getByRole("button", {
+        name: "User subs.",
       });
-      expect(radio).toBeVisible();
-      expect(radio).toBeEnabled();
-      expect(radio).toBeChecked();
+      expect(button).toBeVisible();
+      expect(button).toBeEnabled();
     });
-    it("should render enabled  Prefixed subs radio, ", () => {
-      const radio = screen.getByRole("radio", {
-        name: "Prefixed subs",
+    it("should render enabled  Prefixed subs button, ", () => {
+      const button = screen.getByRole("button", {
+        name: "Prefixed subs.",
       });
-      expect(radio).toBeVisible();
-      expect(radio).toBeEnabled();
+      expect(button).toBeVisible();
+      expect(button).toBeEnabled();
     });
-    it("should render enabled Transactional subs radio, ", () => {
-      const radio = screen.getByRole("radio", {
-        name: "Transactional subs",
+    it("should render enabled Transactional subs button, ", () => {
+      const button = screen.getByRole("button", {
+        name: "Transactional subs.",
       });
-      expect(radio).toBeVisible();
-      expect(radio).toBeEnabled();
+      expect(button).toBeVisible();
+      expect(button).toBeEnabled();
     });
   });
 
-  describe("should render the correct data in Table when sub radio are clicked", () => {
+  describe("should render the correct data in Table when sub button are clicked", () => {
     it("should render User subscriptions in Table, ", () => {
-      const radio = screen.getByRole("radio", {
-        name: "User subs",
-      });
       const rows = screen.getAllByRole("row");
       const rowOne = screen.getByText("aivtopic3user");
       const rowTwo = screen.getByText("declineme");
@@ -203,7 +199,6 @@ describe("TopicSubscriptions.tsx", () => {
       const prefixedRow = screen.queryByText("aivendemot");
       const transactionalRow = screen.queryByText("tsttxnid");
 
-      expect(radio).toBeChecked();
       expect(rows).toHaveLength(4);
       expect(rowOne).toBeVisible();
       expect(rowTwo).toBeVisible();
@@ -213,13 +208,13 @@ describe("TopicSubscriptions.tsx", () => {
     });
 
     it("should render Prefixed subscriptions in Table, ", async () => {
-      const radio = screen.getByRole("radio", {
-        name: "Prefixed subs",
+      const button = screen.getByRole("button", {
+        name: "Prefixed subs.",
       });
 
-      await userEvent.click(radio);
+      await userEvent.click(button);
 
-      expect(radio).toBeChecked();
+      expect(button).toHaveFocus();
 
       const rows = screen.getAllByRole("row");
       const rowOne = screen.getByText("aivendemot");
@@ -233,13 +228,13 @@ describe("TopicSubscriptions.tsx", () => {
     });
 
     it("should render Prefixed subscriptions in Table, ", async () => {
-      const radio = screen.getByRole("radio", {
-        name: "Transactional subs",
+      const button = screen.getByRole("button", {
+        name: "Transactional subs.",
       });
 
-      await userEvent.click(radio);
+      await userEvent.click(button);
 
-      expect(radio).toBeChecked();
+      expect(button).toHaveFocus();
 
       const rows = screen.getAllByRole("row");
       const rowOne = screen.getByText("tsttxnid");

--- a/coral/src/app/features/topics/details/subscriptions/TopicSubscriptions.tsx
+++ b/coral/src/app/features/topics/details/subscriptions/TopicSubscriptions.tsx
@@ -1,4 +1,4 @@
-import { RadioButton, RadioButtonGroup } from "@aivenio/aquarium";
+import { SegmentedControl, SegmentedControlGroup } from "@aivenio/aquarium";
 import { useQuery } from "@tanstack/react-query";
 import { useMemo, useState } from "react";
 import { TableLayout } from "src/app/features/components/layouts/TableLayout";
@@ -51,7 +51,7 @@ const TopicSubscriptions = () => {
   return (
     <TableLayout
       filters={[
-        <RadioButtonGroup
+        <SegmentedControlGroup
           name="Subscription options"
           key="subscription-options"
           onChange={(value: string) => {
@@ -61,22 +61,22 @@ const TopicSubscriptions = () => {
           }}
           value={selectedSubs}
         >
-          <RadioButton name="User subscriptions" value="aclInfoList">
-            User subs
-          </RadioButton>
-          <RadioButton
+          <SegmentedControl name="User subscriptions" value="aclInfoList">
+            User subs.
+          </SegmentedControl>
+          <SegmentedControl
             name="Prefixed subscriptions"
             value="prefixedAclInfoList"
           >
-            Prefixed subs
-          </RadioButton>
-          <RadioButton
+            Prefixed subs.
+          </SegmentedControl>
+          <SegmentedControl
             name="Transactional subscriptions"
             value="transactionalAclInfoList"
           >
-            Transactional subs
-          </RadioButton>
-        </RadioButtonGroup>,
+            Transactional subs.
+          </SegmentedControl>
+        </SegmentedControlGroup>,
       ]}
       table={
         <TopicSubscriptionsTable


### PR DESCRIPTION
## About this change - What it does

Use `SegmentedControlGroup`  instead of `RadioButtonGroup` for subscription options:

### Before

https://github.com/aiven/klaw/assets/20607294/2e23faae-4a82-4c89-88db-04469512f423



### After 

https://github.com/aiven/klaw/assets/20607294/ca831cd0-d285-490b-a61a-0318d4d7e8b5




