### PR TITLE
fix(coral): Show appropriate message when not authorized to see password

### DIFF
--- a/coral/src/app/features/topics/details/subscriptions/components/TopicSubscriptionsDetailsModal.test.tsx
+++ b/coral/src/app/features/topics/details/subscriptions/components/TopicSubscriptionsDetailsModal.test.tsx
@@ -40,6 +40,10 @@ const testServiceAccountData = {
   accountFound: true,
 };
 
+const notOwnerTestServiceAccountData = {
+  accountFound: false,
+};
+
 const testOffsetsData = {
   topicPartitionId: "0",
   currentOffset: "0",
@@ -61,6 +65,7 @@ const testSelectedSubAiven: AclOverviewInfo = {
   showDeleteAcl: true,
   kafkaFlavorType: "AIVEN_FOR_APACHE_KAFKA",
 };
+
 const testSelectedSubNonAiven: AclOverviewInfo = {
   req_no: "1006",
   acl_ip: "0.0.0.0",
@@ -76,6 +81,21 @@ const testSelectedSubNonAiven: AclOverviewInfo = {
   kafkaFlavorType: "APACHE_KAFKA",
 };
 
+const testNotOwnerSelectedSubAiven: AclOverviewInfo = {
+  req_no: "1006",
+  acl_ssl: "Not Authorized to see this",
+  topicname: "aivtopic3",
+  topictype: "Producer",
+  consumergroup: "-na-",
+  environment: "1",
+  environmentName: "DEV",
+  teamname: "Ospo",
+  teamid: 1003,
+  aclPatternType: "LITERAL",
+  showDeleteAcl: true,
+  kafkaFlavorType: "AIVEN_FOR_APACHE_KAFKA",
+};
+
 const defaultPropsAiven = {
   closeDetailsModal: mockCloseDetailsModal,
   isAivenCluster: true,
@@ -87,6 +107,13 @@ const defaultPropsNonAiven = {
   closeDetailsModal: mockCloseDetailsModal,
   isAivenCluster: false,
   selectedSubscription: testSelectedSubNonAiven,
+  offsetsData: testOffsetsData,
+};
+
+const defaultPropsNotOwnerAiven = {
+  closeDetailsModal: mockCloseDetailsModal,
+  isAivenCluster: true,
+  selectedSubscription: testNotOwnerSelectedSubAiven,
   offsetsData: testOffsetsData,
 };
 
@@ -109,6 +136,7 @@ describe("TopicSubscriptionsDetailsModal.tsx", () => {
 
   afterEach(() => {
     cleanup();
+    jest.clearAllMocks();
   });
 
   it("should render correct data in details modal (Aiven)", async () => {
@@ -214,5 +242,64 @@ describe("TopicSubscriptionsDetailsModal.tsx", () => {
     expect(
       screen.queryByText("Service account password")
     ).not.toBeInTheDocument();
+  });
+
+  it("should render correct data in details modal (Aiven consumer, non owner user)", async () => {
+    mockGetAivenServiceAccountDetails.mockResolvedValue(
+      notOwnerTestServiceAccountData
+    );
+
+    customRender(
+      <TopicSubscriptionsDetailsModal {...defaultPropsNotOwnerAiven} />,
+      {
+        queryClient: true,
+      }
+    );
+
+    await waitForElementToBeRemoved(screen.getByTestId("pw-skeleton"));
+
+    expect(findTerm("Environment")).toBeVisible();
+    expect(
+      findDefinition(
+        defaultPropsNotOwnerAiven.selectedSubscription.environmentName
+      )
+    ).toBeVisible();
+
+    expect(findTerm("Subscription type")).toBeVisible();
+    expect(
+      findDefinition(
+        defaultPropsNotOwnerAiven.selectedSubscription.topictype.toUpperCase()
+      )
+    ).toBeVisible();
+
+    expect(findTerm("Pattern type")).toBeVisible();
+    expect(
+      findDefinition(
+        defaultPropsNotOwnerAiven.selectedSubscription.aclPatternType
+      )
+    ).toBeVisible();
+
+    expect(findTerm("Topic name")).toBeVisible();
+    expect(
+      findDefinition(defaultPropsNotOwnerAiven.selectedSubscription.topicname)
+    ).toBeVisible();
+
+    expect(findTerm("Consumer group")).toBeVisible();
+    expect(
+      findDefinition(
+        defaultPropsNotOwnerAiven.selectedSubscription.consumergroup
+      )
+    ).toBeVisible();
+
+    expect(findTerm("IP or Service account based")).toBeVisible();
+    expect(findDefinition("Service account")).toBeVisible();
+
+    expect(findTerm("Service account")).toBeVisible();
+    expect(
+      findDefinition(defaultPropsNotOwnerAiven.selectedSubscription.acl_ssl)
+    ).toBeVisible();
+
+    expect(findTerm("Service account password")).toBeVisible();
+    expect(findDefinition("Not authorized to see this.")).toBeVisible();
   });
 });

--- a/coral/src/app/features/topics/details/subscriptions/components/TopicSubscriptionsDetailsModal.tsx
+++ b/coral/src/app/features/topics/details/subscriptions/components/TopicSubscriptionsDetailsModal.tsx
@@ -211,7 +211,7 @@ const TopicSubscriptionsDetailsModal = ({
               </Typography.SmallStrong>
               {serviceAccountDataLoaded ? (
                 <Typography.Default htmlTag="dd">
-                  {serviceAccountData.password}
+                  {serviceAccountData.password || "Not authorized to see this."}
                 </Typography.Default>
               ) : (
                 <div data-testid={"pw-skeleton"}>


### PR DESCRIPTION
## About this change - What it does

If a user is not authorized to see the details of a subscription, then the password is `undefined`. We currenlty render nothing:


https://github.com/aiven/klaw/assets/20607294/56f8723f-0729-464f-9d0a-3c5678cc7ff6

This PR adds the same text as other pieces of data that are unavailable:

https://github.com/aiven/klaw/assets/20607294/01e2866c-e89d-42cc-b3da-a4f8ca8d7830


