### PR TITLE
TopicOverview additional and updated booleans

### DIFF
--- a/coral/src/app/features/topics/details/TopicDetails.test.tsx
+++ b/coral/src/app/features/topics/details/TopicDetails.test.tsx
@@ -28,7 +28,6 @@ const mockGetSchemaOfTopic = getSchemaOfTopic as jest.MockedFunction<
 const testTopicName = "my-nice-topic";
 const testTopicOverview: TopicOverview = {
   topicExists: true,
-  schemaExists: false,
   prefixAclsExists: false,
   txnAclsExists: false,
   topicInfo: {
@@ -42,8 +41,12 @@ const testTopicOverview: TopicOverview = {
     showDeleteTopic: false,
     topicDeletable: false,
     envName: "DEV",
-    hasOpenACLRequest: true,
-    hasOpenRequest: true,
+    hasACL: false,
+    hasOpenTopicRequest: false,
+    hasOpenACLRequest: false,
+    highestEnv: true,
+    hasOpenRequest: false,
+    hasSchema: false,
   },
   aclInfoList: [
     {

--- a/coral/src/app/features/topics/details/components/TopicDetailsResourceTabs.test.tsx
+++ b/coral/src/app/features/topics/details/components/TopicDetailsResourceTabs.test.tsx
@@ -49,7 +49,6 @@ const testTopicName = "my-nice-topic";
 
 const testTopicOverview: TopicOverview = {
   topicExists: true,
-  schemaExists: false,
   prefixAclsExists: false,
   txnAclsExists: false,
   topicInfo: {
@@ -63,8 +62,12 @@ const testTopicOverview: TopicOverview = {
     showDeleteTopic: false,
     topicDeletable: false,
     envName: "DEV",
-    hasOpenACLRequest: true,
-    hasOpenRequest: true,
+    hasACL: false,
+    hasOpenTopicRequest: false,
+    hasOpenACLRequest: false,
+    highestEnv: true,
+    hasOpenRequest: false,
+    hasSchema: false,
   },
   aclInfoList: [
     {

--- a/coral/src/app/features/topics/details/documentation/TopicDocumentation.test.tsx
+++ b/coral/src/app/features/topics/details/documentation/TopicDocumentation.test.tsx
@@ -23,7 +23,6 @@ const mockUpdateTopicDocumentation =
 const testTopicOverview: TopicOverview = {
   availableEnvironments: [],
   prefixAclsExists: false,
-  schemaExists: false,
   txnAclsExists: false,
   topicPromotionDetails: { status: "" },
   topicIdForDocumentation: 99999,

--- a/coral/src/app/features/topics/details/history/TopicHistory.test.tsx
+++ b/coral/src/app/features/topics/details/history/TopicHistory.test.tsx
@@ -27,7 +27,6 @@ const testTopicHistoryList = [
 ];
 const testTopicOverview: TopicOverview = {
   topicExists: true,
-  schemaExists: false,
   prefixAclsExists: false,
   txnAclsExists: false,
   topicInfo: {
@@ -41,8 +40,12 @@ const testTopicOverview: TopicOverview = {
     topicDeletable: false,
     envName: "DEV",
     topicName: "my awesome topic",
-    hasOpenACLRequest: true,
-    hasOpenRequest: true,
+    hasACL: false,
+    hasOpenTopicRequest: false,
+    hasOpenACLRequest: false,
+    highestEnv: true,
+    hasOpenRequest: false,
+    hasSchema: false,
   },
   aclInfoList: [],
   prefixedAclInfoList: [],

--- a/coral/src/app/features/topics/details/settings/TopicSettings.test.tsx
+++ b/coral/src/app/features/topics/details/settings/TopicSettings.test.tsx
@@ -34,13 +34,15 @@ const testTopicInfo: KlawApiModel<"TopicOverviewInfo"> = {
   topicDeletable: true,
   envName: "DEV",
   topicOwner: true,
+  hasACL: false,
+  hasOpenTopicRequest: false,
   hasOpenACLRequest: false,
   highestEnv: true,
   hasOpenRequest: false,
+  hasSchema: false,
 };
 const testTopicOverview: TopicOverview = {
   topicExists: true,
-  schemaExists: false,
   prefixAclsExists: false,
   txnAclsExists: false,
   topicInfo: testTopicInfo,

--- a/coral/src/app/features/topics/details/subscriptions/TopicSubscriptions.test.tsx
+++ b/coral/src/app/features/topics/details/subscriptions/TopicSubscriptions.test.tsx
@@ -68,7 +68,6 @@ jest.mock("react-router-dom", () => ({
 const testTopicName = "aiventopic1";
 const testTopicOverview: TopicOverview = {
   topicExists: true,
-  schemaExists: false,
   prefixAclsExists: false,
   txnAclsExists: false,
   topicInfo: {
@@ -82,8 +81,12 @@ const testTopicOverview: TopicOverview = {
     topicDeletable: false,
     envName: "DEV",
     topicName: testTopicName,
-    hasOpenACLRequest: true,
-    hasOpenRequest: true,
+    hasACL: false,
+    hasOpenTopicRequest: false,
+    hasOpenACLRequest: false,
+    highestEnv: true,
+    hasOpenRequest: false,
+    hasSchema: false,
   },
   aclInfoList: [
     {

--- a/coral/src/app/features/topics/details/utils.test.ts
+++ b/coral/src/app/features/topics/details/utils.test.ts
@@ -3,7 +3,6 @@ import { TopicOverview } from "src/domain/topic";
 
 const mockUseTopicDetailsDataWithAcl: TopicOverview = {
   topicExists: true,
-  schemaExists: false,
   prefixAclsExists: false,
   txnAclsExists: false,
   topicInfo: {
@@ -17,8 +16,12 @@ const mockUseTopicDetailsDataWithAcl: TopicOverview = {
     showDeleteTopic: false,
     topicDeletable: false,
     envName: "DEV",
-    hasOpenACLRequest: true,
-    hasOpenRequest: true,
+    hasACL: false,
+    hasOpenTopicRequest: false,
+    hasOpenACLRequest: false,
+    highestEnv: true,
+    hasOpenRequest: false,
+    hasSchema: false,
   },
   aclInfoList: [
     {
@@ -63,7 +66,6 @@ const mockUseTopicDetailsDataWithAcl: TopicOverview = {
 
 const mockUseTopicDetailsDataWithoutAcl: TopicOverview = {
   topicExists: true,
-  schemaExists: false,
   prefixAclsExists: false,
   txnAclsExists: false,
   topicInfo: {
@@ -77,8 +79,12 @@ const mockUseTopicDetailsDataWithoutAcl: TopicOverview = {
     showDeleteTopic: false,
     topicDeletable: false,
     envName: "DEV",
-    hasOpenACLRequest: true,
-    hasOpenRequest: true,
+    hasACL: false,
+    hasOpenTopicRequest: false,
+    hasOpenACLRequest: false,
+    highestEnv: true,
+    hasOpenRequest: false,
+    hasSchema: false,
   },
   aclInfoList: [],
   topicHistoryList: [

--- a/coral/src/domain/topic/topic-transformer.test.ts
+++ b/coral/src/domain/topic/topic-transformer.test.ts
@@ -195,7 +195,6 @@ describe("topic-transformer.ts", () => {
     it("transforms topic overview from backend with only required properties", async () => {
       const mockedResponse: KlawApiResponse<"getTopicOverview"> = {
         topicExists: false,
-        schemaExists: false,
         prefixAclsExists: false,
         txnAclsExists: false,
         topicInfoList: [
@@ -209,8 +208,12 @@ describe("topic-transformer.ts", () => {
             showEditTopic: false,
             showDeleteTopic: false,
             topicDeletable: false,
-            hasOpenRequest: false,
+            hasOpenTopicRequest: false,
             hasOpenACLRequest: false,
+            highestEnv: true,
+            hasOpenRequest: false,
+            hasSchema: false,
+            hasACL: false,
             envName: "DEV",
           },
         ],
@@ -228,14 +231,17 @@ describe("topic-transformer.ts", () => {
       const result: TopicOverview = {
         availableEnvironments: [],
         prefixAclsExists: false,
-        schemaExists: false,
         topicExists: false,
         topicIdForDocumentation: 1,
         topicInfo: {
           envId: "4",
           envName: "DEV",
+          hasOpenTopicRequest: false,
           hasOpenACLRequest: false,
+          highestEnv: true,
           hasOpenRequest: false,
+          hasSchema: false,
+          hasACL: false,
           noOfPartitions: 1,
           noOfReplicas: "2",
           showDeleteTopic: false,
@@ -257,7 +263,6 @@ describe("topic-transformer.ts", () => {
     it("transforms topic overview from backend with all properties", async () => {
       const mockedResponse: KlawApiResponse<"getTopicOverview"> = {
         topicExists: false,
-        schemaExists: false,
         prefixAclsExists: false,
         txnAclsExists: false,
         topicInfoList: [
@@ -271,8 +276,12 @@ describe("topic-transformer.ts", () => {
             showEditTopic: false,
             showDeleteTopic: false,
             topicDeletable: false,
-            hasOpenRequest: false,
+            hasOpenTopicRequest: false,
             hasOpenACLRequest: false,
+            highestEnv: true,
+            hasOpenRequest: false,
+            hasSchema: false,
+            hasACL: false,
             envName: "DEV",
           },
         ],
@@ -344,14 +353,17 @@ describe("topic-transformer.ts", () => {
       const result: TopicOverview = {
         availableEnvironments: [],
         prefixAclsExists: false,
-        schemaExists: false,
         topicExists: false,
         topicIdForDocumentation: 1,
         topicInfo: {
           envId: "4",
           envName: "DEV",
+          hasOpenTopicRequest: false,
           hasOpenACLRequest: false,
+          highestEnv: true,
           hasOpenRequest: false,
+          hasSchema: false,
+          hasACL: false,
           noOfPartitions: 1,
           noOfReplicas: "2",
           showDeleteTopic: false,

--- a/coral/types/api.d.ts
+++ b/coral/types/api.d.ts
@@ -1059,7 +1059,6 @@ export type components = {
     };
     TopicOverview: {
       topicExists: boolean;
-      schemaExists: boolean;
       prefixAclsExists: boolean;
       txnAclsExists: boolean;
       topicInfoList: (components["schemas"]["TopicOverviewInfo"])[];
@@ -1086,7 +1085,10 @@ export type components = {
       showDeleteTopic: boolean;
       topicDeletable: boolean;
       hasOpenRequest: boolean;
+      hasOpenTopicRequest: boolean;
       hasOpenACLRequest: boolean;
+      hasACL: boolean;
+      hasSchema: boolean;
       envName: string;
       advancedTopicConfiguration?: {
         [key: string]: string | undefined;
@@ -1330,7 +1332,6 @@ export type components = {
     };
     SchemaOverview: {
       topicExists: boolean;
-      schemaExists: boolean;
       prefixAclsExists: boolean;
       txnAclsExists: boolean;
       allSchemaVersions?: (number)[];

--- a/core/src/main/java/io/aiven/klaw/config/ManageDatabase.java
+++ b/core/src/main/java/io/aiven/klaw/config/ManageDatabase.java
@@ -34,6 +34,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.BeansException;
@@ -98,7 +99,7 @@ public class ManageDatabase implements ApplicationContextAware, InitializingBean
 
   // key tenantId, sub key clusterid Pertenant
   private static Map<Integer, Map<Integer, KwClusters>> kwKafkaConnectClustersPertenant;
-
+  private static Map<Integer, Map<String, Env>> envMapPerTenant = new HashMap<>();
   private static Map<Integer, List<Env>> kafkaEnvListPerTenant = new HashMap<>();
   private static Map<Integer, List<Env>> schemaRegEnvListPerTenant = new HashMap<>();
   private static Map<Integer, List<Env>> kafkaConnectEnvListPerTenant = new HashMap<>();
@@ -296,6 +297,13 @@ public class ManageDatabase implements ApplicationContextAware, InitializingBean
       allClustersSize += kwKafkaClustersPertenant.get(tenantId).size();
     }
     return allClustersSize;
+  }
+
+  public Map<String, Env> getEnvMap(int tenantId) {
+    if (!envMapPerTenant.containsKey(tenantId)) {
+      return new HashMap<>();
+    }
+    return envMapPerTenant.get(tenantId);
   }
 
   public List<Env> getKafkaEnvList(int tenantId) {
@@ -722,6 +730,11 @@ public class ManageDatabase implements ApplicationContextAware, InitializingBean
       envParamsMap.put(env.getId(), env.getParams());
     }
     envParamsMapPerTenant.put(tenantId, envParamsMap);
+
+    //
+    List<Env> allEnvs = handleDbRequests.getAllEnvs(tenantId);
+    envMapPerTenant.put(
+        tenantId, allEnvs.stream().collect(Collectors.toMap(Env::getId, Function.identity())));
   }
 
   public Map<String, List<String>> getRolesPermissionsPerTenant(int tenantId) {

--- a/core/src/main/java/io/aiven/klaw/model/TopicOverviewInfo.java
+++ b/core/src/main/java/io/aiven/klaw/model/TopicOverviewInfo.java
@@ -31,6 +31,8 @@ public class TopicOverviewInfo {
 
   @NotNull private boolean hasOpenRequest;
 
+  @NotNull private boolean hasOpenTopicRequest;
+
   @NotNull private boolean hasOpenACLRequest;
 
   @NotNull private boolean hasACL;

--- a/core/src/main/java/io/aiven/klaw/model/TopicOverviewInfo.java
+++ b/core/src/main/java/io/aiven/klaw/model/TopicOverviewInfo.java
@@ -25,13 +25,17 @@ public class TopicOverviewInfo {
 
   @NotNull private boolean topicDeletable;
 
-  @NotNull private boolean hasOpenRequest;
-
   @NotNull private boolean isTopicOwner;
 
   @NotNull private boolean isHighestEnv;
 
+  @NotNull private boolean hasOpenRequest;
+
   @NotNull private boolean hasOpenACLRequest;
+
+  @NotNull private boolean hasACL;
+
+  @NotNull private boolean hasSchema;
 
   @NotNull private String envName;
 

--- a/core/src/main/java/io/aiven/klaw/model/response/ResourceOverviewAttributes.java
+++ b/core/src/main/java/io/aiven/klaw/model/response/ResourceOverviewAttributes.java
@@ -6,7 +6,6 @@ import lombok.Data;
 @Data
 public class ResourceOverviewAttributes {
   @NotNull boolean topicExists;
-  @NotNull boolean schemaExists;
   @NotNull boolean prefixAclsExists;
   @NotNull boolean txnAclsExists;
 }

--- a/core/src/main/java/io/aiven/klaw/service/SchemaOverviewService.java
+++ b/core/src/main/java/io/aiven/klaw/service/SchemaOverviewService.java
@@ -122,7 +122,7 @@ public class SchemaOverviewService extends BaseOverviewService {
                 topicSchemaVersionsInDb,
                 schemaUpdated,
                 schemaObjects);
-
+        log.info("SchemaObjects {}", schemaObjects);
         // If the schemaObject is null ie does not exist do not try to manipulate it.
         if (schemaObjects != null && !schemaObjects.isEmpty()) {
           Set<Integer> allVersions = schemaObjects.keySet();
@@ -180,8 +180,6 @@ public class SchemaOverviewService extends BaseOverviewService {
           schemaOfObj = WRITER_WITH_DEFAULT_PRETTY_PRINTER.writeValueAsString(dynamicObj);
           schemaDetailsPerEnv.setContent(schemaOfObj);
 
-          //            schemaDetails.add(schemaDetailsPerEnv);
-          schemaOverview.setSchemaExists(true);
           // A team owns a topic across all environments so we can assume if the search returned
           // one or more topics it is owned by this users team.
           if (topics.size() > 0) {
@@ -199,7 +197,7 @@ public class SchemaOverviewService extends BaseOverviewService {
         log.error("Error ", e);
       }
 
-      if (schemaOverview.isSchemaExists()) {
+      if (schemaDetailsPerEnv.getContent() != null) {
         log.debug("SchemaDetails {}", schemaDetailsPerEnv);
         schemaOverview.setSchemaDetailsPerEnv(schemaDetailsPerEnv);
       }

--- a/core/src/main/resources/static/js/browseAcls.js
+++ b/core/src/main/resources/static/js/browseAcls.js
@@ -1,19 +1,19 @@
 'use strict'
 
 // confirmation of delete
-// edit 
+// edit
 // solution for transaction
 // message store / key / gui
 var app = angular.module('browseAclsApp',['textAngular']);
 
 app.controller("browseAclsCtrl", function($scope, $http, $location, $window) {
-	
+
 	// Set http service defaults
 	// We force the "Accept" header to be only "application/json"
 	// otherwise we risk the Accept header being set by default to:
 	// "application/json; text/plain" and this can result in us
 	// getting a "text/plain" response which is not able to be
-	// parsed. 
+	// parsed.
 	//$http.defaults.headers.common['Accept'] = 'application/json';
 	$scope.envSelectedParam;
 
@@ -218,7 +218,7 @@ app.controller("browseAclsCtrl", function($scope, $http, $location, $window) {
 			$scope.checkPendingApprovals = function() {
                 if($scope.dashboardDetails.pendingApprovalsRedirectionPage === '')
                     return;
-                
+
                 if(sessionStorage.getItem("pending_reqs_shown") === null){
                     $scope.redirectToPendingReqs($scope.dashboardDetails.pendingApprovalsRedirectionPage);
                     sessionStorage.setItem("pending_reqs_shown", "true");
@@ -646,6 +646,10 @@ app.controller("browseAclsCtrl", function($scope, $http, $location, $window) {
 		        $scope.resultBrowsePrefix = output.prefixedAclInfoList;
 		        $scope.resultBrowseTxnId = output.transactionalAclInfoList;
             	$scope.topicOverview = output.topicInfoList;
+            	if($scope.topicOverview.length >0) {
+            	$scope.schemaExists = $scope.topicOverview[0].hasSchema;
+            	}
+
             	$scope.topicPromotionDetails = output.topicPromotionDetails;
                 $scope.topicPromotionDetails = output.topicPromotionDetails;
             	$scope.availableEnvironments = output.availableEnvironments;
@@ -653,7 +657,6 @@ app.controller("browseAclsCtrl", function($scope, $http, $location, $window) {
                     $scope.topicOverviewEnvId = $scope.availableEnvironments[0].id;
                 }
 
-            	$scope.schemaExists = output.schemaExists;
             	$scope.prefixAclsExists = output.prefixAclsExists;
             	$scope.txnAclsExists = output.txnAclsExists;
                 $scope.topicHistoryList = output.topicHistoryList;
@@ -666,13 +669,13 @@ app.controller("browseAclsCtrl", function($scope, $http, $location, $window) {
 		    else
 		        $window.location.href = $window.location.origin + $scope.dashboardDetails.contextPath + "/browseTopics";
 		}).error(
-			function(error) 
+			function(error)
 			{
 			    $scope.ShowSpinnerStatusTopics = false;
 				$scope.alert = error;
 			}
 		);
-		
+
 	}
 
     $scope.getSchemaOfTopic = function(){
@@ -700,7 +703,7 @@ app.controller("browseAclsCtrl", function($scope, $http, $location, $window) {
                 $scope.ShowSpinnerStatusSchemas = false;
                 if(output.schemaDetailsPerEnv ){
                     $scope.schemaDetails = output.schemaDetailsPerEnv;
-                    $scope.schemaExists = output.schemaExists;
+                    $scope.schemaExists = output.allSchemaVersions.length > 0;
                     $scope.schemaPromotionDetails = output.schemaPromotionDetails;
                     $scope.allSchemaVersions = output.allSchemaVersions;
                     $scope.displayedSchemaVersion = $scope.schemaDetails.version;

--- a/core/src/test/java/io/aiven/klaw/service/SchemaOverviewServiceTest.java
+++ b/core/src/test/java/io/aiven/klaw/service/SchemaOverviewServiceTest.java
@@ -139,7 +139,6 @@ public class SchemaOverviewServiceTest {
 
     SchemaOverview returnedValue = schemaOverviewService.getSchemaOfTopic(TESTTOPIC, 3, "1");
     assertThat(returnedValue.getSchemaPromotionDetails()).isNull();
-    assertThat(returnedValue.isSchemaExists()).isFalse();
   }
 
   @Test

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -6912,9 +6912,6 @@
           "topicExists" : {
             "type" : "boolean"
           },
-          "schemaExists" : {
-            "type" : "boolean"
-          },
           "prefixAclsExists" : {
             "type" : "boolean"
           },
@@ -6968,7 +6965,7 @@
             "format" : "int32"
           }
         },
-        "required" : [ "availableEnvironments", "prefixAclsExists", "schemaExists", "topicExists", "topicIdForDocumentation", "topicInfoList", "topicPromotionDetails", "txnAclsExists" ]
+        "required" : [ "availableEnvironments", "prefixAclsExists", "topicExists", "topicIdForDocumentation", "topicInfoList", "topicPromotionDetails", "txnAclsExists" ]
       },
       "TopicOverviewInfo" : {
         "properties" : {
@@ -7004,7 +7001,16 @@
           "hasOpenRequest" : {
             "type" : "boolean"
           },
+          "hasOpenTopicRequest" : {
+            "type" : "boolean"
+          },
           "hasOpenACLRequest" : {
+            "type" : "boolean"
+          },
+          "hasACL" : {
+            "type" : "boolean"
+          },
+          "hasSchema" : {
             "type" : "boolean"
           },
           "envName" : {
@@ -7023,7 +7029,7 @@
             "type" : "boolean"
           }
         },
-        "required" : [ "envId", "envName", "hasOpenACLRequest", "hasOpenRequest", "noOfPartitions", "noOfReplicas", "showDeleteTopic", "showEditTopic", "teamId", "teamname", "topicDeletable", "topicName" ]
+        "required" : [ "envId", "envName", "hasACL", "hasOpenACLRequest", "hasOpenRequest", "hasOpenTopicRequest", "hasSchema", "noOfPartitions", "noOfReplicas", "showDeleteTopic", "showEditTopic", "teamId", "teamname", "topicDeletable", "topicName" ]
       },
       "TopicDetailsPerEnv" : {
         "properties" : {
@@ -7703,9 +7709,6 @@
           "topicExists" : {
             "type" : "boolean"
           },
-          "schemaExists" : {
-            "type" : "boolean"
-          },
           "prefixAclsExists" : {
             "type" : "boolean"
           },
@@ -7730,7 +7733,7 @@
             "$ref" : "#/components/schemas/SchemaDetailsPerEnv"
           }
         },
-        "required" : [ "prefixAclsExists", "schemaExists", "schemaPromotionDetails", "topicExists", "txnAclsExists" ]
+        "required" : [ "prefixAclsExists", "schemaPromotionDetails", "topicExists", "txnAclsExists" ]
       },
       "KwReport" : {
         "properties" : {


### PR DESCRIPTION
About this change - What it does
This change removes  from the TopicOverview
schemaExists 
Adds to the TopicOverview
 hasACL: This topic has an active ACL/Subscription in this env
 hasOpenTopicRequest: This topic has a request to claim/update/delete etc topic request in this env
 hasSchema: This Topic Request has a Schema attched to it  in this env

Updates in the TopicOverview
 hasOpenACLRequest: This topic has an acl request attached to it in this env
 hasOpenRequest: This topic has an open request attached to it in this env (at least one of schema/topic/acl)

Resolves: #xxxxx
Why this way
