### PR TITLE
feat(coral): Topic overview, subscriptions - Add Request a subscription button

### DIFF
--- a/coral/src/app/features/topics/acl-request/TopicAclRequest.test.tsx
+++ b/coral/src/app/features/topics/acl-request/TopicAclRequest.test.tsx
@@ -103,7 +103,7 @@ describe("<TopicAclRequest />", () => {
         {
           queryClient: true,
           memoryRouter: true,
-          customRoutePath: "/topic/aivtopic1/subscribe",
+          customRoutePath: "/topic/aivtopic1/subscribe?env=1",
         }
       );
     });
@@ -119,20 +119,17 @@ describe("<TopicAclRequest />", () => {
       const aclConsumerTypeInput = screen.getByRole("radio", {
         name: "Consumer",
       });
-      // Only rendered in Producer form
-      const transactionalIdInput = screen.getByLabelText("Transactional ID");
 
       expect(aclProducerTypeInput).toBeVisible();
       expect(aclProducerTypeInput).toBeChecked();
       expect(aclConsumerTypeInput).not.toBeChecked();
-      expect(transactionalIdInput).toBeVisible();
     });
 
-    it("renders the correct AclIpPrincipleTypeField with Principal option checked when choosing an Aiven cluster environment", async () => {
+    it("renders the correct AclIpPrincipleTypeField when rendering with an Aiven cluster environment", async () => {
       await assertSkeleton();
 
       const principalField = screen.getByRole("radio", {
-        name: "Principal",
+        name: "Service account",
       });
       const ipField = screen.getByRole("radio", {
         name: "IP",
@@ -142,20 +139,6 @@ describe("<TopicAclRequest />", () => {
       expect(principalField).not.toBeChecked();
       expect(ipField).not.toBeEnabled();
       expect(ipField).not.toBeChecked();
-
-      await selectTestEnvironment();
-
-      expect(principalField).not.toBeEnabled();
-      expect(principalField).toBeChecked();
-      expect(ipField).toBeDisabled();
-      expect(ipField).not.toBeChecked();
-
-      const principalsField = await screen.findByRole("combobox", {
-        name: "Service accounts *",
-      });
-
-      expect(principalsField).toBeVisible();
-      expect(principalsField).toBeEnabled();
     });
 
     it("renders the appropriate form when switching between Producer and Consumer ACL types", async () => {
@@ -196,7 +179,7 @@ describe("<TopicAclRequest />", () => {
         {
           queryClient: true,
           memoryRouter: true,
-          customRoutePath: "/topic/aivtopic1/subscribe",
+          customRoutePath: "/topic/aivtopic1/subscribe?env=1",
         }
       );
     });
@@ -221,17 +204,13 @@ describe("<TopicAclRequest />", () => {
       });
 
       expect(ipField).toBeVisible();
-      expect(ipField).not.toBeEnabled();
+      expect(ipField).toBeEnabled();
       expect(ipField).not.toBeChecked();
       expect(principalField).toBeVisible();
-      expect(principalField).not.toBeEnabled();
+      expect(principalField).toBeEnabled();
       expect(principalField).not.toBeChecked();
       expect(hiddenIpsField).toBeNull();
       expect(hiddenPrincipalsField).toBeNull();
-
-      await selectTestEnvironment();
-
-      expect(principalField).toBeEnabled();
 
       await userEvent.click(principalField);
 
@@ -475,7 +454,7 @@ describe("<TopicAclRequest />", () => {
         {
           queryClient: true,
           memoryRouter: true,
-          customRoutePath: "/topic/aivtopic1/subscribe",
+          customRoutePath: "/topic/aivtopic1/subscribe?env=1",
         }
       );
     });
@@ -502,17 +481,13 @@ describe("<TopicAclRequest />", () => {
       });
 
       expect(ipField).toBeVisible();
-      expect(ipField).not.toBeEnabled();
+      expect(ipField).toBeEnabled();
       expect(ipField).not.toBeChecked();
       expect(principalField).toBeVisible();
-      expect(principalField).not.toBeEnabled();
+      expect(principalField).toBeEnabled();
       expect(principalField).not.toBeChecked();
       expect(hiddenIpsField).toBeNull();
       expect(hiddenPrincipalsField).toBeNull();
-
-      await selectTestEnvironment();
-
-      expect(principalField).toBeEnabled();
 
       await userEvent.click(principalField);
 
@@ -545,8 +520,6 @@ describe("<TopicAclRequest />", () => {
 
       const ipField = screen.getByRole("radio", { name: "IP" });
 
-      await selectTestEnvironment();
-
       expect(ipField).toBeEnabled();
 
       await userEvent.click(ipField);
@@ -570,8 +543,6 @@ describe("<TopicAclRequest />", () => {
       await userEvent.click(aclConsumerTypeInput);
 
       const ipField = screen.getByRole("radio", { name: "IP" });
-
-      await selectTestEnvironment();
 
       expect(ipField).toBeEnabled();
 
@@ -597,8 +568,6 @@ describe("<TopicAclRequest />", () => {
       await userEvent.click(aclConsumerTypeInput);
 
       const ipField = screen.getByRole("radio", { name: "IP" });
-
-      await selectTestEnvironment();
 
       expect(ipField).toBeEnabled();
 
@@ -643,8 +612,6 @@ describe("<TopicAclRequest />", () => {
 
       const principalField = screen.getByRole("radio", { name: "Principal" });
 
-      await selectTestEnvironment();
-
       expect(principalField).toBeEnabled();
 
       await userEvent.click(principalField);
@@ -678,8 +645,6 @@ describe("<TopicAclRequest />", () => {
       });
       await userEvent.click(aclConsumerTypeInput);
 
-      await selectTestEnvironment();
-
       const consumerGroupInput = await screen.findByRole("textbox", {
         name: "Consumer group *",
       });
@@ -703,8 +668,6 @@ describe("<TopicAclRequest />", () => {
       });
       await userEvent.click(aclConsumerTypeInput);
 
-      await selectTestEnvironment();
-
       const consumerGroupInput = await screen.findByRole("textbox", {
         name: "Consumer group *",
       });
@@ -727,8 +690,6 @@ describe("<TopicAclRequest />", () => {
         name: "Consumer",
       });
       await userEvent.click(aclConsumerTypeInput);
-
-      await selectTestEnvironment();
 
       const consumerGroupInput = await screen.findByRole("textbox", {
         name: "Consumer group *",
@@ -772,7 +733,7 @@ describe("<TopicAclRequest />", () => {
         {
           queryClient: true,
           memoryRouter: true,
-          customRoutePath: "/topic/aivtopic1/subscribe",
+          customRoutePath: "/topic/aivtopic1/subscribe?env=1",
         }
       );
     });
@@ -1152,7 +1113,7 @@ describe("<TopicAclRequest />", () => {
         {
           queryClient: true,
           memoryRouter: true,
-          customRoutePath: "/topic/aivtopic1/subscribe",
+          customRoutePath: "/topic/aivtopic1/subscribe?env=1",
         }
       );
     });

--- a/coral/src/app/features/topics/acl-request/TopicAclRequest.test.tsx
+++ b/coral/src/app/features/topics/acl-request/TopicAclRequest.test.tsx
@@ -412,6 +412,7 @@ describe("<TopicAclRequest />", () => {
 
       const cancelButton = screen.getByRole("button", { name: "Cancel" });
 
+      mockedNavigate.mockClear();
       await userEvent.click(cancelButton);
 
       await waitFor(() => {
@@ -431,6 +432,7 @@ describe("<TopicAclRequest />", () => {
 
       const cancelButton = screen.getByRole("button", { name: "Cancel" });
 
+      mockedNavigate.mockClear();
       await userEvent.click(cancelButton);
 
       await waitFor(() => {
@@ -738,10 +740,7 @@ describe("<TopicAclRequest />", () => {
       );
     });
 
-    afterEach(() => {
-      cleanup();
-      jest.clearAllMocks();
-    });
+    afterEach(cleanup);
 
     describe("when user cancels form input", () => {
       beforeEach(async () => {
@@ -771,6 +770,7 @@ describe("<TopicAclRequest />", () => {
       });
 
       it('shows a warning dialog if user clicks "Cancel" and has inputs in form', async () => {
+        mockedNavigate.mockClear();
         const form = getForm();
 
         const remarkInput = screen.getByRole("textbox", {
@@ -795,6 +795,7 @@ describe("<TopicAclRequest />", () => {
       });
 
       it("brings the user back to the form when they do not cancel", async () => {
+        mockedNavigate.mockClear();
         const form = getForm();
 
         const remarkInput = screen.getByRole("textbox", {
@@ -859,6 +860,7 @@ describe("<TopicAclRequest />", () => {
 
       afterEach(() => {
         console.error = originalConsoleError;
+        jest.clearAllMocks();
       });
 
       it("renders an error message", async () => {
@@ -934,6 +936,10 @@ describe("<TopicAclRequest />", () => {
             data: { success: true, message: "success" },
           },
         });
+      });
+
+      afterEach(() => {
+        jest.clearAllMocks();
       });
 
       it("creates a new acl request when input was valid", async () => {
@@ -1151,6 +1157,7 @@ describe("<TopicAclRequest />", () => {
       });
 
       it('shows a warning dialog if user clicks "Cancel" and has inputs in form', async () => {
+        mockedNavigate.mockClear();
         const form = getForm();
 
         const remarkInput = screen.getByRole("textbox", {
@@ -1175,6 +1182,7 @@ describe("<TopicAclRequest />", () => {
       });
 
       it("brings the user back to the form when they do not cancel", async () => {
+        mockedNavigate.mockClear();
         const form = getForm();
 
         const remarkInput = screen.getByRole("textbox", {

--- a/coral/src/app/features/topics/acl-request/TopicAclRequest.tsx
+++ b/coral/src/app/features/topics/acl-request/TopicAclRequest.tsx
@@ -23,12 +23,6 @@ const TopicAclRequest = () => {
   const { topicName } = useParams();
   const [searchParams] = useSearchParams();
 
-  // /topic/aivendemotopic/subscribe route requires an env search param to function correctly
-  // So we redirect when it is missing
-  if (topicName !== undefined && searchParams.get("env") === null) {
-    navigate(`/topic/${topicName}/subscriptions`);
-  }
-
   const [aclType, setAclType] = useState<AclType>("PRODUCER");
 
   const topicProducerForm = useForm<TopicProducerFormSchema>({
@@ -54,6 +48,18 @@ const TopicAclRequest = () => {
 
   const { isLoadingExtendedEnvironments, extendedEnvironments } =
     useExtendedEnvironments();
+
+  const currentEnv = searchParams.get("env");
+  const isNotValidEnv =
+    currentEnv === null ||
+    (!isLoadingExtendedEnvironments &&
+      extendedEnvironments.find((env) => currentEnv === env.id) === undefined);
+
+  // /topic/aivendemotopic/subscribe route requires an env search param to function correctly
+  // So we redirect when it is missing
+  if (topicName !== undefined && isNotValidEnv) {
+    navigate(`/topic/${topicName}/subscriptions`);
+  }
 
   // Will trigger infinite rerender when selecting an environment if not memoized
   const selectedEnvironment = useMemo(

--- a/coral/src/app/features/topics/acl-request/TopicAclRequest.tsx
+++ b/coral/src/app/features/topics/acl-request/TopicAclRequest.tsx
@@ -50,14 +50,13 @@ const TopicAclRequest = () => {
     useExtendedEnvironments();
 
   const currentEnv = searchParams.get("env");
-  const isNotValidEnv =
-    currentEnv === null ||
-    (!isLoadingExtendedEnvironments &&
-      extendedEnvironments.find((env) => currentEnv === env.id) === undefined);
+  const isValidEnv =
+    !isLoadingExtendedEnvironments &&
+    extendedEnvironments.find((env) => currentEnv === env.id) !== undefined;
 
   // /topic/aivendemotopic/subscribe route requires an env search param to function correctly
   // So we redirect when it is missing
-  if (topicName !== undefined && isNotValidEnv) {
+  if (topicName !== undefined && !isValidEnv) {
     navigate(`/topic/${topicName}/subscriptions`);
   }
 

--- a/coral/src/app/features/topics/acl-request/TopicAclRequest.tsx
+++ b/coral/src/app/features/topics/acl-request/TopicAclRequest.tsx
@@ -1,7 +1,7 @@
 import { Box } from "@aivenio/aquarium";
 import { useQuery } from "@tanstack/react-query";
 import { useEffect, useMemo, useState } from "react";
-import { useParams } from "react-router-dom";
+import { useNavigate, useParams, useSearchParams } from "react-router-dom";
 import { useForm } from "src/app/components/Form";
 import AclTypeField from "src/app/features/topics/acl-request/fields/AclTypeField";
 import SkeletonForm from "src/app/features/topics/acl-request/forms/SkeletonForm";
@@ -16,9 +16,19 @@ import topicProducerFormSchema, {
 } from "src/app/features/topics/acl-request/form-schemas/topic-acl-request-producer";
 import { getTopicTeam, TopicTeam } from "src/domain/topic";
 import { AclType } from "src/domain/acl";
+import { environment } from "src/app/features/topics/acl-request/form-schemas/topic-acl-request-shared-fields";
 
 const TopicAclRequest = () => {
+  const navigate = useNavigate();
   const { topicName } = useParams();
+  const [searchParams] = useSearchParams();
+
+  // /topic/aivendemotopic/subscribe route requires an env search param to function correctly
+  // So we redirect when it is missing
+  if (topicName !== undefined && searchParams.get("env") === null) {
+    navigate(`/topic/${topicName}/subscriptions`);
+  }
+
   const [aclType, setAclType] = useState<AclType>("PRODUCER");
 
   const topicProducerForm = useForm<TopicProducerFormSchema>({
@@ -27,6 +37,7 @@ const TopicAclRequest = () => {
       topicname: topicName,
       aclType: "PRODUCER",
       aclPatternType: topicName !== undefined ? "LITERAL" : undefined,
+      environment: searchParams.get("env") ?? undefined,
     },
   });
 
@@ -37,6 +48,7 @@ const TopicAclRequest = () => {
       topicname: topicName,
       aclType: "CONSUMER",
       consumergroup: "",
+      environment: searchParams.get("env") ?? undefined,
     },
   });
 
@@ -54,6 +66,7 @@ const TopicAclRequest = () => {
             (env) => env.id === topicConsumerForm.watch("environment")
           ),
     [
+      extendedEnvironments,
       aclType,
       topicProducerForm.watch("environment"),
       topicConsumerForm.watch("environment"),
@@ -117,7 +130,7 @@ const TopicAclRequest = () => {
         });
       }
     }
-  }, [selectedEnvironment]);
+  }, [selectedEnvironment, aclType]);
 
   if (isLoadingExtendedEnvironments) {
     return <SkeletonForm />;
@@ -139,9 +152,9 @@ const TopicAclRequest = () => {
           topicNames={currentTopicNames || []}
           environments={extendedEnvironments}
           isAivenCluster={selectedEnvironment?.isAivenCluster}
-          // This prop is true when user navigated to /topic/{topicName}/subscribe
+          // This prop is true when user navigated to /topic/{topicName}/subscribe?env={id}
           // False when navigating to /request/acl
-          isSubscription={topicName !== undefined}
+          isSubscription={topicName !== undefined && environment !== undefined}
         />
       ) : (
         <TopicProducerForm
@@ -152,9 +165,9 @@ const TopicAclRequest = () => {
           topicNames={currentTopicNames || []}
           environments={extendedEnvironments}
           isAivenCluster={selectedEnvironment?.isAivenCluster}
-          // This prop is true when user navigated to /topic/{topicName}/subscribe
+          // This prop is true when user navigated to /topic/{topicName}/subscribe?env={id}
           // False when navigating to /request/acl
-          isSubscription={topicName !== undefined}
+          isSubscription={topicName !== undefined && environment !== undefined}
         />
       )}
     </Box>

--- a/coral/src/app/features/topics/acl-request/fields/EnvironmentField.tsx
+++ b/coral/src/app/features/topics/acl-request/fields/EnvironmentField.tsx
@@ -6,6 +6,7 @@ interface EnvironmentFieldProps {
   environments: ExtendedEnvironment[];
   selectedTopic?: string;
   prefixed?: boolean;
+  readOnly?: boolean;
 }
 
 const getOptions = (
@@ -50,6 +51,7 @@ const EnvironmentField = ({
   environments,
   selectedTopic,
   prefixed = false,
+  readOnly = false,
 }: EnvironmentFieldProps) => {
   return (
     <NativeSelect
@@ -57,6 +59,7 @@ const EnvironmentField = ({
       labelText="Environment"
       placeholder={"-- Please select --"}
       required
+      readOnly={readOnly}
     >
       {getOptions(environments, prefixed, selectedTopic)}
     </NativeSelect>

--- a/coral/src/app/features/topics/acl-request/forms/TopicConsumerForm.test.tsx
+++ b/coral/src/app/features/topics/acl-request/forms/TopicConsumerForm.test.tsx
@@ -468,13 +468,13 @@ describe("<TopicConsumerForm isSubscription />", () => {
       expect(consumerField).toBeEnabled();
     });
 
-    it("renders required EnvironmentField", () => {
+    it("renders disabled required EnvironmentField", () => {
       const environmentField = screen.getByRole("combobox", {
         name: "Environment *",
       });
 
       expect(environmentField).toBeVisible();
-      expect(environmentField).toBeEnabled();
+      expect(environmentField).toBeDisabled();
       expect(environmentField).toBeRequired();
     });
 
@@ -584,13 +584,13 @@ describe("<TopicConsumerForm isSubscription />", () => {
       expect(consumerField).toBeEnabled();
     });
 
-    it("renders EnvironmentField with DEV selected", () => {
+    it("renders disabled EnvironmentField with DEV selected", () => {
       const environmentField = screen.getByRole("combobox", {
         name: "Environment *",
       });
 
       expect(environmentField).toBeVisible();
-      expect(environmentField).toBeEnabled();
+      expect(environmentField).toBeDisabled();
       expect(environmentField).toHaveDisplayValue("DEV");
     });
 
@@ -704,13 +704,13 @@ describe("<TopicConsumerForm isSubscription />", () => {
       expect(consumerField).toBeEnabled();
     });
 
-    it("renders EnvironmentField with TST selected", () => {
+    it("renders disabled EnvironmentField with TST selected", () => {
       const environmentField = screen.getByRole("combobox", {
         name: "Environment *",
       });
 
       expect(environmentField).toBeVisible();
-      expect(environmentField).toBeEnabled();
+      expect(environmentField).toBeDisabled();
       expect(environmentField).toHaveDisplayValue("TST");
     });
 

--- a/coral/src/app/features/topics/acl-request/forms/TopicConsumerForm.tsx
+++ b/coral/src/app/features/topics/acl-request/forms/TopicConsumerForm.tsx
@@ -143,6 +143,7 @@ const TopicConsumerForm = ({
             <EnvironmentField
               environments={environments}
               selectedTopic={topicname}
+              readOnly={isSubscription}
             />
           </GridItem>
 

--- a/coral/src/app/features/topics/acl-request/forms/TopicProducerForm.test.tsx
+++ b/coral/src/app/features/topics/acl-request/forms/TopicProducerForm.test.tsx
@@ -14,7 +14,6 @@ import TopicProducerForm, {
 } from "src/app/features/topics/acl-request/forms/TopicProducerForm";
 import { ExtendedEnvironment } from "src/app/features/topics/acl-request/queries/useExtendedEnvironments";
 import { getAivenServiceAccounts } from "src/domain/acl/acl-api";
-import { ENVIRONMENT_NOT_INITIALIZED } from "src/domain/environment/environment-types";
 import { customRender } from "src/services/test-utils/render-with-wrappers";
 
 jest.mock("src/domain/acl/acl-api");
@@ -470,7 +469,7 @@ const isSubscriptionBasePropsNotAivenCluster = {
   isAivenCluster: false,
 } as TopicProducerFormProps;
 
-describe("<TopicProducerForm />", () => {
+describe("<TopicProducerForm isSubscription />", () => {
   describe("renders correct fields in pristine form", () => {
     beforeAll(() => {
       const { result } = renderHook(() =>
@@ -478,8 +477,9 @@ describe("<TopicProducerForm />", () => {
           schema: topicProducerFormSchema,
           defaultValues: {
             topicname: "hello",
-            environment: ENVIRONMENT_NOT_INITIALIZED,
+            environment: "1",
             aclType: "PRODUCER",
+            aclPatternType: "LITERAL",
           },
         })
       );
@@ -508,29 +508,31 @@ describe("<TopicProducerForm />", () => {
       expect(consumerField).toBeEnabled();
     });
 
-    it("renders required EnvironmentField", () => {
+    it("renders required and disabled EnvironmentField", () => {
       const environmentField = screen.getByRole("combobox", {
         name: "Environment *",
       });
 
       expect(environmentField).toBeVisible();
-      expect(environmentField).toBeEnabled();
+      expect(environmentField).toBeDisabled();
       expect(environmentField).toBeRequired();
+      expect(environmentField).toHaveValue("1");
     });
 
-    it("renders aclPatternType field", () => {
+    it("renders aclPatternType disabled field with Literal checked", () => {
       const literalField = screen.getByRole("radio", { name: "Literal" });
       const prefixedField = screen.getByRole("radio", {
         name: "Prefixed",
       });
 
       expect(literalField).toBeVisible();
-      expect(literalField).toBeEnabled();
+      expect(literalField).toBeDisabled();
+      expect(literalField).toBeChecked();
       expect(prefixedField).toBeVisible();
-      expect(prefixedField).toBeEnabled();
+      expect(prefixedField).toBeDisabled();
     });
 
-    it("does not render TopicNameOrPrefixField", () => {
+    it("renders readonly Topic name field", () => {
       const topicNameField = screen.queryByRole("combobox", {
         name: "Topic name *",
       });
@@ -538,7 +540,8 @@ describe("<TopicProducerForm />", () => {
         name: "Prefix",
       });
 
-      expect(topicNameField).toBeNull();
+      expect(topicNameField).toBeVisible();
+      expect(topicNameField).toHaveAttribute("aria-readOnly", "true");
       expect(prefixField).toBeNull();
     });
 
@@ -640,13 +643,13 @@ describe("<TopicProducerForm />", () => {
       expect(consumerField).toBeEnabled();
     });
 
-    it("renders EnvironmentField with DEV selected", () => {
+    it("renders disabled EnvironmentField with DEV selected", () => {
       const environmentField = screen.getByRole("combobox", {
         name: "Environment *",
       });
 
       expect(environmentField).toBeVisible();
-      expect(environmentField).toBeEnabled();
+      expect(environmentField).toBeDisabled();
       expect(environmentField).toHaveDisplayValue("DEV");
     });
 
@@ -742,6 +745,7 @@ describe("<TopicProducerForm />", () => {
             topicname: "hello",
             environment: "2",
             aclType: "PRODUCER",
+            aclPatternType: "LITERAL",
           },
         })
       );
@@ -770,26 +774,27 @@ describe("<TopicProducerForm />", () => {
       expect(consumerField).toBeEnabled();
     });
 
-    it("renders EnvironmentField with TST selected", () => {
+    it("renders disabled EnvironmentField with TST selected", () => {
       const environmentField = screen.getByRole("combobox", {
         name: "Environment *",
       });
 
       expect(environmentField).toBeVisible();
-      expect(environmentField).toBeEnabled();
+      expect(environmentField).toBeDisabled();
       expect(environmentField).toHaveDisplayValue("TST");
     });
 
-    it("renders aclPatternType field", () => {
+    it("renders enabled aclPatternType disabled field with Literal checked", () => {
       const literalField = screen.getByRole("radio", { name: "Literal" });
       const prefixedField = screen.getByRole("radio", {
         name: "Prefixed",
       });
 
       expect(literalField).toBeVisible();
-      expect(literalField).toBeEnabled();
+      expect(literalField).toBeDisabled();
+      expect(literalField).toBeChecked();
       expect(prefixedField).toBeVisible();
-      expect(prefixedField).toBeEnabled();
+      expect(prefixedField).toBeDisabled();
     });
 
     it("does not render TopicNameOrPrefixField", () => {
@@ -800,7 +805,8 @@ describe("<TopicProducerForm />", () => {
         name: "Prefix",
       });
 
-      expect(topicNameField).toBeNull();
+      expect(topicNameField).toBeVisible();
+      expect(topicNameField).toHaveAttribute("aria-readOnly", "true");
       expect(prefixField).toBeNull();
     });
 

--- a/coral/src/app/features/topics/acl-request/forms/TopicProducerForm.tsx
+++ b/coral/src/app/features/topics/acl-request/forms/TopicProducerForm.tsx
@@ -142,6 +142,7 @@ const TopicProducerForm = ({
               environments={environments}
               selectedTopic={topicname}
               prefixed={aclPatternType === "PREFIXED"}
+              readOnly={isSubscription}
             />
           </GridItem>
 
@@ -153,7 +154,9 @@ const TopicProducerForm = ({
             <RadioButtonGroup
               name="aclPatternType"
               labelText="Topic pattern type"
-              disabled={topicNames.length === 0 || isAivenCluster}
+              disabled={
+                topicNames.length === 0 || isAivenCluster || isSubscription
+              }
               required
             >
               <BaseRadioButton value="LITERAL">Literal</BaseRadioButton>

--- a/coral/src/services/api.ts
+++ b/coral/src/services/api.ts
@@ -35,7 +35,8 @@ const API_BASE_URL = getHTTPBaseAPIUrl();
 
 const API_PATHS: { [key in keyof ApiOperations]: keyof ApiPaths } = {
   updateSyncSchemas: "/schemas",
-  getSchemaOfTopicFromCluster: "/schemas/kafkaEnv/{kafkaEnvId}/topic/{topicName}/schemaVersion/{schemaVersion}",
+  getSchemaOfTopicFromCluster:
+    "/schemas/kafkaEnv/{kafkaEnvId}/topic/{topicName}/schemaVersion/{schemaVersion}",
   getSchemasOfEnvironment: "/schemas",
   validateSchema: "/validate/schema",
   updateUserTeamFromSwitchTeams: "/user/updateTeam",


### PR DESCRIPTION
# About this change - What it does

- adds `PageHeader` component with "Request a subscription" button
- renders a specific ACL request form for this context:
  - environment is locked to the one currently selected in topic overview
  - topic name is locked to the one in the topic overview
  - pattern type can only be `LITERAL`
  - `/topic/:topicname/subscribe` requires an `env` search param or it will redirect to `topic/:topicName/subscriptions`


https://github.com/aiven/klaw/assets/20607294/7d569891-55f8-4877-91e5-31dc55e3743c


Resolves: #1232
