### PR TITLE
feat(coral): Topic subscriptions - Add stats for consumers and producers

### DIFF
--- a/coral/src/app/features/topics/details/subscriptions/TopicSubscriptions.test.tsx
+++ b/coral/src/app/features/topics/details/subscriptions/TopicSubscriptions.test.tsx
@@ -220,6 +220,35 @@ describe("TopicSubscriptions.tsx", () => {
     jest.clearAllMocks();
   });
 
+  describe("should render boxes with Consumers and Producers stats", () => {
+    it("should render a Producers box with correct data", async () => {
+      const producersBox = screen.getByTitle(
+        "Amount of producer subscriptions"
+      );
+      expect(producersBox).toBeVisible();
+
+      const number = within(producersBox).getByText("3");
+      const name = within(producersBox).getByText("Producers");
+
+      expect(number).toBeVisible();
+      expect(name).toBeVisible();
+    });
+
+    it("should render a Consumers box with correct data", async () => {
+      const consumersBox = screen.getByTitle(
+        "Amount of consumer subscriptions"
+      );
+
+      expect(consumersBox).toBeVisible();
+
+      const number = within(consumersBox).getByText("2");
+      const name = within(consumersBox).getByText("Consumers");
+
+      expect(number).toBeVisible();
+      expect(name).toBeVisible();
+    });
+  });
+
   describe("should render a table and buttons to switch between different kind of subscriptions", () => {
     it("should render a Table", () => {
       const table = screen.getByRole("table", {


### PR DESCRIPTION
## About this change - What it does

Add boxes with the amount of producer and consumer subscriptions for the current topic



https://github.com/aiven/klaw/assets/20607294/3fdf6da8-62fb-4b5f-a6c6-171fdf82ca70

