### PR TITLE
Improvements

### DIFF
--- a/cluster-api/src/main/java/io/aiven/klaw/clusterapi/services/AivenApiService.java
+++ b/cluster-api/src/main/java/io/aiven/klaw/clusterapi/services/AivenApiService.java
@@ -300,7 +300,8 @@ public class AivenApiService {
           newRGroupMap.put("resourceName", "-na-");
           aclsListUpdated.add(newRGroupMap);
         }
-        if (!"ADMIN".equals(aclsMapUpdated.get("operation"))) {
+        if (!"ADMIN".equals(aclsMapUpdated.get("operation"))
+            && !"READWRITE".equals(aclsMapUpdated.get("operation"))) {
           aclsListUpdated.add(aclsMapUpdated);
         }
       }

--- a/cluster-api/src/test/java/io/aiven/klaw/clusterapi/services/AivenApiServiceTest.java
+++ b/cluster-api/src/test/java/io/aiven/klaw/clusterapi/services/AivenApiServiceTest.java
@@ -12,6 +12,7 @@ import io.aiven.klaw.clusterapi.models.ClusterAclRequest;
 import io.aiven.klaw.clusterapi.models.enums.ApiResultStatus;
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import org.junit.jupiter.api.BeforeEach;
@@ -241,6 +242,44 @@ public class AivenApiServiceTest {
 
     Set<String> response = aivenApiService.getServiceAccountUsers("testproject", "testservice");
     assertThat(response).hasSize(0);
+  }
+
+  @Test
+  public void listAcls() throws Exception {
+    String getAclsUrl =
+        "https://api.aiven.io/v1/project/" + "testproject" + "/service/" + "testservice" + "/acl";
+    Map<String, List<Map<String, String>>> aclsResp = new HashMap<>();
+    List<Map<String, String>> aclList = new ArrayList<>();
+
+    Map<String, String> aclMap1 = new HashMap<>();
+    aclMap1.put("permission", "read");
+    aclList.add(aclMap1);
+
+    Map<String, String> aclMap2 = new HashMap<>();
+    aclMap2.put("permission", "write");
+    aclList.add(aclMap2);
+
+    Map<String, String> aclMap3 = new HashMap<>();
+    aclMap3.put("permission", "ADMIN");
+    aclList.add(aclMap3);
+
+    Map<String, String> aclMap4 = new HashMap<>();
+    aclMap4.put("permission", "READWRITE");
+    aclList.add(aclMap4);
+
+    aclsResp.put("acl", aclList);
+    ResponseEntity<Map<String, List<Map<String, String>>>> responseEntityServiceAccount =
+        new ResponseEntity<>(aclsResp, HttpStatus.OK);
+
+    when(restTemplate.exchange(
+            eq(getAclsUrl),
+            eq(HttpMethod.GET),
+            any(),
+            (ParameterizedTypeReference<Map<String, List<Map<String, String>>>>) any()))
+        .thenReturn(responseEntityServiceAccount);
+
+    Set<Map<String, String>> acls = aivenApiService.listAcls("testproject", "testservice");
+    assertThat(acls).hasSize(3);
   }
 
   @Disabled

