### PR TITLE
refactor(CAMA): use context for filters handling

### DIFF
--- a/coral/src/app/features/approvals/acls/AclApprovals.tsx
+++ b/coral/src/app/features/approvals/acls/AclApprovals.tsx
@@ -10,9 +10,12 @@ import RequestDetailsModal from "src/app/features/components/RequestDetailsModal
 import AclTypeFilter from "src/app/features/components/filters/AclTypeFilter";
 import EnvironmentFilter from "src/app/features/components/filters/EnvironmentFilter";
 import { RequestTypeFilter } from "src/app/features/components/filters/RequestTypeFilter";
-import StatusFilter from "src/app/features/components/filters/StatusFilter";
 import { SearchTopicFilter } from "src/app/features/components/filters/SearchTopicFilter";
-import { useFiltersValues } from "src/app/features/components/filters/useFiltersValues";
+import StatusFilter from "src/app/features/components/filters/StatusFilter";
+import {
+  useFiltersContext,
+  withFiltersContext,
+} from "src/app/features/components/filters/useFiltersValues";
 import { TableLayout } from "src/app/features/components/layouts/TableLayout";
 import {
   approveAclRequest,
@@ -33,9 +36,7 @@ function AclApprovals() {
     : 1;
 
   const { aclType, environment, status, search, requestType } =
-    useFiltersValues({
-      defaultStatus: "CREATED",
-    });
+    useFiltersContext();
 
   const [detailsModal, setDetailsModal] = useState<{
     isOpen: boolean;
@@ -243,7 +244,7 @@ function AclApprovals() {
             key={"environment"}
             environmentEndpoint={"getAllEnvironmentsForTopicAndAcl"}
           />,
-          <StatusFilter key={"status"} defaultStatus={"CREATED"} />,
+          <StatusFilter key={"status"} />,
           <RequestTypeFilter key={"requestType"} />,
           <AclTypeFilter key={"aclType"} />,
           <SearchTopicFilter key={"topic"} />,
@@ -271,4 +272,7 @@ function AclApprovals() {
   );
 }
 
-export default AclApprovals;
+export default withFiltersContext({
+  defaultValues: { status: "CREATED" },
+  element: <AclApprovals />,
+});

--- a/coral/src/app/features/approvals/acls/AclApprovals.tsx
+++ b/coral/src/app/features/approvals/acls/AclApprovals.tsx
@@ -15,7 +15,7 @@ import StatusFilter from "src/app/features/components/filters/StatusFilter";
 import {
   useFiltersContext,
   withFiltersContext,
-} from "src/app/features/components/filters/useFiltersValues";
+} from "src/app/features/components/filters/useFiltersContext";
 import { TableLayout } from "src/app/features/components/layouts/TableLayout";
 import {
   approveAclRequest,

--- a/coral/src/app/features/approvals/connectors/ConnectorApprovals.tsx
+++ b/coral/src/app/features/approvals/connectors/ConnectorApprovals.tsx
@@ -13,7 +13,7 @@ import StatusFilter from "src/app/features/components/filters/StatusFilter";
 import {
   useFiltersContext,
   withFiltersContext,
-} from "src/app/features/components/filters/useFiltersValues";
+} from "src/app/features/components/filters/useFiltersContext";
 import { TableLayout } from "src/app/features/components/layouts/TableLayout";
 import {
   approveConnectorRequest,

--- a/coral/src/app/features/approvals/connectors/ConnectorApprovals.tsx
+++ b/coral/src/app/features/approvals/connectors/ConnectorApprovals.tsx
@@ -10,7 +10,10 @@ import RequestDetailsModal from "src/app/features/components/RequestDetailsModal
 import EnvironmentFilter from "src/app/features/components/filters/EnvironmentFilter";
 import { RequestTypeFilter } from "src/app/features/components/filters/RequestTypeFilter";
 import StatusFilter from "src/app/features/components/filters/StatusFilter";
-import { useFiltersValues } from "src/app/features/components/filters/useFiltersValues";
+import {
+  useFiltersContext,
+  withFiltersContext,
+} from "src/app/features/components/filters/useFiltersValues";
 import { TableLayout } from "src/app/features/components/layouts/TableLayout";
 import {
   approveConnectorRequest,
@@ -30,9 +33,7 @@ function ConnectorApprovals() {
     ? Number(searchParams.get("page"))
     : 1;
 
-  const { environment, status, search, requestType } = useFiltersValues({
-    defaultStatus: "CREATED",
-  });
+  const { environment, status, search, requestType } = useFiltersContext();
 
   const [detailsModal, setDetailsModal] = useState<{
     isOpen: boolean;
@@ -271,7 +272,7 @@ function ConnectorApprovals() {
             key={"environment"}
             environmentEndpoint={"getAllEnvironmentsForConnector"}
           />,
-          <StatusFilter key={"status"} defaultStatus={"CREATED"} />,
+          <StatusFilter key={"status"} />,
           <RequestTypeFilter key={"requestType"} />,
           <SearchConnectorFilter key={"search"} />,
         ]}
@@ -285,4 +286,7 @@ function ConnectorApprovals() {
   );
 }
 
-export default ConnectorApprovals;
+export default withFiltersContext({
+  defaultValues: { status: "CREATED" },
+  element: <ConnectorApprovals />,
+});

--- a/coral/src/app/features/approvals/schemas/SchemaApprovals.tsx
+++ b/coral/src/app/features/approvals/schemas/SchemaApprovals.tsx
@@ -11,7 +11,10 @@ import { SchemaRequestDetails } from "src/app/features/components/SchemaRequestD
 import EnvironmentFilter from "src/app/features/components/filters/EnvironmentFilter";
 import StatusFilter from "src/app/features/components/filters/StatusFilter";
 import { SearchTopicFilter } from "src/app/features/components/filters/SearchTopicFilter";
-import { useFiltersValues } from "src/app/features/components/filters/useFiltersValues";
+import {
+  useFiltersContext,
+  withFiltersContext,
+} from "src/app/features/components/filters/useFiltersValues";
 import {
   approveSchemaRequest,
   declineSchemaRequest,
@@ -30,9 +33,7 @@ function SchemaApprovals() {
     ? Number(searchParams.get("page"))
     : 1;
 
-  const { environment, status, search, requestType } = useFiltersValues({
-    defaultStatus: "CREATED",
-  });
+  const { environment, status, search, requestType } = useFiltersContext();
 
   const [detailsModal, setDetailsModal] = useState<{
     isOpen: boolean;
@@ -270,7 +271,7 @@ function SchemaApprovals() {
             key={"environment"}
             environmentEndpoint={"getAllEnvironmentsForSchema"}
           />,
-          <StatusFilter key={"status"} defaultStatus={"CREATED"} />,
+          <StatusFilter key={"status"} />,
           <RequestTypeFilter key={"requestType"} />,
           <SearchTopicFilter key={"topic"} />,
         ]}
@@ -284,4 +285,7 @@ function SchemaApprovals() {
   );
 }
 
-export default SchemaApprovals;
+export default withFiltersContext({
+  defaultValues: { status: "CREATED" },
+  element: <SchemaApprovals />,
+});

--- a/coral/src/app/features/approvals/schemas/SchemaApprovals.tsx
+++ b/coral/src/app/features/approvals/schemas/SchemaApprovals.tsx
@@ -14,7 +14,7 @@ import { SearchTopicFilter } from "src/app/features/components/filters/SearchTop
 import {
   useFiltersContext,
   withFiltersContext,
-} from "src/app/features/components/filters/useFiltersValues";
+} from "src/app/features/components/filters/useFiltersContext";
 import {
   approveSchemaRequest,
   declineSchemaRequest,

--- a/coral/src/app/features/approvals/topics/TopicApprovals.tsx
+++ b/coral/src/app/features/approvals/topics/TopicApprovals.tsx
@@ -12,7 +12,10 @@ import { RequestTypeFilter } from "src/app/features/components/filters/RequestTy
 import StatusFilter from "src/app/features/components/filters/StatusFilter";
 import TeamFilter from "src/app/features/components/filters/TeamFilter";
 import { SearchTopicFilter } from "src/app/features/components/filters/SearchTopicFilter";
-import { useFiltersValues } from "src/app/features/components/filters/useFiltersValues";
+import {
+  useFiltersContext,
+  withFiltersContext,
+} from "src/app/features/components/filters/useFiltersValues";
 import { TableLayout } from "src/app/features/components/layouts/TableLayout";
 import {
   approveTopicRequest,
@@ -33,11 +36,8 @@ function TopicApprovals() {
     ? Number(searchParams.get("page"))
     : 1;
 
-  const { environment, status, search, teamId, requestType } = useFiltersValues(
-    {
-      defaultStatus: "CREATED",
-    }
-  );
+  const { environment, status, search, teamId, requestType } =
+    useFiltersContext();
 
   const [detailsModal, setDetailsModal] = useState<{
     isOpen: boolean;
@@ -282,7 +282,7 @@ function TopicApprovals() {
             key={"environment"}
             environmentEndpoint={"getAllEnvironmentsForTopicAndAcl"}
           />,
-          <StatusFilter key={"status"} defaultStatus={"CREATED"} />,
+          <StatusFilter key={"status"} />,
           <RequestTypeFilter key={"requestType"} />,
           <TeamFilter key={"team"} />,
           <SearchTopicFilter key={"topic"} />,
@@ -297,4 +297,7 @@ function TopicApprovals() {
   );
 }
 
-export default TopicApprovals;
+export default withFiltersContext({
+  defaultValues: { status: "CREATED" },
+  element: <TopicApprovals />,
+});

--- a/coral/src/app/features/approvals/topics/TopicApprovals.tsx
+++ b/coral/src/app/features/approvals/topics/TopicApprovals.tsx
@@ -15,7 +15,7 @@ import { SearchTopicFilter } from "src/app/features/components/filters/SearchTop
 import {
   useFiltersContext,
   withFiltersContext,
-} from "src/app/features/components/filters/useFiltersValues";
+} from "src/app/features/components/filters/useFiltersContext";
 import { TableLayout } from "src/app/features/components/layouts/TableLayout";
 import {
   approveTopicRequest,

--- a/coral/src/app/features/components/filters/AclTypeFilter.test.tsx
+++ b/coral/src/app/features/components/filters/AclTypeFilter.test.tsx
@@ -2,7 +2,7 @@ import { cleanup, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 
 import AclTypeFilter from "src/app/features/components/filters/AclTypeFilter";
-import { withFiltersContext } from "src/app/features/components/filters/useFiltersValues";
+import { withFiltersContext } from "src/app/features/components/filters/useFiltersContext";
 import { customRender } from "src/services/test-utils/render-with-wrappers";
 
 const aclTypesForFilter = ["ALL", "CONSUMER", "PRODUCER"];

--- a/coral/src/app/features/components/filters/AclTypeFilter.test.tsx
+++ b/coral/src/app/features/components/filters/AclTypeFilter.test.tsx
@@ -2,15 +2,18 @@ import { cleanup, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 
 import AclTypeFilter from "src/app/features/components/filters/AclTypeFilter";
+import { withFiltersContext } from "src/app/features/components/filters/useFiltersValues";
 import { customRender } from "src/services/test-utils/render-with-wrappers";
 
 const aclTypesForFilter = ["ALL", "CONSUMER", "PRODUCER"];
+
+const WrappedAclTypeFilter = withFiltersContext({ element: <AclTypeFilter /> });
 
 const filterLabel = "Filter by ACL type";
 describe("AclTypeFilter.tsx", () => {
   describe("renders all necessary elements", () => {
     beforeAll(async () => {
-      customRender(<AclTypeFilter />, {
+      customRender(<WrappedAclTypeFilter />, {
         memoryRouter: true,
       });
     });
@@ -56,7 +59,7 @@ describe("AclTypeFilter.tsx", () => {
     beforeEach(async () => {
       const routePath = `/?aclType=${consumerAcl}`;
 
-      customRender(<AclTypeFilter />, {
+      customRender(<WrappedAclTypeFilter />, {
         memoryRouter: true,
         queryClient: true,
         customRoutePath: routePath,
@@ -81,7 +84,7 @@ describe("AclTypeFilter.tsx", () => {
     const producerAcl = "PRODUCER";
 
     beforeEach(async () => {
-      customRender(<AclTypeFilter />, {
+      customRender(<WrappedAclTypeFilter />, {
         queryClient: true,
         memoryRouter: true,
       });
@@ -109,7 +112,7 @@ describe("AclTypeFilter.tsx", () => {
     const consumerAcl = "CONSUMER";
 
     beforeEach(async () => {
-      customRender(<AclTypeFilter />, {
+      customRender(<WrappedAclTypeFilter />, {
         queryClient: true,
         browserRouter: true,
       });

--- a/coral/src/app/features/components/filters/AclTypeFilter.tsx
+++ b/coral/src/app/features/components/filters/AclTypeFilter.tsx
@@ -1,12 +1,12 @@
 import { NativeSelect } from "@aivenio/aquarium";
-import { useFiltersValues } from "src/app/features/components/filters/useFiltersValues";
+import { useFiltersContext } from "src/app/features/components/filters/useFiltersValues";
 import { AclType } from "src/domain/acl";
 
 type AclTypeForFilter = AclType | "ALL";
 const aclTypesForFilter: AclTypeForFilter[] = ["ALL", "CONSUMER", "PRODUCER"];
 
 function AclTypeFilter() {
-  const { aclType, setFilterValue } = useFiltersValues();
+  const { aclType, setFilterValue } = useFiltersContext();
 
   return (
     <NativeSelect

--- a/coral/src/app/features/components/filters/AclTypeFilter.tsx
+++ b/coral/src/app/features/components/filters/AclTypeFilter.tsx
@@ -1,5 +1,5 @@
 import { NativeSelect } from "@aivenio/aquarium";
-import { useFiltersContext } from "src/app/features/components/filters/useFiltersValues";
+import { useFiltersContext } from "src/app/features/components/filters/useFiltersContext";
 import { AclType } from "src/domain/acl";
 
 type AclTypeForFilter = AclType | "ALL";

--- a/coral/src/app/features/components/filters/EnvironmentFilter.test.tsx
+++ b/coral/src/app/features/components/filters/EnvironmentFilter.test.tsx
@@ -2,7 +2,7 @@ import { cleanup, screen, waitFor } from "@testing-library/react";
 import { waitForElementToBeRemoved } from "@testing-library/react/pure";
 import userEvent from "@testing-library/user-event";
 import EnvironmentFilter from "src/app/features/components/filters/EnvironmentFilter";
-import { withFiltersContext } from "src/app/features/components/filters/useFiltersValues";
+import { withFiltersContext } from "src/app/features/components/filters/useFiltersContext";
 import {
   getAllEnvironmentsForTopicAndAcl,
   getAllEnvironmentsForSchema,

--- a/coral/src/app/features/components/filters/EnvironmentFilter.test.tsx
+++ b/coral/src/app/features/components/filters/EnvironmentFilter.test.tsx
@@ -2,6 +2,7 @@ import { cleanup, screen, waitFor } from "@testing-library/react";
 import { waitForElementToBeRemoved } from "@testing-library/react/pure";
 import userEvent from "@testing-library/user-event";
 import EnvironmentFilter from "src/app/features/components/filters/EnvironmentFilter";
+import { withFiltersContext } from "src/app/features/components/filters/useFiltersValues";
 import {
   getAllEnvironmentsForTopicAndAcl,
   getAllEnvironmentsForSchema,
@@ -40,6 +41,14 @@ const mockEnvironments = [
 
 const filterLabel = "Filter by Environment";
 
+const WrappedEnvironmentFilter = withFiltersContext({
+  element: (
+    <EnvironmentFilter
+      environmentEndpoint={"getAllEnvironmentsForTopicAndAcl"}
+    />
+  ),
+});
+
 describe("EnvironmentFilter.tsx", () => {
   describe("uses a given endpoint to fetch environments", () => {
     beforeEach(() => {
@@ -53,15 +62,10 @@ describe("EnvironmentFilter.tsx", () => {
     });
 
     it("fetches from the getAllEnvironmentsForTopicAndAcl endpoint", () => {
-      customRender(
-        <EnvironmentFilter
-          environmentEndpoint={"getAllEnvironmentsForTopicAndAcl"}
-        />,
-        {
-          memoryRouter: true,
-          queryClient: true,
-        }
-      );
+      customRender(<WrappedEnvironmentFilter />, {
+        memoryRouter: true,
+        queryClient: true,
+      });
 
       expect(mockGetEnvironments).toHaveBeenCalled();
       expect(mockGetSchemaRegistryEnvironments).not.toHaveBeenCalled();
@@ -69,15 +73,17 @@ describe("EnvironmentFilter.tsx", () => {
     });
 
     it("fetches from the getAllEnvironmentsForSchema endpoint", () => {
-      customRender(
-        <EnvironmentFilter
-          environmentEndpoint={"getAllEnvironmentsForSchema"}
-        />,
-        {
-          memoryRouter: true,
-          queryClient: true,
-        }
-      );
+      const WrappedEnvironmentFilter = withFiltersContext({
+        element: (
+          <EnvironmentFilter
+            environmentEndpoint={"getAllEnvironmentsForSchema"}
+          />
+        ),
+      });
+      customRender(<WrappedEnvironmentFilter />, {
+        memoryRouter: true,
+        queryClient: true,
+      });
 
       expect(mockGetSchemaRegistryEnvironments).toHaveBeenCalled();
       expect(mockGetEnvironments).not.toHaveBeenCalled();
@@ -85,15 +91,17 @@ describe("EnvironmentFilter.tsx", () => {
     });
 
     it("fetches from the getAllEnvironmentsForConnector endpoint", () => {
-      customRender(
-        <EnvironmentFilter
-          environmentEndpoint={"getAllEnvironmentsForConnector"}
-        />,
-        {
-          memoryRouter: true,
-          queryClient: true,
-        }
-      );
+      const WrappedEnvironmentFilter = withFiltersContext({
+        element: (
+          <EnvironmentFilter
+            environmentEndpoint={"getAllEnvironmentsForConnector"}
+          />
+        ),
+      });
+      customRender(<WrappedEnvironmentFilter />, {
+        memoryRouter: true,
+        queryClient: true,
+      });
 
       expect(mockGetSyncConnectorsEnvironments).toHaveBeenCalled();
       expect(mockGetEnvironments).not.toHaveBeenCalled();
@@ -107,15 +115,10 @@ describe("EnvironmentFilter.tsx", () => {
       mockGetSchemaRegistryEnvironments.mockResolvedValue([]);
       mockGetSyncConnectorsEnvironments.mockResolvedValue([]);
 
-      customRender(
-        <EnvironmentFilter
-          environmentEndpoint={"getAllEnvironmentsForTopicAndAcl"}
-        />,
-        {
-          memoryRouter: true,
-          queryClient: true,
-        }
-      );
+      customRender(<WrappedEnvironmentFilter />, {
+        memoryRouter: true,
+        queryClient: true,
+      });
       await waitForElementToBeRemoved(
         screen.getByTestId("select-environment-loading")
       );
@@ -165,16 +168,11 @@ describe("EnvironmentFilter.tsx", () => {
       mockGetSchemaRegistryEnvironments.mockResolvedValue([]);
       mockGetSyncConnectorsEnvironments.mockResolvedValue([]);
 
-      customRender(
-        <EnvironmentFilter
-          environmentEndpoint={"getAllEnvironmentsForTopicAndAcl"}
-        />,
-        {
-          memoryRouter: true,
-          queryClient: true,
-          customRoutePath: routePath,
-        }
-      );
+      customRender(<WrappedEnvironmentFilter />, {
+        memoryRouter: true,
+        queryClient: true,
+        customRoutePath: routePath,
+      });
       await waitForElementToBeRemoved(
         screen.getByTestId("select-environment-loading")
       );
@@ -201,15 +199,10 @@ describe("EnvironmentFilter.tsx", () => {
       mockGetSchemaRegistryEnvironments.mockResolvedValue([]);
       mockGetSyncConnectorsEnvironments.mockResolvedValue([]);
 
-      customRender(
-        <EnvironmentFilter
-          environmentEndpoint={"getAllEnvironmentsForTopicAndAcl"}
-        />,
-        {
-          queryClient: true,
-          memoryRouter: true,
-        }
-      );
+      customRender(<WrappedEnvironmentFilter />, {
+        queryClient: true,
+        memoryRouter: true,
+      });
       await waitForElementToBeRemoved(
         screen.getByTestId("select-environment-loading")
       );
@@ -240,15 +233,10 @@ describe("EnvironmentFilter.tsx", () => {
       mockGetSchemaRegistryEnvironments.mockResolvedValue([]);
       mockGetSyncConnectorsEnvironments.mockResolvedValue([]);
 
-      customRender(
-        <EnvironmentFilter
-          environmentEndpoint={"getAllEnvironmentsForTopicAndAcl"}
-        />,
-        {
-          queryClient: true,
-          browserRouter: true,
-        }
-      );
+      customRender(<WrappedEnvironmentFilter />, {
+        queryClient: true,
+        browserRouter: true,
+      });
       await waitForElementToBeRemoved(
         screen.getByTestId("select-environment-loading")
       );

--- a/coral/src/app/features/components/filters/EnvironmentFilter.tsx
+++ b/coral/src/app/features/components/filters/EnvironmentFilter.tsx
@@ -1,6 +1,6 @@
 import { NativeSelect, Option } from "@aivenio/aquarium";
 import { useQuery } from "@tanstack/react-query";
-import { useFiltersValues } from "src/app/features/components/filters/useFiltersValues";
+import { useFiltersContext } from "src/app/features/components/filters/useFiltersValues";
 import {
   Environment,
   getAllEnvironmentsForTopicAndAcl,
@@ -27,7 +27,7 @@ const environmentEndpointMap: {
 };
 
 function EnvironmentFilter({ environmentEndpoint }: EnvironmentFilterProps) {
-  const { environment, setFilterValue } = useFiltersValues();
+  const { environment, setFilterValue } = useFiltersContext();
 
   const { data: environments } = useQuery<Environment[], HTTPError>(
     [environmentEndpoint],

--- a/coral/src/app/features/components/filters/EnvironmentFilter.tsx
+++ b/coral/src/app/features/components/filters/EnvironmentFilter.tsx
@@ -1,6 +1,6 @@
 import { NativeSelect, Option } from "@aivenio/aquarium";
 import { useQuery } from "@tanstack/react-query";
-import { useFiltersContext } from "src/app/features/components/filters/useFiltersValues";
+import { useFiltersContext } from "src/app/features/components/filters/useFiltersContext";
 import {
   Environment,
   getAllEnvironmentsForTopicAndAcl,

--- a/coral/src/app/features/components/filters/MyRequestsFilter.test.tsx
+++ b/coral/src/app/features/components/filters/MyRequestsFilter.test.tsx
@@ -77,8 +77,6 @@ describe("MyRequestsFilter", () => {
     });
     await userEvent.click(showMyRequests);
     await waitFor(() => expect(showMyRequests).not.toBeChecked());
-    await waitFor(() =>
-      expect(window.location.search).toEqual("?showOnlyMyRequests=false&page=1")
-    );
+    await waitFor(() => expect(window.location.search).toEqual("?page=1"));
   });
 });

--- a/coral/src/app/features/components/filters/MyRequestsFilter.test.tsx
+++ b/coral/src/app/features/components/filters/MyRequestsFilter.test.tsx
@@ -2,6 +2,11 @@ import { customRender } from "src/services/test-utils/render-with-wrappers";
 import { MyRequestsFilter } from "src/app/features/components/filters/MyRequestsFilter";
 import { cleanup, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
+import { withFiltersContext } from "src/app/features/components/filters/useFiltersValues";
+
+const WrappedMyRequestsFilter = withFiltersContext({
+  element: <MyRequestsFilter />,
+});
 
 describe("MyRequestsFilter", () => {
   afterEach(() => {
@@ -11,7 +16,7 @@ describe("MyRequestsFilter", () => {
 
   it("is checked if showOnlyMyRequests is true in the url search parameters", async () => {
     window.history.replaceState(null, "", "/?showOnlyMyRequests=true");
-    customRender(<MyRequestsFilter />, {
+    customRender(<WrappedMyRequestsFilter />, {
       browserRouter: true,
     });
     await waitFor(() =>
@@ -28,7 +33,7 @@ describe("MyRequestsFilter", () => {
 
   it("is unchecked if showOnlyMyRequests in the url search parameters has other value than true", async () => {
     window.history.replaceState(null, "", "/?showOnlyMyRequests=abc");
-    customRender(<MyRequestsFilter />, {
+    customRender(<WrappedMyRequestsFilter />, {
       browserRouter: true,
     });
     await waitFor(() =>
@@ -45,7 +50,7 @@ describe("MyRequestsFilter", () => {
 
   it("sets the showOnlyMyRequests and page search parameter when user toggles the switch", async () => {
     window.history.replaceState(null, "", "/");
-    customRender(<MyRequestsFilter />, {
+    customRender(<WrappedMyRequestsFilter />, {
       browserRouter: true,
     });
     await waitFor(() => expect(window.location.search).toEqual(""));
@@ -61,7 +66,7 @@ describe("MyRequestsFilter", () => {
 
   it("unsets the showOnlyMyRequests and page search parameter when user untoggles the switch", async () => {
     window.history.replaceState(null, "", "/?showOnlyMyRequests=true");
-    customRender(<MyRequestsFilter />, {
+    customRender(<WrappedMyRequestsFilter />, {
       browserRouter: true,
     });
     await waitFor(() =>
@@ -72,6 +77,8 @@ describe("MyRequestsFilter", () => {
     });
     await userEvent.click(showMyRequests);
     await waitFor(() => expect(showMyRequests).not.toBeChecked());
-    await waitFor(() => expect(window.location.search).toEqual("?page=1"));
+    await waitFor(() =>
+      expect(window.location.search).toEqual("?showOnlyMyRequests=false&page=1")
+    );
   });
 });

--- a/coral/src/app/features/components/filters/MyRequestsFilter.test.tsx
+++ b/coral/src/app/features/components/filters/MyRequestsFilter.test.tsx
@@ -2,7 +2,7 @@ import { customRender } from "src/services/test-utils/render-with-wrappers";
 import { MyRequestsFilter } from "src/app/features/components/filters/MyRequestsFilter";
 import { cleanup, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { withFiltersContext } from "src/app/features/components/filters/useFiltersValues";
+import { withFiltersContext } from "src/app/features/components/filters/useFiltersContext";
 
 const WrappedMyRequestsFilter = withFiltersContext({
   element: <MyRequestsFilter />,

--- a/coral/src/app/features/components/filters/MyRequestsFilter.tsx
+++ b/coral/src/app/features/components/filters/MyRequestsFilter.tsx
@@ -1,8 +1,8 @@
 import { Switch } from "@aivenio/aquarium";
-import { useFiltersValues } from "src/app/features/components/filters/useFiltersValues";
+import { useFiltersContext } from "src/app/features/components/filters/useFiltersValues";
 
 function MyRequestsFilter() {
-  const { showOnlyMyRequests, setFilterValue } = useFiltersValues();
+  const { showOnlyMyRequests, setFilterValue } = useFiltersContext();
 
   const handleChangeIsMyRequest = (
     event: React.ChangeEvent<HTMLInputElement>

--- a/coral/src/app/features/components/filters/MyRequestsFilter.tsx
+++ b/coral/src/app/features/components/filters/MyRequestsFilter.tsx
@@ -1,5 +1,5 @@
 import { Switch } from "@aivenio/aquarium";
-import { useFiltersContext } from "src/app/features/components/filters/useFiltersValues";
+import { useFiltersContext } from "src/app/features/components/filters/useFiltersContext";
 
 function MyRequestsFilter() {
   const { showOnlyMyRequests, setFilterValue } = useFiltersContext();

--- a/coral/src/app/features/components/filters/RequestTypeFilter.test.tsx
+++ b/coral/src/app/features/components/filters/RequestTypeFilter.test.tsx
@@ -5,7 +5,7 @@ import {
   requestOperationTypeNameMap,
 } from "src/app/features/approvals/utils/request-operation-type-helper";
 import { RequestTypeFilter } from "src/app/features/components/filters/RequestTypeFilter";
-import { withFiltersContext } from "src/app/features/components/filters/useFiltersValues";
+import { withFiltersContext } from "src/app/features/components/filters/useFiltersContext";
 import { customRender } from "src/services/test-utils/render-with-wrappers";
 
 const filterLabel = "Filter by request type";

--- a/coral/src/app/features/components/filters/RequestTypeFilter.test.tsx
+++ b/coral/src/app/features/components/filters/RequestTypeFilter.test.tsx
@@ -5,14 +5,19 @@ import {
   requestOperationTypeNameMap,
 } from "src/app/features/approvals/utils/request-operation-type-helper";
 import { RequestTypeFilter } from "src/app/features/components/filters/RequestTypeFilter";
+import { withFiltersContext } from "src/app/features/components/filters/useFiltersValues";
 import { customRender } from "src/services/test-utils/render-with-wrappers";
 
 const filterLabel = "Filter by request type";
 
+const WrappedRequestTypeFilter = withFiltersContext({
+  element: <RequestTypeFilter />,
+});
+
 describe("RequestTypeFilter.tsx", () => {
   describe("renders all necessary elements", () => {
-    beforeAll(async () => {
-      customRender(<RequestTypeFilter />, {
+    beforeAll(() => {
+      customRender(<WrappedRequestTypeFilter />, {
         memoryRouter: true,
       });
     });
@@ -50,7 +55,7 @@ describe("RequestTypeFilter.tsx", () => {
     beforeEach(async () => {
       const routePath = `/?requestType=${requestTypeDelete}`;
 
-      customRender(<RequestTypeFilter />, {
+      customRender(<WrappedRequestTypeFilter />, {
         memoryRouter: true,
         queryClient: true,
         customRoutePath: routePath,
@@ -79,7 +84,7 @@ describe("RequestTypeFilter.tsx", () => {
     const approvedName = requestOperationTypeNameMap[requestTypeCreate];
 
     beforeEach(async () => {
-      customRender(<RequestTypeFilter />, {
+      customRender(<WrappedRequestTypeFilter />, {
         queryClient: true,
         memoryRouter: true,
       });
@@ -111,7 +116,7 @@ describe("RequestTypeFilter.tsx", () => {
     const deleteName = requestOperationTypeNameMap[defaultRequestType];
 
     beforeEach(async () => {
-      customRender(<RequestTypeFilter />, {
+      customRender(<WrappedRequestTypeFilter />, {
         queryClient: true,
         browserRouter: true,
       });

--- a/coral/src/app/features/components/filters/RequestTypeFilter.tsx
+++ b/coral/src/app/features/components/filters/RequestTypeFilter.tsx
@@ -4,7 +4,7 @@ import {
   requestOperationTypeList,
   requestOperationTypeNameMap,
 } from "src/app/features/approvals/utils/request-operation-type-helper";
-import { useFiltersValues } from "src/app/features/components/filters/useFiltersValues";
+import { useFiltersContext } from "src/app/features/components/filters/useFiltersValues";
 import { RequestOperationType } from "src/domain/requests/requests-types";
 import { ResolveIntersectionTypes } from "types/utils";
 
@@ -13,7 +13,7 @@ type RequestOperationTypeOptions = ResolveIntersectionTypes<
 >;
 
 function RequestTypeFilter() {
-  const { requestType, setFilterValue } = useFiltersValues();
+  const { requestType, setFilterValue } = useFiltersContext();
 
   const handleChangeRequestType = (e: ChangeEvent<HTMLSelectElement>) => {
     const nextOperationType = e.target.value as RequestOperationTypeOptions;

--- a/coral/src/app/features/components/filters/RequestTypeFilter.tsx
+++ b/coral/src/app/features/components/filters/RequestTypeFilter.tsx
@@ -4,7 +4,7 @@ import {
   requestOperationTypeList,
   requestOperationTypeNameMap,
 } from "src/app/features/approvals/utils/request-operation-type-helper";
-import { useFiltersContext } from "src/app/features/components/filters/useFiltersValues";
+import { useFiltersContext } from "src/app/features/components/filters/useFiltersContext";
 import { RequestOperationType } from "src/domain/requests/requests-types";
 import { ResolveIntersectionTypes } from "types/utils";
 

--- a/coral/src/app/features/components/filters/SearchFilter.test.tsx
+++ b/coral/src/app/features/components/filters/SearchFilter.test.tsx
@@ -1,7 +1,7 @@
 import { cleanup, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { SearchFilter } from "src/app/features/components/filters/SearchFilter";
-import { withFiltersContext } from "src/app/features/components/filters/useFiltersValues";
+import { withFiltersContext } from "src/app/features/components/filters/useFiltersContext";
 import { customRender } from "src/services/test-utils/render-with-wrappers";
 
 describe("SearchFilter.tsx", () => {

--- a/coral/src/app/features/components/filters/SearchFilter.test.tsx
+++ b/coral/src/app/features/components/filters/SearchFilter.test.tsx
@@ -1,6 +1,7 @@
 import { cleanup, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { SearchFilter } from "src/app/features/components/filters/SearchFilter";
+import { withFiltersContext } from "src/app/features/components/filters/useFiltersValues";
 import { customRender } from "src/services/test-utils/render-with-wrappers";
 
 describe("SearchFilter.tsx", () => {
@@ -9,12 +10,15 @@ describe("SearchFilter.tsx", () => {
 
   describe("renders default view when no query is set", () => {
     beforeAll(async () => {
-      customRender(
-        <SearchFilter placeholder={placeholder} description={description} />,
-        {
-          memoryRouter: true,
-        }
-      );
+      const WrappedSearchFilter = withFiltersContext({
+        element: (
+          <SearchFilter placeholder={placeholder} description={description} />
+        ),
+      });
+
+      customRender(<WrappedSearchFilter />, {
+        memoryRouter: true,
+      });
     });
 
     afterAll(cleanup);
@@ -49,14 +53,16 @@ describe("SearchFilter.tsx", () => {
 
     beforeEach(async () => {
       const routePath = `/topics?search=${topicTest}`;
+      const WrappedSearchFilter = withFiltersContext({
+        element: (
+          <SearchFilter placeholder={placeholder} description={description} />
+        ),
+      });
 
-      customRender(
-        <SearchFilter placeholder={placeholder} description={description} />,
-        {
-          memoryRouter: true,
-          customRoutePath: routePath,
-        }
-      );
+      customRender(<WrappedSearchFilter />, {
+        memoryRouter: true,
+        customRoutePath: routePath,
+      });
     });
 
     afterEach(() => {
@@ -72,12 +78,15 @@ describe("SearchFilter.tsx", () => {
 
   describe("handles user typing a search", () => {
     beforeEach(async () => {
-      customRender(
-        <SearchFilter placeholder={placeholder} description={description} />,
-        {
-          memoryRouter: true,
-        }
-      );
+      const WrappedSearchFilter = withFiltersContext({
+        element: (
+          <SearchFilter placeholder={placeholder} description={description} />
+        ),
+      });
+
+      customRender(<WrappedSearchFilter />, {
+        memoryRouter: true,
+      });
     });
 
     afterEach(() => {
@@ -96,12 +105,15 @@ describe("SearchFilter.tsx", () => {
 
   describe("updates the search param to preserve topic in url", () => {
     beforeEach(async () => {
-      customRender(
-        <SearchFilter placeholder={placeholder} description={description} />,
-        {
-          browserRouter: true,
-        }
-      );
+      const WrappedSearchFilter = withFiltersContext({
+        element: (
+          <SearchFilter placeholder={placeholder} description={description} />
+        ),
+      });
+
+      customRender(<WrappedSearchFilter />, {
+        browserRouter: true,
+      });
     });
 
     afterEach(() => {

--- a/coral/src/app/features/components/filters/SearchFilter.tsx
+++ b/coral/src/app/features/components/filters/SearchFilter.tsx
@@ -1,7 +1,7 @@
 import { SearchInput } from "@aivenio/aquarium";
 import debounce from "lodash/debounce";
-import { useFiltersValues } from "src/app/features/components/filters/useFiltersValues";
 import type { ChangeEvent } from "react";
+import { useFiltersContext } from "src/app/features/components/filters/useFiltersValues";
 
 type SearchFilterProps = {
   placeholder: string;
@@ -9,7 +9,7 @@ type SearchFilterProps = {
 };
 
 function SearchFilter({ placeholder, description }: SearchFilterProps) {
-  const { search, setFilterValue } = useFiltersValues();
+  const { search, setFilterValue } = useFiltersContext();
   return (
     <>
       <SearchInput

--- a/coral/src/app/features/components/filters/SearchFilter.tsx
+++ b/coral/src/app/features/components/filters/SearchFilter.tsx
@@ -1,7 +1,7 @@
 import { SearchInput } from "@aivenio/aquarium";
 import debounce from "lodash/debounce";
 import type { ChangeEvent } from "react";
-import { useFiltersContext } from "src/app/features/components/filters/useFiltersValues";
+import { useFiltersContext } from "src/app/features/components/filters/useFiltersContext";
 
 type SearchFilterProps = {
   placeholder: string;

--- a/coral/src/app/features/components/filters/StatusFilter.test.tsx
+++ b/coral/src/app/features/components/filters/StatusFilter.test.tsx
@@ -5,7 +5,7 @@ import {
   statusList,
 } from "src/app/features/approvals/utils/request-status-helper";
 import StatusFilter from "src/app/features/components/filters/StatusFilter";
-import { withFiltersContext } from "src/app/features/components/filters/useFiltersValues";
+import { withFiltersContext } from "src/app/features/components/filters/useFiltersContext";
 import { customRender } from "src/services/test-utils/render-with-wrappers";
 
 const filterLabel = "Filter by status";

--- a/coral/src/app/features/components/filters/StatusFilter.test.tsx
+++ b/coral/src/app/features/components/filters/StatusFilter.test.tsx
@@ -5,21 +5,25 @@ import {
   statusList,
 } from "src/app/features/approvals/utils/request-status-helper";
 import StatusFilter from "src/app/features/components/filters/StatusFilter";
+import { withFiltersContext } from "src/app/features/components/filters/useFiltersValues";
 import { customRender } from "src/services/test-utils/render-with-wrappers";
 
 const filterLabel = "Filter by status";
 
 describe("StatusFilter.tsx", () => {
   const testDefaultStatus = "CREATED";
-
+  const WrappedStatusFilter = withFiltersContext({
+    defaultValues: { status: testDefaultStatus },
+    element: <StatusFilter />,
+  });
   describe("renders all necessary elements", () => {
-    beforeAll(async () => {
-      customRender(<StatusFilter defaultStatus={testDefaultStatus} />, {
+    beforeEach(() => {
+      customRender(<WrappedStatusFilter />, {
         memoryRouter: true,
       });
     });
 
-    afterAll(cleanup);
+    afterEach(cleanup);
 
     it("shows a select element for status", () => {
       const select = screen.getByRole("combobox", {
@@ -61,7 +65,7 @@ describe("StatusFilter.tsx", () => {
     beforeEach(async () => {
       const routePath = `/?status=${declinedStatus}`;
 
-      customRender(<StatusFilter defaultStatus={"CREATED"} />, {
+      customRender(<WrappedStatusFilter />, {
         memoryRouter: true,
         queryClient: true,
         customRoutePath: routePath,
@@ -89,11 +93,15 @@ describe("StatusFilter.tsx", () => {
     const defaultStatus = "DECLINED";
     const approvedStatus = "APPROVED";
     const approvedName = requestStatusNameMap[approvedStatus];
+    const WrappedStatusFilter = withFiltersContext({
+      defaultValues: { status: defaultStatus },
+      element: <StatusFilter />,
+    });
 
     beforeEach(async () => {
-      customRender(<StatusFilter defaultStatus={defaultStatus} />, {
-        queryClient: true,
+      customRender(<WrappedStatusFilter />, {
         memoryRouter: true,
+        queryClient: true,
       });
     });
 
@@ -121,9 +129,13 @@ describe("StatusFilter.tsx", () => {
   describe("updates the search param to preserve status in url", () => {
     const deletedStatus = "DELETED";
     const deletedName = requestStatusNameMap["DELETED"];
+    const WrappedStatusFilter = withFiltersContext({
+      defaultValues: { status: "CREATED" },
+      element: <StatusFilter />,
+    });
 
     beforeEach(async () => {
-      customRender(<StatusFilter defaultStatus={"CREATED"} />, {
+      customRender(<WrappedStatusFilter />, {
         queryClient: true,
         browserRouter: true,
       });

--- a/coral/src/app/features/components/filters/StatusFilter.tsx
+++ b/coral/src/app/features/components/filters/StatusFilter.tsx
@@ -3,17 +3,11 @@ import {
   requestStatusNameMap,
   statusList,
 } from "src/app/features/approvals/utils/request-status-helper";
-import { useFiltersValues } from "src/app/features/components/filters/useFiltersValues";
+import { useFiltersContext } from "src/app/features/components/filters/useFiltersValues";
 import { RequestStatus } from "src/domain/requests/requests-types";
 
-type StatusFilterProps = {
-  defaultStatus: RequestStatus;
-};
-
-function StatusFilter(props: StatusFilterProps) {
-  const { defaultStatus } = props;
-
-  const { status, setFilterValue } = useFiltersValues({ defaultStatus });
+function StatusFilter() {
+  const { status, setFilterValue } = useFiltersContext();
 
   return (
     <NativeSelect

--- a/coral/src/app/features/components/filters/StatusFilter.tsx
+++ b/coral/src/app/features/components/filters/StatusFilter.tsx
@@ -3,7 +3,7 @@ import {
   requestStatusNameMap,
   statusList,
 } from "src/app/features/approvals/utils/request-status-helper";
-import { useFiltersContext } from "src/app/features/components/filters/useFiltersValues";
+import { useFiltersContext } from "src/app/features/components/filters/useFiltersContext";
 import { RequestStatus } from "src/domain/requests/requests-types";
 
 function StatusFilter() {

--- a/coral/src/app/features/components/filters/TeamFilter.test.tsx
+++ b/coral/src/app/features/components/filters/TeamFilter.test.tsx
@@ -2,7 +2,7 @@ import { cleanup, screen, waitFor } from "@testing-library/react";
 import { waitForElementToBeRemoved } from "@testing-library/react/pure";
 import userEvent from "@testing-library/user-event";
 import TeamFilter from "src/app/features/components/filters/TeamFilter";
-import { withFiltersContext } from "src/app/features/components/filters/useFiltersValues";
+import { withFiltersContext } from "src/app/features/components/filters/useFiltersContext";
 import { getTeams } from "src/domain/team/team-api";
 import { customRender } from "src/services/test-utils/render-with-wrappers";
 

--- a/coral/src/app/features/components/filters/TeamFilter.test.tsx
+++ b/coral/src/app/features/components/filters/TeamFilter.test.tsx
@@ -2,6 +2,7 @@ import { cleanup, screen, waitFor } from "@testing-library/react";
 import { waitForElementToBeRemoved } from "@testing-library/react/pure";
 import userEvent from "@testing-library/user-event";
 import TeamFilter from "src/app/features/components/filters/TeamFilter";
+import { withFiltersContext } from "src/app/features/components/filters/useFiltersValues";
 import { getTeams } from "src/domain/team/team-api";
 import { customRender } from "src/services/test-utils/render-with-wrappers";
 
@@ -36,13 +37,17 @@ const mockedTeamsResponse = [
   },
 ];
 
+const WrappedTeamFilter = withFiltersContext({
+  element: <TeamFilter />,
+});
+
 const filterLabel = "Filter by team";
 describe("TeamFilter.tsx", () => {
   describe("renders default view when no query is set", () => {
     beforeAll(async () => {
       mockGetTeams.mockResolvedValue(mockedTeamsResponse);
 
-      customRender(<TeamFilter />, {
+      customRender(<WrappedTeamFilter />, {
         memoryRouter: true,
         queryClient: true,
       });
@@ -91,7 +96,7 @@ describe("TeamFilter.tsx", () => {
 
       mockGetTeams.mockResolvedValue(mockedTeamsResponse);
 
-      customRender(<TeamFilter />, {
+      customRender(<WrappedTeamFilter />, {
         memoryRouter: true,
         queryClient: true,
         customRoutePath: routePath,
@@ -122,7 +127,7 @@ describe("TeamFilter.tsx", () => {
     beforeEach(async () => {
       mockGetTeams.mockResolvedValue(mockedTeamsResponse);
 
-      customRender(<TeamFilter />, {
+      customRender(<WrappedTeamFilter />, {
         queryClient: true,
         memoryRouter: true,
       });
@@ -155,7 +160,7 @@ describe("TeamFilter.tsx", () => {
 
     beforeEach(async () => {
       mockGetTeams.mockResolvedValue(mockedTeamsResponse);
-      customRender(<TeamFilter />, {
+      customRender(<WrappedTeamFilter />, {
         queryClient: true,
         browserRouter: true,
       });

--- a/coral/src/app/features/components/filters/TeamFilter.tsx
+++ b/coral/src/app/features/components/filters/TeamFilter.tsx
@@ -1,6 +1,6 @@
 import { NativeSelect, Option } from "@aivenio/aquarium";
 import { useQuery } from "@tanstack/react-query";
-import { useFiltersValues } from "src/app/features/components/filters/useFiltersValues";
+import { useFiltersContext } from "src/app/features/components/filters/useFiltersValues";
 import { getTeams } from "src/domain/team/team-api";
 
 function TeamFilter() {
@@ -8,7 +8,7 @@ function TeamFilter() {
     queryFn: () => getTeams(),
   });
 
-  const { teamId, setFilterValue } = useFiltersValues();
+  const { teamId, setFilterValue } = useFiltersContext();
 
   if (!topicTeams) {
     return (

--- a/coral/src/app/features/components/filters/TeamFilter.tsx
+++ b/coral/src/app/features/components/filters/TeamFilter.tsx
@@ -1,6 +1,6 @@
 import { NativeSelect, Option } from "@aivenio/aquarium";
 import { useQuery } from "@tanstack/react-query";
-import { useFiltersContext } from "src/app/features/components/filters/useFiltersValues";
+import { useFiltersContext } from "src/app/features/components/filters/useFiltersContext";
 import { getTeams } from "src/domain/team/team-api";
 
 function TeamFilter() {

--- a/coral/src/app/features/components/filters/useFiltersContext.test.tsx
+++ b/coral/src/app/features/components/filters/useFiltersContext.test.tsx
@@ -17,7 +17,7 @@ describe("useFiltersValues.tsx", () => {
       } = renderHook(() => useFiltersContext(), {
         wrapper: ({ children }) => (
           <MemoryRouter initialEntries={["/?environment=1"]}>
-            <FiltersProvider defaultValues={{}}>{children}</FiltersProvider>
+            <FiltersProvider>{children}</FiltersProvider>
           </MemoryRouter>
         ),
       });
@@ -30,7 +30,7 @@ describe("useFiltersValues.tsx", () => {
       } = renderHook(() => useFiltersContext(), {
         wrapper: ({ children }) => (
           <MemoryRouter initialEntries={["/?aclType=PRODUCER"]}>
-            <FiltersProvider defaultValues={{}}>{children}</FiltersProvider>
+            <FiltersProvider>{children}</FiltersProvider>
           </MemoryRouter>
         ),
       });
@@ -43,7 +43,7 @@ describe("useFiltersValues.tsx", () => {
       } = renderHook(() => useFiltersContext(), {
         wrapper: ({ children }) => (
           <MemoryRouter initialEntries={["/?status=CREATED"]}>
-            <FiltersProvider defaultValues={{}}>{children}</FiltersProvider>
+            <FiltersProvider>{children}</FiltersProvider>
           </MemoryRouter>
         ),
       });
@@ -56,7 +56,7 @@ describe("useFiltersValues.tsx", () => {
       } = renderHook(() => useFiltersContext(), {
         wrapper: ({ children }) => (
           <MemoryRouter initialEntries={["/?teamId=1"]}>
-            <FiltersProvider defaultValues={{}}>{children}</FiltersProvider>
+            <FiltersProvider>{children}</FiltersProvider>
           </MemoryRouter>
         ),
       });
@@ -69,7 +69,7 @@ describe("useFiltersValues.tsx", () => {
       } = renderHook(() => useFiltersContext(), {
         wrapper: ({ children }) => (
           <MemoryRouter initialEntries={["/?showOnlyMyRequests=true"]}>
-            <FiltersProvider defaultValues={{}}>{children}</FiltersProvider>
+            <FiltersProvider>{children}</FiltersProvider>
           </MemoryRouter>
         ),
       });
@@ -82,7 +82,7 @@ describe("useFiltersValues.tsx", () => {
       } = renderHook(() => useFiltersContext(), {
         wrapper: ({ children }) => (
           <MemoryRouter initialEntries={["/?requestType=CLAIM"]}>
-            <FiltersProvider defaultValues={{}}>{children}</FiltersProvider>
+            <FiltersProvider>{children}</FiltersProvider>
           </MemoryRouter>
         ),
       });
@@ -96,7 +96,7 @@ describe("useFiltersValues.tsx", () => {
       } = renderHook(() => useFiltersContext(), {
         wrapper: ({ children }) => (
           <MemoryRouter initialEntries={["/?search=abc"]}>
-            <FiltersProvider defaultValues={{}}>{children}</FiltersProvider>
+            <FiltersProvider>{children}</FiltersProvider>
           </MemoryRouter>
         ),
       });
@@ -234,7 +234,7 @@ describe("useFiltersValues.tsx", () => {
       } = renderHook(() => useFiltersContext(), {
         wrapper: ({ children }) => (
           <BrowserRouter>
-            <FiltersProvider defaultValues={{}}>{children}</FiltersProvider>
+            <FiltersProvider>{children}</FiltersProvider>
           </BrowserRouter>
         ),
       });
@@ -252,7 +252,7 @@ describe("useFiltersValues.tsx", () => {
       } = renderHook(() => useFiltersContext(), {
         wrapper: ({ children }) => (
           <BrowserRouter>
-            <FiltersProvider defaultValues={{}}>{children}</FiltersProvider>
+            <FiltersProvider>{children}</FiltersProvider>
           </BrowserRouter>
         ),
       });
@@ -270,7 +270,7 @@ describe("useFiltersValues.tsx", () => {
       } = renderHook(() => useFiltersContext(), {
         wrapper: ({ children }) => (
           <BrowserRouter>
-            <FiltersProvider defaultValues={{}}>{children}</FiltersProvider>
+            <FiltersProvider>{children}</FiltersProvider>
           </BrowserRouter>
         ),
       });
@@ -288,7 +288,7 @@ describe("useFiltersValues.tsx", () => {
       } = renderHook(() => useFiltersContext(), {
         wrapper: ({ children }) => (
           <BrowserRouter>
-            <FiltersProvider defaultValues={{}}>{children}</FiltersProvider>
+            <FiltersProvider>{children}</FiltersProvider>
           </BrowserRouter>
         ),
       });
@@ -306,7 +306,7 @@ describe("useFiltersValues.tsx", () => {
       } = renderHook(() => useFiltersContext(), {
         wrapper: ({ children }) => (
           <BrowserRouter>
-            <FiltersProvider defaultValues={{}}>{children}</FiltersProvider>
+            <FiltersProvider>{children}</FiltersProvider>
           </BrowserRouter>
         ),
       });
@@ -324,7 +324,7 @@ describe("useFiltersValues.tsx", () => {
       } = renderHook(() => useFiltersContext(), {
         wrapper: ({ children }) => (
           <BrowserRouter>
-            <FiltersProvider defaultValues={{}}>{children}</FiltersProvider>
+            <FiltersProvider>{children}</FiltersProvider>
           </BrowserRouter>
         ),
       });
@@ -342,7 +342,7 @@ describe("useFiltersValues.tsx", () => {
       } = renderHook(() => useFiltersContext(), {
         wrapper: ({ children }) => (
           <BrowserRouter>
-            <FiltersProvider defaultValues={{}}>{children}</FiltersProvider>
+            <FiltersProvider>{children}</FiltersProvider>
           </BrowserRouter>
         ),
       });

--- a/coral/src/app/features/components/filters/useFiltersContext.test.tsx
+++ b/coral/src/app/features/components/filters/useFiltersContext.test.tsx
@@ -3,7 +3,7 @@ import { BrowserRouter, MemoryRouter } from "react-router-dom";
 import {
   FiltersProvider,
   useFiltersContext,
-} from "src/app/features/components/filters/useFiltersValues";
+} from "src/app/features/components/filters/useFiltersContext";
 
 describe("useFiltersValues.tsx", () => {
   describe("should get correct filter values from search paramns", () => {

--- a/coral/src/app/features/components/filters/useFiltersContext.tsx
+++ b/coral/src/app/features/components/filters/useFiltersContext.tsx
@@ -39,31 +39,6 @@ type UseFilterValuesReturn = {
   setFilterValue: ({ name, value }: SetFiltersParams) => void;
 };
 
-const useFiltersValues = () => {
-  const [searchParams] = useSearchParams();
-
-  const environment = searchParams.get("environment");
-  const aclType = searchParams.get("aclType") as AclType | "ALL";
-  const status = searchParams.get("status") as RequestStatus;
-  const teamId = searchParams.get("teamId");
-  const showOnlyMyRequests = searchParams.get("showOnlyMyRequests") === "true";
-
-  const requestType = searchParams.get("requestType") as
-    | RequestOperationType
-    | "ALL";
-  const search = searchParams.get("search");
-
-  return {
-    environment,
-    aclType,
-    status,
-    teamId,
-    showOnlyMyRequests,
-    requestType,
-    search,
-  };
-};
-
 const emptyValues: Omit<UseFilterValuesReturn, "setFilterValue"> = {
   environment: "ALL",
   aclType: "ALL",
@@ -153,9 +128,4 @@ const withFiltersContext = ({
   return WrappedElement;
 };
 
-export {
-  useFiltersValues,
-  useFiltersContext,
-  FiltersProvider,
-  withFiltersContext,
-};
+export { useFiltersContext, FiltersProvider, withFiltersContext };

--- a/coral/src/app/features/components/filters/useFiltersValues.test.tsx
+++ b/coral/src/app/features/components/filters/useFiltersValues.test.tsx
@@ -1,6 +1,9 @@
 import { cleanup, renderHook } from "@testing-library/react";
 import { BrowserRouter, MemoryRouter } from "react-router-dom";
-import { useFiltersValues } from "src/app/features/components/filters/useFiltersValues";
+import {
+  FiltersProvider,
+  useFiltersContext,
+} from "src/app/features/components/filters/useFiltersValues";
 
 describe("useFiltersValues.tsx", () => {
   describe("should get correct filter values from search paramns", () => {
@@ -11,10 +14,10 @@ describe("useFiltersValues.tsx", () => {
     it("gets the correct environment filter value", () => {
       const {
         result: { current },
-      } = renderHook(() => useFiltersValues(), {
+      } = renderHook(() => useFiltersContext(), {
         wrapper: ({ children }) => (
           <MemoryRouter initialEntries={["/?environment=1"]}>
-            {children}
+            <FiltersProvider defaultValues={{}}>{children}</FiltersProvider>
           </MemoryRouter>
         ),
       });
@@ -24,10 +27,10 @@ describe("useFiltersValues.tsx", () => {
     it("gets the correct aclType filter value", () => {
       const {
         result: { current },
-      } = renderHook(() => useFiltersValues(), {
+      } = renderHook(() => useFiltersContext(), {
         wrapper: ({ children }) => (
           <MemoryRouter initialEntries={["/?aclType=PRODUCER"]}>
-            {children}
+            <FiltersProvider defaultValues={{}}>{children}</FiltersProvider>
           </MemoryRouter>
         ),
       });
@@ -37,10 +40,10 @@ describe("useFiltersValues.tsx", () => {
     it("gets the correct status filter value", () => {
       const {
         result: { current },
-      } = renderHook(() => useFiltersValues(), {
+      } = renderHook(() => useFiltersContext(), {
         wrapper: ({ children }) => (
           <MemoryRouter initialEntries={["/?status=CREATED"]}>
-            {children}
+            <FiltersProvider defaultValues={{}}>{children}</FiltersProvider>
           </MemoryRouter>
         ),
       });
@@ -50,10 +53,10 @@ describe("useFiltersValues.tsx", () => {
     it("gets the correct team filter value", () => {
       const {
         result: { current },
-      } = renderHook(() => useFiltersValues(), {
+      } = renderHook(() => useFiltersContext(), {
         wrapper: ({ children }) => (
           <MemoryRouter initialEntries={["/?teamId=1"]}>
-            {children}
+            <FiltersProvider defaultValues={{}}>{children}</FiltersProvider>
           </MemoryRouter>
         ),
       });
@@ -63,10 +66,10 @@ describe("useFiltersValues.tsx", () => {
     it("gets the correct showOnlyMyRequests filter value", () => {
       const {
         result: { current },
-      } = renderHook(() => useFiltersValues(), {
+      } = renderHook(() => useFiltersContext(), {
         wrapper: ({ children }) => (
           <MemoryRouter initialEntries={["/?showOnlyMyRequests=true"]}>
-            {children}
+            <FiltersProvider defaultValues={{}}>{children}</FiltersProvider>
           </MemoryRouter>
         ),
       });
@@ -76,10 +79,10 @@ describe("useFiltersValues.tsx", () => {
     it("gets the correct operationType filter value", () => {
       const {
         result: { current },
-      } = renderHook(() => useFiltersValues(), {
+      } = renderHook(() => useFiltersContext(), {
         wrapper: ({ children }) => (
           <MemoryRouter initialEntries={["/?requestType=CLAIM"]}>
-            {children}
+            <FiltersProvider defaultValues={{}}>{children}</FiltersProvider>
           </MemoryRouter>
         ),
       });
@@ -90,10 +93,10 @@ describe("useFiltersValues.tsx", () => {
     it("gets the correct search filter value", () => {
       const {
         result: { current },
-      } = renderHook(() => useFiltersValues(), {
+      } = renderHook(() => useFiltersContext(), {
         wrapper: ({ children }) => (
           <MemoryRouter initialEntries={["/?search=abc"]}>
-            {children}
+            <FiltersProvider defaultValues={{}}>{children}</FiltersProvider>
           </MemoryRouter>
         ),
       });
@@ -109,8 +112,14 @@ describe("useFiltersValues.tsx", () => {
       it("gets the correct environment filter value", () => {
         const {
           result: { current },
-        } = renderHook(() => useFiltersValues({ defaultEnvironment: "2" }), {
-          wrapper: ({ children }) => <MemoryRouter>{children}</MemoryRouter>,
+        } = renderHook(() => useFiltersContext(), {
+          wrapper: ({ children }) => (
+            <MemoryRouter>
+              <FiltersProvider defaultValues={{ environment: "2" }}>
+                {children}
+              </FiltersProvider>
+            </MemoryRouter>
+          ),
         });
 
         expect(current.environment).toBe("2");
@@ -119,8 +128,14 @@ describe("useFiltersValues.tsx", () => {
       it("gets the correct aclType filter value", () => {
         const {
           result: { current },
-        } = renderHook(() => useFiltersValues({ defaultAclType: "CONSUMER" }), {
-          wrapper: ({ children }) => <MemoryRouter>{children}</MemoryRouter>,
+        } = renderHook(() => useFiltersContext(), {
+          wrapper: ({ children }) => (
+            <MemoryRouter>
+              <FiltersProvider defaultValues={{ aclType: "CONSUMER" }}>
+                {children}
+              </FiltersProvider>
+            </MemoryRouter>
+          ),
         });
 
         expect(current.aclType).toBe("CONSUMER");
@@ -129,8 +144,14 @@ describe("useFiltersValues.tsx", () => {
       it("gets the correct status filter value", () => {
         const {
           result: { current },
-        } = renderHook(() => useFiltersValues({ defaultStatus: "DELETED" }), {
-          wrapper: ({ children }) => <MemoryRouter>{children}</MemoryRouter>,
+        } = renderHook(() => useFiltersContext(), {
+          wrapper: ({ children }) => (
+            <MemoryRouter>
+              <FiltersProvider defaultValues={{ status: "DELETED" }}>
+                {children}
+              </FiltersProvider>
+            </MemoryRouter>
+          ),
         });
 
         expect(current.status).toBe("DELETED");
@@ -139,8 +160,14 @@ describe("useFiltersValues.tsx", () => {
       it("gets the correct team filter value", () => {
         const {
           result: { current },
-        } = renderHook(() => useFiltersValues({ defaultTeam: "2" }), {
-          wrapper: ({ children }) => <MemoryRouter>{children}</MemoryRouter>,
+        } = renderHook(() => useFiltersContext(), {
+          wrapper: ({ children }) => (
+            <MemoryRouter>
+              <FiltersProvider defaultValues={{ teamId: "2" }}>
+                {children}
+              </FiltersProvider>
+            </MemoryRouter>
+          ),
         });
 
         expect(current.teamId).toBe("2");
@@ -149,12 +176,15 @@ describe("useFiltersValues.tsx", () => {
       it("gets the correct showOnlyMyRequests filter value", () => {
         const {
           result: { current },
-        } = renderHook(
-          () => useFiltersValues({ defaultShowOnlyMyRequests: false }),
-          {
-            wrapper: ({ children }) => <MemoryRouter>{children}</MemoryRouter>,
-          }
-        );
+        } = renderHook(() => useFiltersContext(), {
+          wrapper: ({ children }) => (
+            <MemoryRouter>
+              <FiltersProvider defaultValues={{ showOnlyMyRequests: false }}>
+                {children}
+              </FiltersProvider>
+            </MemoryRouter>
+          ),
+        });
 
         expect(current.showOnlyMyRequests).toBe(false);
       });
@@ -162,12 +192,15 @@ describe("useFiltersValues.tsx", () => {
       it("gets the correct operationType filter value", () => {
         const {
           result: { current },
-        } = renderHook(
-          () => useFiltersValues({ defaultRequestType: "CREATE" }),
-          {
-            wrapper: ({ children }) => <MemoryRouter>{children}</MemoryRouter>,
-          }
-        );
+        } = renderHook(() => useFiltersContext(), {
+          wrapper: ({ children }) => (
+            <MemoryRouter>
+              <FiltersProvider defaultValues={{ requestType: "CREATE" }}>
+                {children}
+              </FiltersProvider>
+            </MemoryRouter>
+          ),
+        });
 
         expect(current.requestType).toBe("CREATE");
       });
@@ -175,8 +208,14 @@ describe("useFiltersValues.tsx", () => {
       it("gets the correct search filter value", () => {
         const {
           result: { current },
-        } = renderHook(() => useFiltersValues({ defaultSearch: "abc" }), {
-          wrapper: ({ children }) => <MemoryRouter>{children}</MemoryRouter>,
+        } = renderHook(() => useFiltersContext(), {
+          wrapper: ({ children }) => (
+            <MemoryRouter>
+              <FiltersProvider defaultValues={{ search: "abc" }}>
+                {children}
+              </FiltersProvider>
+            </MemoryRouter>
+          ),
         });
 
         expect(current.search).toBe("abc");
@@ -192,8 +231,12 @@ describe("useFiltersValues.tsx", () => {
     it("sets the correct environment filter value", () => {
       const {
         result: { current },
-      } = renderHook(() => useFiltersValues(), {
-        wrapper: ({ children }) => <BrowserRouter>{children}</BrowserRouter>,
+      } = renderHook(() => useFiltersContext(), {
+        wrapper: ({ children }) => (
+          <BrowserRouter>
+            <FiltersProvider defaultValues={{}}>{children}</FiltersProvider>
+          </BrowserRouter>
+        ),
       });
 
       current.setFilterValue({
@@ -206,8 +249,12 @@ describe("useFiltersValues.tsx", () => {
     it("sets the correct aclType filter value", () => {
       const {
         result: { current },
-      } = renderHook(() => useFiltersValues(), {
-        wrapper: ({ children }) => <BrowserRouter>{children}</BrowserRouter>,
+      } = renderHook(() => useFiltersContext(), {
+        wrapper: ({ children }) => (
+          <BrowserRouter>
+            <FiltersProvider defaultValues={{}}>{children}</FiltersProvider>
+          </BrowserRouter>
+        ),
       });
 
       current.setFilterValue({
@@ -220,8 +267,12 @@ describe("useFiltersValues.tsx", () => {
     it("sets the correct status filter value", () => {
       const {
         result: { current },
-      } = renderHook(() => useFiltersValues(), {
-        wrapper: ({ children }) => <BrowserRouter>{children}</BrowserRouter>,
+      } = renderHook(() => useFiltersContext(), {
+        wrapper: ({ children }) => (
+          <BrowserRouter>
+            <FiltersProvider defaultValues={{}}>{children}</FiltersProvider>
+          </BrowserRouter>
+        ),
       });
 
       current.setFilterValue({
@@ -234,8 +285,12 @@ describe("useFiltersValues.tsx", () => {
     it("sets the correct team filter value", () => {
       const {
         result: { current },
-      } = renderHook(() => useFiltersValues(), {
-        wrapper: ({ children }) => <BrowserRouter>{children}</BrowserRouter>,
+      } = renderHook(() => useFiltersContext(), {
+        wrapper: ({ children }) => (
+          <BrowserRouter>
+            <FiltersProvider defaultValues={{}}>{children}</FiltersProvider>
+          </BrowserRouter>
+        ),
       });
 
       current.setFilterValue({
@@ -248,8 +303,12 @@ describe("useFiltersValues.tsx", () => {
     it("sets the correct showOnlyMyRequests filter value", () => {
       const {
         result: { current },
-      } = renderHook(() => useFiltersValues(), {
-        wrapper: ({ children }) => <BrowserRouter>{children}</BrowserRouter>,
+      } = renderHook(() => useFiltersContext(), {
+        wrapper: ({ children }) => (
+          <BrowserRouter>
+            <FiltersProvider defaultValues={{}}>{children}</FiltersProvider>
+          </BrowserRouter>
+        ),
       });
 
       current.setFilterValue({
@@ -262,8 +321,12 @@ describe("useFiltersValues.tsx", () => {
     it("sets the correct operationType filter value", () => {
       const {
         result: { current },
-      } = renderHook(() => useFiltersValues(), {
-        wrapper: ({ children }) => <BrowserRouter>{children}</BrowserRouter>,
+      } = renderHook(() => useFiltersContext(), {
+        wrapper: ({ children }) => (
+          <BrowserRouter>
+            <FiltersProvider defaultValues={{}}>{children}</FiltersProvider>
+          </BrowserRouter>
+        ),
       });
 
       current.setFilterValue({
@@ -276,8 +339,12 @@ describe("useFiltersValues.tsx", () => {
     it("sets the correct search filter value", () => {
       const {
         result: { current },
-      } = renderHook(() => useFiltersValues(), {
-        wrapper: ({ children }) => <BrowserRouter>{children}</BrowserRouter>,
+      } = renderHook(() => useFiltersContext(), {
+        wrapper: ({ children }) => (
+          <BrowserRouter>
+            <FiltersProvider defaultValues={{}}>{children}</FiltersProvider>
+          </BrowserRouter>
+        ),
       });
 
       current.setFilterValue({

--- a/coral/src/app/features/connectors/browse/BrowseConnectors.tsx
+++ b/coral/src/app/features/connectors/browse/BrowseConnectors.tsx
@@ -5,7 +5,10 @@ import { useQuery } from "@tanstack/react-query";
 import { getConnectors } from "src/domain/connector/connector-api";
 import { useSearchParams } from "react-router-dom";
 import EnvironmentFilter from "src/app/features/components/filters/EnvironmentFilter";
-import { useFiltersValues } from "src/app/features/components/filters/useFiltersValues";
+import {
+  useFiltersContext,
+  withFiltersContext,
+} from "src/app/features/components/filters/useFiltersValues";
 import { SearchConnectorFilter } from "src/app/features/components/filters/SearchConnectorFilter";
 import TeamFilter from "src/app/features/components/filters/TeamFilter";
 
@@ -14,7 +17,7 @@ function BrowseConnectors() {
   const currentPage = searchParams.get("page")
     ? Number(searchParams.get("page"))
     : 1;
-  const { environment, teamId, search } = useFiltersValues();
+  const { environment, teamId, search } = useFiltersContext();
 
   const {
     data: connectors,
@@ -73,4 +76,6 @@ function BrowseConnectors() {
   );
 }
 
-export default BrowseConnectors;
+export default withFiltersContext({
+  element: <BrowseConnectors />,
+});

--- a/coral/src/app/features/connectors/browse/BrowseConnectors.tsx
+++ b/coral/src/app/features/connectors/browse/BrowseConnectors.tsx
@@ -8,7 +8,7 @@ import EnvironmentFilter from "src/app/features/components/filters/EnvironmentFi
 import {
   useFiltersContext,
   withFiltersContext,
-} from "src/app/features/components/filters/useFiltersValues";
+} from "src/app/features/components/filters/useFiltersContext";
 import { SearchConnectorFilter } from "src/app/features/components/filters/SearchConnectorFilter";
 import TeamFilter from "src/app/features/components/filters/TeamFilter";
 

--- a/coral/src/app/features/requests/acls/AclRequests.test.tsx
+++ b/coral/src/app/features/requests/acls/AclRequests.test.tsx
@@ -6,7 +6,7 @@ import {
   within,
 } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { AclRequests } from "src/app/features/requests/acls/AclRequests";
+import AclRequests from "src/app/features/requests/acls/AclRequests";
 import { deleteAclRequest, getAclRequests } from "src/domain/acl/acl-api";
 import transformAclRequestApiResponse from "src/domain/acl/acl-transformer";
 import { getAllEnvironmentsForTopicAndAcl } from "src/domain/environment";

--- a/coral/src/app/features/requests/acls/AclRequests.tsx
+++ b/coral/src/app/features/requests/acls/AclRequests.tsx
@@ -15,7 +15,7 @@ import { SearchTopicFilter } from "src/app/features/components/filters/SearchTop
 import {
   useFiltersContext,
   withFiltersContext,
-} from "src/app/features/components/filters/useFiltersValues";
+} from "src/app/features/components/filters/useFiltersContext";
 import { AclRequestsTable } from "src/app/features/requests/acls/components/AclRequestsTable";
 import { DeleteRequestDialog } from "src/app/features/requests/components/DeleteRequestDialog";
 import { deleteAclRequest, getAclRequests } from "src/domain/acl/acl-api";

--- a/coral/src/app/features/requests/acls/AclRequests.tsx
+++ b/coral/src/app/features/requests/acls/AclRequests.tsx
@@ -202,6 +202,5 @@ function AclRequests() {
 }
 
 export default withFiltersContext({
-  defaultValues: { status: "ALL" },
   element: <AclRequests />,
 });

--- a/coral/src/app/features/requests/acls/AclRequests.tsx
+++ b/coral/src/app/features/requests/acls/AclRequests.tsx
@@ -12,7 +12,10 @@ import { MyRequestsFilter } from "src/app/features/components/filters/MyRequests
 import { RequestTypeFilter } from "src/app/features/components/filters/RequestTypeFilter";
 import StatusFilter from "src/app/features/components/filters/StatusFilter";
 import { SearchTopicFilter } from "src/app/features/components/filters/SearchTopicFilter";
-import { useFiltersValues } from "src/app/features/components/filters/useFiltersValues";
+import {
+  useFiltersContext,
+  withFiltersContext,
+} from "src/app/features/components/filters/useFiltersValues";
 import { AclRequestsTable } from "src/app/features/requests/acls/components/AclRequestsTable";
 import { DeleteRequestDialog } from "src/app/features/requests/components/DeleteRequestDialog";
 import { deleteAclRequest, getAclRequests } from "src/domain/acl/acl-api";
@@ -33,7 +36,7 @@ function AclRequests() {
     status,
     showOnlyMyRequests,
     requestType,
-  } = useFiltersValues();
+  } = useFiltersContext();
 
   const [modals, setModals] = useState<{
     open: "DETAILS" | "DELETE" | "NONE";
@@ -174,7 +177,7 @@ function AclRequests() {
             environmentEndpoint={"getAllEnvironmentsForTopicAndAcl"}
           />,
           <AclTypeFilter key="aclType" />,
-          <StatusFilter key="status" defaultStatus="ALL" />,
+          <StatusFilter key="status" />,
           <RequestTypeFilter key="operationType" />,
           <SearchTopicFilter key="search" />,
           <MyRequestsFilter key="myRequests" />,
@@ -198,4 +201,7 @@ function AclRequests() {
   );
 }
 
-export { AclRequests };
+export default withFiltersContext({
+  defaultValues: { status: "ALL" },
+  element: <AclRequests />,
+});

--- a/coral/src/app/features/requests/connectors/ConnectorRequests.test.tsx
+++ b/coral/src/app/features/requests/connectors/ConnectorRequests.test.tsx
@@ -5,23 +5,23 @@ import {
   waitForElementToBeRemoved,
   within,
 } from "@testing-library/react";
-import { transformConnectorRequestApiResponse } from "src/domain/connector/connector-transformer";
-import { mockIntersectionObserver } from "src/services/test-utils/mock-intersection-observer";
-import { ConnectorRequests } from "src/app/features/requests/connectors/ConnectorRequests";
-import { customRender } from "src/services/test-utils/render-with-wrappers";
-import {
-  getAllEnvironmentsForTopicAndAcl,
-  getAllEnvironmentsForConnector,
-} from "src/domain/environment";
+import userEvent from "@testing-library/user-event";
+import { requestOperationTypeNameMap } from "src/app/features/approvals/utils/request-operation-type-helper";
+import { requestStatusNameMap } from "src/app/features/approvals/utils/request-status-helper";
+import ConnectorRequests from "src/app/features/requests/connectors/ConnectorRequests";
 import { mockedEnvironmentResponse } from "src/app/features/requests/schemas/utils/mocked-api-responses";
 import {
   deleteConnectorRequest,
   getConnectorRequests,
 } from "src/domain/connector";
-import userEvent from "@testing-library/user-event";
+import { transformConnectorRequestApiResponse } from "src/domain/connector/connector-transformer";
+import {
+  getAllEnvironmentsForConnector,
+  getAllEnvironmentsForTopicAndAcl,
+} from "src/domain/environment";
 import { createEnvironment } from "src/domain/environment/environment-test-helper";
-import { requestStatusNameMap } from "src/app/features/approvals/utils/request-status-helper";
-import { requestOperationTypeNameMap } from "src/app/features/approvals/utils/request-operation-type-helper";
+import { mockIntersectionObserver } from "src/services/test-utils/mock-intersection-observer";
+import { customRender } from "src/services/test-utils/render-with-wrappers";
 
 jest.mock("src/domain/environment/environment-api.ts");
 jest.mock("src/domain/connector/connector-api.ts");

--- a/coral/src/app/features/requests/connectors/ConnectorRequests.tsx
+++ b/coral/src/app/features/requests/connectors/ConnectorRequests.tsx
@@ -10,7 +10,7 @@ import {
 import {
   useFiltersContext,
   withFiltersContext,
-} from "src/app/features/components/filters/useFiltersValues";
+} from "src/app/features/components/filters/useFiltersContext";
 import { SearchConnectorFilter } from "src/app/features/components/filters/SearchConnectorFilter";
 import EnvironmentFilter from "src/app/features/components/filters/EnvironmentFilter";
 import { MyRequestsFilter } from "src/app/features/components/filters/MyRequestsFilter";

--- a/coral/src/app/features/requests/connectors/ConnectorRequests.tsx
+++ b/coral/src/app/features/requests/connectors/ConnectorRequests.tsx
@@ -181,6 +181,5 @@ function ConnectorRequests() {
 }
 
 export default withFiltersContext({
-  defaultValues: { status: "ALL", requestType: "ALL" },
   element: <ConnectorRequests />,
 });

--- a/coral/src/app/features/requests/connectors/ConnectorRequests.tsx
+++ b/coral/src/app/features/requests/connectors/ConnectorRequests.tsx
@@ -7,7 +7,10 @@ import {
   deleteConnectorRequest,
   getConnectorRequests,
 } from "src/domain/connector";
-import { useFiltersValues } from "src/app/features/components/filters/useFiltersValues";
+import {
+  useFiltersContext,
+  withFiltersContext,
+} from "src/app/features/components/filters/useFiltersValues";
 import { SearchConnectorFilter } from "src/app/features/components/filters/SearchConnectorFilter";
 import EnvironmentFilter from "src/app/features/components/filters/EnvironmentFilter";
 import { MyRequestsFilter } from "src/app/features/components/filters/MyRequestsFilter";
@@ -20,9 +23,6 @@ import { parseErrorMsg } from "src/services/mutation-utils";
 import RequestDetailsModal from "src/app/features/components/RequestDetailsModal";
 import { ConnectorRequestDetails } from "src/app/features/components/ConnectorDetailsModalContent";
 
-const defaultStatus = "ALL";
-const defaultType = "ALL";
-
 function ConnectorRequests() {
   const queryClient = useQueryClient();
   const [searchParams, setSearchParams] = useSearchParams();
@@ -31,7 +31,7 @@ function ConnectorRequests() {
     : 1;
 
   const { search, environment, status, showOnlyMyRequests, requestType } =
-    useFiltersValues();
+    useFiltersContext();
 
   const [modals, setModals] = useState<{
     open: "DETAILS" | "DELETE" | "NONE";
@@ -81,7 +81,7 @@ function ConnectorRequests() {
         env: environment,
         search,
         requestStatus: status,
-        operationType: requestType !== defaultType ? requestType : undefined,
+        operationType: requestType !== "ALL" ? requestType : undefined,
       }),
     keepPreviousData: true,
   });
@@ -158,7 +158,7 @@ function ConnectorRequests() {
             key="environment"
             environmentEndpoint="getAllEnvironmentsForConnector"
           />,
-          <StatusFilter key="request-status" defaultStatus={defaultStatus} />,
+          <StatusFilter key="request-status" />,
           <RequestTypeFilter key={"request-type"} />,
           <SearchConnectorFilter key="connector" />,
           <MyRequestsFilter key={"isMyRequest"} />,
@@ -180,4 +180,7 @@ function ConnectorRequests() {
   );
 }
 
-export { ConnectorRequests };
+export default withFiltersContext({
+  defaultValues: { status: "ALL", requestType: "ALL" },
+  element: <ConnectorRequests />,
+});

--- a/coral/src/app/features/requests/schemas/SchemaRequests.test.tsx
+++ b/coral/src/app/features/requests/schemas/SchemaRequests.test.tsx
@@ -11,7 +11,7 @@ import {
   deleteSchemaRequest,
   getSchemaRequests,
 } from "src/domain/schema-request";
-import { SchemaRequests } from "src/app/features/requests/schemas/SchemaRequests";
+import SchemaRequests from "src/app/features/requests/schemas/SchemaRequests";
 import {
   mockedApiResponseSchemaRequests,
   mockedEnvironmentResponse,

--- a/coral/src/app/features/requests/schemas/SchemaRequests.tsx
+++ b/coral/src/app/features/requests/schemas/SchemaRequests.tsx
@@ -3,15 +3,18 @@ import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { useState } from "react";
 import { useSearchParams } from "react-router-dom";
 import { Pagination } from "src/app/components/Pagination";
-import { TableLayout } from "src/app/features/components/layouts/TableLayout";
 import RequestDetailsModal from "src/app/features/components/RequestDetailsModal";
 import { SchemaRequestDetails } from "src/app/features/components/SchemaRequestDetails";
 import EnvironmentFilter from "src/app/features/components/filters/EnvironmentFilter";
 import { MyRequestsFilter } from "src/app/features/components/filters/MyRequestsFilter";
 import { RequestTypeFilter } from "src/app/features/components/filters/RequestTypeFilter";
-import StatusFilter from "src/app/features/components/filters/StatusFilter";
 import { SearchTopicFilter } from "src/app/features/components/filters/SearchTopicFilter";
-import { useFiltersValues } from "src/app/features/components/filters/useFiltersValues";
+import StatusFilter from "src/app/features/components/filters/StatusFilter";
+import {
+  useFiltersContext,
+  withFiltersContext,
+} from "src/app/features/components/filters/useFiltersValues";
+import { TableLayout } from "src/app/features/components/layouts/TableLayout";
 import { DeleteRequestDialog } from "src/app/features/requests/components/DeleteRequestDialog";
 import { SchemaRequestTable } from "src/app/features/requests/schemas/components/SchemaRequestTable";
 import {
@@ -19,9 +22,6 @@ import {
   getSchemaRequests,
 } from "src/domain/schema-request";
 import { parseErrorMsg } from "src/services/mutation-utils";
-
-const defaultStatus = "ALL";
-const defaultType = "ALL";
 
 function SchemaRequests() {
   const queryClient = useQueryClient();
@@ -32,7 +32,7 @@ function SchemaRequests() {
     : 1;
 
   const { search, environment, status, showOnlyMyRequests, requestType } =
-    useFiltersValues();
+    useFiltersContext();
 
   const [modals, setModals] = useState<{
     open: "DETAILS" | "DELETE" | "NONE";
@@ -61,10 +61,10 @@ function SchemaRequests() {
       getSchemaRequests({
         pageNo: String(currentPage),
         env: environment,
-        requestStatus: status !== defaultStatus ? status : undefined,
+        requestStatus: status !== "ALL" ? status : undefined,
         search: search,
         isMyRequest: showOnlyMyRequests,
-        operationType: requestType !== defaultType ? requestType : undefined,
+        operationType: requestType !== "ALL" ? requestType : undefined,
       }),
     keepPreviousData: true,
   });
@@ -168,7 +168,7 @@ function SchemaRequests() {
             key={"environments"}
             environmentEndpoint={"getAllEnvironmentsForSchema"}
           />,
-          <StatusFilter key={"request-status"} defaultStatus={defaultStatus} />,
+          <StatusFilter key={"request-status"} />,
           <RequestTypeFilter key={"request-type"} />,
           <SearchTopicFilter key={"topic"} />,
           <MyRequestsFilter key={"show-only-my-requests"} />,
@@ -192,4 +192,7 @@ function SchemaRequests() {
   );
 }
 
-export { SchemaRequests };
+export default withFiltersContext({
+  defaultValues: { status: "ALL", requestType: "ALL" },
+  element: <SchemaRequests />,
+});

--- a/coral/src/app/features/requests/schemas/SchemaRequests.tsx
+++ b/coral/src/app/features/requests/schemas/SchemaRequests.tsx
@@ -13,7 +13,7 @@ import StatusFilter from "src/app/features/components/filters/StatusFilter";
 import {
   useFiltersContext,
   withFiltersContext,
-} from "src/app/features/components/filters/useFiltersValues";
+} from "src/app/features/components/filters/useFiltersContext";
 import { TableLayout } from "src/app/features/components/layouts/TableLayout";
 import { DeleteRequestDialog } from "src/app/features/requests/components/DeleteRequestDialog";
 import { SchemaRequestTable } from "src/app/features/requests/schemas/components/SchemaRequestTable";

--- a/coral/src/app/features/requests/schemas/SchemaRequests.tsx
+++ b/coral/src/app/features/requests/schemas/SchemaRequests.tsx
@@ -193,6 +193,5 @@ function SchemaRequests() {
 }
 
 export default withFiltersContext({
-  defaultValues: { status: "ALL", requestType: "ALL" },
   element: <SchemaRequests />,
 });

--- a/coral/src/app/features/requests/topics/TopicRequests.test.tsx
+++ b/coral/src/app/features/requests/topics/TopicRequests.test.tsx
@@ -11,7 +11,7 @@ import {
 } from "src/domain/topic/topic-api";
 import { transformGetTopicRequestsResponse } from "src/domain/topic/topic-transformer";
 import { mockIntersectionObserver } from "src/services/test-utils/mock-intersection-observer";
-import { TopicRequests } from "src/app/features/requests/topics/TopicRequests";
+import TopicRequests from "src/app/features/requests/topics/TopicRequests";
 import { customRender } from "src/services/test-utils/render-with-wrappers";
 import userEvent from "@testing-library/user-event";
 import { getAllEnvironmentsForTopicAndAcl } from "src/domain/environment";

--- a/coral/src/app/features/requests/topics/TopicRequests.tsx
+++ b/coral/src/app/features/requests/topics/TopicRequests.tsx
@@ -183,6 +183,5 @@ function TopicRequests() {
 }
 
 export default withFiltersContext({
-  defaultValues: { status: "ALL", requestType: "ALL" },
   element: <TopicRequests />,
 });

--- a/coral/src/app/features/requests/topics/TopicRequests.tsx
+++ b/coral/src/app/features/requests/topics/TopicRequests.tsx
@@ -17,7 +17,7 @@ import { SearchTopicFilter } from "src/app/features/components/filters/SearchTop
 import {
   useFiltersContext,
   withFiltersContext,
-} from "src/app/features/components/filters/useFiltersValues";
+} from "src/app/features/components/filters/useFiltersContext";
 import { MyRequestsFilter } from "src/app/features/components/filters/MyRequestsFilter";
 import EnvironmentFilter from "src/app/features/components/filters/EnvironmentFilter";
 import StatusFilter from "src/app/features/components/filters/StatusFilter";

--- a/coral/src/app/features/requests/topics/TopicRequests.tsx
+++ b/coral/src/app/features/requests/topics/TopicRequests.tsx
@@ -14,14 +14,14 @@ import { parseErrorMsg } from "src/services/mutation-utils";
 import RequestDetailsModal from "src/app/features/components/RequestDetailsModal";
 import TopicDetailsModalContent from "src/app/features/components/TopicDetailsModalContent";
 import { SearchTopicFilter } from "src/app/features/components/filters/SearchTopicFilter";
-import { useFiltersValues } from "src/app/features/components/filters/useFiltersValues";
+import {
+  useFiltersContext,
+  withFiltersContext,
+} from "src/app/features/components/filters/useFiltersValues";
 import { MyRequestsFilter } from "src/app/features/components/filters/MyRequestsFilter";
 import EnvironmentFilter from "src/app/features/components/filters/EnvironmentFilter";
 import StatusFilter from "src/app/features/components/filters/StatusFilter";
 import { RequestTypeFilter } from "src/app/features/components/filters/RequestTypeFilter";
-
-const defaultStatus = "ALL";
-const defaultType = "ALL";
 
 function TopicRequests() {
   const queryClient = useQueryClient();
@@ -31,7 +31,7 @@ function TopicRequests() {
     : 1;
 
   const { search, environment, status, showOnlyMyRequests, requestType } =
-    useFiltersValues();
+    useFiltersContext();
 
   const [modals, setModals] = useState<{
     open: "DETAILS" | "DELETE" | "NONE";
@@ -56,7 +56,7 @@ function TopicRequests() {
         env: environment,
         requestStatus: status,
         isMyRequest: showOnlyMyRequests,
-        operationType: requestType !== defaultType ? requestType : undefined,
+        operationType: requestType !== "ALL" ? requestType : undefined,
       }),
     keepPreviousData: true,
   });
@@ -158,7 +158,7 @@ function TopicRequests() {
             key="environments"
             environmentEndpoint={"getAllEnvironmentsForTopicAndAcl"}
           />,
-          <StatusFilter key="request-status" defaultStatus={defaultStatus} />,
+          <StatusFilter key="request-status" />,
           <RequestTypeFilter key={"request-type"} />,
           <SearchTopicFilter key={"topic"} />,
           <MyRequestsFilter key={"isMyRequest"} />,
@@ -182,4 +182,7 @@ function TopicRequests() {
   );
 }
 
-export { TopicRequests };
+export default withFiltersContext({
+  defaultValues: { status: "ALL", requestType: "ALL" },
+  element: <TopicRequests />,
+});

--- a/coral/src/app/features/topics/browse/BrowseTopics.tsx
+++ b/coral/src/app/features/topics/browse/BrowseTopics.tsx
@@ -4,7 +4,10 @@ import { Pagination } from "src/app/components/Pagination";
 import EnvironmentFilter from "src/app/features/components/filters/EnvironmentFilter";
 import TeamFilter from "src/app/features/components/filters/TeamFilter";
 import { SearchTopicFilter } from "src/app/features/components/filters/SearchTopicFilter";
-import { useFiltersValues } from "src/app/features/components/filters/useFiltersValues";
+import {
+  useFiltersContext,
+  withFiltersContext,
+} from "src/app/features/components/filters/useFiltersValues";
 import { TableLayout } from "src/app/features/components/layouts/TableLayout";
 import TopicTable from "src/app/features/topics/browse/components/TopicTable";
 import { getTopics } from "src/domain/topic";
@@ -16,7 +19,7 @@ function BrowseTopics() {
     ? Number(searchParams.get("page"))
     : 1;
 
-  const { search, environment, teamId } = useFiltersValues();
+  const { search, environment, teamId } = useFiltersContext();
 
   const {
     data: topics,
@@ -74,4 +77,4 @@ function BrowseTopics() {
   );
 }
 
-export default BrowseTopics;
+export default withFiltersContext({ element: <BrowseTopics /> });

--- a/coral/src/app/features/topics/browse/BrowseTopics.tsx
+++ b/coral/src/app/features/topics/browse/BrowseTopics.tsx
@@ -7,7 +7,7 @@ import { SearchTopicFilter } from "src/app/features/components/filters/SearchTop
 import {
   useFiltersContext,
   withFiltersContext,
-} from "src/app/features/components/filters/useFiltersValues";
+} from "src/app/features/components/filters/useFiltersContext";
 import { TableLayout } from "src/app/features/components/layouts/TableLayout";
 import TopicTable from "src/app/features/topics/browse/components/TopicTable";
 import { getTopics } from "src/domain/topic";

--- a/coral/src/app/features/topics/details/subscriptions/TopicSubscriptions.test.tsx
+++ b/coral/src/app/features/topics/details/subscriptions/TopicSubscriptions.test.tsx
@@ -28,6 +28,18 @@ const mockCreateDeleteAclRequest =
     typeof createAclDeletionRequest
   >;
 
+const mockAuthUserReturnValue = {
+  canSwitchTeams: "",
+  teamId: "1003",
+  teamname: "Ospo",
+  username: "Kvothe",
+};
+
+const mockAuthUser = jest.fn();
+jest.mock("src/app/context-provider/AuthProvider", () => ({
+  useAuthContext: () => mockAuthUser(),
+}));
+
 jest.mock("react-router-dom", () => ({
   ...jest.requireActual("react-router-dom"),
   useOutletContext: () => ({ topicName: "aiventopic1" }),
@@ -188,6 +200,8 @@ describe("TopicSubscriptions.tsx", () => {
     mockIntersectionObserver();
     mockGetTopicOverview.mockResolvedValue(mockGetTopicOverviewResponse);
     mockGetTeams.mockResolvedValue(mockedTeamsResponse);
+    mockAuthUser.mockReturnValue(mockAuthUserReturnValue);
+
     customRender(
       // Aquarium context is needed for useToast
       <AquariumContext>
@@ -234,12 +248,13 @@ describe("TopicSubscriptions.tsx", () => {
       expect(button).toBeVisible();
       expect(button).toBeEnabled();
     });
-    it("should render enabled Team filter", () => {
+    it("should render enabled Team filter with default value", () => {
       const filter = screen.getByRole("combobox", {
         name: "Filter by team",
       });
       expect(filter).toBeVisible();
       expect(filter).toBeEnabled();
+      expect(filter).toHaveValue("1003");
     });
     it("should render enabled ACL type filter", () => {
       const filter = screen.getByRole("combobox", {
@@ -311,14 +326,14 @@ describe("TopicSubscriptions.tsx", () => {
     it("should allow searching", async () => {
       const search = screen.getByRole("search");
 
-      await userEvent.type(search, "amathieu");
+      await userEvent.type(search, "declineme");
 
-      expect(search).toHaveValue("amathieu");
+      expect(search).toHaveValue("declineme");
 
       await waitFor(() => {
         const rows = screen.getAllByRole("row");
-        const rowOne = screen.getByText("amathieu");
-        const rowTwo = screen.queryByText("declineme");
+        const rowOne = screen.getByText("declineme");
+        const rowTwo = screen.queryByText("amathieu");
         const rowThree = screen.queryByText("aivtopic3user");
         const prefixedRow = screen.queryByText("aivendemot");
         const transactionalRow = screen.queryByText("tsttxnid");
@@ -333,18 +348,18 @@ describe("TopicSubscriptions.tsx", () => {
   });
 
   describe("should render the correct data in Table when sub button are clicked", () => {
-    it("should render User subscriptions in Table, ", () => {
+    it("should render User subscriptions in Table by default, filtered by current user Team", () => {
       const rows = screen.getAllByRole("row");
-      const rowOne = screen.getByText("aivtopic3user");
-      const rowTwo = screen.getByText("declineme");
-      const rowThree = screen.getByText("amathieu");
+      const rowOne = screen.getByText("declineme");
+      const rowTwo = screen.getByText("aivtopic3user");
+      const rowThree = screen.queryByText("amathieu");
       const prefixedRow = screen.queryByText("aivendemot");
       const transactionalRow = screen.queryByText("tsttxnid");
 
-      expect(rows).toHaveLength(4);
+      expect(rows).toHaveLength(3);
       expect(rowOne).toBeVisible();
       expect(rowTwo).toBeVisible();
-      expect(rowThree).toBeVisible();
+      expect(rowThree).toBeNull();
       expect(prefixedRow).toBeNull();
       expect(transactionalRow).toBeNull();
     });

--- a/coral/src/app/features/topics/details/subscriptions/TopicSubscriptions.tsx
+++ b/coral/src/app/features/topics/details/subscriptions/TopicSubscriptions.tsx
@@ -11,10 +11,14 @@ import pick from "lodash/pick";
 import { useMemo, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { Dialog } from "src/app/components/Dialog";
+import { useAuthContext } from "src/app/context-provider/AuthProvider";
 import AclTypeFilter from "src/app/features/components/filters/AclTypeFilter";
 import { SearchFilter } from "src/app/features/components/filters/SearchFilter";
 import TeamFilter from "src/app/features/components/filters/TeamFilter";
-import { useFiltersValues } from "src/app/features/components/filters/useFiltersValues";
+import {
+  FiltersProvider,
+  useFiltersContext,
+} from "src/app/features/components/filters/useFiltersValues";
 import { TableLayout } from "src/app/features/components/layouts/TableLayout";
 import { useTopicDetails } from "src/app/features/topics/details/TopicDetails";
 import { TopicSubscriptionsTable } from "src/app/features/topics/details/subscriptions/TopicSubscriptionsTable";
@@ -38,8 +42,8 @@ const isSubscriptionsOption = (value: string): value is SubscriptionOptions => {
 };
 
 const TopicSubscriptions = () => {
-  // @ TODO get environment from useTopicDetails too when it is implemented
   const navigate = useNavigate();
+  // @ TODO get environment from useTopicDetails too when it is implemented2
   const { topicName } = useTopicDetails();
 
   const [deleteModal, setDeleteModal] = useState<{
@@ -49,7 +53,7 @@ const TopicSubscriptions = () => {
 
   const toast = useToast();
 
-  const { search, teamId, aclType } = useFiltersValues();
+  const { teamId, aclType, search } = useFiltersContext();
   const {
     data,
     isLoading: dataIsLoading,
@@ -214,4 +218,18 @@ const TopicSubscriptions = () => {
   );
 };
 
-export default TopicSubscriptions;
+// Because we need to set the default value of team filter as the user's current team
+// We need to use the FiltersProvider directly instead of withFiltersContext
+const WithCurrentTeamDefaultFilter = () => {
+  const authUser = useAuthContext();
+
+  return (
+    <FiltersProvider
+      defaultValues={{ paginated: false, teamId: authUser?.teamId }}
+    >
+      <TopicSubscriptions />
+    </FiltersProvider>
+  );
+};
+
+export default WithCurrentTeamDefaultFilter;

--- a/coral/src/app/features/topics/details/subscriptions/TopicSubscriptions.tsx
+++ b/coral/src/app/features/topics/details/subscriptions/TopicSubscriptions.tsx
@@ -18,7 +18,7 @@ import TeamFilter from "src/app/features/components/filters/TeamFilter";
 import {
   FiltersProvider,
   useFiltersContext,
-} from "src/app/features/components/filters/useFiltersValues";
+} from "src/app/features/components/filters/useFiltersContext";
 import { TableLayout } from "src/app/features/components/layouts/TableLayout";
 import { useTopicDetails } from "src/app/features/topics/details/TopicDetails";
 import { TopicSubscriptionsTable } from "src/app/features/topics/details/subscriptions/TopicSubscriptionsTable";

--- a/coral/src/app/pages/requests/acls/index.tsx
+++ b/coral/src/app/pages/requests/acls/index.tsx
@@ -1,4 +1,4 @@
-import { AclRequests } from "src/app/features/requests/acls/AclRequests";
+import AclRequests from "src/app/features/requests/acls/AclRequests";
 import PreviewBanner from "src/app/components/PreviewBanner";
 
 const AclRequestsPage = () => {

--- a/coral/src/app/pages/requests/connectors/index.tsx
+++ b/coral/src/app/pages/requests/connectors/index.tsx
@@ -1,4 +1,4 @@
-import { ConnectorRequests } from "src/app/features/requests/connectors/ConnectorRequests";
+import ConnectorRequests from "src/app/features/requests/connectors/ConnectorRequests";
 import PreviewBanner from "src/app/components/PreviewBanner";
 
 const ConnectorRequestsPage = () => {

--- a/coral/src/app/pages/requests/schemas/index.tsx
+++ b/coral/src/app/pages/requests/schemas/index.tsx
@@ -1,4 +1,4 @@
-import { SchemaRequests } from "src/app/features/requests/schemas/SchemaRequests";
+import SchemaRequests from "src/app/features/requests/schemas/SchemaRequests";
 import PreviewBanner from "src/app/components/PreviewBanner";
 
 const SchemaRequestsPage = () => {

--- a/coral/src/app/pages/requests/topics/index.tsx
+++ b/coral/src/app/pages/requests/topics/index.tsx
@@ -1,4 +1,4 @@
-import { TopicRequests } from "src/app/features/requests/topics/TopicRequests";
+import TopicRequests from "src/app/features/requests/topics/TopicRequests";
 import PreviewBanner from "src/app/components/PreviewBanner";
 
 const TopicRequestsPage = () => {


### PR DESCRIPTION
## About this change - What it does

- Implement a `useFiltersContext` hook as proposed in issue  [#1278](https://github.com/aiven/klaw/issues/1278)
- Implementation requires using the `FilterProvider` or `withFiltersContext` to wrap components wanting to call `useFiltersContext`
- Add a `paginated` default value which allows to not set `page=1` search param when not needed (default is `paginated: true`)
- Only tracks filter values in URL if they are different from the default filter values. Here for example, team Ospo is not tracked in URL search params:


https://github.com/aiven/klaw/assets/20607294/05cc40aa-98e3-49a1-ab2d-1d06c9830ecc


Resolves https://github.com/aiven/klaw/issues/1278
