### PR TITLE
fix(coral): use correct error type and parseErrorMsg

### DIFF
--- a/coral/src/app/features/topics/details/schema/TopicDetailsSchema.tsx
+++ b/coral/src/app/features/topics/details/schema/TopicDetailsSchema.tsx
@@ -25,6 +25,8 @@ import {
   PromoteSchemaPayload,
   promoteSchemaRequest,
 } from "src/domain/schema-request";
+import { HTTPError } from "src/services/api";
+import { parseErrorMsg } from "src/services/mutation-utils";
 import illustration from "/src/app/images/topic-details-schema-Illustration.svg";
 
 function TopicDetailsSchema() {
@@ -80,8 +82,8 @@ function TopicDetailsSchema() {
         });
       },
       {
-        onError: (error: Error) => {
-          setErrorMessage(error.message);
+        onError: (error: HTTPError) => {
+          setErrorMessage(parseErrorMsg(error));
           setShowSchemaPromotionModal(false);
         },
         onSuccess: () => {


### PR DESCRIPTION
## The problem
When encountering a 500 error without a `message` in the error payload, the app crashes.

https://github.com/aiven/klaw/assets/20607294/8272fe32-37f1-4978-93a8-608462ea5faa

## The fix 

- all errors handled by our queries should be of type `HTTPError`
- all error messages we display should be parsed with `parseErrorMsg`


https://github.com/aiven/klaw/assets/20607294/a85c9f59-5f75-4b44-a9f2-325105f5071f


