### PR TITLE
feat(coral): Topic details - Schema data and switching versions

### DIFF
--- a/coral/src/app/features/topics/details/TopicDetails.tsx
+++ b/coral/src/app/features/topics/details/TopicDetails.tsx
@@ -39,6 +39,9 @@ function TopicDetails(props: TopicOverviewProps) {
   const [environmentId, setEnvironmentId] = useState<string | undefined>(
     undefined
   );
+  const [schemaVersion, setSchemaVersion] = useState<number | undefined>(
+    undefined
+  );
 
   const {
     data: topicData,
@@ -55,7 +58,12 @@ function TopicDetails(props: TopicOverviewProps) {
     error: schemaError,
     isLoading: schemaIsLoading,
   } = useQuery(
-    ["schema-overview", topicData?.availableEnvironments, environmentId],
+    [
+      "schema-overview",
+      topicData?.availableEnvironments,
+      environmentId,
+      schemaVersion,
+    ],
     {
       queryFn: () => {
         const getKafkaEnvIds = () => {
@@ -71,6 +79,7 @@ function TopicDetails(props: TopicOverviewProps) {
         return getSchemaOfTopic({
           topicName,
           kafkaEnvId: getKafkaEnvIds(),
+          schemaVersionSearch: schemaVersion,
         });
       },
       enabled: topicData?.availableEnvironments !== undefined,
@@ -111,6 +120,7 @@ function TopicDetails(props: TopicOverviewProps) {
         currentTab={currentTab}
         topicOverview={topicData}
         environmentId={environmentId}
+        setSchemaVersion={setSchemaVersion}
         topicSchemas={schemaData}
       />
     </div>
@@ -120,6 +130,7 @@ function TopicDetails(props: TopicOverviewProps) {
 function useTopicDetails() {
   return useOutletContext<{
     environmentId: string;
+    setSchemaVersion: (id: number) => void;
     topicOverview: TopicOverview;
     topicName: string;
     topicSchemas: TopicSchemaOverview;

--- a/coral/src/app/features/topics/details/components/TopicDetailsResourceTabs.test.tsx
+++ b/coral/src/app/features/topics/details/components/TopicDetailsResourceTabs.test.tsx
@@ -12,6 +12,8 @@ jest.mock("react-router-dom", () => ({
   useNavigate: () => mockedNavigate,
 }));
 
+const mockSetSchemaVersion = jest.fn();
+
 const testMapTabs = [
   {
     linkTo: "overview",
@@ -145,6 +147,7 @@ const defaultProps = {
   isLoading: false,
   topicName: testTopicName,
   topicOverview: testTopicOverview,
+  setSchemaVersion: mockSetSchemaVersion,
 };
 describe("TopicDetailsResourceTabs", () => {
   const user = userEvent.setup();

--- a/coral/src/app/features/topics/details/components/TopicDetailsResourceTabs.tsx
+++ b/coral/src/app/features/topics/details/components/TopicDetailsResourceTabs.tsx
@@ -13,6 +13,7 @@ import { TopicSchemaOverview } from "src/domain/topic/topic-types";
 
 type Props = {
   currentTab: TopicOverviewTabEnum;
+  setSchemaVersion: (id: number) => void;
   environmentId?: string;
   error?: unknown;
   isError: boolean;
@@ -24,6 +25,7 @@ type Props = {
 function TopicOverviewResourcesTabs({
   currentTab,
   environmentId,
+  setSchemaVersion,
   error,
   isError,
   isLoading,
@@ -117,6 +119,7 @@ function TopicOverviewResourcesTabs({
           context={{
             environmentId:
               environmentId || topicOverview.availableEnvironments[0].id,
+            setSchemaVersion,
             topicOverview,
             topicName: topicOverview.topicInfoList[0].topicName,
             topicSchemas,

--- a/coral/src/app/features/topics/details/history/TopicHistory.test.tsx
+++ b/coral/src/app/features/topics/details/history/TopicHistory.test.tsx
@@ -94,6 +94,8 @@ const testTopicSchemas = {
   ],
 };
 
+const mockSetSchemaVersion = jest.fn();
+
 jest.mock("src/app/features/topics/details/TopicDetails");
 
 const mockUseTopicDetails = useTopicDetails as jest.MockedFunction<
@@ -119,6 +121,7 @@ describe("TopicHistory", () => {
         topicName: "hello",
         topicOverview: { ...testTopicOverview, topicHistoryList: [] },
         topicSchemas: testTopicSchemas,
+        setSchemaVersion: mockSetSchemaVersion,
       });
 
       customRender(<TopicHistory />, {
@@ -167,6 +170,7 @@ describe("TopicHistory", () => {
         topicName: "hello",
         topicOverview: testTopicOverview,
         topicSchemas: testTopicSchemas,
+        setSchemaVersion: mockSetSchemaVersion,
       });
 
       customRender(<TopicHistory />, {

--- a/coral/src/app/features/topics/details/history/TopicHistory.tsx
+++ b/coral/src/app/features/topics/details/history/TopicHistory.tsx
@@ -67,7 +67,6 @@ function TopicHistory() {
       };
     }) || [];
 
-  console.log(rows.length);
   return (
     <>
       <PageHeader title={"History"} />

--- a/coral/src/app/features/topics/details/schema/TopicDetailsSchema.test.tsx
+++ b/coral/src/app/features/topics/details/schema/TopicDetailsSchema.test.tsx
@@ -1,5 +1,6 @@
 import { cleanup, screen } from "@testing-library/react";
 import { within } from "@testing-library/react/pure";
+import userEvent from "@testing-library/user-event";
 import { TopicDetailsSchema } from "src/app/features/topics/details/schema/TopicDetailsSchema";
 import { customRender } from "src/services/test-utils/render-with-wrappers";
 
@@ -41,6 +42,7 @@ describe("TopicDetailsSchema", () => {
       latest: true,
     },
   };
+
   beforeAll(() => {
     mockedUseTopicDetails.mockReturnValue({
       topicName: testTopicName,
@@ -125,5 +127,14 @@ describe("TopicDetailsSchema", () => {
     const previewEditor = screen.getByTestId("topic-schema");
 
     expect(previewEditor).toBeVisible();
+  });
+
+  it("allows changing the version of the schema", async () => {
+    const select = screen.getByRole("combobox", { name: "Select version" });
+    await userEvent.selectOptions(select, "2");
+
+    expect(select).toHaveValue("2");
+
+    expect(mockSetSchemaVersion).toHaveBeenCalledWith(2);
   });
 });

--- a/coral/src/app/features/topics/details/schema/TopicDetailsSchema.test.tsx
+++ b/coral/src/app/features/topics/details/schema/TopicDetailsSchema.test.tsx
@@ -133,14 +133,6 @@ describe("TopicDetailsSchema (topic owner)", () => {
     expect(previewEditor).toBeVisible();
   });
 
-  it("shows a Delete button", () => {
-    const button = screen.getByRole("button", {
-      name: "Delete Schema",
-    });
-
-    expect(button).toBeEnabled();
-  });
-
   it("allows changing the version of the schema", async () => {
     const select = screen.getByRole("combobox", { name: "Select version" });
     await userEvent.selectOptions(select, "2");
@@ -179,13 +171,5 @@ describe("TopicDetailsSchema (NOT topic owner)", () => {
     });
 
     expect(banner).not.toBeInTheDocument();
-  });
-
-  it("does not show a Delete button", () => {
-    const button = screen.queryByRole("Delete Schema", {
-      exact: false,
-    });
-
-    expect(button).not.toBeInTheDocument();
   });
 });

--- a/coral/src/app/features/topics/details/schema/TopicDetailsSchema.test.tsx
+++ b/coral/src/app/features/topics/details/schema/TopicDetailsSchema.test.tsx
@@ -119,7 +119,7 @@ describe("TopicDetailsSchema", () => {
 
     expect(compatibilityInfo).toBeVisible();
     expect(compatibilityInfo.parentElement).toHaveTextContent(
-      "Couldn't retrieveCompatibility"
+      "COULDN'T RETRIEVE"
     );
   });
 

--- a/coral/src/app/features/topics/details/schema/TopicDetailsSchema.test.tsx
+++ b/coral/src/app/features/topics/details/schema/TopicDetailsSchema.test.tsx
@@ -1,21 +1,54 @@
-import { cleanup, render, screen } from "@testing-library/react";
-import { TopicDetailsSchema } from "src/app/features/topics/details/schema/TopicDetailsSchema";
+import { cleanup, screen } from "@testing-library/react";
 import { within } from "@testing-library/react/pure";
+import { TopicDetailsSchema } from "src/app/features/topics/details/schema/TopicDetailsSchema";
+import { customRender } from "src/services/test-utils/render-with-wrappers";
 
 const mockedUseTopicDetails = jest.fn();
 jest.mock("src/app/features/topics/details/TopicDetails", () => ({
   useTopicDetails: () => mockedUseTopicDetails(),
 }));
+const mockSetSchemaVersion = jest.fn();
 
 describe("TopicDetailsSchema", () => {
   const testTopicName = "topic-name";
   const testEnvironmentId = 1;
+  const testTopicSchemas = {
+    topicExists: true,
+    schemaExists: true,
+    prefixAclsExists: false,
+    txnAclsExists: false,
+    allSchemaVersions: [3, 2, 1],
+    latestVersion: 3,
+    schemaPromotionDetails: {
+      DEV: {
+        status: "NO_PROMOTION",
+        sourceEnv: "1",
+        targetEnv: "TST",
+        targetEnvId: "2",
+      },
+    },
+    schemaDetailsPerEnv: {
+      id: 0,
+      version: 3,
+      nextVersion: 2,
+      prevVersion: 0,
+      compatibility: "Couldn't retrieve",
+      content:
+        '{\n  "type" : "record",\n  "name" : "klawTestAvro",\n  "namespace" : "klaw.avro",\n  "fields" : [ {\n    "name" : "producer",\n    "type" : "string",\n    "doc" : "Name of the producer"\n  }, {\n    "name" : "body",\n    "type" : "string",\n    "doc" : "The body of the message being sent."\n  }, {\n    "name" : "timestamp",\n    "type" : "long",\n    "doc" : "time in seconds from epoc when the message was created."\n  } ],\n  "doc:" : "A basic schema for testing klaw - this is V3"\n}',
+      env: "DEV",
+      showNext: true,
+      showPrev: false,
+      latest: true,
+    },
+  };
   beforeAll(() => {
     mockedUseTopicDetails.mockReturnValue({
       topicName: testTopicName,
       environmentId: testEnvironmentId,
+      topicSchemas: testTopicSchemas,
+      setSchemaVersion: mockSetSchemaVersion,
     });
-    render(<TopicDetailsSchema />);
+    customRender(<TopicDetailsSchema />, { memoryRouter: true });
   });
 
   afterAll(cleanup);
@@ -36,13 +69,13 @@ describe("TopicDetailsSchema", () => {
     const select = screen.getByRole("combobox", { name: "Select version" });
     const options = within(select).getAllByRole("option");
 
-    expect(options).toHaveLength(1);
-    expect(options[0]).toHaveValue("1");
-    expect(options[0]).toHaveTextContent("version 1");
+    expect(options).toHaveLength(3);
+    expect(options[0]).toHaveValue("3");
+    expect(options[0]).toHaveTextContent("Version 3 (latest)");
   });
 
   it("shows information about available amount of versions", () => {
-    const versions = screen.getByText("5 versions");
+    const versions = screen.getByText("3 versions");
 
     expect(versions).toBeVisible();
   });
@@ -53,7 +86,7 @@ describe("TopicDetailsSchema", () => {
     expect(link).toBeVisible();
     expect(link).toHaveAttribute(
       "href",
-      `/topic/${testTopicName}/request-schema?env=${testEnvironmentId}`
+      `/topic/${testTopicName}/request-schema?env=${testTopicSchemas.schemaDetailsPerEnv.env}`
     );
   });
 
@@ -69,14 +102,14 @@ describe("TopicDetailsSchema", () => {
     const versionsStats = screen.getByText("Version no.");
 
     expect(versionsStats).toBeVisible();
-    expect(versionsStats.parentElement).toHaveTextContent("99Version no.");
+    expect(versionsStats.parentElement).toHaveTextContent("3Version no.");
   });
 
   it("shows schema info about ID", () => {
     const idInfo = screen.getByText("ID");
 
     expect(idInfo).toBeVisible();
-    expect(idInfo.parentElement).toHaveTextContent("999ID");
+    expect(idInfo.parentElement).toHaveTextContent("0ID");
   });
 
   it("shows schema info about compatibility", () => {
@@ -84,7 +117,7 @@ describe("TopicDetailsSchema", () => {
 
     expect(compatibilityInfo).toBeVisible();
     expect(compatibilityInfo.parentElement).toHaveTextContent(
-      "BACKWARDSCompatibility"
+      "Couldn't retrieveCompatibility"
     );
   });
 

--- a/coral/src/app/features/topics/details/schema/TopicDetailsSchema.tsx
+++ b/coral/src/app/features/topics/details/schema/TopicDetailsSchema.tsx
@@ -1,6 +1,7 @@
 import {
   Box,
   Button,
+  EmptyState,
   Icon,
   Label,
   NativeSelect,
@@ -11,12 +12,13 @@ import {
 import add from "@aivenio/aquarium/icons/add";
 import gitNewBranch from "@aivenio/aquarium/icons/gitNewBranch";
 import MonacoEditor from "@monaco-editor/react";
-import { Link } from "react-router-dom";
+import { Link, useNavigate } from "react-router-dom";
 import { useTopicDetails } from "src/app/features/topics/details/TopicDetails";
 import { SchemaPromotionBanner } from "src/app/features/topics/details/schema/components/SchemaPromotionBanner";
 import { SchemaStats } from "src/app/features/topics/details/schema/components/SchemaStats";
 
 function TopicDetailsSchema() {
+  const navigate = useNavigate();
   const {
     topicName,
     topicSchemas: {
@@ -27,13 +29,31 @@ function TopicDetailsSchema() {
     setSchemaVersion,
   } = useTopicDetails();
 
+  const noSchema = allSchemaVersions.length === 0;
+
   function promoteSchema() {
     console.log("dummy function");
+  }
+
+  if (noSchema) {
+    return (
+      <>
+        <PageHeader title="Schema" />
+        <EmptyState
+          title="No schema available for this topic"
+          primaryAction={{
+            onClick: () => navigate(`/topic/${topicName}/request-schema`),
+            text: "Request a new schema",
+          }}
+        />
+      </>
+    );
   }
 
   return (
     <>
       <PageHeader title="Schema" />
+
       <Box display={"flex"} justifyContent={"space-between"}>
         <Box display={"flex"} colGap={"l1"}>
           <NativeSelect

--- a/coral/src/app/features/topics/details/schema/TopicDetailsSchema.tsx
+++ b/coral/src/app/features/topics/details/schema/TopicDetailsSchema.tsx
@@ -27,8 +27,10 @@ function TopicDetailsSchema() {
       schemaDetailsPerEnv,
     },
     setSchemaVersion,
+    topicOverview: { topicInfoList },
   } = useTopicDetails();
 
+  const isTopicOwner = topicInfoList[0].topicOwner;
   const noSchema = allSchemaVersions.length === 0;
 
   function promoteSchema() {
@@ -76,20 +78,24 @@ function TopicDetailsSchema() {
           </Typography.SmallStrong>
         </Box>
 
-        <Box alignSelf={"top"}>
-          <Link
-            to={`/topic/${topicName}/request-schema?env=${schemaDetailsPerEnv?.env}`}
-          >
-            <Button.Primary icon={add}>Request a new version</Button.Primary>
-          </Link>
-        </Box>
+        {isTopicOwner && (
+          <Box alignSelf={"top"}>
+            <Link
+              to={`/topic/${topicName}/request-schema?env=${schemaDetailsPerEnv?.env}`}
+            >
+              <Button.Primary icon={add}>Request a new version</Button.Primary>
+            </Link>
+          </Box>
+        )}
       </Box>
 
       {/*@TODO pass data when API verified */}
-      <SchemaPromotionBanner
-        environment={"TST"}
-        promoteSchema={promoteSchema}
-      />
+      {isTopicOwner && (
+        <SchemaPromotionBanner
+          environment={"TST"}
+          promoteSchema={promoteSchema}
+        />
+      )}
 
       <SchemaStats
         version={schemaDetailsPerEnv?.version || 0}
@@ -125,7 +131,7 @@ function TopicDetailsSchema() {
         </Box>
       </Box>
 
-      <Button.Secondary>Delete Schema</Button.Secondary>
+      {isTopicOwner && <Button.Secondary>Delete Schema</Button.Secondary>}
     </>
   );
 }

--- a/coral/src/app/features/topics/details/schema/TopicDetailsSchema.tsx
+++ b/coral/src/app/features/topics/details/schema/TopicDetailsSchema.tsx
@@ -130,8 +130,6 @@ function TopicDetailsSchema() {
           />
         </Box>
       </Box>
-
-      {isTopicOwner && <Button.Secondary>Delete Schema</Button.Secondary>}
     </>
   );
 }

--- a/coral/src/app/features/topics/details/schema/TopicDetailsSchema.tsx
+++ b/coral/src/app/features/topics/details/schema/TopicDetailsSchema.tsx
@@ -95,7 +95,8 @@ function TopicDetailsSchema() {
         version={schemaDetailsPerEnv?.version || 0}
         id={schemaDetailsPerEnv?.id || 0}
         compatibility={
-          schemaDetailsPerEnv?.compatibility || "Couldn't retrieve"
+          schemaDetailsPerEnv?.compatibility?.toUpperCase() ||
+          "Couldn't retrieve".toUpperCase()
         }
       />
 

--- a/coral/src/app/features/topics/details/schema/TopicDetailsSchema.tsx
+++ b/coral/src/app/features/topics/details/schema/TopicDetailsSchema.tsx
@@ -31,7 +31,8 @@ function TopicDetailsSchema() {
   } = useTopicDetails();
 
   const isTopicOwner = topicInfoList[0].topicOwner;
-  const noSchema = allSchemaVersions.length === 0;
+  const noSchema =
+    allSchemaVersions.length === 0 || schemaDetailsPerEnv === undefined;
 
   function promoteSchema() {
     console.log("dummy function");
@@ -62,7 +63,7 @@ function TopicDetailsSchema() {
             style={{ width: "300px" }}
             aria-label={"Select version"}
             onChange={(e) => setSchemaVersion(Number(e.target.value))}
-            defaultValue={schemaDetailsPerEnv?.version}
+            defaultValue={schemaDetailsPerEnv.version}
           >
             {allSchemaVersions.map((version) => (
               <Option key={version} value={version}>
@@ -81,7 +82,7 @@ function TopicDetailsSchema() {
         {isTopicOwner && (
           <Box alignSelf={"top"}>
             <Link
-              to={`/topic/${topicName}/request-schema?env=${schemaDetailsPerEnv?.env}`}
+              to={`/topic/${topicName}/request-schema?env=${schemaDetailsPerEnv.env}`}
             >
               <Button.Primary icon={add}>Request a new version</Button.Primary>
             </Link>
@@ -98,12 +99,9 @@ function TopicDetailsSchema() {
       )}
 
       <SchemaStats
-        version={schemaDetailsPerEnv?.version || 0}
-        id={schemaDetailsPerEnv?.id || 0}
-        compatibility={
-          schemaDetailsPerEnv?.compatibility?.toUpperCase() ||
-          "Couldn't retrieve".toUpperCase()
-        }
+        version={schemaDetailsPerEnv.version}
+        id={schemaDetailsPerEnv.id}
+        compatibility={schemaDetailsPerEnv.compatibility.toUpperCase()}
       />
 
       <Box marginTop={"l3"} marginBottom={"l2"}>
@@ -115,7 +113,7 @@ function TopicDetailsSchema() {
             height="250px"
             language="json"
             theme={"light"}
-            value={schemaDetailsPerEnv?.content}
+            value={schemaDetailsPerEnv.content}
             loading={"Loading preview"}
             options={{
               ariaLabel: "Schema preview",

--- a/coral/src/app/features/topics/details/schema/TopicDetailsSchema.tsx
+++ b/coral/src/app/features/topics/details/schema/TopicDetailsSchema.tsx
@@ -11,12 +11,21 @@ import {
 import add from "@aivenio/aquarium/icons/add";
 import gitNewBranch from "@aivenio/aquarium/icons/gitNewBranch";
 import MonacoEditor from "@monaco-editor/react";
+import { Link } from "react-router-dom";
 import { useTopicDetails } from "src/app/features/topics/details/TopicDetails";
 import { SchemaPromotionBanner } from "src/app/features/topics/details/schema/components/SchemaPromotionBanner";
 import { SchemaStats } from "src/app/features/topics/details/schema/components/SchemaStats";
 
 function TopicDetailsSchema() {
-  const { topicName, environmentId } = useTopicDetails();
+  const {
+    topicName,
+    topicSchemas: {
+      allSchemaVersions = [],
+      latestVersion,
+      schemaDetailsPerEnv,
+    },
+    setSchemaVersion,
+  } = useTopicDetails();
 
   function promoteSchema() {
     console.log("dummy function");
@@ -30,27 +39,29 @@ function TopicDetailsSchema() {
           <NativeSelect
             style={{ width: "300px" }}
             aria-label={"Select version"}
+            onChange={(e) => setSchemaVersion(Number(e.target.value))}
+            defaultValue={schemaDetailsPerEnv?.version}
           >
-            <Option key={"1"} value={"1"}>
-              version 1
-            </Option>
+            {allSchemaVersions.map((version) => (
+              <Option key={version} value={version}>
+                Version {version} {version === latestVersion && "(latest)"}
+              </Option>
+            ))}
           </NativeSelect>
-          <Typography.SmallTextBold color={"grey-40"}>
+          <Typography.SmallStrong color={"grey-40"}>
             <Box display={"flex"} marginTop={"3"} colGap={"2"}>
               <Icon icon={gitNewBranch} style={{ marginTop: "2px" }} />{" "}
-              <span>5 versions</span>
+              <span>{allSchemaVersions.length} versions</span>
             </Box>
-          </Typography.SmallTextBold>
+          </Typography.SmallStrong>
         </Box>
 
         <Box alignSelf={"top"}>
-          <Button.ExternalLink
-            //@TODO verify if environmentId is the right one
-            href={`/topic/${topicName}/request-schema?env=${environmentId}`}
-            icon={add}
+          <Link
+            to={`/topic/${topicName}/request-schema?env=${schemaDetailsPerEnv?.env}`}
           >
-            Request a new version
-          </Button.ExternalLink>
+            <Button.Primary icon={add}>Request a new version</Button.Primary>
+          </Link>
         </Box>
       </Box>
 
@@ -60,7 +71,13 @@ function TopicDetailsSchema() {
         promoteSchema={promoteSchema}
       />
 
-      <SchemaStats version={99} id={999} compatibility={"BACKWARDS"} />
+      <SchemaStats
+        version={schemaDetailsPerEnv?.version || 0}
+        id={schemaDetailsPerEnv?.id || 0}
+        compatibility={
+          schemaDetailsPerEnv?.compatibility || "Couldn't retrieve"
+        }
+      />
 
       <Box marginTop={"l3"} marginBottom={"l2"}>
         <Label>Schema</Label>
@@ -71,7 +88,7 @@ function TopicDetailsSchema() {
             height="250px"
             language="json"
             theme={"light"}
-            value={"{ huhu: 'huhu' }"}
+            value={schemaDetailsPerEnv?.content}
             loading={"Loading preview"}
             options={{
               ariaLabel: "Schema preview",

--- a/coral/src/app/features/topics/schema-request/TopicSchemaRequest.test.tsx
+++ b/coral/src/app/features/topics/schema-request/TopicSchemaRequest.test.tsx
@@ -151,6 +151,7 @@ describe("TopicSchemaRequest", () => {
 
       expect(select).toBeDisabled();
       expect(select).toHaveValue("1");
+      await waitFor(() => expect(select).toHaveDisplayValue("DEV"));
 
       // only testing this would always return green - even waitFor will return always
       // true, since the mock is not called directly, so waitFor will check, confirm
@@ -184,6 +185,7 @@ describe("TopicSchemaRequest", () => {
 
       expect(select).toBeDisabled();
       await waitFor(() => expect(select).toHaveValue("3"));
+      await waitFor(() => expect(select).toHaveDisplayValue("INFRA"));
 
       // only testing this would always return green - even waitFor will return always
       // true, since the mock is not called directly, so waitFor will check, confirm

--- a/coral/src/app/features/topics/schema-request/TopicSchemaRequest.tsx
+++ b/coral/src/app/features/topics/schema-request/TopicSchemaRequest.tsx
@@ -38,7 +38,7 @@ type TopicSchemaRequestProps = {
 // be able to add this tests. I created na issue in github related to MonacoEditor testing already.
 function TopicSchemaRequest(props: TopicSchemaRequestProps) {
   const { topicName } = props;
-  const [searchParams] = useSearchParams();
+  const [searchParams, setSearchParams] = useSearchParams();
   const presetEnvironment = searchParams.get("env");
 
   const [cancelDialogVisible, setCancelDialogVisible] = useState(false);
@@ -83,11 +83,18 @@ function TopicSchemaRequest(props: TopicSchemaRequestProps) {
     queryFn: () => getEnvironmentsForSchemaRequest(),
     onSuccess: (environments) => {
       if (presetEnvironment) {
-        const isValidEnv = environments.find(
-          (env) => presetEnvironment === env.id
+        const validEnv = environments.find(
+          (env) =>
+            presetEnvironment === env.id || presetEnvironment === env.name
         );
 
-        if (!isValidEnv) {
+        // Allows to pass envirnment name as well as environment id as search param
+        if (validEnv && isNaN(Number(presetEnvironment))) {
+          searchParams.set("env", validEnv.id);
+          setSearchParams(searchParams);
+        }
+
+        if (validEnv === undefined) {
           navigate(-1);
         }
       }

--- a/coral/src/app/features/topics/schema-request/TopicSchemaRequest.tsx
+++ b/coral/src/app/features/topics/schema-request/TopicSchemaRequest.tsx
@@ -38,7 +38,7 @@ type TopicSchemaRequestProps = {
 // be able to add this tests. I created na issue in github related to MonacoEditor testing already.
 function TopicSchemaRequest(props: TopicSchemaRequestProps) {
   const { topicName } = props;
-  const [searchParams, setSearchParams] = useSearchParams();
+  const [searchParams] = useSearchParams();
   const presetEnvironment = searchParams.get("env");
 
   const [cancelDialogVisible, setCancelDialogVisible] = useState(false);
@@ -90,8 +90,8 @@ function TopicSchemaRequest(props: TopicSchemaRequestProps) {
 
         // Allows to pass envirnment name as well as environment id as search param
         if (validEnv && isNaN(Number(presetEnvironment))) {
-          searchParams.set("env", validEnv.id);
-          setSearchParams(searchParams);
+          form.setValue("environment", validEnv.id);
+          return;
         }
 
         if (validEnv === undefined) {

--- a/coral/src/app/features/topics/schema-request/TopicSchemaRequest.tsx
+++ b/coral/src/app/features/topics/schema-request/TopicSchemaRequest.tsx
@@ -88,7 +88,7 @@ function TopicSchemaRequest(props: TopicSchemaRequestProps) {
             presetEnvironment === env.id || presetEnvironment === env.name
         );
 
-        // Allows to pass envirnment name as well as environment id as search param
+        // Allows to pass environment name as well as environment id as search param
         if (validEnv && isNaN(Number(presetEnvironment))) {
           form.setValue("environment", validEnv.id);
           return;

--- a/coral/types/api.d.ts
+++ b/coral/types/api.d.ts
@@ -1300,19 +1300,19 @@ export type components = {
     };
     SchemaDetailsPerEnv: {
       /** Format: int32 */
-      id?: number;
+      id: number;
       /** Format: int32 */
-      version?: number;
+      version: number;
       /** Format: int32 */
-      nextVersion?: number;
+      nextVersion: number;
       /** Format: int32 */
-      prevVersion?: number;
-      compatibility?: string;
-      content?: string;
-      env?: string;
-      showNext?: boolean;
-      showPrev?: boolean;
-      latest?: boolean;
+      prevVersion: number;
+      compatibility: string;
+      content: string;
+      env: string;
+      showNext: boolean;
+      showPrev: boolean;
+      latest: boolean;
     };
     SchemaOverview: {
       topicExists: boolean;

--- a/core/src/main/java/io/aiven/klaw/model/response/SchemaDetailsPerEnv.java
+++ b/core/src/main/java/io/aiven/klaw/model/response/SchemaDetailsPerEnv.java
@@ -1,26 +1,27 @@
 package io.aiven.klaw.model.response;
 
+import jakarta.validation.constraints.NotNull;
 import lombok.Data;
 
 @Data
 public class SchemaDetailsPerEnv {
-  private int id;
+  @NotNull private int id;
 
-  private int version;
+  @NotNull private int version;
 
-  private int nextVersion;
+  @NotNull private int nextVersion;
 
-  private int prevVersion;
+  @NotNull private int prevVersion;
 
-  private String compatibility;
+  @NotNull private String compatibility;
 
-  private String content;
+  @NotNull private String content;
 
-  private String env;
+  @NotNull private String env;
 
-  private boolean showNext;
+  @NotNull private boolean showNext;
 
-  private boolean showPrev;
+  @NotNull private boolean showPrev;
 
-  private boolean latest;
+  @NotNull private boolean latest;
 }

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -7669,7 +7669,8 @@
           "latest" : {
             "type" : "boolean"
           }
-        }
+        },
+        "required" : [ "compatibility", "content", "env", "id", "latest", "nextVersion", "prevVersion", "showNext", "showPrev", "version" ]
       },
       "SchemaOverview" : {
         "properties" : {


### PR DESCRIPTION
## About this change - What it does

https://github.com/aiven/klaw/assets/20607294/866d5d1d-fd47-40cc-b64f-d29252da7e6f


- Render correct data for selected schema
- Refetch data when switching schema version
- redirect to correct form when clicking 'Request new Schema"
  - to achieve this, allow schema request form to use environment name as well as environment ID as `env` search param
- Add empty state when topic has no schema

https://github.com/aiven/klaw/assets/20607294/4ab81b04-89aa-4beb-bdfb-4ebec3ce791b


 


Resolves: #1319
Resolves: #1320