### PR TITLE
Fix acl removefromklaw, teams delete defect

### DIFF
--- a/coral/types/api.d.ts
+++ b/coral/types/api.d.ts
@@ -1225,6 +1225,7 @@ export type components = {
       showDeleteAcl?: boolean;
       /** @enum {string} */
       kafkaFlavorType?: "APACHE_KAFKA" | "AIVEN_FOR_APACHE_KAFKA" | "CONFLUENT" | "CONFLUENT_CLOUD" | "OTHERS";
+      remarks?: string;
     };
     SchemaRequestsResponseModel: {
       environment: string;

--- a/core/src/main/java/io/aiven/klaw/helpers/HandleDbRequests.java
+++ b/core/src/main/java/io/aiven/klaw/helpers/HandleDbRequests.java
@@ -411,4 +411,6 @@ public interface HandleDbRequests {
   List<KwClusters> getClusters();
 
   String updateJsonParams(Map<String, String> jsonParams, Integer req_no, int tenantId);
+
+  String deleteAcls(List<Acl> listDeleteAcls, int tenantId);
 }

--- a/core/src/main/java/io/aiven/klaw/helpers/db/rdbms/DeleteDataJdbc.java
+++ b/core/src/main/java/io/aiven/klaw/helpers/db/rdbms/DeleteDataJdbc.java
@@ -329,4 +329,14 @@ public class DeleteDataJdbc {
         messageSchemaRepo.findAllByTenantIdAndTopicnameAndEnvironment(
             topicObj.getTenantId(), topicObj.getTopicname(), topicObj.getEnvironment()));
   }
+
+  public String deleteAcls(List<Acl> listDeleteAcls, int tenantId) {
+    listDeleteAcls.forEach(
+        a -> {
+          AclID aclID = new AclID(a.getReq_no(), tenantId);
+          Optional<Acl> optionalAcl = aclRepo.findById(aclID);
+          optionalAcl.ifPresent(acl -> aclRepo.delete(acl));
+        });
+    return ApiResultStatus.SUCCESS.value;
+  }
 }

--- a/core/src/main/java/io/aiven/klaw/helpers/db/rdbms/HandleDbRequestsJdbc.java
+++ b/core/src/main/java/io/aiven/klaw/helpers/db/rdbms/HandleDbRequestsJdbc.java
@@ -976,6 +976,11 @@ public class HandleDbRequestsJdbc implements HandleDbRequests {
     return jdbcUpdateHelper.updateJsonParams(jsonParams, req_no, tenantId);
   }
 
+  @Override
+  public String deleteAcls(List<Acl> listDeleteAcls, int tenantId) {
+    return jdbcDeleteHelper.deleteAcls(listDeleteAcls, tenantId);
+  }
+
   public String updateDbWithUpdatedVersions(List<MessageSchema> schemaListUpdated) {
     return jdbcUpdateHelper.updateDbWithUpdatedVersions(schemaListUpdated);
   }

--- a/core/src/main/java/io/aiven/klaw/model/AclInfo.java
+++ b/core/src/main/java/io/aiven/klaw/model/AclInfo.java
@@ -32,4 +32,5 @@ public class AclInfo {
   private String currentPage;
   private boolean showDeleteAcl;
   private KafkaFlavors kafkaFlavorType;
+  private String remarks;
 }

--- a/core/src/main/java/io/aiven/klaw/repository/AclRequestsRepo.java
+++ b/core/src/main/java/io/aiven/klaw/repository/AclRequestsRepo.java
@@ -22,7 +22,8 @@ public interface AclRequestsRepo
       @Param("envId") String envId, @Param("tenantId") Integer tenantId);
 
   @Query(
-      value = "select count(*) from kwaclrequests where teamid = :teamId and tenantid = :tenantId",
+      value =
+          "select count(*) from kwaclrequests where teamid = :teamId and tenantid = :tenantId and topicstatus='created'",
       nativeQuery = true)
   List<Object[]> findAllRecordsCountForTeamId(
       @Param("teamId") Integer teamId, @Param("tenantId") Integer tenantId);

