### PR TITLE
See why a team is not available for deletion with debug logging

### DIFF
--- a/core/src/main/java/io/aiven/klaw/helpers/db/rdbms/SelectDataJdbc.java
+++ b/core/src/main/java/io/aiven/klaw/helpers/db/rdbms/SelectDataJdbc.java
@@ -880,6 +880,11 @@ public class SelectDataJdbc {
   }
 
   public List<UserInfo> selectAllUsersInfoForTeam(Integer teamId, int tenantId) {
+    if (log.isDebugEnabled()) {
+      List<UserInfo> team = userInfoRepo.findAllByTeamIdAndTenantId(teamId, tenantId);
+      log.debug("For team {} Team Details {} with size {}", teamId, team, team.size());
+      return team;
+    }
     return userInfoRepo.findAllByTeamIdAndTenantId(teamId, tenantId);
   }
 
@@ -1460,6 +1465,62 @@ public class SelectDataJdbc {
   }
 
   public int findAllComponentsCountForTeam(Integer teamId, int tenantId) {
+
+    if (log.isDebugEnabled()) {
+      int schemaRequestsRepoCount =
+          ((Long) schemaRequestRepo.findAllRecordsCountForTeamId(teamId, tenantId).get(0)[0])
+              .intValue();
+      int messageSchemaRepoCount =
+          ((Long) messageSchemaRepo.findAllRecordsCountForTeamId(teamId, tenantId).get(0)[0])
+              .intValue();
+      int kafkaConnectorRepoCount =
+          ((Long) kafkaConnectorRepo.findAllRecordsCountForTeamId(teamId, tenantId).get(0)[0])
+              .intValue();
+      int kafkaConnectorRequestsRepoCount =
+          ((Long)
+                  kafkaConnectorRequestsRepo.findAllRecordsCountForTeamId(teamId, tenantId)
+                      .get(0)[0])
+              .intValue();
+      int topicRepoCount =
+          ((Long) topicRepo.findAllRecordsCountForTeamId(teamId, tenantId).get(0)[0]).intValue();
+      int topicRequestsRepoCount =
+          ((Long) topicRequestsRepo.findAllRecordsCountForTeamId(teamId, tenantId).get(0)[0])
+              .intValue();
+      int aclRepoCount =
+          ((Long) aclRepo.findAllRecordsCountForTeamId(teamId, tenantId).get(0)[0]).intValue();
+      int aclRequestRepoCount =
+          ((Long) aclRequestsRepo.findAllRecordsCountForTeamId(teamId, tenantId).get(0)[0])
+              .intValue();
+      log.debug(
+          "For team {} Active Schema Requests {}, number of Schemas in DB {}",
+          teamId,
+          schemaRequestsRepoCount,
+          messageSchemaRepoCount);
+      log.debug(
+          "For team {} Active Connector Requests {}, number of Connector in DB {}",
+          teamId,
+          kafkaConnectorRepoCount,
+          kafkaConnectorRequestsRepoCount);
+      log.debug(
+          "For team {} Active Topic Requests {}, number of Topic in DB {}",
+          teamId,
+          topicRepoCount,
+          topicRequestsRepoCount);
+      log.debug(
+          "For team {} Active ACL Requests {}, number of ACL in DB {}",
+          teamId,
+          aclRepoCount,
+          aclRequestRepoCount);
+      // return here instead of doing a second search
+      return schemaRequestsRepoCount
+          + messageSchemaRepoCount
+          + kafkaConnectorRepoCount
+          + kafkaConnectorRequestsRepoCount
+          + topicRepoCount
+          + topicRequestsRepoCount
+          + aclRepoCount
+          + aclRequestRepoCount;
+    }
     return ((Long) schemaRequestRepo.findAllRecordsCountForTeamId(teamId, tenantId).get(0)[0])
             .intValue()
         + ((Long) messageSchemaRepo.findAllRecordsCountForTeamId(teamId, tenantId).get(0)[0])


### PR DESCRIPTION
Add debug logging to find and print out any issues from trying to delete a team.

About this change - What it does
Allows a user to debug an issue where they are unable to delete a team to see why they can not delete that team.

add the following logging line in klaw cores application.properties to see these additional logging statements.
logging.level.io.aiven.klaw.helpers.db.rdbms.SelectDataJdbc=debug

Resolves: #xxxxx
Why this way
This way the queries are still only executed once but are also logged out.