### PR TITLE
fix(coral): Fix incorrectly displayed 0 values in `StatsDisplay`

### DIFF
--- a/coral/src/app/features/topics/details/components/StatsDisplay.tsx
+++ b/coral/src/app/features/topics/details/components/StatsDisplay.tsx
@@ -12,10 +12,10 @@ interface StatsDisplayProps {
 const StatsDisplay = ({ amount, chip, entity }: StatsDisplayProps) => {
   return (
     <Box.Flex flexDirection="column" justifyContent={"space-around"}>
-      {amount && (
+      {amount !== undefined && (
         <Typography.Heading htmlTag={"div"}>{amount}</Typography.Heading>
       )}
-      {chip && (
+      {chip !== undefined && (
         <div>
           <StatusChip text={chip.text} status={chip.status} />
         </div>

--- a/coral/src/app/features/topics/details/overview/__snapshots__/TopicOverview.test.tsx.snap
+++ b/coral/src/app/features/topics/details/overview/__snapshots__/TopicOverview.test.tsx.snap
@@ -95,7 +95,11 @@ exports[`TopicOverview renders correct DOM according to data from useTopicDetail
                 <div
                   style="display: flex; justify-content: space-around; flex-direction: column;"
                 >
-                  0
+                  <div
+                    class="typography-heading text-grey-80"
+                  >
+                    0
+                  </div>
                   <div
                     class="typography-small text-grey-50"
                   >
@@ -353,7 +357,11 @@ exports[`TopicOverview renders correct DOM according to data from useTopicDetail
               <div
                 style="display: flex; justify-content: space-around; flex-direction: column;"
               >
-                0
+                <div
+                  class="typography-heading text-grey-80"
+                >
+                  0
+                </div>
                 <div
                   class="typography-small text-grey-50"
                 >


### PR DESCRIPTION
## What is the problem?

When the value of the `amount` prop is `0`, the typography styles do not apply

<img width="1492" alt="Screenshot 2023-06-11 at 22 09 57" src="https://github.com/aiven/klaw/assets/20607294/9851f730-b03d-489b-95bc-d74d2a419326">


## The solution

Replace boolean coercion by more specific check (`0` is falsy)


