### PR TITLE
refactor(coral): Remove template string where it could hide type errors.

### DIFF
--- a/coral/src/app/components/FileInput.tsx
+++ b/coral/src/app/components/FileInput.tsx
@@ -67,7 +67,7 @@ function FileInput(props: FileInputProps) {
             display={"flex"}
             alignItems={"center"}
             backgroundColor={"white"}
-            className={`${classes.fakeButton}`}
+            className={classes.fakeButton}
             onClick={handleWrapperClick}
             data-testid="file-input-fake-button"
           >
@@ -126,7 +126,7 @@ function FileInput(props: FileInputProps) {
               ref={inputRef}
               aria-required={props.required}
               aria-invalid={!valid}
-              className={`${classes.fileInput}`}
+              className={classes.fileInput}
               {...(!valid && { "aria-describedby": errorMessageId })}
             />
           </label>

--- a/coral/src/app/features/approvals/acls/components/AclApprovalsTable.test.tsx
+++ b/coral/src/app/features/approvals/acls/components/AclApprovalsTable.test.tsx
@@ -152,13 +152,19 @@ describe("AclApprovalsTable", () => {
     );
   });
 
-  it("has column to describe the ip addresses", () => {
+  it("has column to describe the list with ip addresses", () => {
     renderFromProps();
     expect(
       within(getNthRow(0)).getAllByRole("columnheader")[4]
     ).toHaveTextContent("IP addresses");
-    expect(within(getNthRow(2)).getAllByRole("cell")[4]).toHaveTextContent(
-      "3.3.3.32 3.3.3.33"
+
+    const row = within(getNthRow(2)).getAllByRole("cell")[4];
+
+    expect(within(row).getAllByRole("listitem")[0]).toHaveTextContent(
+      "3.3.3.32"
+    );
+    expect(within(row).getAllByRole("listitem")[1]).toHaveTextContent(
+      "3.3.3.33"
     );
   });
 
@@ -167,6 +173,7 @@ describe("AclApprovalsTable", () => {
     expect(
       within(getNthRow(0)).getAllByRole("columnheader")[5]
     ).toHaveTextContent("Team");
+
     expect(within(getNthRow(1)).getAllByRole("cell")[5]).toHaveTextContent(
       "Ospo"
     );
@@ -182,7 +189,7 @@ describe("AclApprovalsTable", () => {
     );
   });
 
-  it("has column to decsribe the request type", () => {
+  it("has column to describe the request type", () => {
     renderFromProps();
     expect(
       within(getNthRow(0)).getAllByRole("columnheader")[7]
@@ -272,17 +279,23 @@ describe("AclApprovalsTable", () => {
     expect(notPrefixedCells).toHaveLength(1);
   });
 
-  it("renders all values for cells who can have multiple values", () => {
+  it("renders a list for cells who can have multiple values", () => {
     renderFromProps();
     const cells = screen.getAllByRole("cell");
-    expect(
-      cells.filter((cell) => {
-        return cell.textContent === "mbasani maulbach ";
-      })
-    ).toHaveLength(1);
-    expect(
-      cells.filter((cell) => cell.textContent === "3.3.3.32 3.3.3.33 ")
-    ).toHaveLength(1);
+
+    const userNames = cells.filter((cell) => {
+      return cell.textContent === "mbasanimaulbach";
+    })[0];
+
+    expect(within(userNames).getByRole("list")).toBeVisible();
+    expect(within(userNames).getAllByRole("listitem")).toHaveLength(2);
+
+    const ipAdresses = cells.filter((cell) => {
+      return cell.textContent === "3.3.3.323.3.3.33";
+    })[0];
+
+    expect(within(ipAdresses).getByRole("list")).toBeVisible();
+    expect(within(ipAdresses).getAllByRole("listitem")).toHaveLength(2);
   });
 
   it("disables action buttons when status is not CREATED", () => {

--- a/coral/src/app/features/approvals/acls/components/AclApprovalsTable.tsx
+++ b/coral/src/app/features/approvals/acls/components/AclApprovalsTable.tsx
@@ -1,6 +1,6 @@
 import {
   StatusChip,
-  Flexbox,
+  Box,
   DataTable,
   DataTableColumn,
   EmptyState,
@@ -119,19 +119,13 @@ export default function AclApprovalsTable({
       headerName: "Principals/Usernames",
       UNSAFE_render: ({ acl_ssl }: AclRequestTableRow) => {
         return (
-          <Flexbox wrap={"wrap"} gap={"2"}>
+          <Box.Flex wrap={"wrap"} gap={"2"} component={"ul"}>
             {acl_ssl.map((ssl, index) => (
-              <StatusChip
-                dense
-                status="neutral"
-                key={`${ssl}-${index}`}
-                // We need to add a space after text value
-                // Otherwise a list of values would be rendered as value1value2value3 for screen readers
-                // Instead of value1 value2 value3
-                text={`${ssl} `}
-              />
+              <li key={`${ssl}-${index}`}>
+                <StatusChip dense status="neutral" text={ssl} />
+              </li>
             ))}
-          </Flexbox>
+          </Box.Flex>
         );
       },
     },
@@ -140,19 +134,13 @@ export default function AclApprovalsTable({
       headerName: "IP addresses",
       UNSAFE_render: ({ acl_ip }: AclRequestTableRow) => {
         return (
-          <Flexbox wrap={"wrap"} gap={"2"}>
+          <Box.Flex wrap={"wrap"} gap={"2"} component={"ul"}>
             {acl_ip.map((ip, index) => (
-              <StatusChip
-                dense
-                status="neutral"
-                key={`${ip}-${index}`}
-                // We need to add a space after text value
-                // Otherwise a list of values would be rendered as value1value2value3 for screen readers
-                // Instead of value1 value2 value3
-                text={`${ip} `}
-              />
+              <li key={`${ip}-${index}`}>
+                <StatusChip dense status="neutral" text={ip} />
+              </li>
             ))}
-          </Flexbox>
+          </Box.Flex>
         );
       },
     },

--- a/coral/src/app/features/components/AclDetailsModalContent.test.tsx
+++ b/coral/src/app/features/components/AclDetailsModalContent.test.tsx
@@ -105,12 +105,12 @@ describe("AclDetailsModalContent", () => {
     });
     it("renders Principals/Username", () => {
       expect(findTerm("Principals/Usernames")).toBeVisible();
-      expect(findDefinition("User:* ")).toBeVisible();
+      expect(findDefinition("User:*")).toBeVisible();
     });
     it("renders IP addresses", () => {
       expect(findTerm("IP addresses")).toBeVisible();
-      expect(findDefinition("3.3.3.32 ")).toBeVisible();
-      expect(findDefinition("3.3.3.33 ")).toBeVisible();
+      expect(findDefinition("3.3.3.32")).toBeVisible();
+      expect(findDefinition("3.3.3.33")).toBeVisible();
     });
     it("renders Consumer group default text", () => {
       expect(findTerm("Consumer group")).toBeVisible();
@@ -156,8 +156,8 @@ describe("AclDetailsModalContent", () => {
     });
     it("renders Principals/Username", () => {
       expect(findTerm("Principals/Usernames")).toBeVisible();
-      expect(findDefinition("mbasani ")).toBeVisible();
-      expect(findDefinition("maulbach ")).toBeVisible();
+      expect(findDefinition("mbasani")).toBeVisible();
+      expect(findDefinition("maulbach")).toBeVisible();
     });
     it("does not renders IP addresses", () => {
       expect(findTerm("IP addresses")).toBeUndefined();

--- a/coral/src/app/features/components/AclDetailsModalContent.tsx
+++ b/coral/src/app/features/components/AclDetailsModalContent.tsx
@@ -1,4 +1,4 @@
-import { Flexbox, Grid, GridItem, StatusChip } from "@aivenio/aquarium";
+import { Flexbox, Box, Grid, GridItem, StatusChip } from "@aivenio/aquarium";
 import { AclRequest } from "src/domain/acl/acl-types";
 
 interface DetailsModalContentProps {
@@ -59,13 +59,15 @@ const TopicDetailsModalContent = ({ request }: DetailsModalContentProps) => {
       <GridItem colSpan={"span-2"}>
         <Flexbox direction={"column"}>
           <Label>Principals/Usernames</Label>
-          <Flexbox direction={"row"} gap={"2"}>
+          <Box.Flex direction={"row"} gap={"2"} component={"ul"}>
             {acl_ssl.map((principal) => (
-              <dd key={principal}>
-                <StatusChip status={"neutral"} text={`${principal} `} />
-              </dd>
+              <li key={principal}>
+                <dd>
+                  <StatusChip status={"neutral"} text={principal} />
+                </dd>
+              </li>
             ))}
-          </Flexbox>
+          </Box.Flex>
         </Flexbox>
       </GridItem>
 
@@ -73,13 +75,15 @@ const TopicDetailsModalContent = ({ request }: DetailsModalContentProps) => {
         <GridItem colSpan={"span-2"}>
           <Flexbox direction={"column"}>
             <Label>IP addresses</Label>
-            <Flexbox direction={"row"} gap={"2"}>
+            <Box.Flex direction={"row"} gap={"2"} component={"ul"}>
               {acl_ip.map((ip) => (
-                <dd key={ip}>
-                  <StatusChip status={"neutral"} text={`${ip} `} />
-                </dd>
+                <li key={ip}>
+                  <dd>
+                    <StatusChip status={"neutral"} text={ip} />
+                  </dd>
+                </li>
               ))}
-            </Flexbox>
+            </Box.Flex>
           </Flexbox>
         </GridItem>
       )}

--- a/coral/src/app/features/connectors/browse/components/ConnectorTable.tsx
+++ b/coral/src/app/features/connectors/browse/components/ConnectorTable.tsx
@@ -62,14 +62,7 @@ function ConnectorTable(props: ConnectorTableProps) {
           <Box.Flex wrap={"wrap"} gap={"2"} component={"ul"}>
             {environmentsList?.map(({ name, id }) => (
               <li key={id}>
-                <StatusChip
-                  dense
-                  status="neutral"
-                  // We need to add a space after text value
-                  // Otherwise a list of values would be rendered as value1value2value3 for screen readers
-                  // Instead of value1 value2 value3
-                  text={name}
-                />
+                <StatusChip dense status="neutral" text={name} />
               </li>
             ))}
           </Box.Flex>

--- a/coral/src/app/features/requests/acls/components/AclRequestsTable.test.tsx
+++ b/coral/src/app/features/requests/acls/components/AclRequestsTable.test.tsx
@@ -146,7 +146,7 @@ describe("AclRequestsTable", () => {
       within(getNthRow(0)).getAllByRole("columnheader")[3]
     ).toHaveTextContent("IP addresses");
     expect(within(getNthRow(2)).getAllByRole("cell")[3]).toHaveTextContent(
-      "1.1.1.1 2.2.2.2"
+      "1.1.1.12.2.2.2"
     );
   });
 

--- a/coral/src/app/features/requests/acls/components/AclRequestsTable.tsx
+++ b/coral/src/app/features/requests/acls/components/AclRequestsTable.tsx
@@ -1,8 +1,8 @@
 import {
+  Box,
   DataTable,
   DataTableColumn,
   EmptyState,
-  Flexbox,
   StatusChip,
 } from "@aivenio/aquarium";
 import infoIcon from "@aivenio/aquarium/dist/src/icons/infoSign";
@@ -63,19 +63,13 @@ function AclRequestsTable({
       headerName: "Principals/Usernames",
       UNSAFE_render: ({ acl_ssl }: AclRequestTableRow) => {
         return (
-          <Flexbox wrap={"wrap"} gap={"2"}>
+          <Box.Flex wrap={"wrap"} gap={"2"} component={"ul"}>
             {acl_ssl.map((ssl, index) => (
-              <StatusChip
-                dense
-                status="neutral"
-                key={`${ssl}-${index}`}
-                // We need to add a space after text value
-                // Otherwise a list of values would be rendered as value1value2value3 for screen readers
-                // Instead of value1 value2 value3
-                text={`${ssl} `}
-              />
+              <li key={`${ssl}-${index}`}>
+                <StatusChip dense status="neutral" text={ssl} />
+              </li>
             ))}
-          </Flexbox>
+          </Box.Flex>
         );
       },
     },
@@ -84,19 +78,13 @@ function AclRequestsTable({
       headerName: "IP addresses",
       UNSAFE_render: ({ acl_ip }: AclRequestTableRow) => {
         return (
-          <Flexbox wrap={"wrap"} gap={"2"}>
+          <Box.Flex wrap={"wrap"} gap={"2"} component={"ul"}>
             {acl_ip.map((ip, index) => (
-              <StatusChip
-                dense
-                status="neutral"
-                key={`${ip}-${index}`}
-                // We need to add a space after text value
-                // Otherwise a list of values would be rendered as value1value2value3 for screen readers
-                // Instead of value1 value2 value3
-                text={`${ip} `}
-              />
+              <li key={`${ip}-${index}`}>
+                <StatusChip dense status="neutral" text={ip} />
+              </li>
             ))}
-          </Flexbox>
+          </Box.Flex>
         );
       },
     },

--- a/coral/src/app/features/topics/details/subscriptions/TopicSubscriptionsTable.tsx
+++ b/coral/src/app/features/topics/details/subscriptions/TopicSubscriptionsTable.tsx
@@ -111,19 +111,13 @@ const getColumns = (
       headerName: "Principals/Usernames",
       UNSAFE_render: ({ principals }: AclInfoListRow) => {
         return (
-          <Box display="flex" wrap={"wrap"} gap={"2"}>
+          <Box.Flex wrap={"wrap"} gap={"2"} component={"ul"}>
             {principals.map((principal, index) => (
-              <StatusChip
-                dense
-                status="neutral"
-                key={`${principal}-${index}`}
-                // We need to add a space after text value
-                // Otherwise a list of values would be rendered as value1value2value3 for screen readers
-                // Instead of value1 value2 value3
-                text={`${principal} `}
-              />
+              <li key={`${principal}-${index}`}>
+                <StatusChip dense status="neutral" text={principal} />
+              </li>
             ))}
-          </Box>
+          </Box.Flex>
         );
       },
     },
@@ -135,19 +129,13 @@ const getColumns = (
           return "*";
         }
         return (
-          <Box display="flex" wrap={"wrap"} gap={"2"}>
+          <Box.Flex wrap={"wrap"} gap={"2"} component={"ul"}>
             {ips.map((ip, index) => (
-              <StatusChip
-                dense
-                status="neutral"
-                key={`${ip}-${index}`}
-                // We need to add a space after text value
-                // Otherwise a list of values would be rendered as value1value2value3 for screen readers
-                // Instead of value1 value2 value3
-                text={`${ip} `}
-              />
+              <li key={`${ip}-${index}`}>
+                <StatusChip dense status="neutral" text={ip} />
+              </li>
             ))}
-          </Box>
+          </Box.Flex>
         );
       },
     },

--- a/coral/src/app/layout/main-navigation/MainNavigationSubmenuList.test.tsx
+++ b/coral/src/app/layout/main-navigation/MainNavigationSubmenuList.test.tsx
@@ -19,7 +19,7 @@ describe("MainNavigationSubmenuList.tsx", () => {
 
   const testMainNavigationLinks = subNavigationLinks.map((link, index) => {
     return (
-      <a key={`${index}`} href={`${link.href}`}>
+      <a key={`${index}`} href={link.href}>
         {link.name}
       </a>
     );


### PR DESCRIPTION
# About this change - What it does

We had a small bug, where the UI showed `[object Object]` instead of the name of an environmentList, after the environmentList changed from a list of string to a list of objects with `{ id, name }`. We didn't notice this in test/typescript, because we used literal string to pass the env information, like this: 

```
environmentList.map( ( env: string, index: number) => {

    return <element propertyThatIsTypedAsString={`$env} ` />

})
```

To prevent that from happening in the future, I replaced all usage of template strings in passing props where it could cause the same kind of error. 

Hope I found all 🤞 and it's a good learning to use template strings carefully :D 