### PR TITLE
Add link to coral connector

### DIFF
--- a/core/src/main/resources/templates/requestConnector.html
+++ b/core/src/main/resources/templates/requestConnector.html
@@ -431,6 +431,14 @@
 			<div class="row page-titles">
 			</div>
 
+			<div class="row" ng-if="dashboardDetails.coralEnabled === 'true'">
+				<div class="ribbon-wrapper card col-lg-6 col-md-6 col-xlg-2 col-xs-6">
+					<div class="ribbon ribbon-success">New user interface available</div>
+					<p class="ribbon-content">
+						Check out the new interface for <a href="coral/connectors/request">Connector requests.</a>
+					</p>
+				</div>
+			</div>
 			<!-- Row -->
 
 			<div class="row" ng-show="alert != null && alert != ''" ng-init="">


### PR DESCRIPTION
About this change - What it does
Adds a link from the angular UI to the coral ui on the connector request page.

Resolves: #1357 
Why this way
This is consistent with how we now show this option.