### PR TITLE
Only show delete button when no request is open against the Topic

### DIFF
--- a/core/src/main/java/io/aiven/klaw/service/TopicOverviewService.java
+++ b/core/src/main/java/io/aiven/klaw/service/TopicOverviewService.java
@@ -7,11 +7,13 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import io.aiven.klaw.dao.Acl;
 import io.aiven.klaw.dao.Env;
 import io.aiven.klaw.dao.Topic;
+import io.aiven.klaw.dao.TopicRequest;
 import io.aiven.klaw.helpers.HandleDbRequests;
 import io.aiven.klaw.model.TopicHistory;
 import io.aiven.klaw.model.TopicOverviewInfo;
 import io.aiven.klaw.model.enums.AclGroupBy;
 import io.aiven.klaw.model.enums.ApiResultStatus;
+import io.aiven.klaw.model.enums.RequestStatus;
 import io.aiven.klaw.model.response.AclOverviewInfo;
 import io.aiven.klaw.model.response.EnvIdInfo;
 import io.aiven.klaw.model.response.PromotionStatus;
@@ -276,7 +278,9 @@ public class TopicOverviewService extends BaseOverviewService {
               aclInfo.stream()
                   .noneMatch(
                       aclItem -> Objects.equals(aclItem.getEnvironment(), lastItem.getEnvId())));
-          lastItem.setShowDeleteTopic(lastItem.isTopicDeletable());
+          lastItem.setShowDeleteTopic(
+              lastItem.isTopicDeletable()
+                  && !isDeleteRequestAlreadyOpen(topicNameSearch, environmentId, tenantId));
         }
       } else {
         PromotionStatus promotionStatus = new PromotionStatus();
@@ -288,6 +292,25 @@ public class TopicOverviewService extends BaseOverviewService {
       promotionStatus.setStatus(ApiResultStatus.NOT_AUTHORIZED.value);
       topicOverview.setTopicPromotionDetails(promotionStatus);
     }
+  }
+
+  private boolean isDeleteRequestAlreadyOpen(
+      String topicNameSearch, String environmentId, int tenantId) {
+
+    List<TopicRequest> topicReqs =
+        manageDatabase
+            .getHandleDbRequests()
+            .getAllTopicRequests(
+                getUserName(),
+                RequestStatus.CREATED.value,
+                null,
+                environmentId,
+                topicNameSearch,
+                false,
+                tenantId);
+    log.debug("Open Reqs for Topics {} , size {}", topicReqs, topicReqs.size());
+    // there should only ever be 1 delete request and in any other scenario this should be 0.
+    return topicReqs.size() >= 1;
   }
 
   private PromotionStatus getTopicPromotionEnv(


### PR DESCRIPTION
About this change - What it does
It checks if there are any open requests for the topic when determinig if the topic should be able to be deleted.
Resolves: #xxxxx
Why this way
