### PR TITLE
Correct the redirect urls

### DIFF
--- a/core/src/main/resources/static/js/requestAcls.js
+++ b/core/src/main/resources/static/js/requestAcls.js
@@ -595,6 +595,7 @@ app.controller("requestAclsCtrl", function($scope, $http, $location, $window) {
                 for (var i = 0; i < sURLVariables.length; i++)
                 {
                     var sParameterName = sURLVariables[i].split('=');
+                    
                     if (sParameterName[0] == "topicname")
                     {
                         $scope.topicSelectedFromUrl = sParameterName[1]
@@ -602,7 +603,11 @@ app.controller("requestAclsCtrl", function($scope, $http, $location, $window) {
 
                         $scope.getAllTopics("ALL");
                         $scope.getTopicTeam($scope.addAcl.topicname);
-                    }
+                    } else if (sParameterName[0] == "?envId" || sParameterName[0] == "envId")
+                  {
+                      $scope.addAcl.envId  = sParameterName[1];
+                    console.log('EnvId from Url: ' + $scope.addAcl.envId  );
+                  }
                 }
             }
 

--- a/core/src/main/resources/static/js/requestAcls.js
+++ b/core/src/main/resources/static/js/requestAcls.js
@@ -604,10 +604,9 @@ app.controller("requestAclsCtrl", function($scope, $http, $location, $window) {
                         $scope.getAllTopics("ALL");
                         $scope.getTopicTeam($scope.addAcl.topicname);
                     } else if (sParameterName[0] == "envId")
-                  {
-                      $scope.addAcl.envId  = sParameterName[1];
-                    console.log('EnvId from Url: ' + $scope.addAcl.envId  );
-                  }
+                    {
+                        $scope.addAcl.envId  = sParameterName[1];
+                    }
                 }
             }
 

--- a/core/src/main/resources/static/js/requestAcls.js
+++ b/core/src/main/resources/static/js/requestAcls.js
@@ -603,7 +603,7 @@ app.controller("requestAclsCtrl", function($scope, $http, $location, $window) {
 
                         $scope.getAllTopics("ALL");
                         $scope.getTopicTeam($scope.addAcl.topicname);
-                    } else if (sParameterName[0] == "?envId" || sParameterName[0] == "envId")
+                    } else if (sParameterName[0] == "envId")
                   {
                       $scope.addAcl.envId  = sParameterName[1];
                     console.log('EnvId from Url: ' + $scope.addAcl.envId  );

--- a/core/src/main/resources/templates/browseAcls.html
+++ b/core/src/main/resources/templates/browseAcls.html
@@ -638,7 +638,7 @@
 									</ul>
 								</td>
 								<td align="right">
-									<a href="requestAcls?topicname={{topicSelectedParam}}">
+									<a href="requestAcls?topicname={{topicSelectedParam}}&?envId={{topicOverview[0].envId}}">
 										<button type="button" ng-show="dashboardDetails.requestItems=='Authorized'"
 												class="btn waves-effect waves-light btn-rounded btn-sm btn-success">Subscribe</button>
 									</a>

--- a/core/src/main/resources/templates/browseAcls.html
+++ b/core/src/main/resources/templates/browseAcls.html
@@ -638,7 +638,7 @@
 									</ul>
 								</td>
 								<td align="right">
-									<a href="requestAcls?topicname={{topicSelectedParam}}&?envId={{topicOverview[0].envId}}">
+									<a href="requestAcls?topicname={{topicSelectedParam}}&envId={{topicOverview[0].envId}}">
 										<button type="button" ng-show="dashboardDetails.requestItems=='Authorized'"
 												class="btn waves-effect waves-light btn-rounded btn-sm btn-success">Subscribe</button>
 									</a>

--- a/core/src/main/resources/templates/requestAcls.html
+++ b/core/src/main/resources/templates/requestAcls.html
@@ -432,7 +432,7 @@
 				<div class="ribbon-wrapper card col-lg-6 col-md-6 col-xlg-2 col-xs-6">
 					<div class="ribbon ribbon-success">New user interface available</div>
 					<p class="ribbon-content">
-						Check out the new interface for <a href="coral/topic/{{ addAcl.topicname }}/subscribe">ACL requests.</a>
+						Check out the new interface for <a href="coral/topic/{{ addAcl.topicname }}/subscribe?env={{addAcl.envId}}">ACL requests.</a>
 					</p>
 				</div>
 			</div>


### PR DESCRIPTION
About this change - What it does
The coral acl request forms require the environment id to be passed to allow the redirect to be accepted.


Resolves: #xxxxx
Why this way
