### PR TITLE
fix(coral): Harmonize toast copy

### DIFF
--- a/coral/src/app/features/connectors/request/ConnectorRequest.test.tsx
+++ b/coral/src/app/features/connectors/request/ConnectorRequest.test.tsx
@@ -479,7 +479,7 @@ describe("<ConnectorRequest />", () => {
         expect(createConnectorRequest).toHaveBeenCalledTimes(1);
         await waitFor(() =>
           expect(mockedUseToast).toHaveBeenCalledWith({
-            message: "Connector request successful!",
+            message: "Connector request successfully created",
             position: "bottom-left",
             variant: "default",
           })

--- a/coral/src/app/features/connectors/request/ConnectorRequest.tsx
+++ b/coral/src/app/features/connectors/request/ConnectorRequest.tsx
@@ -55,7 +55,7 @@ function ConnectorRequest() {
     onSuccess: () => {
       navigate("/requests/connectors?status=CREATED");
       toast({
-        message: "Connector request successful!",
+        message: "Connector request successfully created",
         position: "bottom-left",
         variant: "default",
       });

--- a/coral/src/app/features/topics/acl-request/TopicAclRequest.test.tsx
+++ b/coral/src/app/features/topics/acl-request/TopicAclRequest.test.tsx
@@ -1084,7 +1084,7 @@ describe("<TopicAclRequest />", () => {
           );
         });
         expect(mockedUseToast).toHaveBeenCalledWith({
-          message: "Acl request successful!",
+          message: "ACL request successfully created",
           position: "bottom-left",
           variant: "default",
         });
@@ -1480,7 +1480,7 @@ describe("<TopicAclRequest />", () => {
           );
         });
         expect(mockedUseToast).toHaveBeenCalledWith({
-          message: "Acl request successful!",
+          message: "ACL request successfully created",
           position: "bottom-left",
           variant: "default",
         });
@@ -2525,7 +2525,7 @@ describe("<TopicAclRequest />", () => {
           );
         });
         expect(mockedUseToast).toHaveBeenCalledWith({
-          message: "Acl request successful!",
+          message: "ACL request successfully created",
           position: "bottom-left",
           variant: "default",
         });
@@ -2944,7 +2944,7 @@ describe("<TopicAclRequest />", () => {
           );
         });
         expect(mockedUseToast).toHaveBeenCalledWith({
-          message: "Acl request successful!",
+          message: "ACL request successfully created",
           position: "bottom-left",
           variant: "default",
         });

--- a/coral/src/app/features/topics/acl-request/forms/TopicConsumerForm.tsx
+++ b/coral/src/app/features/topics/acl-request/forms/TopicConsumerForm.tsx
@@ -74,7 +74,7 @@ const TopicConsumerForm = ({
     onSuccess: () => {
       navigate("/requests/acls?status=CREATED");
       toast({
-        message: "Acl request successful!",
+        message: "ACL request successfully created",
         position: "bottom-left",
         variant: "default",
       });

--- a/coral/src/app/features/topics/acl-request/forms/TopicProducerForm.tsx
+++ b/coral/src/app/features/topics/acl-request/forms/TopicProducerForm.tsx
@@ -89,7 +89,7 @@ const TopicProducerForm = ({
     onSuccess: () => {
       navigate("/requests/acls?status=CREATED");
       toast({
-        message: "Acl request successful!",
+        message: "ACL request successfully created",
         position: "bottom-left",
         variant: "default",
       });

--- a/coral/src/app/features/topics/details/settings/TopicSettings.tsx
+++ b/coral/src/app/features/topics/details/settings/TopicSettings.tsx
@@ -39,7 +39,7 @@ function TopicSettings() {
       onSuccess: () => {
         navigate("/topics");
         toast({
-          message: "Topic deletion request successfully sent",
+          message: "Topic deletion request successfully created",
           position: "bottom-left",
           variant: "default",
         });

--- a/coral/src/app/features/topics/request/TopicRequest.test.tsx
+++ b/coral/src/app/features/topics/request/TopicRequest.test.tsx
@@ -1223,7 +1223,7 @@ describe("<TopicRequest />", () => {
         });
 
         expect(mockedUseToast).toHaveBeenCalledWith({
-          message: "Topic request successful!",
+          message: "Topic request successfully created",
           position: "bottom-left",
           variant: "default",
         });

--- a/coral/src/app/features/topics/request/TopicRequest.tsx
+++ b/coral/src/app/features/topics/request/TopicRequest.tsx
@@ -65,7 +65,7 @@ function TopicRequest() {
     onSuccess: () => {
       navigate("/requests/topics?status=CREATED");
       toast({
-        message: "Topic request successful!",
+        message: "Topic request successfully created",
         position: "bottom-left",
         variant: "default",
       });

--- a/coral/src/app/features/topics/schema-request/TopicSchemaRequest.test.tsx
+++ b/coral/src/app/features/topics/schema-request/TopicSchemaRequest.test.tsx
@@ -906,7 +906,7 @@ describe("TopicSchemaRequest", () => {
       expect(mockCreateSchemaRequest).toHaveBeenCalled();
       await waitFor(() =>
         expect(mockedUseToast).toHaveBeenCalledWith({
-          message: "Schema request successful!",
+          message: "Schema request successfully created",
           position: "bottom-left",
           variant: "default",
         })

--- a/coral/src/app/features/topics/schema-request/TopicSchemaRequest.tsx
+++ b/coral/src/app/features/topics/schema-request/TopicSchemaRequest.tsx
@@ -106,7 +106,7 @@ function TopicSchemaRequest(props: TopicSchemaRequestProps) {
     onSuccess: () => {
       navigate("/requests/schemas?status=CREATED");
       toast({
-        message: "Schema request successful!",
+        message: "Schema request successfully created",
         position: "bottom-left",
         variant: "default",
       });


### PR DESCRIPTION
## About this change - What it does
 https://github.com/aiven/klaw/pull/1352 introduced some inconsistency in the copy for the toast notifications dispatched on successful operations. This PR harmonize them according to the pattern that was reviewed and approved by Harshini.
