### PR TITLE
fix(coral): Fix flash of stale content on TopicOverview

### DIFF
--- a/coral/src/app/features/topics/details/TopicDetails.tsx
+++ b/coral/src/app/features/topics/details/TopicDetails.tsx
@@ -53,8 +53,8 @@ function TopicDetails(props: TopicOverviewProps) {
     data: topicData,
     isError: topicIsError,
     error: topicError,
-    isFetching: topicIsFetching,
-  } = useQuery(["topic-overview", environmentId], {
+    isLoading: topicIsLoading,
+  } = useQuery(["topic-overview", topicName, environmentId], {
     queryFn: () => getTopicOverview({ topicName, environmentId }),
   });
 
@@ -62,8 +62,8 @@ function TopicDetails(props: TopicOverviewProps) {
     data: schemaData,
     isError: schemaIsError,
     error: schemaError,
-    isFetching: schemaIsFetching,
-  } = useQuery(["schema-overview", environmentId, schemaVersion], {
+    isLoading: schemaIsLoading,
+  } = useQuery(["schema-overview", topicName, environmentId, schemaVersion], {
     queryFn: () => {
       if (environmentId !== undefined) {
         return getSchemaOfTopic({
@@ -91,7 +91,7 @@ function TopicDetails(props: TopicOverviewProps) {
       />
 
       <TopicOverviewResourcesTabs
-        isLoading={topicIsFetching || schemaIsFetching}
+        isLoading={topicIsLoading || schemaIsLoading}
         isError={topicIsError || schemaIsError}
         error={topicError || schemaError}
         currentTab={currentTab}

--- a/coral/src/app/features/topics/details/TopicDetails.tsx
+++ b/coral/src/app/features/topics/details/TopicDetails.tsx
@@ -53,8 +53,7 @@ function TopicDetails(props: TopicOverviewProps) {
     data: topicData,
     isError: topicIsError,
     error: topicError,
-    isLoading: topicIsLoading,
-    isFetched: topicDataFetched,
+    isFetching: topicIsFetching,
   } = useQuery(["topic-overview", environmentId], {
     queryFn: () => getTopicOverview({ topicName, environmentId }),
   });
@@ -63,8 +62,7 @@ function TopicDetails(props: TopicOverviewProps) {
     data: schemaData,
     isError: schemaIsError,
     error: schemaError,
-    isLoading: schemaIsLoading,
-    isFetched: schemaDataFetched,
+    isFetching: schemaIsFetching,
   } = useQuery(["schema-overview", environmentId, schemaVersion], {
     queryFn: () => {
       if (environmentId !== undefined) {
@@ -93,7 +91,7 @@ function TopicDetails(props: TopicOverviewProps) {
       />
 
       <TopicOverviewResourcesTabs
-        isLoading={topicIsLoading || schemaIsLoading}
+        isLoading={topicIsFetching || schemaIsFetching}
         isError={topicIsError || schemaIsError}
         error={topicError || schemaError}
         currentTab={currentTab}
@@ -101,9 +99,8 @@ function TopicDetails(props: TopicOverviewProps) {
         // These state setters are used refresh the queries with the correct params...
         // ...when a user selects schema version
         setSchemaVersion={setSchemaVersion}
-        // We pass undefined when data is not fetched to avoid flash of stale data in the UI
-        topicOverview={topicDataFetched ? topicData : undefined}
-        topicSchemas={schemaDataFetched ? schemaData : undefined}
+        topicOverview={topicData}
+        topicSchemas={schemaData}
       />
     </div>
   );


### PR DESCRIPTION
## What the problem is

`isLoading` only is `true` on first load, not on refetch. Therefore, when navigating through different topics, we have a flash of stale content showing : 


https://github.com/aiven/klaw/assets/20607294/ea09e0ef-1a53-4c1b-9694-4c0e21e6c161

## What the fix is 

~~Use `isFetching`, which will be `true` on first load and subsequent fetches. This flashes the loader, which is more appropriate.~~

Use exhaustive keys in our queries so that the cache is properly invalidated when navigating to different topics, but still preserved when appropriate.

https://github.com/aiven/klaw/assets/20607294/5ad88229-7c67-4f7c-87f4-bb5a676ba6a2







## Follow up

Probably would be even more graceful after implementing this: https://github.com/aiven/klaw/issues/1296