--- a/coral/src/app/features/topics/details/subscriptions/TopicSubscriptions.test.tsx
+++ b/coral/src/app/features/topics/details/subscriptions/TopicSubscriptions.test.tsx
@@ -473,7 +473,9 @@ describe("TopicSubscriptions.tsx", () => {
 
       await userEvent.click(createButton);
 
-      expect(mockCreateDeleteAclRequest).toHaveBeenCalledTimes(1);
+      expect(mockCreateDeleteAclRequest).toHaveBeenNthCalledWith(1, {
+        requestId: "1006",
+      });
 
       await waitFor(() => expect(modal).not.toBeVisible());
       await waitFor(() =>

--- a/coral/src/app/features/topics/details/subscriptions/TopicSubscriptions.tsx
+++ b/coral/src/app/features/topics/details/subscriptions/TopicSubscriptions.tsx
@@ -121,7 +121,7 @@ const TopicSubscriptions = () => {
     if (req_no === null) {
       throw Error("Cannot delete request with req_no null");
     }
-    deleteRequest({ req_no });
+    deleteRequest({ requestId: req_no });
   };
 
   const subsStats = useMemo(() => {

--- a/coral/src/domain/acl/acl-api.ts
+++ b/coral/src/domain/acl/acl-api.ts
@@ -116,15 +116,12 @@ const deleteAclRequest = ({ reqIds }: DeleteRequestParams) => {
 };
 
 const createAclDeletionRequest = (
-  params: KlawApiRequestQueryParameters<"deleteAclSubscriptionRequest">
+  payload: KlawApiRequest<"deleteAclSubscriptionRequest">
 ): Promise<KlawApiResponse<"deleteAclSubscriptionRequest">> => {
-  const parsedParams = new URLSearchParams(params);
-  type CreateAclDeletionRequestSearchParams = typeof parsedParams;
-
   return api.post<
     KlawApiResponse<"deleteAclSubscriptionRequest">,
-    CreateAclDeletionRequestSearchParams
-  >(API_PATHS.deleteAclSubscriptionRequest, parsedParams);
+    KlawApiRequest<"deleteAclSubscriptionRequest">
+  >(API_PATHS.deleteAclSubscriptionRequest, payload);
 };
 
 type GetAivenServiceAccountsParams =

--- a/coral/types/api.d.ts
+++ b/coral/types/api.d.ts
@@ -723,6 +723,9 @@ export type components = {
       deleteAssociatedSchema?: boolean;
       otherParams?: string;
     };
+    DeleteAclRequestModel: {
+      requestId: string;
+    };
     KafkaConnectorRequestModel: {
       /** @enum {string} */
       requestOperationType: "CREATE" | "UPDATE" | "PROMOTE" | "CLAIM" | "DELETE";
@@ -2417,9 +2420,9 @@ export type operations = {
     };
   };
   deleteAclSubscriptionRequest: {
-    parameters: {
-      query: {
-        req_no: string;
+    requestBody: {
+      content: {
+        "application/json": components["schemas"]["DeleteAclRequestModel"];
       };
     };
     responses: {

--- a/core/src/main/java/io/aiven/klaw/controller/AclController.java
+++ b/core/src/main/java/io/aiven/klaw/controller/AclController.java
@@ -8,6 +8,7 @@ import io.aiven.klaw.model.enums.Order;
 import io.aiven.klaw.model.enums.RequestOperationType;
 import io.aiven.klaw.model.enums.RequestStatus;
 import io.aiven.klaw.model.requests.AclRequestsModel;
+import io.aiven.klaw.model.requests.DeleteAclRequestModel;
 import io.aiven.klaw.model.response.AclRequestsResponseModel;
 import io.aiven.klaw.model.response.OffsetDetails;
 import io.aiven.klaw.model.response.ServiceAccountDetails;
@@ -164,9 +165,11 @@ public class AclController {
       value = "/createDeleteAclSubscriptionRequest",
       produces = {MediaType.APPLICATION_JSON_VALUE})
   public ResponseEntity<ApiResponse> deleteAclSubscriptionRequest(
-      @RequestParam("req_no") String req_no) throws KlawException {
+      @RequestBody @Valid DeleteAclRequestModel deleteAclRequestModel) throws KlawException {
     return new ResponseEntity<>(
-        aclControllerService.createDeleteAclSubscriptionRequest(req_no), HttpStatus.OK);
+        aclControllerService.createDeleteAclSubscriptionRequest(
+            deleteAclRequestModel.getRequestId()),
+        HttpStatus.OK);
   }
 
   @PostMapping(

--- a/core/src/main/java/io/aiven/klaw/error/KlawErrorMessages.java
+++ b/core/src/main/java/io/aiven/klaw/error/KlawErrorMessages.java
@@ -48,6 +48,8 @@ public class KlawErrorMessages {
   public static final String ACL_ERR_106 =
       "You are not allowed to approve your own subscription requests.";
 
+  public static final String ACL_ERR_107 = "A delete request already exists.";
+
   // Acl sync service
 
   public static final String ACL_SYNC_ERR_102 = "Error in Acl creation. Acl: %s";

--- a/core/src/main/java/io/aiven/klaw/helpers/KwConstants.java
+++ b/core/src/main/java/io/aiven/klaw/helpers/KwConstants.java
@@ -21,6 +21,11 @@ public class KwConstants {
   public static final String EMAIL_NOTIFICATIONS_ENABLED_KEY = "klaw.mail.notifications.enable";
 
   public static final String USER_ROLE = "USER";
+
+  public static final String REQUESTOR_SUBSCRIPTIONS = "requestor_subscriptions";
+
+  public static final String APPROVER_SUBSCRIPTIONS = "approver_subscriptions";
+
   public static final String SUPERADMIN_ROLE = "SUPERADMIN";
 
   public static final String INFRATEAM = "INFRATEAM";

--- a/core/src/main/java/io/aiven/klaw/helpers/db/rdbms/SelectDataJdbc.java
+++ b/core/src/main/java/io/aiven/klaw/helpers/db/rdbms/SelectDataJdbc.java
@@ -1,5 +1,7 @@
 package io.aiven.klaw.helpers.db.rdbms;
 
+import static io.aiven.klaw.helpers.KwConstants.REQUESTOR_SUBSCRIPTIONS;
+
 import com.google.common.collect.Lists;
 import io.aiven.klaw.dao.*;
 import io.aiven.klaw.model.enums.AclPatternType;
@@ -141,7 +143,7 @@ public class SelectDataJdbc {
       String rowRequestOperationType = row.getRequestOperationType();
       if (isApproval) {
         teamSelected = showRequestsOfAllTeams ? null : teamSelected;
-        if ("requestor_subscriptions".equals(role)) {
+        if (REQUESTOR_SUBSCRIPTIONS.equals(role)) {
           teamId = row.getRequestingteam();
         } else {
           teamId = row.getTeamId();

--- a/core/src/main/java/io/aiven/klaw/model/requests/DeleteAclRequestModel.java
+++ b/core/src/main/java/io/aiven/klaw/model/requests/DeleteAclRequestModel.java
@@ -1,0 +1,9 @@
+package io.aiven.klaw.model.requests;
+
+import jakarta.validation.constraints.NotNull;
+import lombok.Data;
+
+@Data
+public class DeleteAclRequestModel {
+  @NotNull String requestId;
+}

--- a/core/src/main/java/io/aiven/klaw/service/AclControllerService.java
+++ b/core/src/main/java/io/aiven/klaw/service/AclControllerService.java
@@ -8,6 +8,7 @@ import static io.aiven.klaw.error.KlawErrorMessages.ACL_ERR_105;
 import static io.aiven.klaw.error.KlawErrorMessages.ACL_ERR_106;
 import static io.aiven.klaw.error.KlawErrorMessages.ACL_ERR_107;
 import static io.aiven.klaw.error.KlawErrorMessages.REQ_ERR_101;
+import static io.aiven.klaw.helpers.KwConstants.REQUESTOR_SUBSCRIPTIONS;
 import static io.aiven.klaw.model.enums.MailType.ACL_DELETE_REQUESTED;
 import static io.aiven.klaw.model.enums.MailType.ACL_REQUESTED;
 import static io.aiven.klaw.model.enums.MailType.ACL_REQUEST_APPROVED;
@@ -604,7 +605,7 @@ public class AclControllerService {
         dbHandle.getAllAclRequests(
             false,
             userName,
-            "requestor_subscriptions",
+            REQUESTOR_SUBSCRIPTIONS,
             RequestStatus.CREATED.value,
             false,
             RequestOperationType.DELETE,

--- a/core/src/main/java/io/aiven/klaw/service/AclControllerService.java
+++ b/core/src/main/java/io/aiven/klaw/service/AclControllerService.java
@@ -646,7 +646,7 @@ public class AclControllerService {
     HandleDbRequests dbHandle = manageDatabase.getHandleDbRequests();
     AclRequests aclReq = dbHandle.getAcl(Integer.parseInt(req_no), tenantId);
 
-    ApiResponse aclValidationResponse = validateAclRequest(aclReq, userDetails);
+    ApiResponse aclValidationResponse = validateAclRequest(aclReq, userDetails, tenantId);
     if (!aclValidationResponse.isSuccess()) {
       return aclValidationResponse;
     }
@@ -683,7 +683,7 @@ public class AclControllerService {
         .build();
   }
 
-  private ApiResponse validateAclRequest(AclRequests aclReq, String userDetails) {
+  private ApiResponse validateAclRequest(AclRequests aclReq, String userDetails, int tenantId) {
     if (aclReq == null || aclReq.getReq_no() == null) {
       return ApiResponse.builder().success(false).message(ACL_ERR_105).build();
     }
@@ -694,6 +694,14 @@ public class AclControllerService {
 
     if (!RequestStatus.CREATED.value.equals(aclReq.getRequestStatus())) {
       return ApiResponse.builder().success(false).message(REQ_ERR_101).build();
+    }
+
+    if (manageDatabase.getTopicsForTenant(tenantId).stream()
+        .noneMatch(
+            topic ->
+                topic.getEnvironment().equals(aclReq.getEnvironment())
+                    && aclReq.getTopicname().equals(topic.getTopicname()))) {
+      return ApiResponse.builder().success(false).message(ACL_ERR_101).build();
     }
 
     // tenant filtering

--- a/core/src/main/java/io/aiven/klaw/service/AclControllerService.java
+++ b/core/src/main/java/io/aiven/klaw/service/AclControllerService.java
@@ -6,6 +6,7 @@ import static io.aiven.klaw.error.KlawErrorMessages.ACL_ERR_103;
 import static io.aiven.klaw.error.KlawErrorMessages.ACL_ERR_104;
 import static io.aiven.klaw.error.KlawErrorMessages.ACL_ERR_105;
 import static io.aiven.klaw.error.KlawErrorMessages.ACL_ERR_106;
+import static io.aiven.klaw.error.KlawErrorMessages.ACL_ERR_107;
 import static io.aiven.klaw.error.KlawErrorMessages.REQ_ERR_101;
 import static io.aiven.klaw.model.enums.MailType.ACL_DELETE_REQUESTED;
 import static io.aiven.klaw.model.enums.MailType.ACL_REQUESTED;
@@ -571,7 +572,7 @@ public class AclControllerService {
   // this will create a delete subscription request
   public ApiResponse createDeleteAclSubscriptionRequest(String req_no) throws KlawException {
     log.info("createDeleteAclSubscriptionRequest {}", req_no);
-    final String userDetails = getCurrentUserName();
+    final String userName = getCurrentUserName();
     if (commonUtilsService.isNotAuthorizedUser(
         getPrincipal(), PermissionType.REQUEST_DELETE_SUBSCRIPTIONS)) {
       return ApiResponse.builder()
@@ -583,18 +584,39 @@ public class AclControllerService {
     HandleDbRequests dbHandle = manageDatabase.getHandleDbRequests();
     Acl acl =
         dbHandle.getSyncAclsFromReqNo(
-            Integer.parseInt(req_no), commonUtilsService.getTenantId(userDetails));
+            Integer.parseInt(req_no), commonUtilsService.getTenantId(userName));
 
     // Verify if user raising request belongs to the same team as the Subscription owner team
-    if (!Objects.equals(acl.getTeamId(), commonUtilsService.getTeamId(userDetails))) {
+    if (!Objects.equals(acl.getTeamId(), commonUtilsService.getTeamId(userName))) {
       return ApiResponse.builder()
           .success(false)
           .message(ApiResultStatus.NOT_AUTHORIZED.value)
           .build();
     }
 
-    if (!commonUtilsService.getEnvsFromUserId(userDetails).contains(acl.getEnvironment())) {
+    if (!commonUtilsService.getEnvsFromUserId(userName).contains(acl.getEnvironment())) {
       return ApiResponse.builder().success(false).message(ApiResultStatus.FAILURE.value).build();
+    }
+
+    // verify if a request already exists
+    int tenantId = commonUtilsService.getTenantId(userName);
+    List<AclRequests> aclRequests =
+        dbHandle.getAllAclRequests(
+            false,
+            userName,
+            "requestor_subscriptions",
+            RequestStatus.CREATED.value,
+            false,
+            RequestOperationType.DELETE,
+            acl.getTopicname(),
+            acl.getEnvironment(),
+            null,
+            AclType.of(acl.getAclType()),
+            true,
+            tenantId);
+
+    if (!aclRequests.isEmpty()) {
+      return ApiResponse.builder().success(false).message(ACL_ERR_107).build();
     }
 
     AclRequests aclRequestsDao = new AclRequests();
@@ -602,11 +624,11 @@ public class AclControllerService {
     copyProperties(acl, aclRequestsDao);
     aclRequestsDao.setAcl_ip(acl.getAclip());
     aclRequestsDao.setAcl_ssl(acl.getAclssl());
-    aclRequestsDao.setRequestor(userDetails);
+    aclRequestsDao.setRequestor(userName);
     aclRequestsDao.setRequestOperationType(RequestOperationType.DELETE.value);
     aclRequestsDao.setOtherParams(req_no);
     aclRequestsDao.setJsonParams(acl.getJsonParams());
-    return executeAclRequestModel(userDetails, aclRequestsDao, ACL_DELETE_REQUESTED);
+    return executeAclRequestModel(userName, aclRequestsDao, ACL_DELETE_REQUESTED);
   }
 
   public ApiResponse approveAclRequests(String req_no) throws KlawException {

--- a/core/src/main/java/io/aiven/klaw/service/UtilControllerService.java
+++ b/core/src/main/java/io/aiven/klaw/service/UtilControllerService.java
@@ -1,6 +1,8 @@
 package io.aiven.klaw.service;
 
 import static io.aiven.klaw.error.KlawErrorMessages.*;
+import static io.aiven.klaw.helpers.KwConstants.APPROVER_SUBSCRIPTIONS;
+import static io.aiven.klaw.helpers.KwConstants.REQUESTOR_SUBSCRIPTIONS;
 import static io.aiven.klaw.model.enums.AuthenticationType.ACTIVE_DIRECTORY;
 import static io.aiven.klaw.model.enums.RolesType.SUPERADMIN;
 
@@ -117,11 +119,11 @@ public class UtilControllerService {
     String roleToSet = "";
     if (!commonUtilsService.isNotAuthorizedUser(
         getPrincipal(), PermissionType.APPROVE_SUBSCRIPTIONS)) {
-      roleToSet = "approver_subscriptions";
+      roleToSet = APPROVER_SUBSCRIPTIONS;
     }
     if (!commonUtilsService.isNotAuthorizedUser(
         getPrincipal(), PermissionType.REQUEST_CREATE_SUBSCRIPTIONS)) {
-      roleToSet = "requestor_subscriptions";
+      roleToSet = REQUESTOR_SUBSCRIPTIONS;
     }
     List<SchemaRequest> allSchemaReqs =
         reqsHandle.getAllSchemaRequests(

--- a/core/src/main/resources/static/js/browseAcls.js
+++ b/core/src/main/resources/static/js/browseAcls.js
@@ -382,6 +382,9 @@ app.controller("browseAclsCtrl", function($scope, $http, $location, $window) {
                 return;
             }
 
+            var deleteAclReq = {};
+            deleteAclReq['requestId'] = reqNo;
+
             swal({
                         title: "Are you sure?",
                         text: "You would like to delete this subscription ?",
@@ -398,8 +401,7 @@ app.controller("browseAclsCtrl", function($scope, $http, $location, $window) {
                                     method: "POST",
                                     url: "createDeleteAclSubscriptionRequest",
                                     headers : { 'Content-Type' : 'application/json' },
-                                    params: {'req_no' : reqNo },
-                                    data: {'req_no' : reqNo }
+                                    data: {'requestId' : reqNo }
                                 }).success(function(output) {
                                     if(!output.success){
                                         $scope.alert = "Delete Request : "+output.message+ ". Please check if there is any pending request.";

--- a/core/src/test/java/io/aiven/klaw/service/AclControllerServiceTest.java
+++ b/core/src/test/java/io/aiven/klaw/service/AclControllerServiceTest.java
@@ -1,5 +1,6 @@
 package io.aiven.klaw.service;
 
+import static io.aiven.klaw.error.KlawErrorMessages.ACL_ERR_101;
 import static io.aiven.klaw.error.KlawErrorMessages.ACL_ERR_107;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
@@ -495,6 +496,10 @@ public class AclControllerServiceTest {
         .thenReturn(ApiResultStatus.SUCCESS.value);
     when(commonUtilsService.getEnvsFromUserId(anyString()))
         .thenReturn(new HashSet<>(Collections.singletonList("1")));
+    Topic t1 = new Topic();
+    t1.setTopicname("testtopic");
+    t1.setEnvironment("1");
+    when(manageDatabase.getTopicsForTenant(anyInt())).thenReturn(List.of(t1));
 
     ApiResponse apiResp = aclControllerService.approveAclRequests("112");
     assertThat(apiResp.isSuccess()).isTrue();
@@ -524,6 +529,10 @@ public class AclControllerServiceTest {
         .thenReturn(ApiResultStatus.SUCCESS.value);
     when(commonUtilsService.getEnvsFromUserId(anyString()))
         .thenReturn(new HashSet<>(Collections.singletonList("1")));
+    Topic t1 = new Topic();
+    t1.setTopicname("testtopic");
+    t1.setEnvironment("1");
+    when(manageDatabase.getTopicsForTenant(anyInt())).thenReturn(List.of(t1));
 
     ApiResponse apiResp = aclControllerService.approveAclRequests("112");
     assertThat(apiResp.isSuccess()).isTrue();
@@ -559,6 +568,10 @@ public class AclControllerServiceTest {
     when(commonUtilsService.getEnvsFromUserId(anyString()))
         .thenReturn(new HashSet<>(Collections.singletonList("1")));
     when(handleDbRequests.getAcl(anyInt(), anyInt())).thenReturn(aclReq);
+    Topic t1 = new Topic();
+    t1.setTopicname("testtopic");
+    t1.setEnvironment("1");
+    when(manageDatabase.getTopicsForTenant(anyInt())).thenReturn(List.of(t1));
 
     ApiResponse apiResponse = ApiResponse.builder().message("failure").build();
     when(clusterApiService.approveAclRequests(any(), anyInt()))
@@ -578,6 +591,11 @@ public class AclControllerServiceTest {
     when(handleDbRequests.getAcl(anyInt(), anyInt())).thenReturn(aclReq);
     when(commonUtilsService.getEnvsFromUserId(anyString()))
         .thenReturn(new HashSet<>(Collections.singletonList("1")));
+
+    Topic t1 = new Topic();
+    t1.setTopicname("testtopic");
+    t1.setEnvironment("1");
+    when(manageDatabase.getTopicsForTenant(anyInt())).thenReturn(List.of(t1));
 
     ApiResponse apiResponse =
         ApiResponse.builder().success(true).message(ApiResultStatus.SUCCESS.value).build();
@@ -1036,6 +1054,27 @@ public class AclControllerServiceTest {
     ApiResponse resultResp = aclControllerService.createDeleteAclSubscriptionRequest(reqNo);
     assertThat(resultResp.getMessage()).isEqualTo(ACL_ERR_107);
     assertThat(resultResp.isSuccess()).isFalse();
+  }
+
+  @Test
+  @Order(37)
+  public void approveAclRequestsFailure4() throws KlawException {
+    String req_no = "1001";
+    AclRequests aclReq = getAclRequestDao();
+
+    stubUserInfo();
+    when(handleDbRequests.getAcl(anyInt(), anyInt())).thenReturn(aclReq);
+    when(commonUtilsService.getEnvsFromUserId(anyString()))
+        .thenReturn(new HashSet<>(Collections.singletonList("1")));
+
+    Topic t1 = new Topic();
+    t1.setTopicname("testtopic1"); // non-existing topic
+    t1.setEnvironment("1");
+    when(manageDatabase.getTopicsForTenant(anyInt())).thenReturn(List.of(t1));
+
+    ApiResponse apiResp = aclControllerService.approveAclRequests(req_no);
+    assertThat(apiResp.getMessage()).isEqualTo(ACL_ERR_101);
+    assertThat(apiResp.isSuccess()).isFalse();
   }
 
   private AclRequestsModel getAclRequestProducer() {

--- a/core/src/test/java/io/aiven/klaw/service/AclControllerServiceTest.java
+++ b/core/src/test/java/io/aiven/klaw/service/AclControllerServiceTest.java
@@ -1,5 +1,6 @@
 package io.aiven.klaw.service;
 
+import static io.aiven.klaw.error.KlawErrorMessages.ACL_ERR_107;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
@@ -999,6 +1000,42 @@ public class AclControllerServiceTest {
             eq(null),
             eq(null),
             eq(101));
+  }
+
+  @Test
+  @Order(36)
+  public void createDeleteAclSubscriptionRequestFailure() throws KlawException {
+    String reqNo = "101";
+    stubUserInfo();
+    Acl acl = utilMethods.getAllAcls().get(1);
+
+    when(commonUtilsService.getTenantId(userDetails.getUsername())).thenReturn(1);
+    when(commonUtilsService.getTeamId(anyString())).thenReturn(101);
+    when(commonUtilsService.getEnvsFromUserId(anyString()))
+        .thenReturn(new HashSet<>(Collections.singletonList("1")));
+    when(handleDbRequests.getSyncAclsFromReqNo(anyInt(), anyInt())).thenReturn(acl);
+    Map<String, String> hashMap = new HashMap<>();
+    hashMap.put("result", ApiResultStatus.SUCCESS.value);
+    when(handleDbRequests.requestForAcl(any())).thenReturn(hashMap);
+
+    when(handleDbRequests.getAllAclRequests(
+            anyBoolean(),
+            anyString(),
+            anyString(),
+            anyString(),
+            anyBoolean(),
+            any(),
+            anyString(),
+            anyString(),
+            any(),
+            any(),
+            anyBoolean(),
+            anyInt()))
+        .thenReturn(Collections.singletonList(getAclRequestDao()));
+
+    ApiResponse resultResp = aclControllerService.createDeleteAclSubscriptionRequest(reqNo);
+    assertThat(resultResp.getMessage()).isEqualTo(ACL_ERR_107);
+    assertThat(resultResp.isSuccess()).isFalse();
   }
 
   private AclRequestsModel getAclRequestProducer() {

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1702,14 +1702,16 @@
       "post" : {
         "tags" : [ "acl-controller" ],
         "operationId" : "deleteAclSubscriptionRequest",
-        "parameters" : [ {
-          "name" : "req_no",
-          "in" : "query",
-          "required" : true,
-          "schema" : {
-            "type" : "string"
-          }
-        } ],
+        "requestBody" : {
+          "content" : {
+            "application/json" : {
+              "schema" : {
+                "$ref" : "#/components/schemas/DeleteAclRequestModel"
+              }
+            }
+          },
+          "required" : true
+        },
         "responses" : {
           "200" : {
             "description" : "OK",
@@ -5871,6 +5873,14 @@
           }
         },
         "required" : [ "description", "environment", "replicationfactor", "requestOperationType", "topicname", "topicpartitions" ]
+      },
+      "DeleteAclRequestModel" : {
+        "properties" : {
+          "requestId" : {
+            "type" : "string"
+          }
+        },
+        "required" : [ "requestId" ]
       },
       "KafkaConnectorRequestModel" : {
         "properties" : {


### PR DESCRIPTION
About this change - What it does

- Sync acls from cluster now gets 'readwrite' acls for Aiven cluster. this is be ignored.
- Submitting Delete Acl request should not be allowed multiple times
- On approve acl request, check if topic exists before.
- CreateDeleteAclSubscriptionrequest change request param to request body

Resolves: #1286
Why this way
readwrite should be ignore, as it's not a standard, and submitting multiple delete acl request should not be allowed 
