### PR TITLE
feat(coral): Topic messages: Add topic message list #1235

### DIFF
--- a/coral/src/app/features/topics/overview/messages/TopicMessages.test.tsx
+++ b/coral/src/app/features/topics/overview/messages/TopicMessages.test.tsx
@@ -1,0 +1,81 @@
+import {
+  cleanup,
+  screen,
+  waitForElementToBeRemoved,
+} from "@testing-library/react";
+import { getTopicMessages } from "src/domain/topic/topic-api";
+import { mockIntersectionObserver } from "src/services/test-utils/mock-intersection-observer";
+import { TopicMessages } from "src/app/features/topics/overview/messages/TopicMessages";
+import { customRender } from "src/services/test-utils/render-with-wrappers";
+import { Outlet, Route, Routes } from "react-router-dom";
+
+jest.mock("src/domain/topic/topic-api.ts");
+
+const mockGetTopicMessages = getTopicMessages as jest.MockedFunction<
+  typeof getTopicMessages
+>;
+
+const mockGetTopicMessagesResponse = {
+  0: "HELLO",
+  1: "WORLD",
+};
+
+const mockGetTopicMessagesNoContentResponse = {
+  status: "failed",
+};
+
+function DummyParent() {
+  return <Outlet context={{ topicName: "test" }} />;
+}
+
+describe("TopicMessages", () => {
+  beforeEach(() => {
+    mockIntersectionObserver();
+  });
+  afterEach(() => {
+    cleanup();
+    jest.resetAllMocks();
+  });
+  it("requests and displays all messages", async () => {
+    mockGetTopicMessages.mockResolvedValue(mockGetTopicMessagesResponse);
+    customRender(
+      <Routes>
+        <Route path="/" element={<DummyParent />}>
+          <Route path="/" element={<TopicMessages />} />
+        </Route>
+      </Routes>,
+      {
+        memoryRouter: true,
+        queryClient: true,
+      }
+    );
+    await waitForElementToBeRemoved(screen.getByTestId("skeleton-table"));
+    expect(mockGetTopicMessages).toHaveBeenCalledTimes(1);
+    expect(mockGetTopicMessages).toHaveBeenCalledWith({
+      topicName: "test",
+      consumerGroupId: "notdefined",
+      envId: "2",
+      offsetId: "5",
+    });
+    screen.getByText("HELLO");
+    screen.getByText("WORLD");
+  });
+  it("informs user of no content when there is no content in the topic", async () => {
+    mockGetTopicMessages.mockResolvedValue(
+      mockGetTopicMessagesNoContentResponse
+    );
+    customRender(
+      <Routes>
+        <Route path="/" element={<DummyParent />}>
+          <Route path="/" element={<TopicMessages />} />
+        </Route>
+      </Routes>,
+      {
+        memoryRouter: true,
+        queryClient: true,
+      }
+    );
+    await waitForElementToBeRemoved(screen.getByTestId("skeleton-table"));
+    screen.getByText("No Message matched your criteria.");
+  });
+});

--- a/coral/src/app/features/topics/overview/messages/TopicMessages.tsx
+++ b/coral/src/app/features/topics/overview/messages/TopicMessages.tsx
@@ -1,0 +1,56 @@
+import { useQuery } from "@tanstack/react-query";
+import { TableLayout } from "src/app/features/components/layouts/TableLayout";
+import { TopicMessageList } from "src/app/features/topics/overview/messages/components/TopicMessageList";
+import { getTopicMessages } from "src/domain/topic/topic-api";
+import {
+  type NoContent,
+  type TopicMessages as TopicMessagesType,
+} from "src/domain/topic/topic-types";
+import { EmptyState } from "@aivenio/aquarium";
+import { useTopicDetails } from "src/app/features/topics/details/TopicDetails";
+
+function isNoContentResult(
+  result: TopicMessagesType | NoContent | undefined
+): result is NoContent {
+  return Boolean(result && "status" in result);
+}
+
+function TopicMessages() {
+  const { topicName } = useTopicDetails();
+  const {
+    data: consumeResult,
+    isLoading,
+    isError,
+    error,
+  } = useQuery({
+    queryKey: ["topicMessages"],
+    queryFn: () =>
+      getTopicMessages({
+        topicName,
+        consumerGroupId: "notdefined",
+        envId: "2",
+        offsetId: "5",
+      }),
+    keepPreviousData: true,
+  });
+
+  if (isNoContentResult(consumeResult)) {
+    return (
+      <EmptyState title="No messages">
+        No Message matched your criteria.
+      </EmptyState>
+    );
+  }
+
+  return (
+    <TableLayout
+      filters={[]}
+      isLoading={isLoading}
+      isErrorLoading={isError}
+      errorMessage={error}
+      table={<TopicMessageList messages={consumeResult ?? {}} />}
+    />
+  );
+}
+
+export { TopicMessages };

