### PR TITLE
Add page header to topic history page

### DIFF
--- a/coral/src/app/features/topics/details/history/TopicHistory.test.tsx
+++ b/coral/src/app/features/topics/details/history/TopicHistory.test.tsx
@@ -133,6 +133,14 @@ describe("TopicHistory", () => {
       cleanup();
     });
 
+    it("shows the page header headline", () => {
+      const headline = screen.getByRole("heading", {
+        name: "History",
+      });
+
+      expect(headline).toBeVisible();
+    });
+
     it("shows a headline informing user about missing history", () => {
       const headline = screen.getByRole("heading", {
         name: "No Topic history",
@@ -171,6 +179,14 @@ describe("TopicHistory", () => {
     afterAll(() => {
       jest.clearAllMocks();
       cleanup();
+    });
+
+    it("shows the page header headline", () => {
+      const headline = screen.getByRole("heading", {
+        name: "History",
+      });
+
+      expect(headline).toBeVisible();
     });
 
     it("shows a table for topics history", () => {

--- a/coral/src/app/features/topics/details/history/TopicHistory.tsx
+++ b/coral/src/app/features/topics/details/history/TopicHistory.tsx
@@ -1,4 +1,9 @@
-import { DataTable, DataTableColumn, EmptyState } from "@aivenio/aquarium";
+import {
+  DataTable,
+  DataTableColumn,
+  EmptyState,
+  PageHeader,
+} from "@aivenio/aquarium";
 import { useTopicDetails } from "src/app/features/topics/details/TopicDetails";
 import { TopicOverview } from "src/domain/topic";
 
@@ -62,21 +67,23 @@ function TopicHistory() {
       };
     }) || [];
 
-  if (!rows.length) {
-    return (
-      <EmptyState title="No Topic history">
-        This Topic contains no history.
-      </EmptyState>
-    );
-  }
-
   return (
-    <DataTable
-      ariaLabel={"Topic history"}
-      columns={columns}
-      rows={rows}
-      noWrap={false}
-    />
+    <>
+      <PageHeader title={"History"} />
+      {!rows.length && (
+        <EmptyState title="No Topic history">
+          This Topic contains no history.
+        </EmptyState>
+      )}
+      {rows.length && (
+        <DataTable
+          ariaLabel={"Topic history"}
+          columns={columns}
+          rows={rows}
+          noWrap={false}
+        />
+      )}
+    </>
   );
 }
 


### PR DESCRIPTION
# About this change - What it does

- Adds a page header to the topic details history view after sync with design


