### PR TITLE
Update to generalise the class name for the topic and connector history

### DIFF
--- a/coral/src/app/features/connectors/details/ConnectorDetails.test.tsx
+++ b/coral/src/app/features/connectors/details/ConnectorDetails.test.tsx
@@ -41,7 +41,7 @@ const testConnectorOverview: ConnectorOverview = {
       '{\n  "connector.class" : "io.confluent.connect.storage.tools.SchemaSourceConnector",\n  "tasks.max" : "1",\n  "name" : "my-connector",\n  "topic" : "testtopic",\n  "topics.regex" : "*"\n}',
     environmentName: "DEV",
   },
-  topicHistoryList: [],
+  connectorHistoryList: [],
   promotionDetails: {
     sourceEnv: "4",
     connectorName: testConnectorName,

--- a/coral/src/app/features/connectors/details/components/ConnectorOverviewResourcesTabs.test.tsx
+++ b/coral/src/app/features/connectors/details/components/ConnectorOverviewResourcesTabs.test.tsx
@@ -45,7 +45,7 @@ const testConnectorOverview: ConnectorOverview = {
       '{\n  "connector.class" : "io.confluent.connect.storage.tools.SchemaSourceConnector",\n  "tasks.max" : "1",\n  "name" : "my-connector",\n  "topic" : "testtopic",\n  "topics.regex" : "*"\n}',
     environmentName: "DEV",
   },
-  topicHistoryList: [],
+  connectorHistoryList: [],
   promotionDetails: {
     sourceEnv: "4",
     connectorName: testConnectorName,

--- a/coral/types/api.d.ts
+++ b/coral/types/api.d.ts
@@ -1049,7 +1049,7 @@ export type components = {
       topicName?: string;
       error?: string;
     };
-    TopicHistory: {
+    ResourceHistory: {
       environmentName: string;
       teamName: string;
       requestedBy: string;
@@ -1067,7 +1067,7 @@ export type components = {
       aclInfoList?: (components["schemas"]["AclOverviewInfo"])[];
       prefixedAclInfoList?: (components["schemas"]["AclOverviewInfo"])[];
       transactionalAclInfoList?: (components["schemas"]["AclOverviewInfo"])[];
-      topicHistoryList?: (components["schemas"]["TopicHistory"])[];
+      topicHistoryList?: (components["schemas"]["ResourceHistory"])[];
       topicPromotionDetails: components["schemas"]["PromotionStatus"];
       availableEnvironments: (components["schemas"]["EnvIdInfo"])[];
       topicDocumentation?: string;
@@ -1417,7 +1417,7 @@ export type components = {
     };
     ConnectorOverview: {
       connectorInfoList: (components["schemas"]["KafkaConnectorModelResponse"])[];
-      topicHistoryList?: (components["schemas"]["TopicHistory"])[];
+      connectorHistoryList?: (components["schemas"]["ResourceHistory"])[];
       promotionDetails?: {
         [key: string]: string | undefined;
       };

--- a/core/src/main/java/io/aiven/klaw/model/ResourceHistory.java
+++ b/core/src/main/java/io/aiven/klaw/model/ResourceHistory.java
@@ -5,7 +5,7 @@ import java.io.Serializable;
 import lombok.Data;
 
 @Data
-public class TopicHistory implements Serializable {
+public class ResourceHistory implements Serializable {
   @NotNull private String environmentName;
 
   @NotNull private String teamName;

--- a/core/src/main/java/io/aiven/klaw/model/response/ConnectorOverview.java
+++ b/core/src/main/java/io/aiven/klaw/model/response/ConnectorOverview.java
@@ -1,6 +1,6 @@
 package io.aiven.klaw.model.response;
 
-import io.aiven.klaw.model.TopicHistory;
+import io.aiven.klaw.model.ResourceHistory;
 import jakarta.validation.constraints.NotNull;
 import java.util.List;
 import java.util.Map;
@@ -9,7 +9,7 @@ import lombok.Data;
 @Data
 public class ConnectorOverview {
   @NotNull List<KafkaConnectorModelResponse> connectorInfoList;
-  private List<TopicHistory> topicHistoryList;
+  private List<ResourceHistory> connectorHistoryList;
   Map<String, String> promotionDetails;
   @NotNull boolean connectorExists;
   @NotNull private List<EnvIdInfo> availableEnvironments;

--- a/core/src/main/java/io/aiven/klaw/model/response/TopicOverview.java
+++ b/core/src/main/java/io/aiven/klaw/model/response/TopicOverview.java
@@ -1,6 +1,6 @@
 package io.aiven.klaw.model.response;
 
-import io.aiven.klaw.model.TopicHistory;
+import io.aiven.klaw.model.ResourceHistory;
 import io.aiven.klaw.model.TopicOverviewInfo;
 import jakarta.validation.constraints.NotNull;
 import java.util.List;
@@ -12,7 +12,7 @@ public class TopicOverview extends ResourceOverviewAttributes {
   private List<AclOverviewInfo> aclInfoList;
   private List<AclOverviewInfo> prefixedAclInfoList;
   private List<AclOverviewInfo> transactionalAclInfoList;
-  private List<TopicHistory> topicHistoryList;
+  private List<ResourceHistory> topicHistoryList;
   @NotNull private PromotionStatus topicPromotionDetails;
   @NotNull private List<EnvIdInfo> availableEnvironments;
 

--- a/core/src/main/java/io/aiven/klaw/service/BaseOverviewService.java
+++ b/core/src/main/java/io/aiven/klaw/service/BaseOverviewService.java
@@ -9,7 +9,7 @@ import com.fasterxml.jackson.databind.ObjectWriter;
 import io.aiven.klaw.config.ManageDatabase;
 import io.aiven.klaw.dao.Acl;
 import io.aiven.klaw.dao.Env;
-import io.aiven.klaw.model.TopicHistory;
+import io.aiven.klaw.model.ResourceHistory;
 import io.aiven.klaw.model.TopicOverviewInfo;
 import io.aiven.klaw.model.enums.AclGroupBy;
 import io.aiven.klaw.model.enums.AclType;
@@ -44,7 +44,7 @@ public abstract class BaseOverviewService {
   public static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
   public static final ObjectWriter WRITER_WITH_DEFAULT_PRETTY_PRINTER =
       OBJECT_MAPPER.writerWithDefaultPrettyPrinter();
-  public static final TypeReference<ArrayList<TopicHistory>> VALUE_TYPE_REF =
+  public static final TypeReference<ArrayList<ResourceHistory>> VALUE_TYPE_REF =
       new TypeReference<>() {};
   private static final String MASKED_FOR_SECURITY = BASE_OVERVIEW_101;
 

--- a/core/src/main/java/io/aiven/klaw/service/CommonUtilsService.java
+++ b/core/src/main/java/io/aiven/klaw/service/CommonUtilsService.java
@@ -14,7 +14,7 @@ import io.aiven.klaw.dao.UserInfo;
 import io.aiven.klaw.helpers.UtilMethods;
 import io.aiven.klaw.model.KwMetadataUpdates;
 import io.aiven.klaw.model.KwTenantConfigModel;
-import io.aiven.klaw.model.TopicHistory;
+import io.aiven.klaw.model.ResourceHistory;
 import io.aiven.klaw.model.charts.ChartsJsOverview;
 import io.aiven.klaw.model.charts.Options;
 import io.aiven.klaw.model.charts.Title;
@@ -77,7 +77,8 @@ public class CommonUtilsService {
 
   public static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
 
-  public static final TypeReference<List<TopicHistory>> VALUE_TYPE_REF = new TypeReference<>() {};
+  public static final TypeReference<List<ResourceHistory>> VALUE_TYPE_REF =
+      new TypeReference<>() {};
 
   @Value("${klaw.enable.authorization.ad:false}")
   private boolean enableUserAuthorizationFromAD;
@@ -716,7 +717,7 @@ public class CommonUtilsService {
     return subTopicsList;
   }
 
-  public List<TopicHistory> saveTopicHistory(
+  public List<ResourceHistory> saveTopicHistory(
       String requestOperationType,
       String topicName,
       String topicEnvironment,
@@ -727,10 +728,10 @@ public class CommonUtilsService {
       int tenantId,
       String entityType,
       String remarks) {
-    List<TopicHistory> topicHistoryList = new ArrayList<>();
+    List<ResourceHistory> topicHistoryList = new ArrayList<>();
     try {
       AtomicReference<String> existingHistory = new AtomicReference<>("");
-      List<TopicHistory> existingTopicHistory;
+      List<ResourceHistory> existingTopicHistory;
       List<Topic> existingTopicList = new ArrayList<>();
       // topic requests (not create) or any acl/schema requests
       if ((!RequestOperationType.CREATE.value.equals(requestOperationType)
@@ -752,7 +753,7 @@ public class CommonUtilsService {
 
       SimpleDateFormat simpleDateFormat = new SimpleDateFormat("yyyy-MMM-dd HH:mm:ss");
 
-      TopicHistory topicHistory = new TopicHistory();
+      ResourceHistory topicHistory = new ResourceHistory();
       topicHistory.setTeamName(manageDatabase.getTeamNameFromTeamId(tenantId, ownerTeamId));
       topicHistory.setEnvironmentName(getEnvDetails(topicEnvironment, tenantId).getName());
       topicHistory.setRequestedBy(requestor);

--- a/core/src/main/java/io/aiven/klaw/service/TopicControllerService.java
+++ b/core/src/main/java/io/aiven/klaw/service/TopicControllerService.java
@@ -34,11 +34,11 @@ import io.aiven.klaw.error.KlawNotAuthorizedException;
 import io.aiven.klaw.helpers.HandleDbRequests;
 import io.aiven.klaw.helpers.KlawResourceUtils;
 import io.aiven.klaw.model.ApiResponse;
+import io.aiven.klaw.model.ResourceHistory;
 import io.aiven.klaw.model.TopicBaseConfig;
 import io.aiven.klaw.model.TopicConfigEntry;
 import io.aiven.klaw.model.TopicConfiguration;
 import io.aiven.klaw.model.TopicConfigurationRequest;
-import io.aiven.klaw.model.TopicHistory;
 import io.aiven.klaw.model.TopicInfo;
 import io.aiven.klaw.model.enums.AclPatternType;
 import io.aiven.klaw.model.enums.AclType;
@@ -840,7 +840,7 @@ public class TopicControllerService {
   }
 
   private void saveToTopicHistory(String userName, int tenantId, TopicRequest topicRequest) {
-    List<TopicHistory> topicHistoryList =
+    List<ResourceHistory> topicHistoryList =
         commonUtilsService.saveTopicHistory(
             topicRequest.getRequestOperationType(),
             topicRequest.getTopicname(),

--- a/core/src/main/java/io/aiven/klaw/service/TopicOverviewService.java
+++ b/core/src/main/java/io/aiven/klaw/service/TopicOverviewService.java
@@ -9,8 +9,8 @@ import io.aiven.klaw.dao.Env;
 import io.aiven.klaw.dao.Topic;
 import io.aiven.klaw.helpers.HandleDbRequests;
 import io.aiven.klaw.helpers.KlawResourceUtils;
+import io.aiven.klaw.model.ResourceHistory;
 import io.aiven.klaw.model.TopicConfigurationRequest;
-import io.aiven.klaw.model.TopicHistory;
 import io.aiven.klaw.model.TopicOverviewInfo;
 import io.aiven.klaw.model.enums.AclGroupBy;
 import io.aiven.klaw.model.enums.PromotionStatusType;
@@ -86,7 +86,7 @@ public class TopicOverviewService extends BaseOverviewService {
     }
 
     List<TopicOverviewInfo> topicInfoList = new ArrayList<>();
-    List<TopicHistory> topicHistoryList = new ArrayList<>();
+    List<ResourceHistory> topicHistoryList = new ArrayList<>();
     enrichTopicOverview(
         tenantId, topics, topicOverview, syncCluster, topicInfoList, topicHistoryList, topicName);
     List<AclOverviewInfo> aclInfo = new ArrayList<>();
@@ -234,9 +234,9 @@ public class TopicOverviewService extends BaseOverviewService {
       TopicOverview topicOverview,
       String syncCluster,
       List<TopicOverviewInfo> topicInfoList,
-      List<TopicHistory> topicHistoryList,
+      List<ResourceHistory> topicHistoryList,
       String topicName) {
-    ArrayList<TopicHistory> topicHistoryFromTopic;
+    ArrayList<ResourceHistory> topicHistoryFromTopic;
     for (Topic topic : topics) {
       TopicOverviewInfo topicInfo = new TopicOverviewInfo();
       topicInfo.setTopicName(topicName);

--- a/core/src/main/resources/static/js/connectorOverview.js
+++ b/core/src/main/resources/static/js/connectorOverview.js
@@ -537,7 +537,7 @@ app.controller("connectorOverviewCtrl", function($scope, $http, $location, $wind
             	}
             	$scope.promotionDetails = output.promotionDetails;
 
-                $scope.topicHistoryList = output.topicHistoryList;
+                $scope.connectorHistoryList = output.connectorHistoryList;
 
             	$scope.connectorDocumentation = output.connectorDocumentation;
             	$scope.tmpconnectorDocumentation = output.connectorDocumentation;

--- a/core/src/main/resources/templates/connectorOverview.html
+++ b/core/src/main/resources/templates/connectorOverview.html
@@ -640,12 +640,12 @@
 								</div>
 								<div class="tab-pane  p-3" id="history" role="tabpanel">
 
-									<div ng-show="topicHistoryList.length == 0" class="ribbon-wrapper card">
+									<div ng-show=" connectorHistoryList.length == 0" class="ribbon-wrapper card">
 										<div class="ribbon ribbon-warning">Notification</div>
 										<p class="ribbon-content">No history available !!</p>
 									</div>
 
-									<table class="table table-hover color-table success-table" ng-show="topicHistoryList.length != 0">
+									<table class="table table-hover color-table success-table" ng-show=" connectorHistoryList.length != 0">
 										<thead><tr>
 											<th align="left" width="14%">Team</th>
 											<th align="left" width="14%">Environment</th>
@@ -657,7 +657,7 @@
 										</tr>
 										</thead>
 										<tbody>
-										<tr ng-repeat="topicHistory in topicHistoryList">
+										<tr ng-repeat="topicHistory in  connectorHistoryList">
 											<td>{{ topicHistory.teamName }}</td>
 											<td><span class="badge badge-info">{{ topicHistory.environmentName }}</span></td>
 											<td>{{ topicHistory.requestedBy }}</td>

--- a/core/src/test/java/io/aiven/klaw/TopicAclControllerIT.java
+++ b/core/src/test/java/io/aiven/klaw/TopicAclControllerIT.java
@@ -21,7 +21,7 @@ import io.aiven.klaw.dao.EnvTag;
 import io.aiven.klaw.model.AclInfo;
 import io.aiven.klaw.model.ApiResponse;
 import io.aiven.klaw.model.KwPropertiesModel;
-import io.aiven.klaw.model.TopicHistory;
+import io.aiven.klaw.model.ResourceHistory;
 import io.aiven.klaw.model.TopicInfo;
 import io.aiven.klaw.model.enums.ApiResultStatus;
 import io.aiven.klaw.model.enums.KafkaClustersType;
@@ -1321,7 +1321,7 @@ public class TopicAclControllerIT {
 
     TopicOverview response = OBJECT_MAPPER.readValue(res, TopicOverview.class);
     assertThat(response.getTopicHistoryList())
-        .extracting(TopicHistory::getRemarks)
+        .extracting(ResourceHistory::getRemarks)
         .containsExactlyInAnyOrder(
             "TOPIC Create", "ACL Create Consumer - User:*", "SCHEMA Create Version : 1");
   }

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -6882,7 +6882,7 @@
         },
         "required" : [ "status" ]
       },
-      "TopicHistory" : {
+      "ResourceHistory" : {
         "properties" : {
           "environmentName" : {
             "type" : "string"
@@ -6949,7 +6949,7 @@
           "topicHistoryList" : {
             "type" : "array",
             "items" : {
-              "$ref" : "#/components/schemas/TopicHistory"
+              "$ref" : "#/components/schemas/ResourceHistory"
             }
           },
           "topicPromotionDetails" : {
@@ -7936,10 +7936,10 @@
               "$ref" : "#/components/schemas/KafkaConnectorModelResponse"
             }
           },
-          "topicHistoryList" : {
+          "connectorHistoryList" : {
             "type" : "array",
             "items" : {
-              "$ref" : "#/components/schemas/TopicHistory"
+              "$ref" : "#/components/schemas/ResourceHistory"
             }
           },
           "promotionDetails" : {


### PR DESCRIPTION
About this change - What it does
This changes the names of the connector overview to reference connectors instead of topics to reduce confusion on a shared resource.
Resolves: #xxxxx
Why this way
