### PR TITLE
refactor(coral): Enable passing env through query for schema requests

### DIFF
--- a/coral/src/app/features/topics/schema-request/TopicSchemaRequest.test.tsx
+++ b/coral/src/app/features/topics/schema-request/TopicSchemaRequest.test.tsx
@@ -7,7 +7,10 @@ import {
 } from "@testing-library/react/pure";
 import userEvent from "@testing-library/user-event";
 import { TopicSchemaRequest } from "src/app/features/topics/schema-request/TopicSchemaRequest";
-import { getEnvironmentsForSchemaRequest } from "src/domain/environment";
+import {
+  Environment,
+  getEnvironmentsForSchemaRequest,
+} from "src/domain/environment";
 import { createMockEnvironmentDTO } from "src/domain/environment/environment-test-helper";
 import { transformEnvironmentApiResponse } from "src/domain/environment/environment-transformer";
 import { createSchemaRequest } from "src/domain/schema-request";
@@ -88,6 +91,7 @@ describe("TopicSchemaRequest", () => {
 
       customRender(<TopicSchemaRequest topicName={testTopicName} />, {
         queryClient: true,
+        memoryRouter: true,
       });
 
       const form = getForm();
@@ -98,7 +102,7 @@ describe("TopicSchemaRequest", () => {
       // it has not been called because it has not happened yet. Checking for the
       // form makes implicitly sure that navigate was not called (otherwise no form)
       // and this assertion is mostly for readability
-      expect(mockedUsedNavigate).not.toHaveBeenCalledWith("/topics");
+      expect(mockedUsedNavigate).not.toHaveBeenCalled();
     });
 
     it("redirects user if topicName prop does not exist in list of topicNames", async () => {
@@ -106,10 +110,63 @@ describe("TopicSchemaRequest", () => {
 
       customRender(<TopicSchemaRequest topicName={testTopicName} />, {
         queryClient: true,
+        memoryRouter: true,
       });
 
       await waitFor(() => {
-        expect(mockedUsedNavigate).toHaveBeenCalledWith("/topics");
+        expect(mockedUsedNavigate).toHaveBeenCalledWith(-1);
+      });
+    });
+  });
+
+  describe("checks if env passed from url is part of environments for a schema", () => {
+    beforeEach(() => {
+      mockGetTopicNames.mockResolvedValue([testTopicName]);
+      mockCreateSchemaRequest.mockImplementation(jest.fn());
+    });
+
+    afterEach(() => {
+      cleanup();
+      useQuerySpy.mockRestore();
+    });
+
+    it("does not redirect user if env query is part of list of environments", async () => {
+      mockGetSchemaRegistryEnvironments.mockResolvedValue([
+        ...mockedGetSchemaRegistryEnvironments,
+      ]);
+
+      customRender(<TopicSchemaRequest topicName={testTopicName} />, {
+        queryClient: true,
+        memoryRouter: true,
+        customRoutePath: "/topic/testtopic/request-schema?env=999",
+      });
+
+      const form = getForm();
+      expect(form).toBeVisible();
+
+      // only testing this would always return green - even waitFor will return always
+      // true, since the mock is not called directly, so waitFor will check, confirm
+      // it has not been called because it has not happened yet. Checking for the
+      // form makes implicitly sure that navigate was not called (otherwise no form)
+      // and this assertion is mostly for readability
+      expect(mockedUsedNavigate).not.toHaveBeenCalled();
+    });
+
+    it("redirects user if env query does not exist in list of environments", async () => {
+      const fakeEnv = { name: "BUH", id: "999" } as Environment;
+      mockGetSchemaRegistryEnvironments.mockResolvedValue([
+        ...mockedGetSchemaRegistryEnvironments,
+        fakeEnv,
+      ]);
+
+      customRender(<TopicSchemaRequest topicName={testTopicName} />, {
+        queryClient: true,
+        memoryRouter: true,
+        customRoutePath: "/topic/testtopic/request-schema?env=999",
+      });
+
+      await waitFor(() => {
+        expect(mockedUsedNavigate).toHaveBeenCalledWith(-1);
       });
     });
   });
@@ -125,6 +182,7 @@ describe("TopicSchemaRequest", () => {
 
       customRender(<TopicSchemaRequest topicName={testTopicName} />, {
         queryClient: true,
+        memoryRouter: true,
       });
     });
 
@@ -159,6 +217,7 @@ describe("TopicSchemaRequest", () => {
 
       customRender(<TopicSchemaRequest topicName={testTopicName} />, {
         queryClient: true,
+        memoryRouter: true,
       });
       await waitForElementToBeRemoved(
         screen.getByTestId("environments-select-loading")
@@ -282,6 +341,7 @@ describe("TopicSchemaRequest", () => {
 
       customRender(<TopicSchemaRequest topicName={testTopicName} />, {
         queryClient: true,
+        memoryRouter: true,
       });
       await waitForElementToBeRemoved(
         screen.getByTestId("environments-select-loading")
@@ -359,6 +419,7 @@ describe("TopicSchemaRequest", () => {
         />,
         {
           queryClient: true,
+          memoryRouter: true,
         }
       );
       await waitForElementToBeRemoved(
@@ -477,6 +538,7 @@ describe("TopicSchemaRequest", () => {
         />,
         {
           queryClient: true,
+          memoryRouter: true,
         }
       );
       await waitForElementToBeRemoved(
@@ -581,6 +643,7 @@ describe("TopicSchemaRequest", () => {
         />,
         {
           queryClient: true,
+          memoryRouter: true,
         }
       );
       await waitForElementToBeRemoved(

--- a/coral/src/app/features/topics/schema-request/TopicSchemaRequest.tsx
+++ b/coral/src/app/features/topics/schema-request/TopicSchemaRequest.tsx
@@ -1,7 +1,7 @@
 import { Alert, Box, Button } from "@aivenio/aquarium";
 import { useMutation, useQuery } from "@tanstack/react-query";
 import { useState } from "react";
-import { useNavigate } from "react-router-dom";
+import { useNavigate, useSearchParams } from "react-router-dom";
 import { Dialog } from "src/app/components/Dialog";
 import {
   Form,
@@ -38,6 +38,11 @@ type TopicSchemaRequestProps = {
 // be able to add this tests. I created na issue in github related to MonacoEditor testing already.
 function TopicSchemaRequest(props: TopicSchemaRequestProps) {
   const { topicName } = props;
+  const [searchParams] = useSearchParams();
+
+  const [presetEnvironment, setPresetEnvironment] = useState<
+    string | undefined
+  >();
 
   const [cancelDialogVisible, setCancelDialogVisible] = useState(false);
   const [successModalOpen, setSuccessModalOpen] = useState(false);
@@ -48,6 +53,7 @@ function TopicSchemaRequest(props: TopicSchemaRequestProps) {
     defaultValues: {
       topicname: topicName,
       schemafull: props.schemafullValueForTest || undefined,
+      environment: presetEnvironment,
     },
   });
 
@@ -67,7 +73,7 @@ function TopicSchemaRequest(props: TopicSchemaRequestProps) {
 
       const topicExists = data?.includes(topicName);
       if (!topicExists) {
-        navigate("/topics");
+        navigate(-1);
       }
     },
   });
@@ -78,6 +84,20 @@ function TopicSchemaRequest(props: TopicSchemaRequestProps) {
   >({
     queryKey: ["schemaRegistryEnvironments"],
     queryFn: () => getEnvironmentsForSchemaRequest(),
+    onSuccess: (environments) => {
+      const currentEnv = searchParams.get("env");
+      if (currentEnv) {
+        const isValidEnv =
+          environments.find((env) => currentEnv === env.id) !== undefined;
+        if (!isValidEnv) {
+          navigate(-1);
+        } else {
+          console.log("currentEnv", currentEnv);
+          setPresetEnvironment(currentEnv);
+          form.setValue("environment", currentEnv);
+        }
+      }
+    },
   });
 
   const schemaRequestMutation = useMutation(createSchemaRequest, {
@@ -169,7 +189,10 @@ function TopicSchemaRequest(props: TopicSchemaRequestProps) {
             <NativeSelect<TopicRequestFormSchema>
               name={"environment"}
               labelText={"Environment"}
-              placeholder={"-- Please select --"}
+              placeholder={
+                presetEnvironment ? undefined : "-- Please select --"
+              }
+              readOnly={presetEnvironment !== undefined}
               required={true}
             >
               {environments.map((env) => {

--- a/coral/src/app/features/topics/schema-request/TopicSchemaRequest.tsx
+++ b/coral/src/app/features/topics/schema-request/TopicSchemaRequest.tsx
@@ -89,8 +89,6 @@ function TopicSchemaRequest(props: TopicSchemaRequestProps) {
 
         if (!isValidEnv) {
           navigate(-1);
-        } else {
-          form.setValue("environment", presetEnvironment);
         }
       }
     },

--- a/coral/src/app/features/topics/schema-request/TopicSchemaRequest.tsx
+++ b/coral/src/app/features/topics/schema-request/TopicSchemaRequest.tsx
@@ -39,10 +39,7 @@ type TopicSchemaRequestProps = {
 function TopicSchemaRequest(props: TopicSchemaRequestProps) {
   const { topicName } = props;
   const [searchParams] = useSearchParams();
-
-  const [presetEnvironment, setPresetEnvironment] = useState<
-    string | undefined
-  >();
+  const presetEnvironment = searchParams.get("env");
 
   const [cancelDialogVisible, setCancelDialogVisible] = useState(false);
   const [successModalOpen, setSuccessModalOpen] = useState(false);
@@ -53,7 +50,7 @@ function TopicSchemaRequest(props: TopicSchemaRequestProps) {
     defaultValues: {
       topicname: topicName,
       schemafull: props.schemafullValueForTest || undefined,
-      environment: presetEnvironment,
+      environment: presetEnvironment || undefined,
     },
   });
 
@@ -85,16 +82,15 @@ function TopicSchemaRequest(props: TopicSchemaRequestProps) {
     queryKey: ["schemaRegistryEnvironments"],
     queryFn: () => getEnvironmentsForSchemaRequest(),
     onSuccess: (environments) => {
-      const currentEnv = searchParams.get("env");
-      if (currentEnv) {
-        const isValidEnv =
-          environments.find((env) => currentEnv === env.id) !== undefined;
+      if (presetEnvironment) {
+        const isValidEnv = environments.find(
+          (env) => presetEnvironment === env.id
+        );
+
         if (!isValidEnv) {
           navigate(-1);
         } else {
-          console.log("currentEnv", currentEnv);
-          setPresetEnvironment(currentEnv);
-          form.setValue("environment", currentEnv);
+          form.setValue("environment", presetEnvironment);
         }
       }
     },
@@ -189,10 +185,8 @@ function TopicSchemaRequest(props: TopicSchemaRequestProps) {
             <NativeSelect<TopicRequestFormSchema>
               name={"environment"}
               labelText={"Environment"}
-              placeholder={
-                presetEnvironment ? undefined : "-- Please select --"
-              }
-              readOnly={presetEnvironment !== undefined}
+              placeholder={"-- Please select --"}
+              readOnly={Boolean(presetEnvironment)}
               required={true}
             >
               {environments.map((env) => {


### PR DESCRIPTION
# About this change - What it does

- env can now be passed via query param in the url to fill out the schema form
- I added `navigate(-1)` (which is the last page the user came from) instead of to a certain page, because we don't know (necessarily) where a user came from now. 
----> I could update that for the other forms, too?

Resolves: #1307

