### PR TITLE
feat(coral): Topic messages: Add filter to set offset #1237

### DIFF
--- a/coral/src/app/features/topics/overview/messages/TopicMessages.test.tsx
+++ b/coral/src/app/features/topics/overview/messages/TopicMessages.test.tsx
@@ -1,9 +1,4 @@
-import {
-  cleanup,
-  screen,
-  waitFor,
-  waitForElementToBeRemoved,
-} from "@testing-library/react";
+import { cleanup, screen, waitFor } from "@testing-library/react";
 import { getTopicMessages } from "src/domain/topic/topic-api";
 import { mockIntersectionObserver } from "src/services/test-utils/mock-intersection-observer";
 import { TopicMessages } from "src/app/features/topics/overview/messages/TopicMessages";
@@ -38,7 +33,24 @@ describe("TopicMessages", () => {
     cleanup();
     jest.resetAllMocks();
   });
-  it("requests and displays all messages", async () => {
+  it("informs user to specify offset and fetch topic messages", async () => {
+    mockGetTopicMessages.mockResolvedValue(
+      mockGetTopicMessagesNoContentResponse
+    );
+    customRender(
+      <Routes>
+        <Route path="/" element={<DummyParent />}>
+          <Route path="/" element={<TopicMessages />} />
+        </Route>
+      </Routes>,
+      {
+        memoryRouter: true,
+        queryClient: true,
+      }
+    );
+    screen.getByText("Select offset and Update results.");
+  });
+  it("requests and displays all messages when Update results is pressed", async () => {
     mockGetTopicMessages.mockResolvedValue(mockGetTopicMessagesResponse);
     customRender(
       <Routes>
@@ -51,8 +63,12 @@ describe("TopicMessages", () => {
         queryClient: true,
       }
     );
-    await waitForElementToBeRemoved(screen.getByTestId("skeleton-table"));
-    expect(mockGetTopicMessages).toHaveBeenCalledTimes(1);
+    await userEvent.click(
+      screen.getByRole("button", {
+        name: "Consume and display the latest 5 messages from topic test",
+      })
+    );
+    await waitFor(() => expect(mockGetTopicMessages).toHaveBeenCalledTimes(1));
     expect(mockGetTopicMessages).toHaveBeenCalledWith({
       topicName: "test",
       consumerGroupId: "notdefined",
@@ -77,8 +93,14 @@ describe("TopicMessages", () => {
         queryClient: true,
       }
     );
-    await waitForElementToBeRemoved(screen.getByTestId("skeleton-table"));
-    screen.getByText("This Topic contains no Messages.");
+    await userEvent.click(
+      screen.getByRole("button", {
+        name: "Consume and display the latest 5 messages from topic test",
+      })
+    );
+    await waitFor(() => {
+      screen.getByText("This Topic contains no Messages.");
+    });
   });
 
   describe("user can filter messages by offset", () => {
@@ -91,7 +113,7 @@ describe("TopicMessages", () => {
       jest.resetAllMocks();
     });
 
-    it("populates the filter from the url search parameters", () => {
+    it("populates the filter from the url search parameters", async () => {
       customRender(
         <Routes>
           <Route path="/" element={<DummyParent />}>
@@ -104,11 +126,18 @@ describe("TopicMessages", () => {
           customRoutePath: "/?offset=25",
         }
       );
-      expect(getTopicMessages).toHaveBeenNthCalledWith(1, {
-        topicName: "test",
-        consumerGroupId: "notdefined",
-        envId: "2",
-        offsetId: "25",
+      await userEvent.click(
+        screen.getByRole("button", {
+          name: "Consume and display the latest 25 messages from topic test",
+        })
+      );
+      await waitFor(() => {
+        expect(getTopicMessages).toHaveBeenNthCalledWith(1, {
+          topicName: "test",
+          consumerGroupId: "notdefined",
+          envId: "2",
+          offsetId: "25",
+        });
       });
     });
     it("applies offset filter by selecting a fixed offset value", async () => {
@@ -123,51 +152,18 @@ describe("TopicMessages", () => {
           memoryRouter: true,
         }
       );
-      userEvent.click(screen.getByRole("radio", { name: "50" }));
+      await userEvent.click(screen.getByRole("radio", { name: "50" }));
+      await userEvent.click(
+        screen.getByRole("button", {
+          name: "Consume and display the latest 50 messages from topic test",
+        })
+      );
       await waitFor(() => {
-        expect(getTopicMessages).toHaveBeenNthCalledWith(2, {
+        expect(getTopicMessages).toHaveBeenNthCalledWith(1, {
           topicName: "test",
           consumerGroupId: "notdefined",
           envId: "2",
           offsetId: "50",
-        });
-      });
-    });
-  });
-
-  describe("user can consume latest messages based on selected offset", () => {
-    beforeEach(() => {
-      mockGetTopicMessages.mockResolvedValue(mockGetTopicMessagesResponse);
-    });
-
-    afterEach(() => {
-      cleanup();
-      jest.resetAllMocks();
-    });
-
-    it("requests messages from the selected offset", async () => {
-      customRender(
-        <Routes>
-          <Route path="/" element={<DummyParent />}>
-            <Route path="/" element={<TopicMessages />} />
-          </Route>
-        </Routes>,
-        {
-          queryClient: true,
-          memoryRouter: true,
-        }
-      );
-      await userEvent.click(
-        screen.getByRole("button", {
-          name: "Consume and display the latest 5 messages from topic test",
-        })
-      );
-      await waitFor(() => {
-        expect(getTopicMessages).toHaveBeenNthCalledWith(2, {
-          topicName: "test",
-          consumerGroupId: "notdefined",
-          envId: "2",
-          offsetId: "5",
         });
       });
     });

--- a/coral/src/app/features/topics/overview/messages/TopicMessages.tsx
+++ b/coral/src/app/features/topics/overview/messages/TopicMessages.tsx
@@ -6,8 +6,14 @@ import {
   type NoContent,
   type TopicMessages as TopicMessagesType,
 } from "src/domain/topic/topic-types";
-import { EmptyState } from "@aivenio/aquarium";
+import { Box, Button, EmptyState } from "@aivenio/aquarium";
 import { useTopicDetails } from "src/app/features/topics/details/TopicDetails";
+import refreshIcon from "@aivenio/aquarium/dist/src/icons/refresh";
+import { TopicMessageOffsetFilter } from "src/app/features/topics/overview/messages/components/TopicMessageOffsetFilter";
+import {
+  Offset,
+  useOffsetFilter,
+} from "src/app/features/topics/overview/messages/useOffsetFilter";
 
 function isNoContentResult(
   result: TopicMessagesType | NoContent | undefined
@@ -17,38 +23,69 @@ function isNoContentResult(
 
 function TopicMessages() {
   const { topicName } = useTopicDetails();
+  const [offset, setOffset] = useOffsetFilter();
   const {
     data: consumeResult,
     isLoading,
     isError,
+    isRefetching,
     error,
+    refetch: updateResults,
   } = useQuery({
-    queryKey: ["topicMessages"],
+    queryKey: ["topicMessages", offset],
     queryFn: () =>
       getTopicMessages({
         topicName,
         consumerGroupId: "notdefined",
         envId: "2",
-        offsetId: "5",
+        offsetId: offset,
       }),
-    keepPreviousData: true,
+    keepPreviousData: false,
   });
 
-  if (isNoContentResult(consumeResult)) {
-    return (
-      <EmptyState title="No messages">
-        No Message matched your criteria.
-      </EmptyState>
-    );
+  const isConsuming = isLoading || isRefetching;
+
+  function handleUpdateResultClick(): void {
+    updateResults();
+  }
+
+  function handleOffsetChange(offset: Offset): void {
+    setOffset(offset);
   }
 
   return (
     <TableLayout
-      filters={[]}
-      isLoading={isLoading}
+      filters={[
+        <TopicMessageOffsetFilter
+          key={"offset"}
+          value={offset}
+          disabled={isConsuming}
+          onChange={handleOffsetChange}
+        />,
+        <Box.Flex key={"consume"} justifyContent="flex-end">
+          <Button.Primary
+            onClick={handleUpdateResultClick}
+            disabled={isConsuming}
+            loading={isConsuming}
+            aria-label={`Consume and display the latest ${offset} messages from topic ${topicName}`}
+            icon={refreshIcon}
+          >
+            Update results
+          </Button.Primary>
+        </Box.Flex>,
+      ]}
+      isLoading={isConsuming}
       isErrorLoading={isError}
       errorMessage={error}
-      table={<TopicMessageList messages={consumeResult ?? {}} />}
+      table={
+        isNoContentResult(consumeResult) ? (
+          <EmptyState title="No messages">
+            This Topic contains no Messages.
+          </EmptyState>
+        ) : (
+          <TopicMessageList messages={consumeResult ?? {}} />
+        )
+      }
     />
   );
 }

--- a/coral/src/app/features/topics/overview/messages/components/TopicMessageItem.test.tsx
+++ b/coral/src/app/features/topics/overview/messages/components/TopicMessageItem.test.tsx
@@ -10,6 +10,11 @@ describe("TopicMessageItem", () => {
     render(<TopicMessageItem message="Hello World" offsetId="0" />);
     screen.getByText("Hello World");
   });
+  it("indicates if the message has no content", () => {
+    render(<TopicMessageItem message="" offsetId="0" />);
+    screen.getByText("Empty message");
+    expect(screen.getByLabelText("Expand message 0")).toBeDisabled();
+  });
   it("truncates the message at 100 characters", () => {
     render(<TopicMessageItem message={"H".repeat(101)} offsetId="0" />);
     screen.getByText("H".repeat(97) + "...");

--- a/coral/src/app/features/topics/overview/messages/components/TopicMessageItem.tsx
+++ b/coral/src/app/features/topics/overview/messages/components/TopicMessageItem.tsx
@@ -13,6 +13,25 @@ function TopicMessageItem({ offsetId, message }: Props) {
   const [expanded, setExpanded] = useState<boolean>(false);
   const panelTrigger = useId();
   const panelId = useId();
+
+  function getMessage(): React.ReactNode {
+    if (!message) {
+      return (
+        <Typography.SmallStrong color="grey-40">
+          <i>Empty message</i>
+        </Typography.SmallStrong>
+      );
+    } else if (expanded) {
+      return <Typography.SmallStrong>{message}</Typography.SmallStrong>;
+    } else {
+      return (
+        <Typography.SmallStrong>
+          {truncate(message, { length: 100 })}
+        </Typography.SmallStrong>
+      );
+    }
+  }
+
   return (
     <BorderBox padding={"4"} marginBottom={"4"}>
       <Box.Flex component={"h3"}>
@@ -21,6 +40,7 @@ function TopicMessageItem({ offsetId, message }: Props) {
             id={panelTrigger}
             icon={expanded ? minimizeIcon : expandIcon}
             aria-label={`Expand message ${offsetId}`}
+            disabled={!message}
             aria-expanded={expanded}
             aria-controls={panelId}
             onClick={() => setExpanded(!expanded)}
@@ -32,9 +52,7 @@ function TopicMessageItem({ offsetId, message }: Props) {
           id={panelId}
           aria-labelledby={panelTrigger}
         >
-          <Typography.SmallStrong>
-            {expanded ? message : truncate(message, { length: 100 })}
-          </Typography.SmallStrong>
+          {getMessage()}
         </Box>
       </Box.Flex>
     </BorderBox>

--- a/coral/src/app/features/topics/overview/messages/components/TopicMessageOffsetFilter.test.tsx
+++ b/coral/src/app/features/topics/overview/messages/components/TopicMessageOffsetFilter.test.tsx
@@ -1,0 +1,46 @@
+import { cleanup, render, screen, within } from "@testing-library/react";
+import { TopicMessageOffsetFilter } from "src/app/features/topics/overview/messages/components/TopicMessageOffsetFilter";
+import userEvent from "@testing-library/user-event";
+
+describe("TopicMessageOffsetFilter", () => {
+  afterEach(() => {
+    cleanup();
+  });
+  it("displays 5, 25 and 50 as possible offset values as options", () => {
+    render(
+      <TopicMessageOffsetFilter
+        value="25"
+        onChange={jest.fn()}
+        disabled={false}
+      />
+    );
+    screen.getByRole("radio", { name: "5" });
+    screen.getByRole("radio", { name: "25" });
+    screen.getByRole("radio", { name: "50" });
+  });
+  it("is possible to select an option", async () => {
+    const onChange = jest.fn();
+    render(
+      <TopicMessageOffsetFilter
+        value="25"
+        onChange={onChange}
+        disabled={false}
+      />
+    );
+    await userEvent.click(screen.getByRole("radio", { name: "50" }));
+    expect(onChange).toHaveBeenCalledTimes(1);
+    expect(onChange).toHaveBeenCalledWith("50");
+  });
+  it("is not possible to select an option if the input is disabled", () => {
+    render(
+      <TopicMessageOffsetFilter
+        value="25"
+        onChange={jest.fn()}
+        disabled={true}
+      />
+    );
+    within(screen.getByRole("group", { name: "Offset" }))
+      .getAllByRole("radio")
+      .forEach((option) => expect(option).toBeDisabled());
+  });
+});

--- a/coral/src/app/features/topics/overview/messages/components/TopicMessageOffsetFilter.tsx
+++ b/coral/src/app/features/topics/overview/messages/components/TopicMessageOffsetFilter.tsx
@@ -1,0 +1,39 @@
+import {
+  RadioButton,
+  RadioButtonGroup,
+  RadioButtonGroupProps,
+} from "@aivenio/aquarium";
+import {
+  type Offset,
+  offsets,
+} from "src/app/features/topics/overview/messages/useOffsetFilter";
+
+type Props = {
+  value: Offset;
+  disabled?: RadioButtonGroupProps["disabled"];
+  onChange: (offset: Offset) => void;
+};
+
+function TopicMessageOffsetFilter({
+  value,
+  disabled = false,
+  onChange,
+}: Props) {
+  return (
+    <RadioButtonGroup
+      name={"offset"}
+      value={value}
+      labelText="Offset"
+      disabled={disabled}
+      onChange={(value) => onChange(value as Offset)}
+    >
+      {offsets.map((offset) => (
+        <RadioButton key={offset} value={offset}>
+          {offset}
+        </RadioButton>
+      ))}
+    </RadioButtonGroup>
+  );
+}
+
+export { TopicMessageOffsetFilter };

--- a/coral/src/app/features/topics/overview/messages/useOffsetFilter.test.tsx
+++ b/coral/src/app/features/topics/overview/messages/useOffsetFilter.test.tsx
@@ -1,0 +1,53 @@
+import { cleanup, renderHook } from "@testing-library/react";
+import { BrowserRouter, MemoryRouter } from "react-router-dom";
+import { useOffsetFilter } from "src/app/features/topics/overview/messages/useOffsetFilter";
+
+describe("useOffsetFilter.tsx", () => {
+  afterEach(() => {
+    window.history.pushState({}, "", "/");
+    cleanup();
+  });
+  it("returns 5 as the default offset value", () => {
+    const {
+      result: { current },
+    } = renderHook(() => useOffsetFilter(), {
+      wrapper: ({ children }) => <MemoryRouter>{children}</MemoryRouter>,
+    });
+    const offset = current[0];
+    expect(offset).toBe("5");
+  });
+  it("gets the offset from search params", () => {
+    const {
+      result: { current },
+    } = renderHook(() => useOffsetFilter(), {
+      wrapper: ({ children }) => (
+        <MemoryRouter initialEntries={["/?offset=25"]}>{children}</MemoryRouter>
+      ),
+    });
+    const offset = current[0];
+    expect(offset).toEqual("25");
+  });
+  it("gets the default offset if provided value is not one of the fixed values", () => {
+    const {
+      result: { current },
+    } = renderHook(() => useOffsetFilter(), {
+      wrapper: ({ children }) => (
+        <MemoryRouter initialEntries={["/?offset=100"]}>
+          {children}
+        </MemoryRouter>
+      ),
+    });
+    const offset = current[0];
+    expect(offset).toEqual("5");
+  });
+  it("sets the offset to search params", async () => {
+    const {
+      result: { current },
+    } = renderHook(() => useOffsetFilter(), {
+      wrapper: ({ children }) => <BrowserRouter>{children}</BrowserRouter>,
+    });
+    const setOffset = current[1];
+    setOffset("25");
+    expect(window.location.search).toBe("?offset=25");
+  });
+});

--- a/coral/src/app/features/topics/overview/messages/useOffsetFilter.tsx
+++ b/coral/src/app/features/topics/overview/messages/useOffsetFilter.tsx
@@ -1,0 +1,41 @@
+import { useEffect } from "react";
+import { useSearchParams } from "react-router-dom";
+
+const offsets = ["5", "25", "50"] as const;
+type Offset = typeof offsets[number];
+
+const NAME = "offset";
+const defaultOffset: typeof offsets[0] = "5";
+
+function isOffset(offset: string | null): offset is Offset {
+  return Boolean(offset && offsets.includes(offset as Offset));
+}
+
+function useOffsetFilter(): [Offset, (offset: Offset) => void] {
+  const [searchParams, setSearchParams] = useSearchParams();
+  const offset = searchParams.get(NAME);
+
+  useEffect(() => {
+    if (!isOffset(offset)) {
+      searchParams.set(NAME, defaultOffset);
+      setSearchParams(searchParams);
+    }
+  }, [offset]);
+
+  function getOffset(): Offset {
+    return isOffset(offset) ? offset : defaultOffset;
+  }
+
+  function setOffset(offset: string): void {
+    if (!isOffset(offset)) {
+      searchParams.set(NAME, defaultOffset);
+    } else {
+      searchParams.set(NAME, offset);
+    }
+    setSearchParams(searchParams);
+  }
+
+  return [getOffset(), setOffset];
+}
+
+export { useOffsetFilter, offsets, isOffset, type Offset };

--- a/coral/src/services/api.ts
+++ b/coral/src/services/api.ts
@@ -35,7 +35,8 @@ const API_BASE_URL = getHTTPBaseAPIUrl();
 
 const API_PATHS: { [key in keyof ApiOperations]: keyof ApiPaths } = {
   updateSyncSchemas: "/schemas",
-  getSchemaOfTopicFromCluster: "/schemas/kafkaEnv/{kafkaEnvId}/topic/{topicName}/schemaVersion/{schemaVersion}",
+  getSchemaOfTopicFromCluster:
+    "/schemas/kafkaEnv/{kafkaEnvId}/topic/{topicName}/schemaVersion/{schemaVersion}",
   getSchemasOfEnvironment: "/schemas",
   validateSchema: "/validate/schema",
   updateUserTeamFromSwitchTeams: "/user/updateTeam",


### PR DESCRIPTION
User is able to specify the offset a.k.a the amount of messages starting from latest. In addition, a button to refresh messages

[Screencast from 2023-05-26 10-28-03.webm](https://github.com/aiven/klaw/assets/15416578/52c7d377-eaf6-4d70-be58-31cc0020e88c)


Resolves: #1237
Resolves: #1239
