### PR TITLE
fix(coral): Add default value for context environmentId in useTopicDetails

### DIFF
--- a/coral/src/app/features/topics/details/TopicDetails.tsx
+++ b/coral/src/app/features/topics/details/TopicDetails.tsx
@@ -66,7 +66,7 @@ function TopicDetails(props: TopicOverviewProps) {
         error={error}
         currentTab={currentTab}
         topicOverview={data}
-        environmentId={environmentId || ""}
+        environmentId={environmentId}
       />
     </div>
   );

--- a/coral/src/app/features/topics/details/components/TopicDetailsResourceTabs.tsx
+++ b/coral/src/app/features/topics/details/components/TopicDetailsResourceTabs.tsx
@@ -12,7 +12,7 @@ import { parseErrorMsg } from "src/services/mutation-utils";
 
 type Props = {
   currentTab: TopicOverviewTabEnum;
-  environmentId: string;
+  environmentId?: string;
   error?: unknown;
   isError: boolean;
   isLoading: boolean;
@@ -112,7 +112,8 @@ function TopicOverviewResourcesTabs({
       <div data-testid={"tabpanel-content"}>
         <Outlet
           context={{
-            environmentId,
+            environmentId:
+              environmentId || topicOverview.availableEnvironments[0].id,
             topicOverview,
             topicName: topicOverview.topicInfoList[0].topicName,
           }}


### PR DESCRIPTION
## The problem

Because we have the `environmentId` value in the `useTopicDetails` context hook relies on the `environmentId` state defined in `TopicDetails`, it is `undefined` until the user choose to interact with the environment select input. This leads to some unexpected behaviour and a desync between what is shown in the UI and what is accessible in the `useTopicDetails` hook. For example, navigating to create a new subscription lead to an emnpty `env` search param:

https://github.com/aiven/klaw/assets/20607294/70c9aecd-c020-406b-9cd2-e9c069932997

## The fix

Add the first environment in the list as default value for `environmentId`, as it seems to be what is fetched from the API.



