### PR TITLE
feat(coral) Topic overview - Add topic history view and table [epic #1299]

### DIFF
--- a/coral/src/app/features/topics/details/history/TopicHistory.test.tsx
+++ b/coral/src/app/features/topics/details/history/TopicHistory.test.tsx
@@ -71,9 +71,9 @@ const columnsFieldMap = [
   { columnHeader: "Logs", relatedField: "remarks" },
   { columnHeader: "Team", relatedField: "teamName" },
   { columnHeader: "Requested by", relatedField: "requestedBy" },
-  { columnHeader: "Requested time", relatedField: "requestedTime" },
+  { columnHeader: "Requested on", relatedField: "requestedTime" },
   { columnHeader: "Approved by", relatedField: "approvedBy" },
-  { columnHeader: "Approved time", relatedField: "approvedTime" },
+  { columnHeader: "Approved on", relatedField: "approvedTime" },
 ];
 
 describe("TopicHistory", () => {
@@ -197,8 +197,8 @@ describe("TopicHistory", () => {
 
           let text = field;
           if (
-            column.columnHeader === "Requested time" ||
-            column.columnHeader === "Approved time"
+            column.columnHeader === "Requested on" ||
+            column.columnHeader === "Approved on"
           ) {
             text = `${field}${"\u00A0"}UTC`;
           }

--- a/coral/src/app/features/topics/details/history/TopicHistory.test.tsx
+++ b/coral/src/app/features/topics/details/history/TopicHistory.test.tsx
@@ -1,0 +1,213 @@
+import { TopicOverview } from "src/domain/topic";
+import { customRender } from "src/services/test-utils/render-with-wrappers";
+import { TopicHistory } from "src/app/features/topics/details/history/TopicHistory";
+import { mockIntersectionObserver } from "src/services/test-utils/mock-intersection-observer";
+import { cleanup, screen, within } from "@testing-library/react";
+import { useTopicDetails } from "src/app/features/topics/details/TopicDetails";
+
+const testTopicHistoryList = [
+  {
+    environmentName: "DEV",
+    teamName: "Richmond1",
+    requestedBy: "tedlasso",
+    requestedTime: "2022-Nov-04 14:41:18",
+    approvedBy: "roykent",
+    approvedTime: "2022-Nov-04 14:48:38",
+    remarks: "Create",
+  },
+  {
+    environmentName: "DEV",
+    teamName: "Richmond2",
+    requestedBy: "rebeccawelton",
+    requestedTime: "2022-Nov-04 15:41:18",
+    approvedBy: "Keeleyjones",
+    approvedTime: "2022-Nov-04 15:48:38",
+    remarks: "Delete",
+  },
+];
+const testTopicOverview: TopicOverview = {
+  topicExists: true,
+  schemaExists: false,
+  prefixAclsExists: false,
+  txnAclsExists: false,
+  topicInfoList: [
+    {
+      noOfPartitions: 1,
+      noOfReplicas: "1",
+      teamname: "Ospo",
+      teamId: 1003,
+      envId: "1",
+      showEditTopic: true,
+      showDeleteTopic: false,
+      topicDeletable: false,
+      envName: "DEV",
+      topicName: "my awesome topic",
+    },
+  ],
+  aclInfoList: [],
+  prefixedAclInfoList: [],
+  transactionalAclInfoList: [],
+  topicHistoryList: testTopicHistoryList,
+  topicPromotionDetails: {
+    topicName: "aivtopic3",
+    status: "NO_PROMOTION",
+  },
+  availableEnvironments: [
+    {
+      id: "1",
+      name: "DEV",
+    },
+  ],
+  topicIdForDocumentation: 1015,
+};
+
+jest.mock("src/app/features/topics/details/TopicDetails");
+
+const mockUseTopicDetails = useTopicDetails as jest.MockedFunction<
+  typeof useTopicDetails
+>;
+
+const columnsFieldMap = [
+  { columnHeader: "Logs", relatedField: "remarks" },
+  { columnHeader: "Team", relatedField: "teamName" },
+  { columnHeader: "Requested by", relatedField: "requestedBy" },
+  { columnHeader: "Requested time", relatedField: "requestedTime" },
+  { columnHeader: "Approved by", relatedField: "approvedBy" },
+  { columnHeader: "Approved time", relatedField: "approvedTime" },
+];
+
+describe("TopicHistory", () => {
+  beforeAll(mockIntersectionObserver);
+
+  describe("handles an empty history", () => {
+    beforeAll(() => {
+      mockUseTopicDetails.mockReturnValue({
+        environmentId: "1",
+        topicName: "hello",
+        topicOverview: { ...testTopicOverview, topicHistoryList: [] },
+      });
+
+      customRender(<TopicHistory />, {
+        memoryRouter: true,
+      });
+    });
+
+    afterAll(() => {
+      jest.clearAllMocks();
+      cleanup();
+    });
+
+    it("shows a headline informing user about missing history", () => {
+      const headline = screen.getByRole("heading", {
+        name: "No Topic history",
+      });
+
+      expect(headline).toBeVisible();
+    });
+
+    it("shows information about missing history", () => {
+      const infoText = screen.getByText("This Topic contains no history.");
+
+      expect(infoText).toBeVisible();
+    });
+
+    it("does not render a table", () => {
+      const table = screen.queryByRole("table");
+
+      expect(table).not.toBeInTheDocument();
+    });
+  });
+
+  describe("shows a table with topics history", () => {
+    beforeAll(() => {
+      mockUseTopicDetails.mockReturnValue({
+        environmentId: "1",
+        topicName: "hello",
+        topicOverview: testTopicOverview,
+      });
+
+      customRender(<TopicHistory />, {
+        memoryRouter: true,
+      });
+    });
+
+    afterAll(() => {
+      jest.clearAllMocks();
+      cleanup();
+    });
+
+    it("shows a table for topics history", () => {
+      const table = screen.getByRole("table", {
+        name: "Topic history",
+      });
+
+      expect(table).toBeVisible();
+    });
+
+    it("shows all column headers", () => {
+      const table = screen.getByRole("table", {
+        name: "Topic history",
+      });
+      const header = within(table).getAllByRole("columnheader");
+
+      expect(header).toHaveLength(columnsFieldMap.length);
+    });
+
+    it("shows a row for each given requests plus header row", () => {
+      const table = screen.getByRole("table", {
+        name: "Topic history",
+      });
+      const row = within(table).getAllByRole("row");
+
+      expect(row).toHaveLength(testTopicHistoryList.length + 1);
+    });
+
+    it(`renders the right amount of cells based in topics history list`, () => {
+      const table = screen.getByRole("table", {
+        name: "Topic history",
+      });
+      const cells = within(table).getAllByRole("cell");
+
+      expect(cells).toHaveLength(
+        columnsFieldMap.length * testTopicHistoryList.length
+      );
+    });
+
+    columnsFieldMap.forEach((column) => {
+      it(`shows a column header for ${column.columnHeader}`, () => {
+        const table = screen.getByRole("table", {
+          name: "Topic history",
+        });
+        const header = within(table).getByRole("columnheader", {
+          name: column.columnHeader,
+        });
+
+        expect(header).toBeVisible();
+      });
+
+      testTopicHistoryList.forEach((historyEntry, index) => {
+        it(`shows field ${column.relatedField} for history entry number ${index}`, () => {
+          const table = screen.getByRole("table", {
+            name: "Topic history",
+          });
+
+          // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+          //@ts-ignore
+          const field = historyEntry[column.relatedField];
+
+          let text = field;
+          if (
+            column.columnHeader === "Requested time" ||
+            column.columnHeader === "Approved time"
+          ) {
+            text = `${field}${"\u00A0"}UTC`;
+          }
+
+          const cell = within(table).getByRole("cell", { name: text });
+
+          expect(cell).toBeVisible();
+        });
+      });
+    });
+  });
+});

--- a/coral/src/app/features/topics/details/history/TopicHistory.tsx
+++ b/coral/src/app/features/topics/details/history/TopicHistory.tsx
@@ -4,8 +4,8 @@ import { TopicOverview } from "src/domain/topic";
 
 interface TopicHistoryRow {
   id: number;
-  logs: string; //Remarks
-  team: string; //
+  logs: string;
+  team: string;
   requestedBy: string;
   requestedTime: string;
   approvedBy: string;
@@ -30,7 +30,7 @@ function TopicHistory() {
     {
       type: "text",
       field: "requestedTime",
-      headerName: "Requested time",
+      headerName: "Requested on",
       formatter: (value) => {
         return `${value}${"\u00A0"}UTC`;
       },
@@ -39,7 +39,7 @@ function TopicHistory() {
     {
       type: "text",
       field: "approvedTime",
-      headerName: "Approved time",
+      headerName: "Approved on",
       formatter: (value) => {
         return `${value}${"\u00A0"}UTC`;
       },

--- a/coral/src/app/features/topics/details/history/TopicHistory.tsx
+++ b/coral/src/app/features/topics/details/history/TopicHistory.tsx
@@ -1,0 +1,83 @@
+import { DataTable, DataTableColumn, EmptyState } from "@aivenio/aquarium";
+import { useTopicDetails } from "src/app/features/topics/details/TopicDetails";
+import { TopicOverview } from "src/domain/topic";
+
+interface TopicHistoryRow {
+  id: number;
+  logs: string; //Remarks
+  team: string; //
+  requestedBy: string;
+  requestedTime: string;
+  approvedBy: string;
+  approvedTime: string;
+}
+
+function TopicHistory() {
+  const { topicOverview } = useTopicDetails();
+
+  const columns: Array<DataTableColumn<TopicHistoryRow>> = [
+    {
+      type: "status",
+      field: "logs",
+      headerName: "Logs",
+      status: ({ logs }) => ({
+        status: "neutral",
+        text: logs,
+      }),
+    },
+    { type: "text", field: "team", headerName: "Team" },
+    { type: "text", field: "requestedBy", headerName: "Requested by" },
+    {
+      type: "text",
+      field: "requestedTime",
+      headerName: "Requested time",
+      formatter: (value) => {
+        return `${value}${"\u00A0"}UTC`;
+      },
+    },
+    { type: "text", field: "approvedBy", headerName: "Approved by" },
+    {
+      type: "text",
+      field: "approvedTime",
+      headerName: "Approved time",
+      formatter: (value) => {
+        return `${value}${"\u00A0"}UTC`;
+      },
+    },
+  ];
+
+  const historyList: TopicOverview["topicHistoryList"] =
+    topicOverview.topicHistoryList;
+
+  const rows: TopicHistoryRow[] =
+    historyList?.map((historyEntry, index): TopicHistoryRow => {
+      return {
+        id: index,
+        logs: historyEntry.remarks,
+        team: historyEntry.teamName,
+        requestedBy: historyEntry.requestedBy,
+        requestedTime: historyEntry.requestedTime,
+        approvedBy: historyEntry.approvedBy,
+        approvedTime: historyEntry.approvedTime,
+      };
+    }) || [];
+
+  if (!rows.length) {
+    return (
+      <EmptyState title="No Topic history">
+        This Topic contains no history.
+      </EmptyState>
+    );
+  }
+
+  return (
+    <DataTable
+      ariaLabel={"Topic history"}
+      columns={columns}
+      rows={rows}
+      noWrap={false}
+    />
+  );
+}
+
+export { TopicHistory };

--- a/coral/src/app/pages/topics/details/history/index.tsx
+++ b/coral/src/app/pages/topics/details/history/index.tsx
@@ -1,0 +1,7 @@
+import { TopicHistory } from "src/app/features/topics/details/history/TopicHistory";
+
+function TopicHistoryPage() {
+  return <TopicHistory />;
+}
+
+export { TopicHistoryPage };

--- a/coral/src/app/router.tsx
+++ b/coral/src/app/router.tsx
@@ -31,6 +31,7 @@ import {
 import { getRouterBasename } from "src/config";
 import { createRouteBehindFeatureFlag } from "src/services/feature-flags/route-utils";
 import { FeatureFlag } from "src/services/feature-flags/types";
+import { TopicHistoryPage } from "src/app/pages/topics/details/history";
 import { TopicMessagesPage } from "src/app/pages/topics/details/messages";
 import { TopicSubscriptionsPage } from "src/app/pages/topics/details/subscriptions";
 import { TopicOverviewPage } from "src/app/pages/topics/details/overview";
@@ -88,7 +89,7 @@ const routes: Array<RouteObject> = [
           },
           {
             path: TOPIC_OVERVIEW_TAB_ID_INTO_PATH[TopicOverviewTabEnum.HISTORY],
-            element: <div>HISTORY</div>,
+            element: <TopicHistoryPage />,
             id: TopicOverviewTabEnum.HISTORY,
           },
           {

--- a/core/src/main/java/io/aiven/klaw/service/KafkaConnectControllerService.java
+++ b/core/src/main/java/io/aiven/klaw/service/KafkaConnectControllerService.java
@@ -677,7 +677,7 @@ public class KafkaConnectControllerService {
       topicHistory.setRequestedTime(simpleDateFormat.format(connectorRequest.getRequesttime()));
       topicHistory.setApprovedBy(userName);
       topicHistory.setApprovedTime(simpleDateFormat.format(new Date()));
-      topicHistory.setRemarks(connectorRequest.getRequestOperationType());
+      topicHistory.setRemarks("Connector " + connectorRequest.getRequestOperationType());
       topicHistoryList.add(topicHistory);
 
       connectorRequest.setHistory(OBJECT_MAPPER.writer().writeValueAsString(topicHistoryList));

--- a/core/src/main/java/io/aiven/klaw/service/TopicControllerService.java
+++ b/core/src/main/java/io/aiven/klaw/service/TopicControllerService.java
@@ -837,7 +837,7 @@ public class TopicControllerService {
       topicHistory.setRequestedTime(simpleDateFormat.format(topicRequest.getRequesttime()));
       topicHistory.setApprovedBy(userName);
       topicHistory.setApprovedTime(simpleDateFormat.format(new Date()));
-      topicHistory.setRemarks(topicRequest.getRequestOperationType());
+      topicHistory.setRemarks("Topic " + topicRequest.getRequestOperationType());
       topicHistoryList.add(topicHistory);
 
       topicRequest.setHistory(OBJECT_MAPPER.writer().writeValueAsString(topicHistoryList));


### PR DESCRIPTION
# About this change - What it does

- adds the table showing topic history

## Recording


https://github.com/aiven/klaw/assets/943800/6d3ce12c-864b-4ad6-837e-c42ac463ad0c


Resolves: #1299 


