### PR TITLE
refactor(coral): Improve error handling for documentation

### DIFF
--- a/coral/src/app/features/topics/details/documentation/TopicDocumentation.test.tsx
+++ b/coral/src/app/features/topics/details/documentation/TopicDocumentation.test.tsx
@@ -284,10 +284,17 @@ describe("TopicDocumentation", () => {
   });
 
   describe("enables user to update documentation", () => {
+    const existingDocumentation = "# Hello" as TopicDocumentationMarkdown;
     const userInput = "**Hello world**";
 
     beforeEach(() => {
-      mockUseTopicDetails.mockReturnValue(mockTopicDetails);
+      mockUseTopicDetails.mockReturnValue({
+        ...mockTopicDetails,
+        topicOverview: {
+          ...mockTopicDetails.topicOverview,
+          topicDocumentation: existingDocumentation,
+        },
+      });
       mockUpdateTopicDocumentation.mockResolvedValue({
         success: true,
         message: "",
@@ -306,11 +313,11 @@ describe("TopicDocumentation", () => {
     });
 
     it("enables user to cancel editing the documentation", async () => {
-      const addButton = screen.getByRole("button", {
-        name: "Add documentation",
+      const editButton = screen.getByRole("button", {
+        name: "Edit documentation",
       });
 
-      await user.click(addButton);
+      await user.click(editButton);
 
       const markdownEditor = screen.getByRole("textbox", {
         name: "Markdown editor",
@@ -326,18 +333,16 @@ describe("TopicDocumentation", () => {
       expect(mockUpdateTopicDocumentation).not.toHaveBeenCalled();
       expect(markdownEditor).not.toBeInTheDocument();
 
-      const noDocumentation = screen.getByRole("heading", {
-        name: "No documentation",
-      });
-      expect(noDocumentation).toBeVisible();
+      const previewMode = screen.getByTestId("react-markdown-mock");
+      expect(previewMode).toBeVisible();
     });
 
     it("saves documentation when user clicks button", async () => {
-      const addButton = screen.getByRole("button", {
-        name: "Add documentation",
+      const editButton = screen.getByRole("button", {
+        name: "Edit documentation",
       });
 
-      await user.click(addButton);
+      await user.click(editButton);
 
       const markdownEditor = screen.getByRole("textbox", {
         name: "Markdown editor",
@@ -353,7 +358,97 @@ describe("TopicDocumentation", () => {
       expect(mockUpdateTopicDocumentation).toHaveBeenCalledWith({
         topicName: "documentation-test-topic",
         topicIdForDocumentation: 99999,
-        topicDocumentation: userInput,
+        topicDocumentation: existingDocumentation + userInput,
+      });
+    });
+
+    it("shows preview mode after successful update", async () => {
+      const editDocumentation = screen.getByRole("button", {
+        name: "Edit documentation",
+      });
+
+      await user.click(editDocumentation);
+
+      const markdownEditor = screen.getByRole("textbox", {
+        name: "Markdown editor",
+      });
+      await user.type(markdownEditor, userInput);
+
+      const saveButton = screen.getByRole("button", {
+        name: "Save documentation",
+      });
+
+      await user.click(saveButton);
+
+      const markdownView = await screen.findByTestId("react-markdown-mock");
+      expect(markdownEditor).not.toBeVisible();
+      expect(markdownView).toBeVisible();
+    });
+  });
+
+  describe("handles errors with updating documentation", () => {
+    const existingDocumentation = "# Hello" as TopicDocumentationMarkdown;
+    const userInput = "**Hello world**";
+
+    const originalConsoleError = console.error;
+    beforeEach(() => {
+      console.error = jest.fn();
+      mockUseTopicDetails.mockReturnValue({
+        ...mockTopicDetails,
+        topicOverview: {
+          ...mockTopicDetails.topicOverview,
+          topicDocumentation: existingDocumentation,
+        },
+      });
+      mockUpdateTopicDocumentation.mockRejectedValue({
+        success: false,
+        message: "this is error",
+      });
+
+      customRender(
+        <AquariumContext>
+          <TopicDocumentation />
+        </AquariumContext>,
+        { queryClient: true }
+      );
+    });
+
+    afterEach(() => {
+      console.error = originalConsoleError;
+      jest.resetAllMocks();
+      cleanup();
+    });
+
+    it("shows errors without saving documentation when user clicks button", async () => {
+      const editButton = screen.getByRole("button", {
+        name: "Edit documentation",
+      });
+
+      await user.click(editButton);
+
+      const markdownEditor = screen.getByRole("textbox", {
+        name: "Markdown editor",
+      });
+      await user.type(markdownEditor, userInput);
+
+      const saveButton = screen.getByRole("button", {
+        name: "Save documentation",
+      });
+
+      await user.click(saveButton);
+
+      const error = screen.getByRole("alert");
+      expect(error).toBeVisible();
+      expect(error).toHaveTextContent(
+        "The documentation could not be saved, there was an error"
+      );
+
+      const previewMode = screen.queryByTestId("react-markdown-mock");
+      expect(markdownEditor).toBeVisible();
+      expect(previewMode).not.toBeInTheDocument();
+      expect(console.error).toHaveBeenCalledWith({
+        success: false,
+        message: "this is error",
       });
     });
   });

--- a/coral/src/app/features/topics/details/documentation/TopicDocumentation.test.tsx
+++ b/coral/src/app/features/topics/details/documentation/TopicDocumentation.test.tsx
@@ -23,10 +23,10 @@ const mockUpdateTopicDocumentation =
     typeof updateTopicDocumentation
   >;
 
-const mockDocumentationTransformationError = jest.fn();
+const mockIsDocumentationTransformationError = jest.fn();
 jest.mock("src/domain/helper/documentation-helper", () => ({
-  documentationTransformationError: () =>
-    mockDocumentationTransformationError(),
+  isDocumentationTransformationError: () =>
+    mockIsDocumentationTransformationError(),
 }));
 
 const testTopicOverview: TopicOverview = {
@@ -396,7 +396,7 @@ describe("TopicDocumentation", () => {
     const originalConsoleError = console.error;
     beforeEach(() => {
       console.error = jest.fn();
-      mockDocumentationTransformationError.mockReturnValue(true);
+      mockIsDocumentationTransformationError.mockReturnValue(true);
       mockUseTopicDetails.mockReturnValue({
         ...mockTopicDetails,
         topicOverview: {

--- a/coral/src/app/features/topics/details/documentation/TopicDocumentation.tsx
+++ b/coral/src/app/features/topics/details/documentation/TopicDocumentation.tsx
@@ -10,7 +10,7 @@ import {
 import { parseErrorMsg } from "src/services/mutation-utils";
 import { DocumentationEditor } from "src/app/components/documentation/DocumentationEditor";
 import { DocumentationView } from "src/app/components/documentation/DocumentationView";
-import { documentationTransformationError } from "src/domain/helper/documentation-helper";
+import { isDocumentationTransformationError } from "src/domain/helper/documentation-helper";
 
 function TopicDocumentation() {
   const queryClient = useQueryClient();
@@ -97,7 +97,7 @@ function TopicDocumentation() {
     );
   }
 
-  if (documentationTransformationError(topicOverview.topicDocumentation)) {
+  if (isDocumentationTransformationError(topicOverview.topicDocumentation)) {
     return (
       <>
         <PageHeader title={"Documentation"} />

--- a/coral/src/app/features/topics/details/documentation/TopicDocumentation.tsx
+++ b/coral/src/app/features/topics/details/documentation/TopicDocumentation.tsx
@@ -10,6 +10,7 @@ import {
 import { parseErrorMsg } from "src/services/mutation-utils";
 import { DocumentationEditor } from "src/app/components/documentation/DocumentationEditor";
 import { DocumentationView } from "src/app/components/documentation/DocumentationView";
+import { documentationTransformationError } from "src/domain/helper/documentation-helper";
 
 function TopicDocumentation() {
   const queryClient = useQueryClient();
@@ -92,6 +93,20 @@ function TopicDocumentation() {
       <>
         <PageHeader title={"Documentation"} />
         <NoDocumentationBanner addDocumentation={() => setEditMode(true)} />
+      </>
+    );
+  }
+
+  if (documentationTransformationError(topicOverview.topicDocumentation)) {
+    return (
+      <>
+        <PageHeader title={"Documentation"} />
+        <Box role="alert">
+          <Alert type="error">
+            Something went wrong while trying to transform the documentation
+            into the right format.
+          </Alert>
+        </Box>
       </>
     );
   }

--- a/coral/src/app/features/topics/details/documentation/TopicDocumentation.tsx
+++ b/coral/src/app/features/topics/details/documentation/TopicDocumentation.tsx
@@ -42,7 +42,9 @@ function TopicDocumentation() {
           setEditMode(false);
         });
       },
-      onError: () => setEditMode(false),
+      onError: () => {
+        setSaving(false);
+      },
     }
   );
 

--- a/coral/src/domain/helper/documentation-helper.ts
+++ b/coral/src/domain/helper/documentation-helper.ts
@@ -31,6 +31,18 @@ type MarkdownString = Awaited<ReturnType<typeof createMarkdown>>;
 // transformation errors that otherwise can't be determined
 const documentationTransformError =
   "6e6c85af-71b4-4021-b7fe-bf99c81f2c6aZ-d3841163-ba74-4db4-b874-35b973d2a80e-32e866bd-99d0-4a64-ac15-5b73104ab0ff";
+
+/** There can be edge cases where transforming `stringifiedHtml` from backend
+ * into a markdown string causes an error. To be able to handle that error
+ * gracefully while still getting `topicOverview` but also show our users
+ * helpful information, we set the value of `documentationTransformError`
+ * as property for topicOverview.topicDocumentation. If topicDocumentation
+ * matches this string, we know that there was an error and can inform the user.
+ */
+function documentationTransformationError(documentation: MarkdownStringBrand) {
+  return documentation === documentationTransformError;
+}
+
 // `createMarkdown` is used to transform documentation on the api response
 //  for example on TopicOverview. The `topicDocumentation` is a html string
 //  that we transform to markdown.
@@ -55,9 +67,6 @@ async function createMarkdown(stringifiedHtml: string) {
   }
 }
 
-function documentationTransformationError(documentation: MarkdownStringBrand) {
-  return documentation === documentationTransformError;
-}
 // The type MarkdownString does provide us a bit of type safety against slips,
 // in case someone tries to pass a (not properly sanitized) html string
 // to updateTopicDocumentation
@@ -85,6 +94,7 @@ async function createStringifiedHtml(markdownString: string) {
 
       return String(result) as StringifiedHtmlBrand;
     } catch (error) {
+      // Throw specific error to show clear information to users
       throw Error(
         "Something went wrong while transforming the documentation into the right format to save."
       );

--- a/coral/src/domain/helper/documentation-helper.ts
+++ b/coral/src/domain/helper/documentation-helper.ts
@@ -29,18 +29,20 @@ type MarkdownString = Awaited<ReturnType<typeof createMarkdown>>;
 
 // very unique string to be able to identify documentation
 // transformation errors that otherwise can't be determined
-const documentationTransformError =
+const DOCUMENTATION_TRANSFORM_ERROR =
   "6e6c85af-71b4-4021-b7fe-bf99c81f2c6aZ-d3841163-ba74-4db4-b874-35b973d2a80e-32e866bd-99d0-4a64-ac15-5b73104ab0ff";
 
 /** There can be edge cases where transforming `stringifiedHtml` from backend
  * into a markdown string causes an error. To be able to handle that error
  * gracefully while still getting `topicOverview` but also show our users
- * helpful information, we set the value of `documentationTransformError`
+ * helpful information, we set the value of `isDocumentationTransformationError`
  * as property for topicOverview.topicDocumentation. If topicDocumentation
  * matches this string, we know that there was an error and can inform the user.
  */
-function documentationTransformationError(documentation: MarkdownStringBrand) {
-  return documentation === documentationTransformError;
+function isDocumentationTransformationError(
+  documentation: MarkdownStringBrand
+) {
+  return documentation === DOCUMENTATION_TRANSFORM_ERROR;
 }
 
 // `createMarkdown` is used to transform documentation on the api response
@@ -60,7 +62,7 @@ async function createMarkdown(stringifiedHtml: string) {
       return String(result) as MarkdownStringBrand;
     } catch (error) {
       console.error(error);
-      return documentationTransformError as MarkdownStringBrand;
+      return DOCUMENTATION_TRANSFORM_ERROR as MarkdownStringBrand;
     }
   } else {
     return "" as MarkdownStringBrand;
@@ -107,6 +109,6 @@ async function createStringifiedHtml(markdownString: string) {
 export {
   createMarkdown,
   createStringifiedHtml,
-  documentationTransformationError,
+  isDocumentationTransformationError,
 };
 export type { MarkdownString, StringifiedHtml };


### PR DESCRIPTION
# About this change - What it does

While my 💻  decided to have a brain fart today which lead to my local coral deciding it didn't know what ES modules are ( 🤷‍♀️  computers!), I discovered that we don't have a good error handling in case something goes wrong when we transform `stringifiedHtml` into a markdown string. We _do_ get an error and show it to the user, but since we're doing that transformation when we're getting the `topicOverview`, the error bubbled up to that until it was threaded like an error happening during that api call. 

Now, when transforming stringifiedHtml to markdown for `topicOverview`, instead of letting that error bubble, we:
- catch it
- log a `console.error` for developers / admins to be able to see it and act 
- add a very unique id as `topicDocumentation` on `topicOverview`

In `TopicDocumentation`, there's a new check for a `documentationTransformationError`. If that returns `true`, we show a message to the user informing them about it and do not show the add/edit button. 

This way, the error is handled in a way that everyone that needs to know about it will but it does not break more functionality then necessary. 


### Bonus
I skipped / forgot about adding a test case for "handles an error correctly" in `TopicDocumentation` and yes, that promptly lead to me NOT noticing a bug I added -> when the mutation returned an error, I set `editMode` to false. And the Error is shown in the UI for... the edit mode 🤦‍♀️  (aka: never). 

Now the edit mode is not set to false and `setSaving` set to `false` here.



## Recordings

## Before

https://github.com/aiven/klaw/assets/943800/c63509db-00a4-45c4-951f-348a1b086ceb



## After


https://github.com/aiven/klaw/assets/943800/2cbb63af-05f3-4839-aff0-7eeba6013394

