### PR TITLE
fix(coral): Show loading state instead of stale data

### DIFF
--- a/coral/src/app/features/topics/details/TopicDetails.tsx
+++ b/coral/src/app/features/topics/details/TopicDetails.tsx
@@ -50,6 +50,17 @@ function TopicDetails(props: TopicOverviewProps) {
     return <Navigate to={`/topic/${topicName}/overview`} replace={true} />;
   }
 
+  // If we rely on isLoading only,
+  // when a user navigates to another topic overview after having previously seen a different topic
+  // the TopicOverviewResourcesTabs rendered data will be stale for a second (showing previous topic data)
+  // while the query is refetching the data
+  // However, using isRefetching is also an issue, because then we will show the loading state every time the user switches environment
+  // Instead of only the first time they switch
+  // This isRefetchingTopicOverview variable ensures that we only show loading state when there is a desync between the topic name in pops
+  // and the topic name in the available data
+  const isRefetchingTopicOverview =
+    data?.topicInfoList[0].topicName !== topicName;
+
   return (
     <div>
       <TopicDetailsHeader
@@ -61,7 +72,7 @@ function TopicDetails(props: TopicOverviewProps) {
       />
 
       <TopicOverviewResourcesTabs
-        isLoading={isLoading}
+        isLoading={isLoading || isRefetchingTopicOverview}
         isError={isError}
         error={error}
         currentTab={currentTab}


### PR DESCRIPTION
## The problem

We have a flash of stale data when navigating to Topic overview in succession:

https://github.com/aiven/klaw/assets/20607294/0d25d8af-41fe-4fba-979a-ab57fc4f5cda

This is because we rely on `isLoading`, which is only `true` the first time we fire a query.

## The solution

Display loading state when a discrepancy is detected between the topic name passed as props and the one in the current data. Still preserves the instant switch between environments after first fetch (as opposed to using another value from the `useQuery` like `isRefetching`):

https://github.com/aiven/klaw/assets/20607294/e3b57567-3864-495d-8efb-d61cbde61911




