### PR TITLE
refactor(coral): Add toast notification to switch-team.

### DIFF
--- a/coral/src/app/features/team-info/SwitchTeamsDropdown.tsx
+++ b/coral/src/app/features/team-info/SwitchTeamsDropdown.tsx
@@ -1,8 +1,15 @@
-import { Box, Button, DropdownMenu, Skeleton } from "@aivenio/aquarium";
+import {
+  Box,
+  Button,
+  DropdownMenu,
+  Skeleton,
+  useToast,
+} from "@aivenio/aquarium";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { getTeamsOfUser, updateTeam } from "src/domain/team/team-api";
 import { Dialog } from "src/app/components/Dialog";
 import { useState } from "react";
+import { parseErrorMsg } from "src/services/mutation-utils";
 
 type SwitchTeamsDropdownProps = {
   userName: string;
@@ -14,6 +21,7 @@ function SwitchTeamsDropdown({
   currentTeam,
 }: SwitchTeamsDropdownProps) {
   const queryClient = useQueryClient();
+  const toast = useToast();
 
   const [modal, setModal] = useState<{
     open: boolean;
@@ -30,10 +38,18 @@ function SwitchTeamsDropdown({
     {
       onSuccess: async () => {
         await queryClient.refetchQueries();
+        toast({
+          message: "Team changed successfully.",
+          variant: "default",
+          position: "bottom-left",
+        });
       },
       onError(error: Error) {
-        //@ TODO error notification when we have toasts!
-        console.error(error);
+        toast({
+          message: `Error while switching teams. ${parseErrorMsg(error)}`,
+          variant: "danger",
+          position: "bottom-left",
+        });
       },
       onSettled() {
         setModal({ open: false, newTeamId: null });

--- a/coral/src/app/features/team-info/TeamInfo.test.tsx
+++ b/coral/src/app/features/team-info/TeamInfo.test.tsx
@@ -1,3 +1,4 @@
+import { Context as AquariumContext } from "@aivenio/aquarium";
 import { customRender } from "src/services/test-utils/render-with-wrappers";
 import { cleanup, screen } from "@testing-library/react";
 import { TeamInfo } from "src/app/features/team-info/TeamInfo";
@@ -49,9 +50,14 @@ describe("TeamInfo", () => {
 
     beforeAll(() => {
       mockGetTeamsOfUser.mockResolvedValue([]);
-      customRender(<TeamInfo />, {
-        queryClient: true,
-      });
+      customRender(
+        <AquariumContext>
+          <TeamInfo />
+        </AquariumContext>,
+        {
+          queryClient: true,
+        }
+      );
     });
     afterAll(cleanup);
 
@@ -85,9 +91,14 @@ describe("TeamInfo", () => {
 
     beforeAll(() => {
       mockGetTeamsOfUser.mockResolvedValue(testTeams);
-      customRender(<TeamInfo />, {
-        queryClient: true,
-      });
+      customRender(
+        <AquariumContext>
+          <TeamInfo />
+        </AquariumContext>,
+        {
+          queryClient: true,
+        }
+      );
     });
     afterAll(cleanup);
 


### PR DESCRIPTION
# About this change - What it does

- Adds toast notification for success and error to switch-team functionality. 

Resolves: #1458

