### PR TITLE
(fix/refactor): Followup for Promote and Edit topic requests

### DIFF
--- a/coral/src/app/features/topics/details/overview/TopicOverview.tsx
+++ b/coral/src/app/features/topics/details/overview/TopicOverview.tsx
@@ -54,10 +54,7 @@ function TopicOverview() {
         <TopicPromotionBanner
           topicPromotionDetails={topicPromotionDetails}
           isTopicOwner={topicOwner}
-          hasOpenRequest={
-            hasOpenTopicRequest ||
-            topicPromotionDetails.status === "REQUEST_OPEN"
-          }
+          hasOpenRequest={hasOpenTopicRequest}
         />
       )}
 

--- a/coral/src/app/features/topics/details/overview/TopicOverview.tsx
+++ b/coral/src/app/features/topics/details/overview/TopicOverview.tsx
@@ -54,7 +54,10 @@ function TopicOverview() {
         <TopicPromotionBanner
           topicPromotionDetails={topicPromotionDetails}
           isTopicOwner={topicOwner}
-          hasOpenRequest={hasOpenTopicRequest}
+          hasOpenRequest={
+            hasOpenTopicRequest ||
+            topicPromotionDetails.status === "REQUEST_OPEN"
+          }
         />
       )}
 

--- a/coral/src/app/features/topics/details/overview/components/TopicPromotionBanner.test.tsx
+++ b/coral/src/app/features/topics/details/overview/components/TopicPromotionBanner.test.tsx
@@ -1,4 +1,4 @@
-import { screen } from "@testing-library/react";
+import { cleanup, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { TopicPromotionBanner } from "src/app/features/topics/details/overview/components/TopicPromotionBanner";
 import { customRender } from "src/services/test-utils/render-with-wrappers";
@@ -18,17 +18,32 @@ const promoteProps = {
   hasOpenRequest: false,
 };
 
-const promotionDetailForSee: TopicOverview["topicPromotionDetails"] = {
-  status: "SUCCESS",
-  targetEnv: "TST",
-  sourceEnv: "DEV",
-  targetEnvId: "2",
-  topicName: "topic-hello",
-};
-const seeProps = {
+const promotionDetailForSeeOpenRequest: TopicOverview["topicPromotionDetails"] =
+  {
+    status: "SUCCESS",
+    targetEnv: "TST",
+    sourceEnv: "DEV",
+    targetEnvId: "2",
+    topicName: "topic-hello",
+  };
+const seeOpenRequestProps = {
   isTopicOwner: false,
-  topicPromotionDetails: promotionDetailForSee,
+  topicPromotionDetails: promotionDetailForSeeOpenRequest,
   hasOpenRequest: true,
+};
+
+const promotionDetailForSeeOpenPromotionRequest: TopicOverview["topicPromotionDetails"] =
+  {
+    status: "REQUEST_OPEN",
+    targetEnv: "TST",
+    sourceEnv: "DEV",
+    targetEnvId: "2",
+    topicName: "topic-hello",
+  };
+const seeOpenPromotionRequestProps = {
+  isTopicOwner: false,
+  topicPromotionDetails: promotionDetailForSeeOpenPromotionRequest,
+  hasOpenRequest: false,
 };
 
 const promotionDetailForNoPromotion: TopicOverview["topicPromotionDetails"] = {
@@ -49,6 +64,8 @@ jest.mock("react-router-dom", () => ({
 }));
 
 describe("TopicPromotionBanner (with promotion banner)", () => {
+  afterEach(cleanup);
+
   it("renders correct banner (promote topic)", async () => {
     customRender(<TopicPromotionBanner {...promoteProps} />, {
       memoryRouter: true,
@@ -66,8 +83,8 @@ describe("TopicPromotionBanner (with promotion banner)", () => {
     );
   });
 
-  it("renders correct banner (see promotion request)", async () => {
-    customRender(<TopicPromotionBanner {...seeProps} />, {
+  it("renders correct banner (see open request)", async () => {
+    customRender(<TopicPromotionBanner {...seeOpenRequestProps} />, {
       memoryRouter: true,
     });
 
@@ -84,7 +101,25 @@ describe("TopicPromotionBanner (with promotion banner)", () => {
     );
   });
 
-  it("renders nothing (status === 'NO_PROMOTION')", () => {
+  it("renders correct banner (see open promotion request)", async () => {
+    customRender(<TopicPromotionBanner {...seeOpenPromotionRequestProps} />, {
+      memoryRouter: true,
+    });
+
+    const button = screen.getByRole("button", {
+      name: "See the request",
+    });
+
+    expect(button).toBeEnabled();
+
+    await userEvent.click(button);
+
+    expect(mockedNavigate).toHaveBeenCalledWith(
+      `/requests/topics?search=${promoteProps.topicPromotionDetails.topicName}&requestType=PROMOTE&status=CREATED&page=1`
+    );
+  });
+
+  it("renders nothing (status === 'NO_PROMOTION', status !== 'NOT_AUTHORIZED')", () => {
     const { container } = customRender(
       <TopicPromotionBanner {...nullProps} />,
       {

--- a/coral/src/app/features/topics/details/overview/components/TopicPromotionBanner.tsx
+++ b/coral/src/app/features/topics/details/overview/components/TopicPromotionBanner.tsx
@@ -22,10 +22,54 @@ const TopicPromotionBanner = ({
     isTopicOwner &&
     status !== "NO_PROMOTION" &&
     status !== "NOT_AUTHORIZED" &&
-    !hasOpenRequest &&
     targetEnv !== undefined &&
     sourceEnv !== undefined &&
     targetEnvId !== undefined;
+
+  // hasOpenTopicRequest is true for any request open on the current topic in the current environment (source environment)
+  if (hasOpenRequest) {
+    return (
+      <GridItem colSpan={"span-2"}>
+        <Banner image={illustration} layout="vertical" title={""}>
+          <Box element={"p"} marginBottom={"l1"}>
+            There is an open request for {topicName}.
+          </Box>
+          <Button.Primary
+            onClick={() =>
+              navigate(
+                `/requests/topics?search=${topicName}&status=CREATED&page=1`
+              )
+            }
+          >
+            See the request
+          </Button.Primary>
+        </Banner>
+      </GridItem>
+    );
+  }
+
+  // status is "REQUEST_OPEN" when there is a promotion request open on a topic in the target environment for promotion,
+  // ie not the current topic + source environment
+  if (status === "REQUEST_OPEN") {
+    return (
+      <GridItem colSpan={"span-2"}>
+        <Banner image={illustration} layout="vertical" title={""}>
+          <Box element={"p"} marginBottom={"l1"}>
+            There is already an open promotion request for {topicName}.
+          </Box>
+          <Button.Primary
+            onClick={() =>
+              navigate(
+                `/requests/topics?search=${topicName}&requestType=PROMOTE&status=CREATED&page=1`
+              )
+            }
+          >
+            See the request
+          </Button.Primary>
+        </Banner>
+      </GridItem>
+    );
+  }
 
   if (showRequestPromotionBanner) {
     return (
@@ -43,27 +87,6 @@ const TopicPromotionBanner = ({
             }
           >
             Promote
-          </Button.Primary>
-        </Banner>
-      </GridItem>
-    );
-  }
-
-  if (hasOpenRequest) {
-    return (
-      <GridItem colSpan={"span-2"}>
-        <Banner image={illustration} layout="vertical" title={""}>
-          <Box element={"p"} marginBottom={"l1"}>
-            There is an open request for {topicName}.
-          </Box>
-          <Button.Primary
-            onClick={() =>
-              navigate(
-                `/requests/topics?search=${topicName}&status=CREATED&page=1`
-              )
-            }
-          >
-            See the request
           </Button.Primary>
         </Banner>
       </GridItem>

--- a/coral/src/app/features/topics/details/overview/components/TopicPromotionBanner.tsx
+++ b/coral/src/app/features/topics/details/overview/components/TopicPromotionBanner.tsx
@@ -21,6 +21,7 @@ const TopicPromotionBanner = ({
   const showRequestPromotionBanner =
     isTopicOwner &&
     status !== "NO_PROMOTION" &&
+    status !== "NOT_AUTHORIZED" &&
     !hasOpenRequest &&
     targetEnv !== undefined &&
     sourceEnv !== undefined &&

--- a/coral/src/app/features/topics/details/overview/components/TopicPromotionBanner.tsx
+++ b/coral/src/app/features/topics/details/overview/components/TopicPromotionBanner.tsx
@@ -20,8 +20,7 @@ const TopicPromotionBanner = ({
 
   const showRequestPromotionBanner =
     isTopicOwner &&
-    status !== "NO_PROMOTION" &&
-    status !== "NOT_AUTHORIZED" &&
+    status === "SUCCESS" &&
     targetEnv !== undefined &&
     sourceEnv !== undefined &&
     targetEnvId !== undefined;

--- a/coral/src/app/features/topics/request/TopicEditRequest.tsx
+++ b/coral/src/app/features/topics/request/TopicEditRequest.tsx
@@ -150,6 +150,7 @@ function TopicEditRequest() {
   const {
     mutateAsync: edit,
     isLoading: editIsLoading,
+    error: editIsError,
     error: editError,
   } = useMutation(editTopic, {
     onSuccess: () => {
@@ -197,7 +198,7 @@ function TopicEditRequest() {
           Do you want to cancel this request? The data added will be lost.
         </Dialog>
       )}
-      {editError !== undefined && (
+      {editIsError && (
         <Box marginBottom={"l1"} role="alert">
           <Alert type="error">{parseErrorMsg(editError)}</Alert>
         </Box>

--- a/coral/src/app/features/topics/request/TopicEditRequest.tsx
+++ b/coral/src/app/features/topics/request/TopicEditRequest.tsx
@@ -150,7 +150,7 @@ function TopicEditRequest() {
   const {
     mutateAsync: edit,
     isLoading: editIsLoading,
-    error: editIsError,
+    isError: editIsError,
     error: editError,
   } = useMutation(editTopic, {
     onSuccess: () => {

--- a/coral/src/app/features/topics/request/TopicPromotionRequest.test.tsx
+++ b/coral/src/app/features/topics/request/TopicPromotionRequest.test.tsx
@@ -7,7 +7,9 @@ import { getAllEnvironmentsForTopicAndAcl } from "src/domain/environment";
 import { mockedEnvironmentResponse } from "src/domain/environment/environment-api.msw";
 import { transformEnvironmentApiResponse } from "src/domain/environment/environment-transformer";
 import { getTopicDetailsPerEnv, promoteTopic } from "src/domain/topic";
+import { getTopicAdvancedConfigOptions } from "src/domain/topic/topic-api";
 import { customRender } from "src/services/test-utils/render-with-wrappers";
+import * as ReactQuery from "@tanstack/react-query";
 
 const mockedUsedNavigate = jest.fn();
 jest.mock("react-router-dom", () => ({
@@ -28,12 +30,24 @@ const mockPromoteTopic = promoteTopic as jest.MockedFunction<
 const mockGetTopicDetailsPerEnv = getTopicDetailsPerEnv as jest.MockedFunction<
   typeof getTopicDetailsPerEnv
 >;
+const mockgGetTopicAdvancedConfigOptions =
+  getTopicAdvancedConfigOptions as jest.MockedFunction<
+    typeof getTopicAdvancedConfigOptions
+  >;
 
 jest.mock("src/domain/environment/environment-api.ts");
 const mockGetAllEnvironmentsForTopicAndAcl =
   getAllEnvironmentsForTopicAndAcl as jest.MockedFunction<
     typeof getAllEnvironmentsForTopicAndAcl
   >;
+
+const mockError = {
+  isError: true,
+  error: {
+    success: false,
+    message: "Failure. Not authorized to request topic for this environment.",
+  },
+};
 
 const mockEnvironments = transformEnvironmentApiResponse(
   mockedEnvironmentResponse
@@ -66,45 +80,255 @@ const mockTopicDetails = {
   },
 };
 
+const mockTransformedGetTopicAdvancedConfigOptions = [
+  {
+    key: "CLEANUP_POLICY",
+    name: "cleanup.policy",
+    documentation: {
+      link: "https://kafka.apache.org/documentation/#topicconfigs_cleanup.policy",
+      text: "Specify the cleanup policy for log segments in a topic.",
+    },
+  },
+  {
+    key: "COMPRESSION_TYPE",
+    name: "compression.type",
+    documentation: {
+      link: "https://kafka.apache.org/documentation/#topicconfigs_compression.type",
+      text: "Specify the type of compression used for log segments in a topic.",
+    },
+  },
+  {
+    key: "DELETE_RETENTION_MS",
+    name: "delete.retention.ms",
+    documentation: {
+      link: "https://kafka.apache.org/documentation/#topicconfigs_delete.retention.ms",
+      text: "Specify retention time in milliseconds for the delete tombstone markers for log compacted topics.",
+    },
+  },
+  {
+    key: "FILE_DELETE_DELAY_MS",
+    name: "file.delete.delay.ms",
+    documentation: {
+      link: "https://kafka.apache.org/documentation/#topicconfigs_file.delete.delay.ms",
+      text: "Specify the wait time in milliseconds before deleting a file from the filesystem.",
+    },
+  },
+  {
+    key: "FLUSH_MESSAGES",
+    name: "flush.messages",
+    documentation: {
+      link: "https://kafka.apache.org/documentation/#topicconfigs_flush.messages",
+      text: "Specify the number of messages that must be written to a topic before a flush is forced.",
+    },
+  },
+  {
+    key: "FLUSH_MS",
+    name: "flush.ms",
+    documentation: {
+      link: "https://kafka.apache.org/documentation/#topicconfigs_flush.ms",
+      text: "Specify the wait time in milliseconds before forcing a flush of data.",
+    },
+  },
+  {
+    key: "FOLLOWER_REPLICATION_THROTTLED_REPLICAS",
+    name: "follower.replication.throttled.replicas",
+    documentation: {
+      link: "https://kafka.apache.org/documentation/#topicconfigs_follower.replication.throttled.replicas",
+      text: "Specify the list of replicas that are currently throttled for replication for this topic.",
+    },
+  },
+  {
+    key: "INDEX_INTERVAL_BYTES",
+    name: "index.interval.bytes",
+    documentation: {
+      link: "https://kafka.apache.org/documentation/#topicconfigs_index.interval.bytes",
+      text: "Specify the interval at which log file offsets will be indexed.",
+    },
+  },
+  {
+    key: "LEADER_REPLICATION_THROTTLED_REPLICAS",
+    name: "leader.replication.throttled.replicas",
+    documentation: {
+      link: "https://kafka.apache.org/documentation/#topicconfigs_leader.replication.throttled.replicas",
+      text: "Specify replicas for which log replication should be throttled on the leader side.",
+    },
+  },
+  {
+    key: "MAX_COMPACTION_LAG_MS",
+    name: "max.compaction.lag.ms",
+    documentation: {
+      link: "https://kafka.apache.org/documentation/#topicconfigs_max.compaction.lag.ms",
+      text: "Specify maximum time a message will remain ineligible for compaction in the log.",
+    },
+  },
+  {
+    key: "MAX_MESSAGE_BYTES",
+    name: "max.message.bytes",
+    documentation: {
+      link: "https://kafka.apache.org/documentation/#topicconfigs_max.message.bytes",
+      text: "Specify the maximum size in bytes for a batch.",
+    },
+  },
+  {
+    key: "MESSAGE_DOWNCONVERSION_ENABLE",
+    name: "message.downconversion.enable",
+    documentation: {
+      link: "https://kafka.apache.org/documentation/#topicconfigs_message.downconversion.enable",
+      text: "Enable or disable automatic down conversion of messages.",
+    },
+  },
+  {
+    key: "MESSAGE_FORMAT_VERSION",
+    name: "message.format.version",
+    documentation: {
+      link: "https://kafka.apache.org/documentation/#topicconfigs_message.format.version",
+      text: "Specify the message format version to be used by the broker to append messages to logs.",
+    },
+  },
+  {
+    key: "MESSAGE_TIMESTAMP_DIFFERENCE_MAX_MS",
+    name: "message.timestamp.difference.max.ms",
+    documentation: {
+      link: "https://kafka.apache.org/documentation/#topicconfigs_message.timestamp.difference.max.ms",
+      text: "Specify the maximum time difference in milliseconds allowed between the timestamp of a message and time received.",
+    },
+  },
+  {
+    key: "MESSAGE_TIMESTAMP_TYPE",
+    name: "message.timestamp.type",
+    documentation: {
+      link: "https://kafka.apache.org/documentation/#topicconfigs_message.timestamp.type",
+      text: "Specify if `CreateTime` or `LogAppendTime` should be used as the timestamp of the message.",
+    },
+  },
+  {
+    key: "MIN_CLEANABLE_DIRTY_RATIO",
+    name: "min.cleanable.dirty.ratio",
+    documentation: {
+      link: "https://kafka.apache.org/documentation/#topicconfigs_min.cleanable.dirty.ratio",
+      text: "Specify the ratio of log to retention size to initiate log compaction.",
+    },
+  },
+  {
+    key: "MIN_COMPACTION_LAG_MS",
+    name: "min.compaction.lag.ms",
+    documentation: {
+      link: "https://kafka.apache.org/documentation/#topicconfigs_min.compaction.lag.ms",
+      text: "Specify the minimum time a message will remain uncompacted in the log.",
+    },
+  },
+  {
+    key: "MIN_INSYNC_REPLICAS",
+    name: "min.insync.replicas",
+    documentation: {
+      link: "https://kafka.apache.org/documentation/#topicconfigs_min.insync.replicas",
+      text: "Specify the minimum number of replicas required for a write to be considered successful.",
+    },
+  },
+  {
+    key: "PREALLOCATE",
+    name: "preallocate",
+    documentation: {
+      link: "https://kafka.apache.org/documentation/#topicconfigs_preallocate",
+      text: "Enable or disable preallocation of file disk for a new log segment.",
+    },
+  },
+  {
+    key: "RETENTION_BYTES",
+    name: "retention.bytes",
+    documentation: {
+      link: "https://kafka.apache.org/documentation/#topicconfigs_retention.bytes",
+      text: "Specify the maximum size a partition before log segment are discarded to free up space.",
+    },
+  },
+  {
+    key: "RETENTION_MS",
+    name: "retention.ms",
+    documentation: {
+      link: "https://kafka.apache.org/documentation/#topicconfigs_retention.ms",
+      text: "Specify the retention period in milliseconds for logs before discarding it to free up space.",
+    },
+  },
+  {
+    key: "SEGMENT_BYTES",
+    name: "segment.bytes",
+    documentation: {
+      link: "https://kafka.apache.org/documentation/#topicconfigs_segment.bytes",
+      text: "Specify the maximum size of a log segment file in bytes.",
+    },
+  },
+  {
+    key: "SEGMENT_INDEX_BYTES",
+    name: "segment.index.bytes",
+    documentation: {
+      link: "https://kafka.apache.org/documentation/#topicconfigs_segment.index.bytes",
+      text: "Specify the maximum size of the index in bytes that maps offsets to file positions.",
+    },
+  },
+  {
+    key: "SEGMENT_JITTER_MS",
+    name: "segment.jitter.ms",
+    documentation: {
+      link: "https://kafka.apache.org/documentation/#topicconfigs_segment.jitter.ms",
+      text: "Specify the maximum jitter time in milliseconds.",
+    },
+  },
+  {
+    key: "SEGMENT_MS",
+    name: "segment.ms",
+    documentation: {
+      link: "https://kafka.apache.org/documentation/#topicconfigs_segment.ms",
+      text: "Specify the maximum time in milliseconds before a log segment is rolled.",
+    },
+  },
+  {
+    key: "UNCLEAN_LEADER_ELECTION_ENABLE",
+    name: "unclean.leader.election.enable",
+    documentation: {
+      link: "https://kafka.apache.org/documentation/#topicconfigs_unclean.leader.election.enable",
+      text: "Enable or disable unclean leader election.",
+    },
+  },
+];
+
 describe("<TopicPromotionRequest />", () => {
-  const originalConsoleError = console.error;
-
-  beforeAll(() => {
-    console.error = jest.fn();
-    mockGetAllEnvironmentsForTopicAndAcl.mockResolvedValue(mockEnvironments);
-    mockGetTopicDetailsPerEnv.mockResolvedValue(mockTopicDetails);
-
-    customRender(
-      <Routes>
-        <Route
-          path="/topic/:topicName/request-promotion"
-          element={
-            <AquariumContext>
-              <TopicPromotionRequest />
-            </AquariumContext>
-          }
-        />
-      </Routes>,
-      {
-        queryClient: true,
-        memoryRouter: true,
-        customRoutePath:
-          "/topic/test-topic-name/request-promotion?sourceEnv=1&targetEnv=2",
-      }
-    );
-  });
-
-  afterEach(() => {
-    mockedUsedNavigate.mockClear();
-  });
-
-  afterAll(() => {
-    console.error = originalConsoleError;
-    cleanup();
-    jest.clearAllMocks();
-  });
-
   describe("Renders all fields with correct default values and disabled states", () => {
+    beforeEach(() => {
+      mockGetAllEnvironmentsForTopicAndAcl.mockResolvedValue(mockEnvironments);
+      mockGetTopicDetailsPerEnv.mockResolvedValue(mockTopicDetails);
+      mockgGetTopicAdvancedConfigOptions.mockResolvedValue(
+        mockTransformedGetTopicAdvancedConfigOptions
+      );
+
+      customRender(
+        <Routes>
+          <Route
+            path="/topic/:topicName/request-promotion"
+            element={
+              <AquariumContext>
+                <TopicPromotionRequest />
+              </AquariumContext>
+            }
+          />
+        </Routes>,
+        {
+          queryClient: true,
+          memoryRouter: true,
+          customRoutePath:
+            "/topic/test-topic-name/request-promotion?sourceEnv=1&targetEnv=2",
+        }
+      );
+    });
+
+    afterEach(() => {
+      cleanup();
+      jest.clearAllMocks();
+    });
+
+    it("does not show an error", async () => {
+      expect(screen.queryByRole("alert")).not.toBeInTheDocument();
+    });
+
     it("shows a disabled select element for 'Environment' with correct default value", async () => {
       const select = await screen.findByRole("combobox", {
         name: "Environment *",
@@ -145,8 +369,10 @@ describe("<TopicPromotionRequest />", () => {
       const mockedAdvancedConfig = screen.getByTestId("advancedConfiguration");
 
       expect(mockedAdvancedConfig).toBeEnabled();
-      expect(mockedAdvancedConfig).toHaveDisplayValue(
-        JSON.stringify({ "cleanup.policy": "compact" })
+      await waitFor(() =>
+        expect(mockedAdvancedConfig).toHaveDisplayValue(
+          JSON.stringify({ "cleanup.policy": "compact" })
+        )
       );
     });
 
@@ -158,7 +384,7 @@ describe("<TopicPromotionRequest />", () => {
 
       expect(input).toHaveAttribute("readonly");
       expect(input).toBeRequired();
-      expect(input).toHaveDisplayValue(description);
+      await waitFor(() => expect(input).toHaveDisplayValue(description));
     });
 
     it("shows an enabled text input element for 'Message for approval'", async () => {
@@ -172,6 +398,38 @@ describe("<TopicPromotionRequest />", () => {
   });
 
   describe("enables user to create a new topic request", () => {
+    beforeEach(() => {
+      mockGetAllEnvironmentsForTopicAndAcl.mockResolvedValue(mockEnvironments);
+      mockGetTopicDetailsPerEnv.mockResolvedValue(mockTopicDetails);
+      mockgGetTopicAdvancedConfigOptions.mockResolvedValue(
+        mockTransformedGetTopicAdvancedConfigOptions
+      );
+
+      customRender(
+        <Routes>
+          <Route
+            path="/topic/:topicName/request-promotion"
+            element={
+              <AquariumContext>
+                <TopicPromotionRequest />
+              </AquariumContext>
+            }
+          />
+        </Routes>,
+        {
+          queryClient: true,
+          memoryRouter: true,
+          customRoutePath:
+            "/topic/test-topic-name/request-promotion?sourceEnv=1&targetEnv=2",
+        }
+      );
+    });
+
+    afterEach(() => {
+      cleanup();
+      jest.clearAllMocks();
+    });
+
     it("creates a new topic request when input was valid", async () => {
       await userEvent.click(
         screen.getByRole("button", { name: "Submit promotion request" })
@@ -289,6 +547,209 @@ describe("<TopicPromotionRequest />", () => {
       await userEvent.click(cancelButton);
 
       expect(mockedUsedNavigate).toHaveBeenCalledWith(-1);
+    });
+  });
+
+  describe("shows an alert message when new topic update request was not successful", () => {
+    beforeEach(() => {
+      mockGetAllEnvironmentsForTopicAndAcl.mockResolvedValue(mockEnvironments);
+      mockGetTopicDetailsPerEnv.mockResolvedValue(mockTopicDetails);
+      mockgGetTopicAdvancedConfigOptions.mockResolvedValue(
+        mockTransformedGetTopicAdvancedConfigOptions
+      );
+      jest
+        .spyOn(ReactQuery, "useMutation")
+        .mockImplementation(jest.fn().mockReturnValue(mockError));
+
+      customRender(
+        <Routes>
+          <Route
+            path="/topic/:topicName/request-promotion"
+            element={
+              <AquariumContext>
+                <TopicPromotionRequest />
+              </AquariumContext>
+            }
+          />
+        </Routes>,
+        {
+          queryClient: true,
+          memoryRouter: true,
+          customRoutePath:
+            "/topic/test-topic-name/request-promotion?sourceEnv=1&targetEnv=2",
+        }
+      );
+    });
+    afterEach(() => {
+      cleanup();
+      jest.clearAllMocks();
+    });
+
+    it("render an alert when server rejects update request", async () => {
+      await waitFor(() =>
+        expect(screen.getByRole("alert")).toHaveTextContent(
+          mockError.error.message
+        )
+      );
+    });
+  });
+
+  describe("correctly redirects and warn on navigation when topic does not exist", () => {
+    beforeEach(() => {
+      mockGetAllEnvironmentsForTopicAndAcl.mockResolvedValue(mockEnvironments);
+      mockGetTopicDetailsPerEnv.mockResolvedValue({ topicExists: false });
+      mockgGetTopicAdvancedConfigOptions.mockResolvedValue(
+        mockTransformedGetTopicAdvancedConfigOptions
+      );
+
+      customRender(
+        <Routes>
+          <Route
+            path="/topic/:topicName/request-promotion"
+            element={
+              <AquariumContext>
+                <TopicPromotionRequest />
+              </AquariumContext>
+            }
+          />
+        </Routes>,
+        {
+          queryClient: true,
+          memoryRouter: true,
+          customRoutePath:
+            "/topic/DOESNOTEXIST/request-promotion?sourceEnv=1&targetEnv=2",
+        }
+      );
+    });
+    afterEach(() => {
+      cleanup();
+      jest.clearAllMocks();
+    });
+
+    it("redirects user to browse topics page", async () => {
+      await waitFor(() => {
+        expect(mockedUsedNavigate).toHaveBeenCalledWith("/topics", {
+          replace: true,
+        });
+      });
+    });
+
+    it("shows a notification that topic name does not exist", async () => {
+      await waitFor(() => {
+        expect(mockedUseToast).toHaveBeenCalledWith({
+          message: `No topic was found with name DOESNOTEXIST`,
+          position: "bottom-left",
+          variant: "danger",
+        });
+      });
+    });
+  });
+
+  describe("correctly redirects and warn on navigation when target environment does not exist", () => {
+    beforeEach(() => {
+      mockGetAllEnvironmentsForTopicAndAcl.mockResolvedValue(mockEnvironments);
+      mockGetTopicDetailsPerEnv.mockResolvedValue({ topicExists: false });
+      mockgGetTopicAdvancedConfigOptions.mockResolvedValue(
+        mockTransformedGetTopicAdvancedConfigOptions
+      );
+
+      customRender(
+        <Routes>
+          <Route
+            path="/topic/:topicName/request-promotion"
+            element={
+              <AquariumContext>
+                <TopicPromotionRequest />
+              </AquariumContext>
+            }
+          />
+        </Routes>,
+        {
+          queryClient: true,
+          memoryRouter: true,
+          customRoutePath:
+            "/topic/test-topic-name/request-promotion?sourceEnv=1&targetEnv=99999",
+        }
+      );
+    });
+    afterEach(() => {
+      cleanup();
+      jest.clearAllMocks();
+    });
+
+    it("redirects user to topic overview page", async () => {
+      await waitFor(() => {
+        expect(mockedUsedNavigate).toHaveBeenCalledWith(
+          "/topic/test-topic-name",
+          {
+            replace: true,
+          }
+        );
+      });
+    });
+
+    it("shows a notification that topic name does not exist", async () => {
+      await waitFor(() => {
+        expect(mockedUseToast).toHaveBeenCalledWith({
+          message: `No target environment was found with ID 99999`,
+          position: "bottom-left",
+          variant: "danger",
+        });
+      });
+    });
+  });
+
+  describe("correctly redirects and warn on navigation when target environment does not exist", () => {
+    beforeEach(() => {
+      mockGetAllEnvironmentsForTopicAndAcl.mockResolvedValue(mockEnvironments);
+      mockGetTopicDetailsPerEnv.mockResolvedValue({ topicExists: false });
+      mockgGetTopicAdvancedConfigOptions.mockResolvedValue(
+        mockTransformedGetTopicAdvancedConfigOptions
+      );
+
+      customRender(
+        <Routes>
+          <Route
+            path="/topic/:topicName/request-promotion"
+            element={
+              <AquariumContext>
+                <TopicPromotionRequest />
+              </AquariumContext>
+            }
+          />
+        </Routes>,
+        {
+          queryClient: true,
+          memoryRouter: true,
+          customRoutePath:
+            "/topic/test-topic-name/request-promotion?sourceEnv=99999&targetEnv=2",
+        }
+      );
+    });
+    afterEach(() => {
+      cleanup();
+      jest.clearAllMocks();
+    });
+
+    it("redirects user to topic overview page", async () => {
+      await waitFor(() => {
+        expect(mockedUsedNavigate).toHaveBeenCalledWith(
+          "/topic/test-topic-name",
+          {
+            replace: true,
+          }
+        );
+      });
+    });
+
+    it("shows a notification that topic name does not exist", async () => {
+      await waitFor(() => {
+        expect(mockedUseToast).toHaveBeenCalledWith({
+          message: `No source environment was found with ID 99999`,
+          position: "bottom-left",
+          variant: "danger",
+        });
+      });
     });
   });
 });


### PR DESCRIPTION
## About this change - What it does

Some issues surfaced after merging the PRs for Edit (https://github.com/aiven/klaw/pull/1436) and Promote (https://github.com/aiven/klaw/pull/1420) topic, as well as with the changes made to the `promotionDetails`  property on `TopicOverview` (https://github.com/aiven/klaw/pull/1440). This PR addresses them:

- The error message was always showing on the form, because of a wrong check: 220510bc718e5db7884b205738f2281147009931
- The Promote topic form was lacking in error handling, and its tests were not well organized: 29fde145d9111ad1db84aeaa3bae4ccecdc0b078
- The Promotion banner shown on the Topic overview tab was not taking the changes to `promotionDetails` and `TopicOverview` into account: 323f7b765f667e4a20755236e5feec20672e130e
- The promotion banner now show two different state if a request is already opened on the topic, or if specifically a promotion request is already opened [ef139f5](https://github.com/aiven/klaw/pull/1457/commits/ef139f56040b7663a1c1804bb4fda531a1684079)

