### PR TITLE
fix(coral): fix redirect on first load for Request submission from Subscriptions tab

### DIFF
--- a/coral/src/app/features/topics/acl-request/TopicAclRequest.tsx
+++ b/coral/src/app/features/topics/acl-request/TopicAclRequest.tsx
@@ -46,17 +46,20 @@ const TopicAclRequest = () => {
     },
   });
 
-  const { isLoadingExtendedEnvironments, extendedEnvironments } =
+  const { extendedEnvironments, hasFetchedExtendedEnvironments } =
     useExtendedEnvironments();
 
   const currentEnv = searchParams.get("env");
   const isValidEnv =
-    !isLoadingExtendedEnvironments &&
     extendedEnvironments.find((env) => currentEnv === env.id) !== undefined;
 
   // /topic/aivendemotopic/subscribe route requires an env search param to function correctly
   // So we redirect when it is missing
-  if (topicName !== undefined && !isValidEnv) {
+  if (
+    hasFetchedExtendedEnvironments &&
+    topicName !== undefined &&
+    !isValidEnv
+  ) {
     navigate(`/topic/${topicName}/subscriptions`);
   }
 
@@ -137,7 +140,7 @@ const TopicAclRequest = () => {
     }
   }, [selectedEnvironment, aclType]);
 
-  if (isLoadingExtendedEnvironments) {
+  if (!hasFetchedExtendedEnvironments) {
     return <SkeletonForm />;
   }
 

--- a/coral/src/app/features/topics/acl-request/queries/useExtendedEnvironments.tsx
+++ b/coral/src/app/features/topics/acl-request/queries/useExtendedEnvironments.tsx
@@ -32,7 +32,7 @@ const getExtensionData = ({ envId, envType }: GetExtensionDataParams) => {
 const useExtendedEnvironments = () => {
   const {
     data: extendedEnvironments = [],
-    isLoading: isLoadingExtendedEnvironments,
+    isFetched: hasFetchedExtendedEnvironments,
   } = useQuery<ExtendedEnvironment[], Error>(["topic-environments"], {
     queryFn: async () => {
       const environments = await getAllEnvironmentsForTopicAndAcl();
@@ -58,7 +58,7 @@ const useExtendedEnvironments = () => {
 
   return {
     extendedEnvironments,
-    isLoadingExtendedEnvironments,
+    hasFetchedExtendedEnvironments,
   };
 };
 


### PR DESCRIPTION
## The problem

`useExtendedEnvironments` returns the `data` and `isLoading` values from `useQuery`. However, there is a render tick that will have `isLoading` as `false` while `data` is still the empty value. In `TopicSubscriptions`, this results in the `isValidEnv` check to fail, and redirect when clicking "Request new subscription". The second click behaves correctly, as the data is already fetched. 

 

https://github.com/aiven/klaw/assets/20607294/7a1d8b03-a855-44ce-b765-3403ac5c467e

## The solution

Use `isFetched` instead of `isLoading` to ensure the data is present:


https://github.com/aiven/klaw/assets/20607294/2a20ae69-0a4c-41ca-8c70-47e3850c8ca4




