### PR TITLE
feat(coral): Connector details: Connector documentation

### DIFF
--- a/coral/src/app/features/connectors/details/documentation/ConnectorDocumentation.test.tsx
+++ b/coral/src/app/features/connectors/details/documentation/ConnectorDocumentation.test.tsx
@@ -1,0 +1,351 @@
+import { Context as AquariumContext } from "@aivenio/aquarium";
+import { cleanup, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { useConnectorDetails } from "src/app/features/connectors/details/ConnectorDetails";
+import { ConnectorDocumentation } from "src/app/features/connectors/details/documentation/ConnectorDocumentation";
+import {
+  ConnectorDocumentationMarkdown,
+  ConnectorOverview,
+  updateConnectorDocumentation,
+} from "src/domain/connector";
+import { mockIntersectionObserver } from "src/services/test-utils/mock-intersection-observer";
+import { customRender } from "src/services/test-utils/render-with-wrappers";
+
+jest.mock("src/app/features/connectors/details/ConnectorDetails");
+const mockUseConnectorDetails = useConnectorDetails as jest.MockedFunction<
+  typeof useConnectorDetails
+>;
+
+jest.mock("src/domain/connector/connector-api.ts");
+const mockUpdateConnectorDocumentation =
+  updateConnectorDocumentation as jest.MockedFunction<
+    typeof updateConnectorDocumentation
+  >;
+
+const testConnectorOverview: ConnectorOverview = {
+  availableEnvironments: [],
+  connectorIdForDocumentation: 99999,
+  connectorInfo: {
+    connectorName: "documentation-test-connector",
+  } as ConnectorOverview["connectorInfo"],
+  connectorExists: true,
+};
+
+const mockConnectorDetails = {
+  connectorIsRefetching: false,
+  environmentId: "1",
+  connectorOverview: testConnectorOverview,
+};
+
+const mockedUseToast = jest.fn();
+jest.mock("@aivenio/aquarium", () => ({
+  ...jest.requireActual("@aivenio/aquarium"),
+  useToast: () => mockedUseToast,
+}));
+
+describe("ConnectorDocumentation", () => {
+  beforeAll(mockIntersectionObserver);
+
+  const user = userEvent.setup();
+
+  describe("if the connector has no documentation yet", () => {
+    describe("shows all necessary elements", () => {
+      beforeAll(() => {
+        mockUseConnectorDetails.mockReturnValue(mockConnectorDetails);
+        mockUpdateConnectorDocumentation.mockResolvedValue({
+          success: true,
+          message: "",
+        });
+        customRender(
+          <AquariumContext>
+            <ConnectorDocumentation />
+          </AquariumContext>,
+          { queryClient: true }
+        );
+      });
+
+      afterAll(cleanup);
+
+      it("shows headline No Documentation", () => {
+        const headline = screen.getByRole("heading", {
+          name: "No documentation",
+        });
+        expect(headline).toBeVisible();
+      });
+
+      it("shows a button to add documentation", () => {
+        const addDocumentationButton = screen.getByRole("button", {
+          name: "Add documentation",
+        });
+        expect(addDocumentationButton).toBeEnabled();
+      });
+    });
+
+    describe("enables user to add documentation", () => {
+      beforeEach(() => {
+        mockUseConnectorDetails.mockReturnValue(mockConnectorDetails);
+        mockUpdateConnectorDocumentation.mockResolvedValue({
+          success: true,
+          message: "",
+        });
+        customRender(
+          <AquariumContext>
+            <ConnectorDocumentation />
+          </AquariumContext>,
+          { queryClient: true }
+        );
+      });
+
+      afterEach(cleanup);
+
+      it("shows no editor on default", () => {
+        const markdownEditor = screen.queryByRole("textbox", {
+          name: "Markdown editor",
+        });
+        expect(markdownEditor).not.toBeInTheDocument();
+      });
+
+      it("shows the edit mode when user clicks button to add documentation", async () => {
+        const addDocumentationButton = screen.getByRole("button", {
+          name: "Add documentation",
+        });
+        const headlineNoDocumentation = screen.getByRole("heading", {
+          name: "No documentation",
+        });
+
+        expect(headlineNoDocumentation).toBeVisible();
+        await user.click(addDocumentationButton);
+
+        const markdownEditor = screen.getByRole("textbox", {
+          name: "Markdown editor",
+        });
+        const headlineEdit = screen.getByRole("heading", {
+          name: "Edit documentation",
+        });
+
+        expect(markdownEditor).toBeVisible();
+        expect(headlineNoDocumentation).not.toBeInTheDocument();
+        expect(headlineEdit).toBeVisible();
+      });
+    });
+  });
+
+  describe("if the connector has existing documentation", () => {
+    const existingDocumentation = "# Hello" as ConnectorDocumentationMarkdown;
+
+    describe("shows all necessary elements", () => {
+      beforeAll(() => {
+        mockUseConnectorDetails.mockReturnValue({
+          ...mockConnectorDetails,
+          connectorOverview: {
+            ...mockConnectorDetails.connectorOverview,
+            connectorDocumentation: existingDocumentation,
+          },
+        });
+
+        mockUpdateConnectorDocumentation.mockResolvedValue({
+          success: true,
+          message: "",
+        });
+
+        customRender(
+          <AquariumContext>
+            <ConnectorDocumentation />
+          </AquariumContext>,
+          { queryClient: true }
+        );
+      });
+
+      afterAll(cleanup);
+
+      it("shows documentation headline", () => {
+        const headline = screen.getByRole("heading", { name: "Documentation" });
+
+        expect(headline).toBeVisible();
+      });
+
+      it("shows the documentation", () => {
+        const markdownView = screen.getByTestId("react-markdown-mock");
+
+        expect(markdownView).toBeVisible();
+        expect(markdownView).toHaveTextContent(existingDocumentation);
+      });
+
+      it("shows a button to edit documentation", () => {
+        const addDocumentationButton = screen.getByRole("button", {
+          name: "Edit documentation",
+        });
+        expect(addDocumentationButton).toBeEnabled();
+      });
+    });
+
+    describe("enables user to edit documentation", () => {
+      beforeEach(() => {
+        mockUseConnectorDetails.mockReturnValue({
+          ...mockConnectorDetails,
+          connectorOverview: {
+            ...mockConnectorDetails.connectorOverview,
+            connectorDocumentation: existingDocumentation,
+          },
+        });
+
+        customRender(
+          <AquariumContext>
+            <ConnectorDocumentation />
+          </AquariumContext>,
+          { queryClient: true }
+        );
+      });
+
+      afterEach(cleanup);
+
+      it("shows the edit mode when user clicks button to edit documentation", async () => {
+        const editDocumentation = screen.getByRole("button", {
+          name: "Edit documentation",
+        });
+
+        await user.click(editDocumentation);
+
+        const markdownEditor = screen.getByRole("textbox", {
+          name: "Markdown editor",
+        });
+        const headlineEdit = screen.getByRole("heading", {
+          name: "Edit documentation",
+        });
+
+        expect(markdownEditor).toBeVisible();
+        expect(headlineEdit).toBeVisible();
+      });
+    });
+  });
+
+  describe("if documentation is updating", () => {
+    const existingDocumentation = "# Hello" as ConnectorDocumentationMarkdown;
+
+    beforeAll(() => {
+      mockUseConnectorDetails.mockReturnValue({
+        ...mockConnectorDetails,
+        connectorIsRefetching: true,
+        connectorOverview: {
+          ...mockConnectorDetails.connectorOverview,
+          connectorDocumentation: existingDocumentation,
+        },
+      });
+
+      mockUpdateConnectorDocumentation.mockResolvedValue({
+        success: true,
+        message: "",
+      });
+
+      customRender(
+        <AquariumContext>
+          <ConnectorDocumentation />
+        </AquariumContext>,
+        { queryClient: true }
+      );
+    });
+
+    afterAll(cleanup);
+
+    it("shows documentation headline", () => {
+      const headline = screen.getByRole("heading", { name: "Documentation" });
+
+      expect(headline).toBeVisible();
+    });
+
+    it("shows accessible information about loading documentation", () => {
+      const loadingInformation = screen.getByText("Loading documentation");
+
+      expect(loadingInformation).toBeVisible();
+      expect(loadingInformation).toHaveClass("visually-hidden");
+    });
+
+    it("shows no documentation", () => {
+      const markdownView = screen.queryByTestId("react-markdown-mock");
+
+      expect(markdownView).not.toBeInTheDocument();
+    });
+
+    it("shows no button to edit documentation", () => {
+      const addDocumentationButton = screen.queryByRole("button", {
+        name: "Edit documentation",
+      });
+      expect(addDocumentationButton).not.toBeInTheDocument();
+    });
+  });
+
+  describe("enables user to update documentation", () => {
+    const userInput = "**Hello world**";
+
+    beforeEach(() => {
+      mockUseConnectorDetails.mockReturnValue(mockConnectorDetails);
+      mockUpdateConnectorDocumentation.mockResolvedValue({
+        success: true,
+        message: "",
+      });
+      customRender(
+        <AquariumContext>
+          <ConnectorDocumentation />
+        </AquariumContext>,
+        { queryClient: true }
+      );
+    });
+
+    afterEach(() => {
+      jest.resetAllMocks();
+      cleanup();
+    });
+
+    it("enables user to cancel editing the documentation", async () => {
+      const addButton = screen.getByRole("button", {
+        name: "Add documentation",
+      });
+
+      await user.click(addButton);
+
+      const markdownEditor = screen.getByRole("textbox", {
+        name: "Markdown editor",
+      });
+      await user.type(markdownEditor, userInput);
+
+      const cancelButton = screen.getByRole("button", {
+        name: "Cancel",
+      });
+
+      await user.click(cancelButton);
+
+      expect(mockUpdateConnectorDocumentation).not.toHaveBeenCalled();
+      expect(markdownEditor).not.toBeInTheDocument();
+
+      const noDocumentation = screen.getByRole("heading", {
+        name: "No documentation",
+      });
+      expect(noDocumentation).toBeVisible();
+    });
+
+    it("saves documentation when user clicks button", async () => {
+      const addButton = screen.getByRole("button", {
+        name: "Add documentation",
+      });
+
+      await user.click(addButton);
+
+      const markdownEditor = screen.getByRole("textbox", {
+        name: "Markdown editor",
+      });
+      await user.type(markdownEditor, userInput);
+
+      const saveButton = screen.getByRole("button", {
+        name: "Save documentation",
+      });
+
+      await user.click(saveButton);
+
+      expect(mockUpdateConnectorDocumentation).toHaveBeenCalledWith({
+        connectorName: "documentation-test-connector",
+        connectorIdForDocumentation: 99999,
+        connectorDocumentation: userInput,
+      });
+    });
+  });
+});

--- a/coral/src/app/features/connectors/details/documentation/ConnectorDocumentation.tsx
+++ b/coral/src/app/features/connectors/details/documentation/ConnectorDocumentation.tsx
@@ -1,0 +1,116 @@
+import { Alert, Box, PageHeader, Skeleton, useToast } from "@aivenio/aquarium";
+import { NoDocumentationBanner } from "src/app/features/connectors/details/documentation/components/NoDocumentationBanner";
+import { useConnectorDetails } from "src/app/features/connectors/details/ConnectorDetails";
+import { useState } from "react";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import {
+  ConnectorDocumentationMarkdown,
+  updateConnectorDocumentation,
+} from "src/domain/connector";
+import { parseErrorMsg } from "src/services/mutation-utils";
+import { DocumentationEditor } from "src/app/components/documentation/DocumentationEditor";
+import { DocumentationView } from "src/app/components/documentation/DocumentationView";
+
+function ConnectorDocumentation() {
+  const queryClient = useQueryClient();
+
+  const [editMode, setEditMode] = useState(false);
+  const [saving, setSaving] = useState(false);
+
+  const { connectorOverview, connectorIsRefetching } = useConnectorDetails();
+
+  const toast = useToast();
+
+  const { mutate, isError, error } = useMutation(
+    (markdownString: ConnectorDocumentationMarkdown) => {
+      setSaving(true);
+      return updateConnectorDocumentation({
+        connectorName: connectorOverview.connectorInfo.connectorName,
+        connectorIdForDocumentation:
+          connectorOverview.connectorIdForDocumentation,
+        connectorDocumentation: markdownString,
+      });
+    },
+    {
+      onSuccess: () => {
+        queryClient.refetchQueries(["connector-overview"]).then(() => {
+          toast({
+            message: "Documentation successfully updated",
+            position: "bottom-left",
+            variant: "default",
+          });
+          setSaving(false);
+          setEditMode(false);
+        });
+      },
+      onError: () => setEditMode(false),
+    }
+  );
+
+  if (connectorIsRefetching) {
+    return (
+      <>
+        <PageHeader title={"Documentation"} />
+        <Box paddingTop={"l2"}>
+          <div className={"visually-hidden"}>Loading documentation</div>
+          <Skeleton />
+        </Box>
+      </>
+    );
+  }
+
+  if (editMode) {
+    return (
+      <>
+        <PageHeader title={"Edit documentation"} />
+        <>
+          {isError && (
+            <Box marginBottom={"l1"} role="alert">
+              <Alert type="error">
+                The documentation could not be saved, there was an error: <br />
+                {parseErrorMsg(error)}
+              </Alert>
+            </Box>
+          )}
+          <DocumentationEditor
+            documentation={connectorOverview.connectorDocumentation}
+            save={(text) => mutate(text)}
+            cancel={() => setEditMode(false)}
+            isSaving={saving}
+          />
+        </>
+      </>
+    );
+  }
+
+  if (
+    connectorOverview.connectorDocumentation === undefined ||
+    connectorOverview.connectorDocumentation.length === 0
+  ) {
+    return (
+      <>
+        <PageHeader title={"Documentation"} />
+        <NoDocumentationBanner addDocumentation={() => setEditMode(true)} />
+      </>
+    );
+  }
+
+  return (
+    <>
+      <PageHeader
+        title={"Documentation"}
+        primaryAction={{
+          text: "Edit documentation",
+          onClick: () => setEditMode(true),
+        }}
+      />
+      <Box paddingTop={"l2"}>
+        <DocumentationView
+          markdownString={connectorOverview.connectorDocumentation}
+        />
+      </Box>
+    </>
+  );
+}
+
+export { ConnectorDocumentation };

--- a/coral/src/app/features/connectors/details/documentation/components/NoDocumentationBanner.test.tsx
+++ b/coral/src/app/features/connectors/details/documentation/components/NoDocumentationBanner.test.tsx
@@ -1,0 +1,54 @@
+import { NoDocumentationBanner } from "src/app/features/connectors/details/documentation/components/NoDocumentationBanner";
+import { cleanup, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+const testAddDocumentation = jest.fn();
+
+describe("NoDocumentationBanner", () => {
+  const user = userEvent.setup();
+
+  describe("shows all necessary elements", () => {
+    beforeAll(() => {
+      render(<NoDocumentationBanner addDocumentation={testAddDocumentation} />);
+    });
+
+    afterAll(cleanup);
+
+    it("shows headline No Documentation", () => {
+      const headline = screen.getByRole("heading", {
+        name: "No documentation",
+      });
+      expect(headline).toBeVisible();
+    });
+
+    it("shows information that no documentation is available for this connector", () => {
+      const infoText = screen.getByText(
+        "You can add documentation for your connector."
+      );
+      expect(infoText).toBeVisible();
+    });
+
+    it("shows button to add a documentation", () => {
+      const button = screen.getByRole("button", { name: "Add documentation" });
+      expect(button).toBeVisible();
+    });
+  });
+
+  describe("triggers a addDocumentation event", () => {
+    beforeEach(() => {
+      render(<NoDocumentationBanner addDocumentation={testAddDocumentation} />);
+    });
+
+    afterEach(() => {
+      cleanup();
+      jest.clearAllMocks();
+    });
+
+    it("adds documentation when user clicks button", async () => {
+      const button = screen.getByRole("button", { name: "Add documentation" });
+      await user.click(button);
+
+      expect(testAddDocumentation).toHaveBeenCalled();
+    });
+  });
+});

--- a/coral/src/app/features/connectors/details/documentation/components/NoDocumentationBanner.tsx
+++ b/coral/src/app/features/connectors/details/documentation/components/NoDocumentationBanner.tsx
@@ -1,0 +1,25 @@
+import { EmptyState, EmptyStateLayout } from "@aivenio/aquarium";
+import illustration from "src/app/images/topic-details-documentation-illustration.svg";
+
+type NoDocumentationBannerProps = {
+  addDocumentation: () => void;
+};
+function NoDocumentationBanner({
+  addDocumentation,
+}: NoDocumentationBannerProps) {
+  return (
+    <EmptyState
+      title={"No documentation"}
+      image={illustration}
+      layout={EmptyStateLayout.CenterHorizontal}
+      primaryAction={{
+        text: "Add documentation",
+        onClick: addDocumentation,
+      }}
+    >
+      You can add documentation for your connector.
+    </EmptyState>
+  );
+}
+
+export { NoDocumentationBanner };

--- a/coral/src/app/router.tsx
+++ b/coral/src/app/router.tsx
@@ -1,4 +1,5 @@
 import { createBrowserRouter, RouteObject } from "react-router-dom";
+import { ConnectorDocumentation } from "src/app/features/connectors/details/documentation/ConnectorDocumentation";
 import { ConnectorOverview } from "src/app/features/connectors/details/overview/ConnectorOverview";
 import Layout from "src/app/layout/Layout";
 import LayoutWithoutNav from "src/app/layout/LayoutWithoutNav";
@@ -131,7 +132,7 @@ const routes: Array<RouteObject> = [
             path: CONNECTOR_OVERVIEW_TAB_ID_INTO_PATH[
               ConnectorOverviewTabEnum.DOCUMENTATION
             ],
-            element: <div>DOCUMENTATION</div>,
+            element: <ConnectorDocumentation />,
             id: ConnectorOverviewTabEnum.DOCUMENTATION,
           },
           {

--- a/coral/src/domain/connector/connector-transformer.ts
+++ b/coral/src/domain/connector/connector-transformer.ts
@@ -5,6 +5,7 @@ import {
 } from "src/domain/connector/connector-types";
 import { KlawApiResponse } from "types/utils";
 import omit from "lodash/omit";
+import { createMarkdown } from "src/domain/helper/documentation-helper";
 
 const transformConnectorApiResponse = (
   data: KlawApiResponse<"getConnectors">
@@ -40,12 +41,26 @@ const transformConnectorRequestApiResponse = (
   };
 };
 
-function transformConnectorOverviewResponse(
+async function transformConnectorOverviewResponse(
   apiResponse: KlawApiResponse<"getConnectorOverview">
-): ConnectorOverview {
+): Promise<ConnectorOverview> {
+  // while we save documentation in stringified html to be
+  // backwards compatible with the Angular app for now,
+  // we're planing to migrate to pure Markdown at some
+  // point and don't want stringfied html to bleed into
+  // an area outside from `/domain`
+
+  let documentation;
+  if (
+    apiResponse.connectorDocumentation &&
+    apiResponse.connectorDocumentation.trim().length > 0
+  ) {
+    documentation = await createMarkdown(apiResponse.connectorDocumentation);
+  }
   return {
     ...omit(apiResponse, ["connectorInfoList"]),
     connectorInfo: apiResponse.connectorInfoList[0],
+    connectorDocumentation: documentation,
   };
 }
 

--- a/coral/src/domain/connector/connector-types.ts
+++ b/coral/src/domain/connector/connector-types.ts
@@ -1,3 +1,4 @@
+import { MarkdownString } from "src/domain/helper/documentation-helper";
 import {
   KlawApiModel,
   KlawApiRequest,
@@ -9,6 +10,8 @@ type Connector = KlawApiModel<"KafkaConnectorModelResponse">;
 type ConnectorApiResponse = ResolveIntersectionTypes<Paginated<Connector[]>>;
 
 type ConnectorRequest = KlawApiModel<"KafkaConnectorRequestsResponseModel">;
+
+type ConnectorDocumentationMarkdown = MarkdownString;
 
 type ConnectorRequestsForApprover = ResolveIntersectionTypes<
   Paginated<ConnectorRequest[]>
@@ -28,14 +31,16 @@ type ConnectorOverview = ResolveIntersectionTypes<
     // there is only ever one entry in this list, and we want to access
     // it accordingly, that's why we transform it to connectorInfo instead
     connectorInfo: KlawApiModel<"KafkaConnectorModelResponse">;
+    connectorDocumentation?: ConnectorDocumentationMarkdown;
   }
 >;
 
 export type {
   Connector,
   ConnectorApiResponse,
+  ConnectorDocumentationMarkdown,
+  ConnectorOverview,
   ConnectorRequest,
   ConnectorRequestsForApprover,
   CreateConnectorRequestPayload,
-  ConnectorOverview,
 };

--- a/coral/src/domain/connector/index.ts
+++ b/coral/src/domain/connector/index.ts
@@ -7,9 +7,11 @@ import {
   getConnectorRequests,
   getConnectorRequestsForApprover,
   getConnectors,
+  updateConnectorDocumentation,
 } from "src/domain/connector/connector-api";
 import {
   Connector,
+  ConnectorDocumentationMarkdown,
   ConnectorOverview,
   ConnectorRequest,
   ConnectorRequestsForApprover,
@@ -25,6 +27,7 @@ export {
   getConnectorRequests,
   getConnectorRequestsForApprover,
   getConnectors,
+  updateConnectorDocumentation,
 };
 
 export type {
@@ -33,4 +36,5 @@ export type {
   ConnectorRequest,
   ConnectorRequestsForApprover,
   CreateConnectorRequestPayload,
+  ConnectorDocumentationMarkdown,
 };


### PR DESCRIPTION
## About this change - What it does

Add documentation tab (same implementation as Topic documentation tab).

## Followup

This PR may receive additional commits if this PR gets merged, to bring both in line: https://github.com/aiven/klaw/pull/1461

We could also reflect on creating shared components for both entities.


Resolves: #1449

