### PR TITLE
fix(coral): link to angular for topic overview if feature flag is not enabled.

### DIFF
--- a/coral/src/app/features/topics/browse/components/TopicTable.tsx
+++ b/coral/src/app/features/topics/browse/components/TopicTable.tsx
@@ -9,6 +9,9 @@ import {
 import link from "@aivenio/aquarium/dist/src/icons/link";
 import { Link } from "react-router-dom";
 import { Topic } from "src/domain/topic";
+import useFeatureFlag from "src/services/feature-flags/hook/useFeatureFlag";
+import { FeatureFlag } from "src/services/feature-flags/types";
+import { createTopicOverviewLink } from "src/app/features/topics/browse/utils/create-topic-overview-link";
 
 type TopicListProps = {
   topics: Topic[];
@@ -24,17 +27,29 @@ interface TopicsTableRow {
 
 function TopicTable(props: TopicListProps) {
   const { topics, ariaLabel } = props;
+  const topicDetailsEnabled = useFeatureFlag(
+    FeatureFlag.FEATURE_FLAG_TOPIC_OVERVIEW
+  );
 
   const columns: Array<DataTableColumn<TopicsTableRow>> = [
     {
       type: "custom",
       field: "topicName",
       headerName: "Topic",
-      UNSAFE_render: ({ topicName }: TopicsTableRow) => (
-        <Link to={`/topic/${topicName}/overview`}>
-          {topicName} <InlineIcon icon={link} />
-        </Link>
-      ),
+      UNSAFE_render: ({ topicName }: TopicsTableRow) => {
+        if (!topicDetailsEnabled) {
+          return (
+            <a href={createTopicOverviewLink(topicName)}>
+              {topicName} <InlineIcon icon={link} />
+            </a>
+          );
+        }
+        return (
+          <Link to={`/topic/${topicName}/overview`}>
+            {topicName} <InlineIcon icon={link} />
+          </Link>
+        );
+      },
     },
     {
       type: "custom",

--- a/coral/src/app/features/topics/browse/utils/create-topic-overview-link.test.ts
+++ b/coral/src/app/features/topics/browse/utils/create-topic-overview-link.test.ts
@@ -1,0 +1,34 @@
+import { createTopicOverviewLink } from "src/app/features/topics/browse/utils/create-topic-overview-link";
+
+describe("create-topic-overview-links", () => {
+  beforeAll(() => {
+    // deleting the global window.location allows us to set it to a URL for easier testing
+    // otherwise the assignment is ignored
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-ignore
+    delete window.location;
+  });
+
+  it("creates a link based on a topic name and the origin location", () => {
+    const testWindowLocationOrigin = "http://klaw.com";
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-ignore
+    window.location = new URL(testWindowLocationOrigin);
+
+    const link = createTopicOverviewLink("testTopic");
+
+    expect(link).toEqual("http://klaw.com/topicOverview?topicname=testTopic");
+  });
+
+  it("creates a link based on a topic name  and the origin location with port", () => {
+    const testWindowLocationOrigin = "http://localhost:8080";
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-ignore
+    window.location = new URL(testWindowLocationOrigin);
+
+    const link = createTopicOverviewLink("testTopic");
+    expect(link).toEqual(
+      "http://localhost:8080/topicOverview?topicname=testTopic"
+    );
+  });
+});

--- a/coral/src/app/features/topics/browse/utils/create-topic-overview-link.ts
+++ b/coral/src/app/features/topics/browse/utils/create-topic-overview-link.ts
@@ -1,0 +1,8 @@
+const urlPartKlawAngularApp = "topicOverview?topicname=";
+
+function createTopicOverviewLink(topicName: string): string {
+  const originLocationKlawAngular = window.location.origin;
+  return `${originLocationKlawAngular}/${urlPartKlawAngularApp}${topicName}`;
+}
+
+export { createTopicOverviewLink };


### PR DESCRIPTION
# About this change - What it does

- if the feature flag for topic overview is not enabled, the links in topic list go to the original Klaw app
(feature flag is only enabled in DEVELOPMENT mode, so it's not in the build)