### PR TITLE
refactor: Use ClusterStatus enum instead of strings for clusterStatus and envStatus

### DIFF
--- a/coral/types/api.d.ts
+++ b/coral/types/api.d.ts
@@ -1446,7 +1446,8 @@ export type components = {
       showDeleteCluster: boolean;
       totalNoPages: string;
       allPageNos: (string)[];
-      clusterStatus?: string;
+      /** @enum {string} */
+      clusterStatus: "OFFLINE" | "ONLINE" | "NOT_KNOWN";
       associatedServers?: string;
       projectName?: string;
       serviceName?: string;

--- a/coral/types/api.d.ts
+++ b/coral/types/api.d.ts
@@ -968,7 +968,8 @@ export type components = {
     };
     EnvUpdatedStatus: {
       result: string;
-      envstatus: string;
+      /** @enum {string} */
+      envStatus: "OFFLINE" | "ONLINE" | "NOT_KNOWN";
     };
     TopicsCountPerEnv: {
       status?: string;
@@ -1257,7 +1258,8 @@ export type components = {
       clusterId: number;
       tenantName: string;
       clusterName: string;
-      envStatus: string;
+      /** @enum {string} */
+      envStatus: "OFFLINE" | "ONLINE" | "NOT_KNOWN";
       otherParams: string;
       showDeleteEnv: boolean;
       totalNoPages: string;

--- a/core/src/main/java/io/aiven/klaw/dao/Env.java
+++ b/core/src/main/java/io/aiven/klaw/dao/Env.java
@@ -2,10 +2,13 @@ package io.aiven.klaw.dao;
 
 import io.aiven.klaw.helpers.EnvParamsConverter;
 import io.aiven.klaw.helpers.EnvTagConverter;
+import io.aiven.klaw.model.enums.ClusterStatus;
 import io.aiven.klaw.model.response.EnvParams;
 import jakarta.persistence.Column;
 import jakarta.persistence.Convert;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
 import jakarta.persistence.Id;
 import jakarta.persistence.IdClass;
 import jakarta.persistence.Table;
@@ -49,7 +52,8 @@ public class Env implements Serializable {
   private String envExists;
 
   @Column(name = "envstatus")
-  private String envStatus;
+  @Enumerated(EnumType.STRING)
+  private ClusterStatus envStatus;
 
   @Convert(converter = EnvTagConverter.class)
   @Column(name = "associatedenv")

--- a/core/src/main/java/io/aiven/klaw/dao/KwClusters.java
+++ b/core/src/main/java/io/aiven/klaw/dao/KwClusters.java
@@ -1,5 +1,6 @@
 package io.aiven.klaw.dao;
 
+import io.aiven.klaw.model.enums.ClusterStatus;
 import io.aiven.klaw.model.enums.KafkaSupportedProtocol;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -49,7 +50,8 @@ public class KwClusters implements Serializable {
   private String publicKey;
 
   @Column(name = "cstatus")
-  private String clusterStatus;
+  @Enumerated(EnumType.STRING)
+  private ClusterStatus clusterStatus;
 
   @Column(name = "projectname")
   private String projectName;

--- a/core/src/main/java/io/aiven/klaw/model/response/EnvModelResponse.java
+++ b/core/src/main/java/io/aiven/klaw/model/response/EnvModelResponse.java
@@ -1,6 +1,7 @@
 package io.aiven.klaw.model.response;
 
 import io.aiven.klaw.dao.EnvTag;
+import io.aiven.klaw.model.enums.ClusterStatus;
 import io.aiven.klaw.model.enums.KafkaClustersType;
 import jakarta.validation.constraints.NotNull;
 import java.io.Serializable;
@@ -28,7 +29,7 @@ public class EnvModelResponse implements Serializable {
 
   @NotNull private String clusterName;
 
-  @NotNull private String envStatus;
+  @NotNull private ClusterStatus envStatus;
 
   @NotNull private String otherParams;
 

--- a/core/src/main/java/io/aiven/klaw/model/response/EnvUpdatedStatus.java
+++ b/core/src/main/java/io/aiven/klaw/model/response/EnvUpdatedStatus.java
@@ -1,5 +1,6 @@
 package io.aiven.klaw.model.response;
 
+import io.aiven.klaw.model.enums.ClusterStatus;
 import jakarta.validation.constraints.NotNull;
 import lombok.Data;
 
@@ -7,5 +8,5 @@ import lombok.Data;
 public class EnvUpdatedStatus {
   @NotNull private String result;
 
-  @NotNull private String envstatus;
+  @NotNull private ClusterStatus envStatus;
 }

--- a/core/src/main/java/io/aiven/klaw/model/response/KwClustersModelResponse.java
+++ b/core/src/main/java/io/aiven/klaw/model/response/KwClustersModelResponse.java
@@ -1,5 +1,6 @@
 package io.aiven.klaw.model.response;
 
+import io.aiven.klaw.model.enums.ClusterStatus;
 import io.aiven.klaw.model.enums.KafkaSupportedProtocol;
 import jakarta.validation.constraints.NotNull;
 import java.io.Serializable;
@@ -31,7 +32,7 @@ public class KwClustersModelResponse implements Serializable {
 
   @NotNull private List<String> allPageNos;
 
-  private String clusterStatus;
+  @NotNull private ClusterStatus clusterStatus;
 
   private String associatedServers;
 

--- a/core/src/main/java/io/aiven/klaw/service/ClusterApiService.java
+++ b/core/src/main/java/io/aiven/klaw/service/ClusterApiService.java
@@ -163,14 +163,14 @@ public class ClusterApiService {
 
       ResponseEntity<ClusterStatus> resultBody =
           getRestTemplate().exchange(uri, HttpMethod.GET, getHttpEntity(), ClusterStatus.class);
-      return Objects.requireNonNull(resultBody.getBody()).value;
+      return Objects.requireNonNull(resultBody.getBody().value);
     } catch (Exception e) {
       log.error("Error from getClusterApiStatus ", e);
       return ClusterStatus.OFFLINE.value;
     }
   }
 
-  String getKafkaClusterStatus(
+  ClusterStatus getKafkaClusterStatus(
       String bootstrapHost,
       KafkaSupportedProtocol protocol,
       String clusterIdentification,
@@ -196,10 +196,10 @@ public class ClusterApiService {
 
       ResponseEntity<ClusterStatus> resultBody =
           getRestTemplate().exchange(uri, HttpMethod.GET, getHttpEntity(), ClusterStatus.class);
-      return Objects.requireNonNull(resultBody.getBody()).value;
+      return Objects.requireNonNull(resultBody.getBody());
     } catch (Exception e) {
       log.error("Error from getKafkaClusterStatus ", e);
-      return ClusterStatus.NOT_KNOWN.value;
+      return ClusterStatus.NOT_KNOWN;
     }
   }
 

--- a/core/src/main/java/io/aiven/klaw/service/ClusterApiService.java
+++ b/core/src/main/java/io/aiven/klaw/service/ClusterApiService.java
@@ -148,7 +148,8 @@ public class ClusterApiService {
     }
   }
 
-  public String getClusterApiStatus(String clusterApiUrl, boolean testConnection, int tenantId) {
+  public ClusterStatus getClusterApiStatus(
+      String clusterApiUrl, boolean testConnection, int tenantId) {
     log.info(
         "getClusterApiStatus clusterApiUrl {} testConnection{}", clusterApiUrl, testConnection);
     getClusterApiProperties(tenantId);
@@ -163,10 +164,10 @@ public class ClusterApiService {
 
       ResponseEntity<ClusterStatus> resultBody =
           getRestTemplate().exchange(uri, HttpMethod.GET, getHttpEntity(), ClusterStatus.class);
-      return Objects.requireNonNull(resultBody.getBody().value);
+      return Objects.requireNonNull(resultBody.getBody());
     } catch (Exception e) {
       log.error("Error from getClusterApiStatus ", e);
-      return ClusterStatus.OFFLINE.value;
+      return ClusterStatus.OFFLINE;
     }
   }
 

--- a/core/src/main/java/io/aiven/klaw/service/EnvControllerService.java
+++ b/core/src/main/java/io/aiven/klaw/service/EnvControllerService.java
@@ -96,7 +96,7 @@ public class EnvControllerService {
             kwClusters.getKafkaFlavor(),
             tenantId);
 
-    env.setEnvStatus(status.value);
+    env.setEnvStatus(status);
     manageDatabase.getHandleDbRequests().addNewEnv(env);
   }
 }

--- a/core/src/main/java/io/aiven/klaw/service/EnvControllerService.java
+++ b/core/src/main/java/io/aiven/klaw/service/EnvControllerService.java
@@ -4,6 +4,7 @@ import io.aiven.klaw.config.ManageDatabase;
 import io.aiven.klaw.dao.Env;
 import io.aiven.klaw.dao.KwClusters;
 import io.aiven.klaw.error.KlawException;
+import io.aiven.klaw.model.enums.ClusterStatus;
 import io.aiven.klaw.model.enums.KafkaClustersType;
 import java.util.*;
 import lombok.extern.slf4j.Slf4j;
@@ -81,7 +82,7 @@ public class EnvControllerService {
   }
 
   private void updateEnvStatusPerEnv(Integer tenantId, Env env) throws KlawException {
-    String status;
+    ClusterStatus status;
     KwClusters kwClusters =
         manageDatabase
             .getClusters(KafkaClustersType.of(env.getType()), tenantId)
@@ -95,7 +96,7 @@ public class EnvControllerService {
             kwClusters.getKafkaFlavor(),
             tenantId);
 
-    env.setEnvStatus(status);
+    env.setEnvStatus(status.value);
     manageDatabase.getHandleDbRequests().addNewEnv(env);
   }
 }

--- a/core/src/main/java/io/aiven/klaw/service/EnvsClustersTenantsControllerService.java
+++ b/core/src/main/java/io/aiven/klaw/service/EnvsClustersTenantsControllerService.java
@@ -1350,12 +1350,12 @@ public class EnvsClustersTenantsControllerService {
       status = ClusterStatus.OFFLINE;
       log.error("Error from getUpdateEnvStatus ", e);
     }
-    env.setEnvStatus(status.value);
+    env.setEnvStatus(status);
     manageDatabase.getHandleDbRequests().addNewEnv(env);
     manageDatabase.loadEnvMapForOneTenant(tenantId);
 
     envUpdatedStatus.setResult(ApiResultStatus.SUCCESS.value);
-    envUpdatedStatus.setEnvstatus(status.value);
+    envUpdatedStatus.setEnvStatus(status);
 
     return envUpdatedStatus;
   }

--- a/core/src/main/java/io/aiven/klaw/service/EnvsClustersTenantsControllerService.java
+++ b/core/src/main/java/io/aiven/klaw/service/EnvsClustersTenantsControllerService.java
@@ -33,6 +33,7 @@ import io.aiven.klaw.helpers.HandleDbRequests;
 import io.aiven.klaw.model.ApiResponse;
 import io.aiven.klaw.model.KwTenantModel;
 import io.aiven.klaw.model.enums.ApiResultStatus;
+import io.aiven.klaw.model.enums.ClusterStatus;
 import io.aiven.klaw.model.enums.EntityType;
 import io.aiven.klaw.model.enums.KafkaClustersType;
 import io.aiven.klaw.model.enums.KafkaFlavors;
@@ -1331,7 +1332,7 @@ public class EnvsClustersTenantsControllerService {
     int tenantId = commonUtilsService.getTenantId(getUserName());
     Env env = manageDatabase.getHandleDbRequests().getEnvDetails(envId, tenantId);
 
-    String status;
+    ClusterStatus status;
     try {
       KwClusters kwClusters =
           manageDatabase
@@ -1346,15 +1347,15 @@ public class EnvsClustersTenantsControllerService {
               kwClusters.getKafkaFlavor(),
               tenantId);
     } catch (Exception e) {
-      status = "OFFLINE";
+      status = ClusterStatus.OFFLINE;
       log.error("Error from getUpdateEnvStatus ", e);
     }
-    env.setEnvStatus(status);
+    env.setEnvStatus(status.value);
     manageDatabase.getHandleDbRequests().addNewEnv(env);
     manageDatabase.loadEnvMapForOneTenant(tenantId);
 
     envUpdatedStatus.setResult(ApiResultStatus.SUCCESS.value);
-    envUpdatedStatus.setEnvstatus(status);
+    envUpdatedStatus.setEnvstatus(status.value);
 
     return envUpdatedStatus;
   }

--- a/core/src/main/java/io/aiven/klaw/service/ServerConfigService.java
+++ b/core/src/main/java/io/aiven/klaw/service/ServerConfigService.java
@@ -24,6 +24,7 @@ import io.aiven.klaw.model.KwTenantConfigModel;
 import io.aiven.klaw.model.ServerConfigProperties;
 import io.aiven.klaw.model.TenantConfig;
 import io.aiven.klaw.model.enums.ApiResultStatus;
+import io.aiven.klaw.model.enums.ClusterStatus;
 import io.aiven.klaw.model.enums.EntityType;
 import io.aiven.klaw.model.enums.MetadataOperationType;
 import io.aiven.klaw.model.enums.PermissionType;
@@ -565,17 +566,20 @@ public class ServerConfigService {
   public ConnectivityStatus testClusterApiConnection(String clusterApiUrl) throws KlawException {
     ConnectivityStatus connectivityStatus = new ConnectivityStatus();
     int tenantId = commonUtilsService.getTenantId(getUserName());
-    String clusterApiStatus = clusterApiService.getClusterApiStatus(clusterApiUrl, true, tenantId);
-    if ("ONLINE".equals(clusterApiStatus)) {
-      clusterApiStatus = ApiResultStatus.SUCCESS.value;
+    ClusterStatus clusterApiStatus =
+        clusterApiService.getClusterApiStatus(clusterApiUrl, true, tenantId);
+
+    String apiResultStatus = "";
+    if (ClusterStatus.ONLINE.equals(clusterApiStatus)) {
+      apiResultStatus = ApiResultStatus.SUCCESS.value;
       KwPropertiesModel kwPropertiesModel = new KwPropertiesModel();
       kwPropertiesModel.setKwKey(CLUSTER_CONN_URL_KEY);
       kwPropertiesModel.setKwValue(clusterApiUrl);
       updateKwCustomProperty(kwPropertiesModel);
     } else {
-      clusterApiStatus = ApiResultStatus.FAILURE.value;
+      apiResultStatus = ApiResultStatus.FAILURE.value;
     }
-    connectivityStatus.setConnectionStatus(clusterApiStatus);
+    connectivityStatus.setConnectionStatus(apiResultStatus);
     return connectivityStatus;
   }
 

--- a/core/src/main/resources/static/js/envs.js
+++ b/core/src/main/resources/static/js/envs.js
@@ -141,7 +141,7 @@ app.controller("envsCtrl", function($scope, $http, $location, $window) {
 
                     swal({
                          title: "",
-                         text: "Current Status: "+output.envstatus,
+                         text: "Current Status: "+output.envStatus,
                          timer: 2000,
                          showConfirmButton: false
                      });

--- a/core/src/test/java/io/aiven/klaw/TopicAclControllerIT.java
+++ b/core/src/test/java/io/aiven/klaw/TopicAclControllerIT.java
@@ -24,6 +24,7 @@ import io.aiven.klaw.model.KwPropertiesModel;
 import io.aiven.klaw.model.ResourceHistory;
 import io.aiven.klaw.model.TopicInfo;
 import io.aiven.klaw.model.enums.ApiResultStatus;
+import io.aiven.klaw.model.enums.ClusterStatus;
 import io.aiven.klaw.model.enums.KafkaClustersType;
 import io.aiven.klaw.model.enums.KafkaSupportedProtocol;
 import io.aiven.klaw.model.enums.RequestOperationType;
@@ -408,7 +409,7 @@ public class TopicAclControllerIT {
   public void approveTopic() throws Exception {
     String topicName = TopicAclControllerIT.topicName + topicId1;
     when(clusterApiService.getClusterApiStatus(anyString(), anyBoolean(), anyInt()))
-        .thenReturn("ONLINE");
+        .thenReturn(ClusterStatus.ONLINE);
     ApiResponse apiResponse =
         ApiResponse.builder().success(true).message(ApiResultStatus.SUCCESS.value).build();
 
@@ -1014,7 +1015,7 @@ public class TopicAclControllerIT {
     // approve the topic
     String topicName = TopicAclControllerIT.topicName + topicID;
     when(clusterApiService.getClusterApiStatus(anyString(), anyBoolean(), anyInt()))
-        .thenReturn("ONLINE");
+        .thenReturn(ClusterStatus.ONLINE);
     ApiResponse apiResponse =
         ApiResponse.builder().success(true).message(ApiResultStatus.SUCCESS.value).build();
 

--- a/core/src/test/java/io/aiven/klaw/service/ClusterApiServiceTest.java
+++ b/core/src/test/java/io/aiven/klaw/service/ClusterApiServiceTest.java
@@ -111,9 +111,9 @@ public class ClusterApiServiceTest {
         new ResponseEntity<>(ClusterStatus.ONLINE, HttpStatus.OK);
     when(restTemplate.exchange(anyString(), eq(HttpMethod.GET), any(), eq(ClusterStatus.class)))
         .thenReturn(response);
-    String resultGetClusterApiStatus =
+    ClusterStatus resultGetClusterApiStatus =
         clusterApiService.getClusterApiStatus("/topics/getApiStatus", false, 1);
-    assertThat(resultGetClusterApiStatus).isEqualTo(ClusterStatus.ONLINE.value);
+    assertThat(resultGetClusterApiStatus).isEqualTo(ClusterStatus.ONLINE);
 
     ClusterStatus resultGetClusterStatus =
         clusterApiService.getKafkaClusterStatus(
@@ -129,8 +129,8 @@ public class ClusterApiServiceTest {
             Mockito.anyString(), eq(HttpMethod.GET), Mockito.any(), eq(String.class)))
         .thenThrow(new RuntimeException("error"));
 
-    String resultGetClusterApiStatus = clusterApiService.getClusterApiStatus("", false, 1);
-    assertThat(resultGetClusterApiStatus).isEqualTo("OFFLINE");
+    ClusterStatus resultGetClusterApiStatus = clusterApiService.getClusterApiStatus("", false, 1);
+    assertThat(resultGetClusterApiStatus).isEqualTo(ClusterStatus.OFFLINE);
 
     ClusterStatus resultGetKafkaClusterStatus =
         clusterApiService.getKafkaClusterStatus(

--- a/core/src/test/java/io/aiven/klaw/service/ClusterApiServiceTest.java
+++ b/core/src/test/java/io/aiven/klaw/service/ClusterApiServiceTest.java
@@ -111,13 +111,14 @@ public class ClusterApiServiceTest {
         new ResponseEntity<>(ClusterStatus.ONLINE, HttpStatus.OK);
     when(restTemplate.exchange(anyString(), eq(HttpMethod.GET), any(), eq(ClusterStatus.class)))
         .thenReturn(response);
-    String result = clusterApiService.getClusterApiStatus("/topics/getApiStatus", false, 1);
-    assertThat(result).isEqualTo(ClusterStatus.ONLINE.value);
+    String resultGetClusterApiStatus =
+        clusterApiService.getClusterApiStatus("/topics/getApiStatus", false, 1);
+    assertThat(resultGetClusterApiStatus).isEqualTo(ClusterStatus.ONLINE.value);
 
-    result =
+    ClusterStatus resultGetClusterStatus =
         clusterApiService.getKafkaClusterStatus(
             "", KafkaSupportedProtocol.PLAINTEXT, "", "", "", 1);
-    assertThat(result).isEqualTo(ClusterStatus.ONLINE.value);
+    assertThat(resultGetClusterStatus).isEqualTo(ClusterStatus.ONLINE);
   }
 
   @Test
@@ -128,13 +129,14 @@ public class ClusterApiServiceTest {
             Mockito.anyString(), eq(HttpMethod.GET), Mockito.any(), eq(String.class)))
         .thenThrow(new RuntimeException("error"));
 
-    String result = clusterApiService.getClusterApiStatus("", false, 1);
-    assertThat(result).isEqualTo("OFFLINE");
+    String resultGetClusterApiStatus = clusterApiService.getClusterApiStatus("", false, 1);
+    assertThat(resultGetClusterApiStatus).isEqualTo("OFFLINE");
 
-    result =
+    ClusterStatus resultGetKafkaClusterStatus =
         clusterApiService.getKafkaClusterStatus(
             "", KafkaSupportedProtocol.PLAINTEXT, "", "", "", 1);
-    assertThat(result).isEqualTo("NOT_KNOWN");
+
+    assertThat(resultGetKafkaClusterStatus).isEqualTo(ClusterStatus.NOT_KNOWN);
   }
 
   @Test

--- a/core/src/test/java/io/aiven/klaw/service/ServerConfigServiceTest.java
+++ b/core/src/test/java/io/aiven/klaw/service/ServerConfigServiceTest.java
@@ -22,6 +22,7 @@ import io.aiven.klaw.model.KwTenantConfigModel;
 import io.aiven.klaw.model.ServerConfigProperties;
 import io.aiven.klaw.model.TenantConfig;
 import io.aiven.klaw.model.enums.ApiResultStatus;
+import io.aiven.klaw.model.enums.ClusterStatus;
 import io.aiven.klaw.model.enums.KafkaClustersType;
 import io.aiven.klaw.model.response.KwPropertiesResponse;
 import java.util.Arrays;
@@ -448,7 +449,7 @@ public class ServerConfigServiceTest {
     env.setTenantId(101);
     env.setId(envId);
     env.setType(envType); // kafka,schemaregistry
-    env.setEnvStatus("NOT_KNOWN");
+    env.setEnvStatus(ClusterStatus.NOT_KNOWN);
     env.setEnvExists("true");
     env.setClusterId(clusterId);
 

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -6650,11 +6650,12 @@
           "result" : {
             "type" : "string"
           },
-          "envstatus" : {
-            "type" : "string"
+          "envStatus" : {
+            "type" : "string",
+            "enum" : [ "OFFLINE", "ONLINE", "NOT_KNOWN" ]
           }
         },
-        "required" : [ "envstatus", "result" ]
+        "required" : [ "envStatus", "result" ]
       },
       "TopicsCountPerEnv" : {
         "properties" : {
@@ -7485,7 +7486,8 @@
             "type" : "string"
           },
           "envStatus" : {
-            "type" : "string"
+            "type" : "string",
+            "enum" : [ "OFFLINE", "ONLINE", "NOT_KNOWN" ]
           },
           "otherParams" : {
             "type" : "string"

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -8019,7 +8019,8 @@
             }
           },
           "clusterStatus" : {
-            "type" : "string"
+            "type" : "string",
+            "enum" : [ "OFFLINE", "ONLINE", "NOT_KNOWN" ]
           },
           "associatedServers" : {
             "type" : "string"
@@ -8034,7 +8035,7 @@
             "type" : "string"
           }
         },
-        "required" : [ "allPageNos", "bootstrapServers", "clusterId", "clusterName", "clusterType", "kafkaFlavor", "protocol", "showDeleteCluster", "totalNoPages" ]
+        "required" : [ "allPageNos", "bootstrapServers", "clusterId", "clusterName", "clusterStatus", "clusterType", "kafkaFlavor", "protocol", "showDeleteCluster", "totalNoPages" ]
       },
       "ClusterInfo" : {
         "properties" : {


### PR DESCRIPTION
# About this change - What it does

- uses enum `ClusterStatus` for all `clusterStatus` values instead of string
- uses enum `ClusterStatus` for all `envStatus`  values instead of string
- uses enum `ClusterStatus` as return type for `testClusterApiConnection`  values instead of string
- changes `envstatus` to `envStatus` for `EnvUpdatedStatus` model


Relates to: #1462 

