### PR TITLE
OpenApi.yaml was not correctly committed as part of PR 1347

### DIFF
--- a/coral/src/app/features/topics/details/TopicDetails.test.tsx
+++ b/coral/src/app/features/topics/details/TopicDetails.test.tsx
@@ -44,6 +44,7 @@ const testTopicOverview: TopicOverview = {
       topicDeletable: false,
       envName: "DEV",
       hasOpenACLRequest: true,
+      hasOpenRequest: true,
     },
   ],
   aclInfoList: [

--- a/coral/src/app/features/topics/details/components/TopicDetailsResourceTabs.test.tsx
+++ b/coral/src/app/features/topics/details/components/TopicDetailsResourceTabs.test.tsx
@@ -63,6 +63,7 @@ const testTopicOverview: TopicOverview = {
       topicDeletable: false,
       envName: "DEV",
       hasOpenACLRequest: true,
+      hasOpenRequest: true,
     },
   ],
   aclInfoList: [

--- a/coral/src/app/features/topics/details/history/TopicHistory.test.tsx
+++ b/coral/src/app/features/topics/details/history/TopicHistory.test.tsx
@@ -43,6 +43,7 @@ const testTopicOverview: TopicOverview = {
       envName: "DEV",
       topicName: "my awesome topic",
       hasOpenACLRequest: true,
+      hasOpenRequest: true,
     },
   ],
   aclInfoList: [],

--- a/coral/src/app/features/topics/details/subscriptions/TopicSubscriptions.test.tsx
+++ b/coral/src/app/features/topics/details/subscriptions/TopicSubscriptions.test.tsx
@@ -59,6 +59,7 @@ const testTopicOverview: TopicOverview = {
       envName: "DEV",
       topicName: testTopicName,
       hasOpenACLRequest: true,
+      hasOpenRequest: true,
     },
   ],
   aclInfoList: [

--- a/coral/src/app/features/topics/details/utils.test.ts
+++ b/coral/src/app/features/topics/details/utils.test.ts
@@ -19,6 +19,7 @@ const mockUseTopicDetailsDataWithAcl: TopicOverview = {
       topicDeletable: false,
       envName: "DEV",
       hasOpenACLRequest: true,
+      hasOpenRequest: true,
     },
   ],
   aclInfoList: [
@@ -83,6 +84,7 @@ const mockUseTopicDetailsDataWithoutAcl: TopicOverview = {
       topicDeletable: false,
       envName: "DEV",
       hasOpenACLRequest: true,
+      hasOpenRequest: true,
     },
   ],
   aclInfoList: [],

--- a/coral/types/api.d.ts
+++ b/coral/types/api.d.ts
@@ -1063,6 +1063,7 @@ export type components = {
       showEditTopic: boolean;
       showDeleteTopic: boolean;
       topicDeletable: boolean;
+      hasOpenRequest: boolean;
       hasOpenACLRequest: boolean;
       envName: string;
       topicOwner?: boolean;

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -6888,6 +6888,9 @@
           "topicDeletable" : {
             "type" : "boolean"
           },
+          "hasOpenRequest" : {
+            "type" : "boolean"
+          },
           "hasOpenACLRequest" : {
             "type" : "boolean"
           },
@@ -6901,7 +6904,7 @@
             "type" : "boolean"
           }
         },
-        "required" : [ "envId", "envName", "hasOpenACLRequest", "noOfPartitions", "noOfReplicas", "showDeleteTopic", "showEditTopic", "teamId", "teamname", "topicDeletable", "topicName" ]
+        "required" : [ "envId", "envName", "hasOpenACLRequest", "hasOpenRequest", "noOfPartitions", "noOfReplicas", "showDeleteTopic", "showEditTopic", "teamId", "teamname", "topicDeletable", "topicName" ]
       },
       "TopicDetailsPerEnv" : {
         "properties" : {


### PR DESCRIPTION
About this change - What it does
This resolves a miss where a file was not checked in as part of PR 1347
Resolves: #xxxxx
Why this way
