### PR TITLE
feat(coral): Topic overview - Subscriptions tab: Add details modal

### DIFF
--- a/coral/src/app/features/topics/details/components/TopicDetailsHeader.test.tsx
+++ b/coral/src/app/features/topics/details/components/TopicDetailsHeader.test.tsx
@@ -20,7 +20,7 @@ const mockSetEnvironmentId = jest.fn();
 const defaultProps = {
   topicName: testTopicName,
   environments: testEnvironments,
-  environmentId: "1",
+  environmentId: undefined,
   setEnvironmentId: mockSetEnvironmentId,
   topicExists: true,
 };
@@ -104,7 +104,7 @@ describe("TopicDetailsHeader", () => {
       expect(select).toBeEnabled();
     });
 
-    it("shows the first element from environments as the selected one", () => {
+    it("sets environmentId to be the first element from environments if it is undefined on load", () => {
       const select = screen.getByRole("combobox", {
         name: "Select environment",
       });

--- a/coral/src/app/features/topics/details/components/TopicDetailsHeader.tsx
+++ b/coral/src/app/features/topics/details/components/TopicDetailsHeader.tsx
@@ -1,4 +1,3 @@
-import { useNavigate } from "react-router-dom";
 import {
   Box,
   Button,
@@ -7,9 +6,10 @@ import {
   Option,
   Typography,
 } from "@aivenio/aquarium";
-import { EnvironmentInfo } from "src/domain/environment";
-import { Dispatch, SetStateAction } from "react";
 import database from "@aivenio/aquarium/dist/src/icons/database";
+import { Dispatch, SetStateAction, useEffect } from "react";
+import { useNavigate } from "react-router-dom";
+import { EnvironmentInfo } from "src/domain/environment";
 
 type TopicOverviewHeaderProps = {
   topicName: string;
@@ -27,6 +27,18 @@ function TopicDetailsHeader(props: TopicOverviewHeaderProps) {
     setEnvironmentId,
     topicExists,
   } = props;
+
+  // The call to getConsumerOffsets in TopicDetails needs an environmentId
+  // But on first load, environmentId is undefined
+  // So we need to set it in this way, to be able to fetch correctly
+  // Ideally, environmentId should be available on first load
+  // Because this setEnvironmentId will trigger a superfluous refetch of getTopicOverview
+  // @TODO: find a better way to have the initial env of the Topic overview be the lowest env, instead of undefined
+  useEffect(() => {
+    if (environments !== undefined && environmentId === undefined) {
+      setEnvironmentId(environments[0].id);
+    }
+  }, [environments, environmentId, setEnvironmentId]);
 
   const navigate = useNavigate();
 
@@ -56,7 +68,7 @@ function TopicDetailsHeader(props: TopicOverviewHeaderProps) {
           {environments && topicExists && (
             <NativeSelectBase
               aria-label={"Select environment"}
-              value={environmentId || environments[0]?.id}
+              value={environmentId}
               onChange={(event) => {
                 setEnvironmentId(event.target.value);
               }}
@@ -84,13 +96,13 @@ function TopicDetailsHeader(props: TopicOverviewHeaderProps) {
 
         {topicExists && environments && environments.length > 0 && (
           <Box display={"flex"} alignItems={"center"} colGap={"2"}>
-            <Typography.SmallTextBold color={"grey-40"}>
+            <Typography.SmallStrong color={"grey-40"}>
               <Icon icon={database} />
-            </Typography.SmallTextBold>
-            <Typography.SmallTextBold color={"grey-40"}>
+            </Typography.SmallStrong>
+            <Typography.SmallStrong color={"grey-40"}>
               {environments.length}{" "}
               {environments.length === 1 ? "Environment" : "Environments"}
-            </Typography.SmallTextBold>
+            </Typography.SmallStrong>
           </Box>
         )}
       </Box>

--- a/coral/src/app/features/topics/details/components/TopicDetailsResourceTabs.test.tsx
+++ b/coral/src/app/features/topics/details/components/TopicDetailsResourceTabs.test.tsx
@@ -13,6 +13,8 @@ jest.mock("react-router-dom", () => ({
 }));
 
 const mockSetSchemaVersion = jest.fn();
+const mockSetConsumerGroupId = jest.fn();
+const mockSetAclReqNo = jest.fn();
 
 const testMapTabs = [
   {
@@ -135,6 +137,19 @@ const testTopicOverview: TopicOverview = {
   topicIdForDocumentation: 1,
 };
 
+const testOffsetsData = {
+  topicPartitionId: "0",
+  currentOffset: "0",
+  endOffset: "0",
+  lag: "0",
+};
+
+const testServiceAccountData = {
+  username: "nkira",
+  password: "service-account-pw",
+  accountFound: true,
+};
+
 const defaultProps = {
   currentTab: TopicOverviewTabEnum.OVERVIEW,
   environmentId: "1",
@@ -143,6 +158,10 @@ const defaultProps = {
   topicName: testTopicName,
   topicOverview: testTopicOverview,
   setSchemaVersion: mockSetSchemaVersion,
+  setConsumerGroupId: mockSetConsumerGroupId,
+  setAclReqNo: mockSetAclReqNo,
+  offsetsData: testOffsetsData,
+  serviceAccountData: testServiceAccountData,
 };
 describe("TopicDetailsResourceTabs", () => {
   const user = userEvent.setup();

--- a/coral/src/app/features/topics/details/components/TopicDetailsResourceTabs.tsx
+++ b/coral/src/app/features/topics/details/components/TopicDetailsResourceTabs.tsx
@@ -10,27 +10,39 @@ import { TopicOverview } from "src/domain/topic";
 import loading from "@aivenio/aquarium/icons/loading";
 import { parseErrorMsg } from "src/services/mutation-utils";
 import { TopicSchemaOverview } from "src/domain/topic/topic-types";
+import {
+  ConsumerOffsets,
+  ServiceAccountDetails,
+} from "src/domain/acl/acl-types";
 
 type Props = {
   currentTab: TopicOverviewTabEnum;
   setSchemaVersion: (id: number) => void;
+  setConsumerGroupId: (id?: string) => void;
+  setAclReqNo: (aclReqNo?: string) => void;
   environmentId?: string;
   error?: unknown;
   isError: boolean;
   isLoading: boolean;
   topicOverview?: TopicOverview;
   topicSchemas?: TopicSchemaOverview;
+  offsetsData?: ConsumerOffsets;
+  serviceAccountData?: ServiceAccountDetails;
 };
 
 function TopicOverviewResourcesTabs({
   currentTab,
   environmentId,
   setSchemaVersion,
+  setConsumerGroupId,
+  setAclReqNo,
   error,
   isError,
   isLoading,
   topicOverview,
   topicSchemas,
+  offsetsData,
+  serviceAccountData,
 }: Props) {
   const navigate = useNavigate();
   const topicName = topicOverview?.topicInfo.topicName;
@@ -120,11 +132,15 @@ function TopicOverviewResourcesTabs({
             environmentId:
               environmentId || topicOverview.availableEnvironments[0].id,
             setSchemaVersion,
+            setConsumerGroupId,
+            setAclReqNo,
             topicOverview,
             topicName: topicOverview.topicInfo.topicName,
             topicSchemas,
             userCanDeleteTopic: topicOverview.topicInfo.topicDeletable,
             topicHasOpenDeleteRequest: !topicOverview.topicInfo.showDeleteTopic,
+            offsetsData,
+            serviceAccountData,
           }}
         />
       </div>

--- a/coral/src/app/features/topics/details/history/TopicHistory.test.tsx
+++ b/coral/src/app/features/topics/details/history/TopicHistory.test.tsx
@@ -89,7 +89,22 @@ const testTopicSchemas = {
   ],
 };
 
+const testOffsetsData = {
+  topicPartitionId: "0",
+  currentOffset: "0",
+  endOffset: "0",
+  lag: "0",
+};
+
+const testServiceAccountData = {
+  username: "nkira",
+  password: "service-account-pw",
+  accountFound: true,
+};
+
 const mockSetSchemaVersion = jest.fn();
+const mockSetConsumerGroupId = jest.fn();
+const mockSetAclReqNo = jest.fn();
 
 jest.mock("src/app/features/topics/details/TopicDetails");
 
@@ -117,6 +132,10 @@ describe("TopicHistory", () => {
         topicOverview: { ...testTopicOverview, topicHistoryList: [] },
         topicSchemas: testTopicSchemas,
         setSchemaVersion: mockSetSchemaVersion,
+        setConsumerGroupId: mockSetConsumerGroupId,
+        setAclReqNo: mockSetAclReqNo,
+        offsetsData: testOffsetsData,
+        serviceAccountData: testServiceAccountData,
       });
 
       customRender(<TopicHistory />, {
@@ -166,6 +185,10 @@ describe("TopicHistory", () => {
         topicOverview: testTopicOverview,
         topicSchemas: testTopicSchemas,
         setSchemaVersion: mockSetSchemaVersion,
+        setConsumerGroupId: mockSetConsumerGroupId,
+        setAclReqNo: mockSetAclReqNo,
+        offsetsData: testOffsetsData,
+        serviceAccountData: testServiceAccountData,
       });
 
       customRender(<TopicHistory />, {

--- a/coral/src/app/features/topics/details/subscriptions/TopicSubscriptions.test.tsx
+++ b/coral/src/app/features/topics/details/subscriptions/TopicSubscriptions.test.tsx
@@ -160,11 +160,32 @@ const testTopicOverview: TopicOverview = {
   topicPromotionDetails: { status: "STATUS" },
   topicIdForDocumentation: 1,
 };
+
+const testOffsetsData = {
+  topicPartitionId: "0",
+  currentOffset: "0",
+  endOffset: "0",
+  lag: "0",
+};
+
+const testServiceAccountData = {
+  username: "nkira",
+  password: "service-account-pw",
+  accountFound: true,
+};
+
+const mockSetConsumerGroupId = jest.fn();
+const mockSetAclReqNo = jest.fn();
+
 jest.mock("react-router-dom", () => ({
   ...jest.requireActual("react-router-dom"),
   useOutletContext: () => ({
     topicOverview: testTopicOverview,
     environmentId: "333",
+    setConsumerGroupId: mockSetConsumerGroupId,
+    setAclReqNo: mockSetAclReqNo,
+    offsetsData: testOffsetsData,
+    serviceAccountData: testServiceAccountData,
   }),
 }));
 
@@ -482,4 +503,60 @@ describe("TopicSubscriptions.tsx", () => {
       );
     });
   });
+
+  describe("should allow seeing details of a subscription", () => {
+    it("should render a modal when clicking the Details button and close it when clicking Close button", async () => {
+      const firstDataRow = screen.getAllByRole("row")[1];
+      const button = within(firstDataRow).getByRole("button", {
+        name: "Show details of request 1006",
+      });
+
+      await userEvent.click(button);
+
+      expect(mockSetConsumerGroupId).toHaveBeenCalledWith("-na-");
+      expect(mockSetAclReqNo).toHaveBeenCalledWith("1006");
+
+      const modal = screen.getByRole("dialog");
+
+      expect(within(modal).getByText("Subscription details")).toBeVisible();
+
+      const cancelButton = within(modal).getByRole("button", {
+        name: "Close",
+      });
+
+      await userEvent.click(cancelButton);
+
+      expect(mockSetConsumerGroupId).toHaveBeenCalledWith(undefined);
+      expect(mockSetAclReqNo).toHaveBeenCalledWith(undefined);
+
+      await waitFor(() => expect(modal).not.toBeVisible());
+    });
+  });
+  // @TODO in PR handling proper display of the data
+  // it("should render correct data in details modal", async () => {
+  //   const firstDataRow = screen.getAllByRole("row")[1];
+  //   const button = within(firstDataRow).getByRole("button", {
+  //     name: "Show details of request 1006",
+  //   });
+
+  //   await userEvent.click(button);
+
+  //   expect(mockSetConsumerGroupId).toHaveBeenCalledWith("-na-");
+  //   expect(mockSetAclReqNo).toHaveBeenCalledWith("1006");
+
+  //   const modal = screen.getByRole("dialog");
+
+  //   expect(within(modal).getByText("Subscription details")).toBeVisible();
+
+  //   const cancelButton = within(modal).getByRole("button", {
+  //     name: "Close",
+  //   });
+
+  //   await userEvent.click(cancelButton);
+
+  //   expect(mockSetConsumerGroupId).toHaveBeenCalledWith(undefined);
+  //   expect(mockSetAclReqNo).toHaveBeenCalledWith(undefined);
+
+  //   await waitFor(() => expect(modal).not.toBeVisible());
+  // });
 });

--- a/coral/src/app/features/topics/details/subscriptions/TopicSubscriptionsTable.test.tsx
+++ b/coral/src/app/features/topics/details/subscriptions/TopicSubscriptionsTable.test.tsx
@@ -86,6 +86,7 @@ const userSubsColumnNames = [
   "IP addresses",
   "ACL type",
   "Team",
+  "Details",
   "Delete",
 ];
 
@@ -95,6 +96,7 @@ const prefixedSubsColumnNames = [
   "IP addresses",
   "ACL type",
   "Team",
+  "Details",
   "Delete",
 ];
 const transactionalSubsColumnNames = [
@@ -103,10 +105,12 @@ const transactionalSubsColumnNames = [
   "IP addresses",
   "ACL type",
   "Team",
+  "Details",
   "Delete",
 ];
 
 const mockOnDelete = jest.fn();
+const mockOnDetails = jest.fn();
 
 describe("TopicSubscriptionsTable.tsx", () => {
   beforeAll(() => {
@@ -122,6 +126,7 @@ describe("TopicSubscriptionsTable.tsx", () => {
       render(
         <TopicSubscriptionsTable
           onDelete={mockOnDelete}
+          onDetails={mockOnDetails}
           filteredData={[]}
           selectedSubs="aclInfoList"
         />
@@ -139,6 +144,7 @@ describe("TopicSubscriptionsTable.tsx", () => {
       render(
         <TopicSubscriptionsTable
           onDelete={mockOnDelete}
+          onDetails={mockOnDetails}
           filteredData={mockUserSubs}
           selectedSubs="aclInfoList"
         />
@@ -153,6 +159,7 @@ describe("TopicSubscriptionsTable.tsx", () => {
       render(
         <TopicSubscriptionsTable
           onDelete={mockOnDelete}
+          onDetails={mockOnDetails}
           filteredData={mockedPrefixedSubs}
           selectedSubs="prefixedAclInfoList"
         />
@@ -167,6 +174,7 @@ describe("TopicSubscriptionsTable.tsx", () => {
       render(
         <TopicSubscriptionsTable
           onDelete={mockOnDelete}
+          onDetails={mockOnDetails}
           filteredData={mockedTransactionalSubs}
           selectedSubs="transactionalAclInfoList"
         />
@@ -179,16 +187,20 @@ describe("TopicSubscriptionsTable.tsx", () => {
     });
   });
 
-  describe("should call onDelete when clicking Delete button", () => {
-    afterEach(cleanup);
-    it("calls onDelete when clicking Delete button", async () => {
+  describe("should call correct fns when clicking action buttons", () => {
+    beforeEach(() =>
       render(
         <TopicSubscriptionsTable
           onDelete={mockOnDelete}
+          onDetails={mockOnDetails}
           filteredData={mockUserSubs}
           selectedSubs="aclInfoList"
         />
-      );
+      )
+    );
+    afterEach(cleanup);
+
+    it("calls onDelete when clicking Delete button", async () => {
       const firstDataRow = screen.getAllByRole("row")[1];
       const button = within(firstDataRow).getByRole("button", {
         name: "Create deletion request for request 1006",
@@ -197,6 +209,21 @@ describe("TopicSubscriptionsTable.tsx", () => {
       await userEvent.click(button);
 
       expect(mockOnDelete).toHaveBeenCalledWith("1006");
+    });
+
+    it("calls onDetails when clicking Details button", async () => {
+      const firstDataRow = screen.getAllByRole("row")[1];
+      const button = within(firstDataRow).getByRole("button", {
+        name: "Show details of request 1006",
+      });
+
+      await userEvent.click(button);
+
+      expect(mockOnDetails).toHaveBeenCalledWith({
+        consumerGroupId: "-na-",
+        aclReqNo: "1006",
+        isAivenCluster: true,
+      });
     });
   });
 });

--- a/coral/src/app/features/topics/details/subscriptions/TopicSubscriptionsTable.tsx
+++ b/coral/src/app/features/topics/details/subscriptions/TopicSubscriptionsTable.tsx
@@ -6,6 +6,7 @@ import {
   StatusChip,
 } from "@aivenio/aquarium";
 import deleteIcon from "@aivenio/aquarium/dist/src/icons/delete";
+import infoIcon from "@aivenio/aquarium/dist/src/icons/infoSign";
 import { AclOverviewInfo } from "src/domain/topic/topic-types";
 
 type SubscriptionOptions =
@@ -17,6 +18,15 @@ interface TopicSubscriptionsTableProps {
   selectedSubs: SubscriptionOptions;
   filteredData: AclOverviewInfo[];
   onDelete: (req_no: string) => void;
+  onDetails: ({
+    isAivenCluster,
+    aclReqNo,
+    consumerGroupId,
+  }: {
+    isAivenCluster: boolean;
+    aclReqNo: string;
+    consumerGroupId?: string;
+  }) => void;
 }
 
 interface AclInfoListRow {
@@ -28,6 +38,8 @@ interface AclInfoListRow {
   showDeleteAcl: AclOverviewInfo["showDeleteAcl"];
   topicname?: AclOverviewInfo["topicname"];
   transactionalId?: AclOverviewInfo["transactionalId"];
+  consumerGroupId?: AclOverviewInfo["consumergroup"];
+  kafkaFlavorType?: AclOverviewInfo["kafkaFlavorType"];
 }
 
 const getRows = (
@@ -44,6 +56,8 @@ const getRows = (
       showDeleteAcl,
       topicname,
       transactionalId,
+      consumergroup,
+      kafkaFlavorType,
     }) => {
       const row: AclInfoListRow = {
         id: req_no,
@@ -52,6 +66,8 @@ const getRows = (
         aclType: topictype,
         team: teamname,
         showDeleteAcl,
+        consumerGroupId: consumergroup,
+        kafkaFlavorType: kafkaFlavorType,
       };
 
       if (selectedSubs === "prefixedAclInfoList") {
@@ -69,7 +85,8 @@ const getRows = (
 
 const getColumns = (
   selectedSubs: SubscriptionOptions,
-  onDelete: TopicSubscriptionsTableProps["onDelete"]
+  onDelete: TopicSubscriptionsTableProps["onDelete"],
+  onDetails: TopicSubscriptionsTableProps["onDetails"]
 ): Array<DataTableColumn<AclInfoListRow>> => {
   const additionalColumns: {
     [key in
@@ -149,6 +166,26 @@ const getColumns = (
     },
     {
       type: "action",
+      headerName: "Details",
+      headerInvisible: true,
+      width: 30,
+      action: ({ consumerGroupId, kafkaFlavorType, id }) => ({
+        text: "Details",
+        icon: infoIcon,
+        onClick: () => {
+          onDetails({
+            consumerGroupId,
+            aclReqNo: id,
+            isAivenCluster:
+              kafkaFlavorType !== undefined &&
+              kafkaFlavorType === "AIVEN_FOR_APACHE_KAFKA",
+          });
+        },
+        "aria-label": `Show details of request ${id}`,
+      }),
+    },
+    {
+      type: "action",
       headerName: "Delete",
       headerInvisible: true,
       width: 30,
@@ -176,9 +213,10 @@ export const TopicSubscriptionsTable = ({
   selectedSubs,
   filteredData,
   onDelete,
+  onDetails,
 }: TopicSubscriptionsTableProps) => {
   const rows = getRows(selectedSubs, filteredData);
-  const columns = getColumns(selectedSubs, onDelete);
+  const columns = getColumns(selectedSubs, onDelete, onDetails);
 
   return rows.length === 0 ? (
     <EmptyState title="No subscriptions">

--- a/coral/src/app/features/topics/details/subscriptions/components/TopicSubscriptionsDetailsModal.test.tsx
+++ b/coral/src/app/features/topics/details/subscriptions/components/TopicSubscriptionsDetailsModal.test.tsx
@@ -1,0 +1,52 @@
+import { cleanup, render } from "@testing-library/react";
+import TopicSubscriptionsDetailsModal from "src/app/features/topics/details/subscriptions/components/TopicSubscriptionsDetailsModal";
+import { AclOverviewInfo } from "src/domain/topic/topic-types";
+
+const mockCloseDetailsModal = jest.fn();
+
+const testServiceAccountData = {
+  username: "nkira",
+  password: "service-account-pw",
+  accountFound: true,
+};
+
+const testOffsetsData = {
+  topicPartitionId: "0",
+  currentOffset: "0",
+  endOffset: "0",
+  lag: "0",
+};
+
+const testSelectedSub: AclOverviewInfo = {
+  req_no: "1006",
+  acl_ssl: "aivtopic3user",
+  topicname: "aivtopic3",
+  topictype: "Producer",
+  consumergroup: "-na-",
+  environment: "1",
+  environmentName: "DEV",
+  teamname: "Ospo",
+  teamid: 1003,
+  aclPatternType: "LITERAL",
+  showDeleteAcl: true,
+  kafkaFlavorType: "AIVEN_FOR_APACHE_KAFKA",
+};
+
+const defaultProps = {
+  closeDetailsModal: mockCloseDetailsModal,
+  isAivenCluster: true,
+  selectedSub: testSelectedSub,
+  offsetsData: testOffsetsData,
+  serviceAccountData: testServiceAccountData,
+};
+
+describe("TopicSubscriptionsDetailsModal.tsx", () => {
+  afterAll(() => {
+    cleanup();
+  });
+
+  // @TODO finish testing in PR handling proper display of the data
+  it("should render correct data in details modal", async () => {
+    render(<TopicSubscriptionsDetailsModal {...defaultProps} />);
+  });
+});

--- a/coral/src/app/features/topics/details/subscriptions/components/TopicSubscriptionsDetailsModal.tsx
+++ b/coral/src/app/features/topics/details/subscriptions/components/TopicSubscriptionsDetailsModal.tsx
@@ -1,0 +1,73 @@
+import { Modal } from "src/app/components/Modal";
+import {
+  ConsumerOffsets,
+  ServiceAccountDetails,
+} from "src/domain/acl/acl-types";
+import { AclOverviewInfo } from "src/domain/topic/topic-types";
+
+interface TopicSubscriptionsDetailsModalProps {
+  closeDetailsModal: () => void;
+  isAivenCluster: boolean;
+  selectedSub: AclOverviewInfo;
+  offsetsData?: ConsumerOffsets;
+  serviceAccountData?: ServiceAccountDetails;
+}
+
+const TopicSubscriptionsDetailsModal = ({
+  closeDetailsModal,
+  isAivenCluster,
+  selectedSub,
+  offsetsData,
+  serviceAccountData,
+}: TopicSubscriptionsDetailsModalProps) => {
+  return (
+    <Modal
+      title={"Subscription details"}
+      primaryAction={{
+        text: "Close",
+        onClick: closeDetailsModal,
+      }}
+      close={closeDetailsModal}
+    >
+      <>
+        <p>isAivenClusetr: {String(isAivenCluster)}</p>
+        <p>Env: {selectedSub.environmentName}</p>
+        <p>ACL type: {selectedSub.topictype}</p>
+        <p>ACL pattern: {selectedSub.aclPatternType}</p>
+        <p>Topic name: {selectedSub.topicname}</p>
+        <p>Consumer group: {selectedSub.consumergroup}</p>
+        <p>
+          {isAivenCluster ? "Service accounts" : "Principals"}:{" "}
+          {selectedSub.acl_ssl}
+        </p>
+        <p>
+          {selectedSub.acl_ip === undefined
+            ? null
+            : `IP: ${selectedSub.acl_ip}`}
+        </p>
+        <p>
+          {isAivenCluster
+            ? `Service account password: ${
+                serviceAccountData?.password || "Loading"
+              }`
+            : null}
+        </p>
+        <p>
+          {!isAivenCluster && selectedSub.topictype === "Consumer"
+            ? `Consumer offset: Partition ${
+                offsetsData?.topicPartitionId || "Loading"
+              } |
+              Current offset ${
+                offsetsData?.currentOffset || "Loading"
+              } | End offset
+              ${offsetsData?.endOffset || "Loading"} | Lag ${
+                offsetsData?.lag || "Loading"
+              }`
+            : null}
+        </p>
+      </>
+    </Modal>
+  );
+};
+
+export default TopicSubscriptionsDetailsModal;

--- a/coral/src/domain/acl/acl-api.ts
+++ b/coral/src/domain/acl/acl-api.ts
@@ -137,6 +137,31 @@ function getAivenServiceAccounts(
   );
 }
 
+type GetAivenServiceAccountDetailsParams =
+  KlawApiRequestQueryParameters<"getAivenServiceAccountDetails">;
+type getAivenServiceAccountDetailsResponse =
+  KlawApiResponse<"getAivenServiceAccountDetails">;
+function getAivenServiceAccountDetails(
+  params: GetAivenServiceAccountDetailsParams
+): Promise<getAivenServiceAccountDetailsResponse> {
+  return api.get<getAivenServiceAccountDetailsResponse>(
+    API_PATHS.getAivenServiceAccountDetails,
+    new URLSearchParams(params)
+  );
+}
+
+type GetConsumerOffsetsParams =
+  KlawApiRequestQueryParameters<"getConsumerOffsets">;
+type GetConsumerOffsetsResponse = KlawApiResponse<"getConsumerOffsets">;
+function getConsumerOffsets(
+  params: GetConsumerOffsetsParams
+): Promise<GetConsumerOffsetsResponse> {
+  return api.get<GetConsumerOffsetsResponse>(
+    API_PATHS.getConsumerOffsets,
+    new URLSearchParams(params)
+  );
+}
+
 export {
   createAclRequest,
   getAclRequestsForApprover,
@@ -145,5 +170,7 @@ export {
   declineAclRequest,
   deleteAclRequest,
   getAivenServiceAccounts,
+  getAivenServiceAccountDetails,
   createAclDeletionRequest,
+  getConsumerOffsets,
 };

--- a/coral/src/domain/acl/acl-types.ts
+++ b/coral/src/domain/acl/acl-types.ts
@@ -1,9 +1,9 @@
 import {
+  KlawApiModel,
   KlawApiRequest,
   KlawApiRequestQueryParameters,
-  KlawApiModel,
-  ResolveIntersectionTypes,
   Paginated,
+  ResolveIntersectionTypes,
 } from "types/utils";
 
 // Several types are dependent on topictype when it is "Consumer":
@@ -61,12 +61,18 @@ type AclRequestsForApprover = ResolveIntersectionTypes<Paginated<AclRequest[]>>;
 
 type AclType = KlawApiModel<"AclRequestsResponseModel">["aclType"];
 
+type ConsumerOffsets = KlawApiModel<"OffsetDetails">;
+
+type ServiceAccountDetails = KlawApiModel<"ServiceAccountDetails">;
+
 export type {
-  CreateAclRequestTopicTypeProducer,
-  CreateAclRequestTopicTypeConsumer,
-  GetCreatedAclRequestParameters,
-  GetCreatedAclRequestForApproverParameters,
   AclRequest,
   AclRequestsForApprover,
   AclType,
+  ConsumerOffsets,
+  CreateAclRequestTopicTypeConsumer,
+  CreateAclRequestTopicTypeProducer,
+  GetCreatedAclRequestForApproverParameters,
+  GetCreatedAclRequestParameters,
+  ServiceAccountDetails,
 };


### PR DESCRIPTION
## About this change - What it does

- add necessary data fetching 
- add action column in table
- add modal component



https://github.com/aiven/klaw/assets/20607294/36370c28-86c6-489f-9cb1-6eafcee777e3


## Notes 

- Relies on the changes in this PR (the commit e497db67e129a9544721f3f7fc788716b104f6a4 in this PR's commit history): https://github.com/aiven/klaw/pull/1382
- To be improved: because some of the data fetching being done to render the correct data in the modal relies on always having an `environmentId` available, and because the previous behaviour was to have `undefined` as initial value for `environmentId` (the call to `getTopicOverview` will return the data for the "lowest" environment if no `environmentId` is passed, which is what we want), we currently do a double call to `getTopicOverview`:
  - first call with undefined, gives us access to `availableEnvironments`
  - we set the first of these `availableEnvironments` as `environmentId` in a `useEffect` in `TopicDetailsHeader`
  - the  `getTopicOverview` query is refetched with the `environmentId` value,  because it has a dependency on `environmentId`
  

https://github.com/aiven/klaw/assets/20607294/2a03cc09-7aab-477f-876c-b91b60caf895


  

## Follow up

UI work and testing for the modal will be done in follow up PRs.

Resolves: #1383