--- a/core/src/main/java/io/aiven/klaw/repository/KwKafkaConnectorRequestsRepo.java
+++ b/core/src/main/java/io/aiven/klaw/repository/KwKafkaConnectorRequestsRepo.java
@@ -33,7 +33,7 @@ public interface KwKafkaConnectorRequestsRepo
 
   @Query(
       value =
-          "select count(*) from kwkafkaconnectorrequests where teamid = :teamId and tenantid = :tenantId",
+          "select count(*) from kwkafkaconnectorrequests where teamid = :teamId and tenantid = :tenantId and connectorstatus='created'",
       nativeQuery = true)
   List<Object[]> findAllRecordsCountForTeamId(
       @Param("teamId") Integer teamId, @Param("tenantId") Integer tenantId);

--- a/core/src/main/java/io/aiven/klaw/repository/SchemaRequestRepo.java
+++ b/core/src/main/java/io/aiven/klaw/repository/SchemaRequestRepo.java
@@ -26,7 +26,7 @@ public interface SchemaRequestRepo
 
   @Query(
       value =
-          "select count(*) from kwschemarequests where teamid = :teamId and tenantid = :tenantId",
+          "select count(*) from kwschemarequests where teamid = :teamId and tenantid = :tenantId and topicstatus='created'",
       nativeQuery = true)
   List<Object[]> findAllRecordsCountForTeamId(
       @Param("teamId") Integer teamId, @Param("tenantId") Integer tenantId);

--- a/core/src/main/java/io/aiven/klaw/repository/TopicRequestsRepo.java
+++ b/core/src/main/java/io/aiven/klaw/repository/TopicRequestsRepo.java
@@ -26,7 +26,7 @@ public interface TopicRequestsRepo
 
   @Query(
       value =
-          "select count(*) from kwtopicrequests where teamid = :teamId and tenantid = :tenantId",
+          "select count(*) from kwtopicrequests where teamid = :teamId and tenantid = :tenantId and topicstatus='created'",
       nativeQuery = true)
   List<Object[]> findAllRecordsCountForTeamId(
       @Param("teamId") Integer teamId, @Param("tenantId") Integer tenantId);

