### PR TITLE
Fix teamdelete

### DIFF
--- a/core/src/main/java/io/aiven/klaw/dao/Team.java
+++ b/core/src/main/java/io/aiven/klaw/dao/Team.java
@@ -55,4 +55,7 @@ public class Team implements Serializable {
 
   @Column(name = "otherparams")
   private String otherParams;
+
+  @Column(name = "active")
+  private boolean active;
 }

--- a/core/src/main/java/io/aiven/klaw/helpers/db/rdbms/DeleteDataJdbc.java
+++ b/core/src/main/java/io/aiven/klaw/helpers/db/rdbms/DeleteDataJdbc.java
@@ -212,11 +212,18 @@ public class DeleteDataJdbc {
 
   public String deleteTeamRequest(Integer teamId, int tenantId) {
     log.debug("deleteTeamRequest {}", teamId);
-    Team team = new Team();
-    team.setTeamId(teamId);
-    team.setTenantId(tenantId);
+    TeamID teamID = new TeamID();
+    teamID.setTeamId(teamId);
+    teamID.setTenantId(tenantId);
 
-    teamRepo.delete(team);
+    Optional<Team> teamOptional = teamRepo.findById(teamID);
+    if (teamOptional.isPresent()) {
+      Team teamFound = teamOptional.get();
+      teamFound.setActive(false);
+      teamFound.setTeamname(teamFound.getTeamname() + "-DELETED");
+      teamRepo.save(teamFound);
+    }
+
     return ApiResultStatus.SUCCESS.value;
   }
 

--- a/core/src/main/java/io/aiven/klaw/helpers/db/rdbms/InsertDataJdbc.java
+++ b/core/src/main/java/io/aiven/klaw/helpers/db/rdbms/InsertDataJdbc.java
@@ -311,6 +311,7 @@ public class InsertDataJdbc {
     int teamId = getNextTeamId(team.getTenantId());
     TeamID teamID = new TeamID(teamId, team.getTenantId());
     team.setTeamId(teamId);
+    team.setActive(true);
 
     Optional<Team> teamExists = teamRepo.findById(teamID);
     if (teamExists.isPresent()) {

--- a/core/src/main/java/io/aiven/klaw/helpers/db/rdbms/SelectDataJdbc.java
+++ b/core/src/main/java/io/aiven/klaw/helpers/db/rdbms/SelectDataJdbc.java
@@ -862,7 +862,7 @@ public class SelectDataJdbc {
   }
 
   public List<Team> selectAllTeams(int tenantId) {
-    return teamRepo.findAllByTenantId(tenantId);
+    return teamRepo.findAllByTenantId(tenantId).stream().filter(Team::isActive).toList();
   }
 
   public AclRequests selectAcl(int req_no, int tenantId) {
@@ -1801,7 +1801,7 @@ public class SelectDataJdbc {
   }
 
   public List<Team> selectTeams() {
-    return Lists.newArrayList(teamRepo.findAll());
+    return Lists.newArrayList(teamRepo.findAll()).stream().filter(Team::isActive).toList();
   }
 
   public List<KwProperties> selectKwProperties() {

--- a/core/src/main/java/io/aiven/klaw/helpers/db/rdbms/UpdateDataJdbc.java
+++ b/core/src/main/java/io/aiven/klaw/helpers/db/rdbms/UpdateDataJdbc.java
@@ -505,7 +505,7 @@ public class UpdateDataJdbc {
     log.debug("updateTeam {}", team);
     TeamID teamID = new TeamID(team.getTeamId(), team.getTenantId());
     Optional<Team> teamExists = teamRepo.findById(teamID);
-    if (teamExists.isEmpty()) {
+    if (teamExists.isEmpty() || !teamExists.get().isActive()) {
       return "Failure. Team doesn't exist";
     }
 

--- a/core/src/main/resources/db/changelog/changelog.yaml
+++ b/core/src/main/resources/db/changelog/changelog.yaml
@@ -1092,3 +1092,14 @@ databaseChangeLog:
                     name: locked_by
                     type: VARCHAR2(255)
               tableName: kwshedlock
+    - changeSet:
+        id: 29-06-2023 Column if team is active or deleted
+        author: muralibasani
+        changes:
+          - addColumn:
+              columns:
+                - column:
+                    name: active
+                    type: BOOLEAN
+                    defaultValue: true
+              tableName: kwteams

--- a/core/src/test/java/io/aiven/klaw/UsersTeamsControllerIT.java
+++ b/core/src/test/java/io/aiven/klaw/UsersTeamsControllerIT.java
@@ -268,6 +268,20 @@ public class UsersTeamsControllerIT {
 
     response =
         mvc.perform(
+                MockMvcRequestBuilders.get("/getAllTeamsSU")
+                    .with(user(superAdmin).password(superAdminPwd))
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .accept(MediaType.APPLICATION_JSON))
+            .andExpect(status().isOk())
+            .andReturn()
+            .getResponse()
+            .getContentAsString();
+    List<TeamModelResponse> teamModels =
+        OBJECT_MAPPER.readValue(response, new TypeReference<>() {});
+    assertThat(teamModels).hasSize(3);
+
+    response =
+        mvc.perform(
                 MockMvcRequestBuilders.post("/deleteTeamRequest")
                     .with(user(superAdmin).password(superAdminPwd))
                     .param("teamId", "1004")
@@ -293,8 +307,22 @@ public class UsersTeamsControllerIT {
             .andReturn()
             .getResponse()
             .getContentAsString();
+    TeamModelResponse teamModelResponse =
+        OBJECT_MAPPER.readValue(response, new TypeReference<>() {});
+    assertThat(teamModelResponse.getTeamname()).isEqualTo(newTeam + "-DELETED");
 
-    assertThat(response).isEmpty();
+    response =
+        mvc.perform(
+                MockMvcRequestBuilders.get("/getAllTeamsSU")
+                    .with(user(superAdmin).password(superAdminPwd))
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .accept(MediaType.APPLICATION_JSON))
+            .andExpect(status().isOk())
+            .andReturn()
+            .getResponse()
+            .getContentAsString();
+    teamModels = OBJECT_MAPPER.readValue(response, new TypeReference<>() {});
+    assertThat(teamModels).hasSize(2);
   }
 
   // Delete team failure
@@ -369,7 +397,7 @@ public class UsersTeamsControllerIT {
 
     List<TeamModelResponse> teamModels =
         OBJECT_MAPPER.readValue(response, new TypeReference<>() {});
-    assertThat(teamModels).hasSize(3);
+    assertThat(teamModels).hasSize(2);
   }
 
   // Create user with USER role, switch teams

--- a/core/src/test/java/io/aiven/klaw/UtilMethods.java
+++ b/core/src/test/java/io/aiven/klaw/UtilMethods.java
@@ -432,6 +432,7 @@ public class UtilMethods {
     team.setTenantId(101);
     team.setTeamphone("3142342343242");
     team.setTeammail("test@test.com");
+    team.setActive(true);
 
     ServiceAccounts serviceAccounts = new ServiceAccounts();
     Set<String> serviceAccountsList = new HashSet<>();


### PR DESCRIPTION
About this change - What it does

On deletion of a team
- make the team inactive, and filter it when getting all the teams
- rename the team name to team-DELETED
- never retrieve this team anytime, except if its already in any completed requests, the name is displayed based on id.

Resolves: #xxxxx
Why this way
to keep track of all teams even after deleted, so all requests are traceable