--- a/coral/src/app/features/topics/overview/messages/components/TopicMessageItem.test.tsx
+++ b/coral/src/app/features/topics/overview/messages/components/TopicMessageItem.test.tsx
@@ -1,0 +1,22 @@
+import { cleanup, render, screen } from "@testing-library/react";
+import { TopicMessageItem } from "src/app/features/topics/overview/messages/components/TopicMessageItem";
+import userEvent from "@testing-library/user-event";
+
+describe("TopicMessageItem", () => {
+  afterEach(() => {
+    cleanup();
+  });
+  it("displays the message", () => {
+    render(<TopicMessageItem message="Hello World" offsetId="0" />);
+    screen.getByText("Hello World");
+  });
+  it("truncates the message at 100 characters", () => {
+    render(<TopicMessageItem message={"H".repeat(101)} offsetId="0" />);
+    screen.getByText("H".repeat(97) + "...");
+  });
+  it("display the message in full if expand button is pressed", async () => {
+    render(<TopicMessageItem message={"H".repeat(101)} offsetId="0" />);
+    await userEvent.click(screen.getByLabelText("Expand message 0"));
+    screen.getByText("H".repeat(101));
+  });
+});

--- a/coral/src/app/features/topics/overview/messages/components/TopicMessageItem.tsx
+++ b/coral/src/app/features/topics/overview/messages/components/TopicMessageItem.tsx
@@ -1,0 +1,44 @@
+import { BorderBox, Box, Button, Typography } from "@aivenio/aquarium";
+import expandIcon from "@aivenio/aquarium/icons/chevronRight";
+import minimizeIcon from "@aivenio/aquarium/icons/chevronDown";
+import { useState, useId } from "react";
+import truncate from "lodash/truncate";
+
+type Props = {
+  offsetId: string;
+  message: string;
+};
+
+function TopicMessageItem({ offsetId, message }: Props) {
+  const [expanded, setExpanded] = useState<boolean>(false);
+  const panelTrigger = useId();
+  const panelId = useId();
+  return (
+    <BorderBox padding={"4"} marginBottom={"4"}>
+      <Box.Flex component={"h3"}>
+        <Box marginRight="2">
+          <Button.Icon
+            id={panelTrigger}
+            icon={expanded ? minimizeIcon : expandIcon}
+            aria-label={`Expand message ${offsetId}`}
+            aria-expanded={expanded}
+            aria-controls={panelId}
+            onClick={() => setExpanded(!expanded)}
+          />
+        </Box>
+        <Box
+          paddingTop="2"
+          grow={1}
+          id={panelId}
+          aria-labelledby={panelTrigger}
+        >
+          <Typography.SmallStrong>
+            {expanded ? message : truncate(message, { length: 100 })}
+          </Typography.SmallStrong>
+        </Box>
+      </Box.Flex>
+    </BorderBox>
+  );
+}
+
+export { TopicMessageItem };

--- a/coral/src/app/features/topics/overview/messages/components/TopicMessageList.test.tsx
+++ b/coral/src/app/features/topics/overview/messages/components/TopicMessageList.test.tsx
@@ -1,0 +1,18 @@
+import { cleanup, render, screen } from "@testing-library/react";
+import { TopicMessageList } from "src/app/features/topics/overview/messages/components/TopicMessageList";
+
+const messages = {
+  0: "HELLO",
+  1: "WORLD",
+};
+
+describe("TopicMessageList", () => {
+  afterEach(() => {
+    cleanup();
+  });
+  it("displays all messages", () => {
+    render(<TopicMessageList messages={messages} />);
+    screen.getByText("HELLO");
+    screen.getByText("WORLD");
+  });
+});

--- a/coral/src/app/features/topics/overview/messages/components/TopicMessageList.tsx
+++ b/coral/src/app/features/topics/overview/messages/components/TopicMessageList.tsx
@@ -1,0 +1,22 @@
+import { TopicMessages } from "src/domain/topic/topic-types";
+import { TopicMessageItem } from "src/app/features/topics/overview/messages/components/TopicMessageItem";
+
+type Props = {
+  messages: TopicMessages;
+};
+
+function TopicMessageList({ messages }: Props) {
+  return (
+    <>
+      {Object.keys(messages).map((offsetId) => (
+        <TopicMessageItem
+          key={offsetId}
+          offsetId={offsetId}
+          message={messages[offsetId] ?? ""}
+        />
+      ))}
+    </>
+  );
+}
+
+export { TopicMessageList };

