### PR TITLE
Fix(Coral): Topic Creation retrieves a sublist of environments based on admin config

### DIFF
--- a/coral/src/app/features/topics/request/TopicRequest.test.tsx
+++ b/coral/src/app/features/topics/request/TopicRequest.test.tsx
@@ -2,7 +2,7 @@ import { Context as AquariumContext } from "@aivenio/aquarium";
 import { cleanup, screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import TopicRequest from "src/app/features/topics/request/TopicRequest";
-import { mockgetEnvironmentsForTopicRequestByTeam } from "src/domain/environment/environment-api.msw";
+import { mockgetEnvironmentsForTopicRequest } from "src/domain/environment/environment-api.msw";
 import { createMockEnvironmentDTO } from "src/domain/environment/environment-test-helper";
 import {
   defaultgetTopicAdvancedConfigOptionsResponse,
@@ -41,7 +41,7 @@ describe("<TopicRequest />", () => {
   describe("Environment select", () => {
     describe("renders all necessary elements by default", () => {
       beforeAll(() => {
-        mockgetEnvironmentsForTopicRequestByTeam({
+        mockgetEnvironmentsForTopicRequest({
           mswInstance: server,
           response: {
             data: [
@@ -102,7 +102,7 @@ describe("<TopicRequest />", () => {
 
     describe("when field is clicked", () => {
       beforeEach(() => {
-        mockgetEnvironmentsForTopicRequestByTeam({
+        mockgetEnvironmentsForTopicRequest({
           mswInstance: server,
           response: {
             data: [
@@ -168,7 +168,7 @@ describe("<TopicRequest />", () => {
   describe("Topic name", () => {
     describe("informs user about valid input with placeholder per default", () => {
       beforeAll(() => {
-        mockgetEnvironmentsForTopicRequestByTeam({
+        mockgetEnvironmentsForTopicRequest({
           mswInstance: server,
           response: {
             data: [
@@ -221,7 +221,7 @@ describe("<TopicRequest />", () => {
 
     describe("informs user about valid input with placeholder when regex should be applied", () => {
       beforeAll(() => {
-        mockgetEnvironmentsForTopicRequestByTeam({
+        mockgetEnvironmentsForTopicRequest({
           mswInstance: server,
           response: {
             data: [
@@ -274,7 +274,7 @@ describe("<TopicRequest />", () => {
 
     describe("informs user about valid input with a prefix is needed", () => {
       beforeAll(() => {
-        mockgetEnvironmentsForTopicRequestByTeam({
+        mockgetEnvironmentsForTopicRequest({
           mswInstance: server,
           response: {
             data: [
@@ -327,7 +327,7 @@ describe("<TopicRequest />", () => {
 
     describe("when topic name does not have enough characters", () => {
       beforeAll(() => {
-        mockgetEnvironmentsForTopicRequestByTeam({
+        mockgetEnvironmentsForTopicRequest({
           mswInstance: server,
           response: {
             data: [
@@ -381,7 +381,7 @@ describe("<TopicRequest />", () => {
 
     describe("when topic name does not match the default pattern", () => {
       beforeAll(() => {
-        mockgetEnvironmentsForTopicRequestByTeam({
+        mockgetEnvironmentsForTopicRequest({
           mswInstance: server,
           response: {
             data: [
@@ -435,7 +435,7 @@ describe("<TopicRequest />", () => {
 
     describe("when environment params have topicPrefix defined", () => {
       beforeEach(() => {
-        mockgetEnvironmentsForTopicRequestByTeam({
+        mockgetEnvironmentsForTopicRequest({
           mswInstance: server,
           response: {
             data: [
@@ -526,7 +526,7 @@ describe("<TopicRequest />", () => {
 
     describe("when environment params have topicSuffix defined", () => {
       beforeAll(() => {
-        mockgetEnvironmentsForTopicRequestByTeam({
+        mockgetEnvironmentsForTopicRequest({
           mswInstance: server,
           response: {
             data: [
@@ -584,7 +584,7 @@ describe("<TopicRequest />", () => {
   describe("Replication factor", () => {
     describe("renders all necessary elements on default", () => {
       beforeAll(() => {
-        mockgetEnvironmentsForTopicRequestByTeam({
+        mockgetEnvironmentsForTopicRequest({
           mswInstance: server,
           response: {
             data: [
@@ -664,7 +664,7 @@ describe("<TopicRequest />", () => {
 
     describe("when environment is changed", () => {
       beforeEach(() => {
-        mockgetEnvironmentsForTopicRequestByTeam({
+        mockgetEnvironmentsForTopicRequest({
           mswInstance: server,
           response: {
             data: [
@@ -789,7 +789,7 @@ describe("<TopicRequest />", () => {
 
   describe("Topic partitions", () => {
     beforeAll(() => {
-      mockgetEnvironmentsForTopicRequestByTeam({
+      mockgetEnvironmentsForTopicRequest({
         mswInstance: server,
         response: {
           data: [
@@ -865,7 +865,7 @@ describe("<TopicRequest />", () => {
 
   describe("when environment is changed", () => {
     beforeEach(() => {
-      mockgetEnvironmentsForTopicRequestByTeam({
+      mockgetEnvironmentsForTopicRequest({
         mswInstance: server,
         response: {
           data: [
@@ -972,7 +972,7 @@ describe("<TopicRequest />", () => {
 
   describe("AdvancedConfiguration", () => {
     beforeAll(() => {
-      mockgetEnvironmentsForTopicRequestByTeam({
+      mockgetEnvironmentsForTopicRequest({
         mswInstance: server,
         response: {
           data: [createMockEnvironmentDTO({ name: "DEV", id: "1" })],
@@ -1021,7 +1021,7 @@ describe("<TopicRequest />", () => {
 
   describe("form submission", () => {
     beforeAll(async () => {
-      mockgetEnvironmentsForTopicRequestByTeam({
+      mockgetEnvironmentsForTopicRequest({
         mswInstance: server,
         response: {
           data: [createMockEnvironmentDTO({ name: "DEV", id: "1" })],
@@ -1230,7 +1230,7 @@ describe("<TopicRequest />", () => {
     };
 
     beforeEach(async () => {
-      mockgetEnvironmentsForTopicRequestByTeam({
+      mockgetEnvironmentsForTopicRequest({
         mswInstance: server,
         response: {
           data: [createMockEnvironmentDTO({ name: "DEV", id: "1" })],

--- a/coral/src/app/features/topics/request/TopicRequest.tsx
+++ b/coral/src/app/features/topics/request/TopicRequest.tsx
@@ -23,7 +23,7 @@ import formSchema, {
 import SelectOrNumberInput from "src/app/features/topics/request/components/SelectOrNumberInput";
 import type { Schema } from "src/app/features/topics/request/form-schemas/topic-request-form";
 import { Environment } from "src/domain/environment";
-import { getEnvironmentsForTopicRequestByTeam } from "src/domain/environment/environment-api";
+import { getEnvironmentsForTopicRequest } from "src/domain/environment/environment-api";
 import AdvancedConfiguration from "src/app/features/topics/request/components/AdvancedConfiguration";
 import { requestTopic } from "src/domain/topic/topic-api";
 import { parseErrorMsg } from "src/services/mutation-utils";
@@ -40,7 +40,7 @@ function TopicRequest() {
 
   const { data: environments } = useQuery<Environment[], Error>(
     ["environments-for-team"],
-    getEnvironmentsForTopicRequestByTeam
+    getEnvironmentsForTopicRequest
   );
 
   const defaultValues = Array.isArray(environments)

--- a/coral/src/domain/environment/environment-api.msw.ts
+++ b/coral/src/domain/environment/environment-api.msw.ts
@@ -37,18 +37,6 @@ function mockgetEnvironmentsForTopicRequest({
   );
 }
 
-function mockgetEnvironmentsForTopicRequestByTeam({
-  mswInstance,
-  response,
-}: MockApi<"getEnvsBaseCluster">) {
-  const url = `${getHTTPBaseAPIUrl()}/getEnvsBaseCluster`;
-  mswInstance.use(
-    rest.get(url, async (req, res, ctx) => {
-      return res(ctx.status(response.status ?? 200), ctx.json(response.data));
-    })
-  );
-}
-
 const mockedEnvironmentResponse = [
   createMockEnvironmentDTO({ name: "DEV", id: "1" }),
   createMockEnvironmentDTO({ name: "TST", id: "2" }),
@@ -81,7 +69,6 @@ const getMockedResponseGetClusterInfoFromEnv = (
 export {
   mockgetAllEnvironmentsForTopicAndAcl,
   mockgetEnvironmentsForTopicRequest,
-  mockgetEnvironmentsForTopicRequestByTeam,
   mockedEnvironmentResponse,
   mockGetClusterInfoFromEnv,
   getMockedResponseGetClusterInfoFromEnv,

--- a/coral/src/domain/environment/environment-api.msw.ts
+++ b/coral/src/domain/environment/environment-api.msw.ts
@@ -40,8 +40,8 @@ function mockgetEnvironmentsForTopicRequest({
 function mockgetEnvironmentsForTopicRequestByTeam({
   mswInstance,
   response,
-}: MockApi<"getEnvsBaseClusterFilteredForTeam">) {
-  const url = `${getHTTPBaseAPIUrl()}/getEnvsBaseClusterFilteredForTeam`;
+}: MockApi<"getEnvsBaseCluster">) {
+  const url = `${getHTTPBaseAPIUrl()}/getEnvsBaseCluster`;
   mswInstance.use(
     rest.get(url, async (req, res, ctx) => {
       return res(ctx.status(response.status ?? 200), ctx.json(response.data));

--- a/coral/src/domain/environment/environment-api.ts
+++ b/coral/src/domain/environment/environment-api.ts
@@ -24,12 +24,6 @@ const getEnvironmentsForTopicRequest = async (): Promise<Environment[]> => {
     .then(transformEnvironmentApiResponse);
 };
 
-const getEnvironmentsForTopicRequestByTeam = (): Promise<Environment[]> => {
-  return api
-    .get<KlawApiResponse<"getEnvsBaseCluster">>(API_PATHS.getEnvsBaseCluster)
-    .then(transformEnvironmentApiResponse);
-};
-
 const getAllEnvironmentsForSchema = (): Promise<Environment[]> => {
   return api
     .get<KlawApiResponse<"getSchemaRegEnvs">>(API_PATHS.getSchemaRegEnvs)
@@ -70,7 +64,6 @@ export {
   getAllEnvironmentsForTopicAndAcl,
   getEnvironmentsForTopicRequest,
   getClusterInfo,
-  getEnvironmentsForTopicRequestByTeam,
   getAllEnvironmentsForSchema,
   getEnvironmentsForSchemaRequest,
   getAllEnvironmentsForConnector,

--- a/coral/src/domain/environment/environment-api.ts
+++ b/coral/src/domain/environment/environment-api.ts
@@ -26,8 +26,8 @@ const getEnvironmentsForTopicRequest = async (): Promise<Environment[]> => {
 
 const getEnvironmentsForTopicRequestByTeam = (): Promise<Environment[]> => {
   return api
-    .get<KlawApiResponse<"getEnvsBaseClusterFilteredForTeam">>(
-      API_PATHS.getEnvsBaseClusterFilteredForTeam
+    .get<KlawApiResponse<"getEnvsBaseCluster">>(
+      API_PATHS.getEnvsBaseCluster
     )
     .then(transformEnvironmentApiResponse);
 };

--- a/coral/src/domain/environment/environment-api.ts
+++ b/coral/src/domain/environment/environment-api.ts
@@ -26,9 +26,7 @@ const getEnvironmentsForTopicRequest = async (): Promise<Environment[]> => {
 
 const getEnvironmentsForTopicRequestByTeam = (): Promise<Environment[]> => {
   return api
-    .get<KlawApiResponse<"getEnvsBaseCluster">>(
-      API_PATHS.getEnvsBaseCluster
-    )
+    .get<KlawApiResponse<"getEnvsBaseCluster">>(API_PATHS.getEnvsBaseCluster)
     .then(transformEnvironmentApiResponse);
 };
 


### PR DESCRIPTION
The rest endpoint to get only the allowed/configured envs are returned for topic creation

About this change - What it does
Use The following rest api endpoint
/getEnvsBaseCluster
instead of
/getEnvsBaseClusterFilteredForTeam 
to retrieve the configured list of allowed kafka envs instead of a list of all envs.
Resolves: #xxxxx
Why this way
