### PR TITLE
feat(coral): Add `getSchemaOfTopic` to `topic-api` domain

### DIFF
--- a/coral/src/domain/topic/topic-api.ts
+++ b/coral/src/domain/topic/topic-api.ts
@@ -234,6 +234,15 @@ const getTopicOverview = ({
   );
 };
 
+const getSchemaOfTopic = (
+  params: KlawApiRequestQueryParameters<"getSchemaOfTopic">
+) => {
+  return api.get<KlawApiResponse<"getSchemaOfTopic">>(
+    API_PATHS.getSchemaOfTopic,
+    new URLSearchParams(convertQueryValuesToString(params))
+  );
+};
+
 export {
   getTopics,
   getTopicNames,
@@ -247,4 +256,5 @@ export {
   deleteTopicRequest,
   getTopicOverview,
   getTopicMessages,
+  getSchemaOfTopic,
 };

--- a/coral/src/domain/topic/topic-types.ts
+++ b/coral/src/domain/topic/topic-types.ts
@@ -42,6 +42,7 @@ type TopicRequestApiResponse = ResolveIntersectionTypes<
 type AclOverviewInfo = KlawApiModel<"AclOverviewInfo">;
 type TopicOverviewApiResponse = KlawApiResponse<"getTopicOverview">;
 type TopicOverview = KlawApiModel<"TopicOverview">;
+type TopicSchemaOverview = KlawApiModel<"SchemaOverview">;
 
 export type {
   Topic,
@@ -58,4 +59,5 @@ export type {
   TopicMessages,
   NoContent,
   TopicOverview,
+  TopicSchemaOverview,
 };

--- a/coral/src/services/api-helper.ts
+++ b/coral/src/services/api-helper.ts
@@ -3,13 +3,16 @@ import isPlainObject from "lodash/isPlainObject";
 import toString from "lodash/toString";
 
 type QueryToTransform = {
-  [key: string]: string | boolean | number | QueryToTransform;
+  [key: string]: string | boolean | number | string[] | QueryToTransform;
 };
 
 function convertQueryValuesToString(
   query: QueryToTransform
 ): Record<string, string> {
   return cloneDeepWith(query, (value) => {
+    if (Array.isArray(value)) {
+      return value.join(",");
+    }
     // returning undefined if the value for the customizer function
     // is an object makes sure we're iterating over everything
     // this is not strictly needed for our current use-case


### PR DESCRIPTION
## About this change - What it does

- add `getSchemaOfTopic`
- modify `convertQueryValuesToString` to be able to parse arrays of strings as well (the `kafkaEnvIds` param is typed as `string[]`, I assume that this means the param should transform `[1, 2]` to `1,2`, but to be verified.

## EDIT

The types for `kafkaEnvIds` are wrong, only the first ID is taken into account, so it should be corrected to be `string` and not `string[]` (talking under the authority of @aindriu-aiven ). This PR still is valid, I think, as it stands currently.