--- a/coral/src/app/pages/topics/overview/messages/index.tsx
+++ b/coral/src/app/pages/topics/overview/messages/index.tsx
@@ -1,0 +1,7 @@
+import { TopicMessages } from "src/app/features/topics/overview/messages/TopicMessages";
+
+function TopicMessagesPage() {
+  return <TopicMessages />;
+}
+
+export { TopicMessagesPage };

--- a/coral/src/app/router.tsx
+++ b/coral/src/app/router.tsx
@@ -33,6 +33,7 @@ import {
 import { getRouterBasename } from "src/config";
 import { createRouteBehindFeatureFlag } from "src/services/feature-flags/route-utils";
 import { FeatureFlag } from "src/services/feature-flags/types";
+import { TopicMessagesPage } from "src/app/pages/topics/overview/messages";
 
 const routes: Array<RouteObject> = [
   // Login is currently the responsibility of the
@@ -70,7 +71,7 @@ const routes: Array<RouteObject> = [
             path: TOPIC_OVERVIEW_TAB_ID_INTO_PATH[
               TopicOverviewTabEnum.MESSAGES
             ],
-            element: <div>MESSAGES</div>,
+            element: <TopicMessagesPage />,
             id: TopicOverviewTabEnum.MESSAGES,
           },
           {

--- a/coral/src/domain/topic/topic-api.ts
+++ b/coral/src/domain/topic/topic-api.ts
@@ -12,8 +12,10 @@ import {
   transformTopicApiResponse,
 } from "src/domain/topic/topic-transformer";
 import {
+  NoContent,
   TopicAdvancedConfigurationOptions,
   TopicApiResponse,
+  TopicMessages,
   TopicRequestApiResponse,
 } from "src/domain/topic/topic-types";
 import api, { API_PATHS } from "src/services/api";
@@ -164,6 +166,15 @@ const getTopicRequests = (
     .then(transformGetTopicRequestsResponse);
 };
 
+const getTopicMessages = (
+  params: KlawApiRequestQueryParameters<"getTopicEvents">
+): Promise<TopicMessages | NoContent> => {
+  return api.get<KlawApiResponse<"getTopicEvents">>(
+    "/getTopicEvents",
+    new URLSearchParams(params)
+  );
+};
+
 const approveTopicRequest = ({
   reqIds,
 }: {
@@ -235,4 +246,5 @@ export {
   declineTopicRequest,
   deleteTopicRequest,
   getTopicOverview,
+  getTopicMessages,
 };

--- a/coral/src/domain/topic/topic-types.ts
+++ b/coral/src/domain/topic/topic-types.ts
@@ -14,6 +14,12 @@ type TopicApiResponse = ResolveIntersectionTypes<Paginated<Topic[]>>;
 type Topic = KlawApiModel<"TopicInfo">;
 type TopicNames = KlawApiResponse<"getTopicsOnly">;
 type TopicTeam = KlawApiModel<"TopicTeamResponse">;
+type TopicMessages = {
+  [key: string]: string | undefined;
+};
+type NoContent = {
+  status: boolean;
+};
 
 type TopicAdvancedConfigurationOptions = {
   key: string;
@@ -48,4 +54,6 @@ export type {
   TopicRequestApiResponse,
   TopicOvervieApiResponse,
   AclOverviewInfo,
+  TopicMessages,
+  NoContent,
 };


### PR DESCRIPTION
User is able to view topic content

- "5" is hardcoded as the offset (always 5 latest messages) for the message request. The filter + button to consume has it's own ticket.
- selected env is hardcoded for the message request, needs a follow up pr when the env is selectable and available through `useTopicDetails`
- `partition` and `timestamp` are not available as metadata
- The "notdefined" for consumer group is copied over from the old ui. I assume it is a magic value that shifts the responsibility for making up the consumer group id in the client to the server side.

If consuming messages is succesful, the api returns messages as: `{ 0: 'HELLO', 1: 'WORLD' }` where key = offset. If there is no topic content or consuming failed, the endpoint returns `{ "status": false }`. Currently, the deviating response is handled with a typeguard.

![image](https://github.com/aiven/klaw/assets/15416578/2e47d73e-7b21-48e7-9b89-c845d37aa79c)


Resolves:  #1235