--- a/core/src/main/java/io/aiven/klaw/service/UsersTeamsControllerService.java
+++ b/core/src/main/java/io/aiven/klaw/service/UsersTeamsControllerService.java
@@ -379,20 +379,25 @@ public class UsersTeamsControllerService {
   }
 
   public List<TeamModelResponse> getAllTeamsSU() {
-    int tenantId = commonUtilsService.getTenantId(getUserName());
+    String userName = getUserName();
+    int tenantId = commonUtilsService.getTenantId(userName);
 
     List<TeamModelResponse> teamModels =
         getTeamModels(manageDatabase.getTeamObjForTenant(tenantId));
 
-    if (!commonUtilsService.isNotAuthorizedUser(
-        getUserName(), PermissionType.ADD_EDIT_DELETE_TEAMS)) {
+    if (!commonUtilsService.isNotAuthorizedUser(userName, PermissionType.ADD_EDIT_DELETE_TEAMS)) {
       teamModels.forEach(
           teamModel -> {
             teamModel.setShowDeleteTeam(
-                manageDatabase
-                        .getHandleDbRequests()
-                        .getAllComponentsCountForTeam(teamModel.getTeamId(), tenantId)
-                    <= 0);
+                (manageDatabase
+                            .getHandleDbRequests()
+                            .getAllComponentsCountForTeam(teamModel.getTeamId(), tenantId)
+                        == 0)
+                    && (manageDatabase
+                            .getHandleDbRequests()
+                            .getAllUsersInfoForTeam(teamModel.getTeamId(), tenantId)
+                            .size()
+                        == 0));
           });
     }
 

--- a/core/src/main/resources/static/js/synchronizeAcls.js
+++ b/core/src/main/resources/static/js/synchronizeAcls.js
@@ -237,7 +237,7 @@ app.controller("synchronizeAclsCtrl", function($scope, $http, $location, $window
             		closeOnConfirm: true,
             		closeOnCancel: true
             	}).then(function(isConfirm){
-            		if (isConfirm.dismiss != "cancel") {
+            		if (isConfirm.dismiss !== "cancel") {
             		    $scope.ShowSpinnerStatus = true;
             			$http({
                             method: "POST",
@@ -250,7 +250,6 @@ app.controller("synchronizeAclsCtrl", function($scope, $http, $location, $window
                             $scope.alert = "Acl Sync Request : "+output.message;
                             $scope.updatedSyncArray = [];
 
-//                            $scope.getAcls(1);
                              if(output.success){
                               swal({
                             		   title: "",
@@ -258,6 +257,7 @@ app.controller("synchronizeAclsCtrl", function($scope, $http, $location, $window
                             		   timer: 2000,
                             		   showConfirmButton: false
                             	   });
+                                 $scope.getAcls(1);
                             }else $scope.showSubmitFailed('','');
                         }).error(
                             function(error)

--- a/core/src/main/resources/templates/synchronizeAcls.html
+++ b/core/src/main/resources/templates/synchronizeAcls.html
@@ -543,6 +543,7 @@
 										<th>Principal / User</th>
 										<th>AclType</th>
 										<th>Team</th>
+										<th>Info</th>
 									</tr>
 								</thead>
 								<tbody>
@@ -575,6 +576,24 @@
 												ng-model="resultBrowset.teamname" ng-value="resultBrowset.teamname"
 												ng-options="possibleTeams as possibleTeams for possibleTeams in resultBrowset.possibleTeams">
 										</select>
+									</td>
+									<td ng-show="resultBrowset.remarks == 'DELETED'">
+										<a class="mytooltip" href="javascript:void(0)" style="color:red;">
+											<i class="fas fa-stopwatch"></i>
+											<span class="tooltip-content3">Acl deleted on cluster. Select REMOVE-FROM-KLAW team to delete from Klaw.</span>
+										</a>
+									</td>
+									<td ng-show="resultBrowset.remarks == 'IN_SYNC'">
+										<a class="mytooltip" href="javascript:void(0)" style="color:green;">
+											<i class="fas fa-chess-rook"></i>
+											<span class="tooltip-content3">Acl in sync.</span>
+										</a>
+									</td>
+									<td ng-show="resultBrowset.remarks != 'IN_SYNC' && resultBrowset.remarks != 'DELETED'">
+										<a class="mytooltip" href="javascript:void(0)" style="color:blue;">
+											<i class="fa fa-exclamation-triangle" style="color: #FFBF00"></i>
+											<span class="tooltip-content3">Acl added on cluster.</span>
+										</a>
 									</td>
 								</tr>
 

--- a/core/src/test/java/io/aiven/klaw/TopicAclControllerIT.java
+++ b/core/src/test/java/io/aiven/klaw/TopicAclControllerIT.java
@@ -855,7 +855,10 @@ public class TopicAclControllerIT {
             .getContentAsString();
 
     List<AclInfo> response = OBJECT_MAPPER.readValue(res, new TypeReference<>() {});
-    assertThat(response).hasSize(1);
+    assertThat(response).hasSize(2);
+    assertThat(response)
+        .extracting(AclInfo::getRemarks)
+        .containsExactlyInAnyOrder("DELETED", "ADDED");
   }
 
   // delete acl requests

--- a/core/src/test/java/io/aiven/klaw/service/SchemaRegistryControllerServiceTest.java
+++ b/core/src/test/java/io/aiven/klaw/service/SchemaRegistryControllerServiceTest.java
@@ -632,8 +632,8 @@ public class SchemaRegistryControllerServiceTest {
             NullPointerException.class,
             () -> schemaRegistryControllerService.uploadSchema(schemaRequest));
     assertThat(ex.getMessage())
-        .isEqualTo(
-            "Cannot invoke \"java.lang.Boolean.booleanValue()\" because \"this.validateCompatiblityOnSave\" is null");
+        .contains("Cannot invoke \"java.lang.Boolean.booleanValue()\"")
+        .contains("validateCompatiblityOnSave\" is null");
   }
 
   @Test

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -7373,6 +7373,9 @@
           "kafkaFlavorType" : {
             "type" : "string",
             "enum" : [ "APACHE_KAFKA", "AIVEN_FOR_APACHE_KAFKA", "CONFLUENT", "CONFLUENT_CLOUD", "OTHERS" ]
+          },
+          "remarks" : {
+            "type" : "string"
           }
         }
       },

--- a/pom.xml
+++ b/pom.xml
@@ -37,7 +37,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>3.0.6</version>
+        <version>3.1.0</version>
         <relativePath/>
     </parent>
 


### PR DESCRIPTION
About this change - What it does

- In Acl sync from Cluster : if acls exist in klaw and not in cluster, show an option to remove from klaw
- Team deletion should be possible now (fix in a few db queries, requests in created state)

Resolves: #xxxxx (partially fixes 1286)
Why this way

It is now possible to remove acls from klaw, and delete teams
