### PR TITLE
Aiven acl deletion if not found on cluster

### DIFF
--- a/cluster-api/src/main/java/io/aiven/klaw/clusterapi/services/AivenApiService.java
+++ b/cluster-api/src/main/java/io/aiven/klaw/clusterapi/services/AivenApiService.java
@@ -25,6 +25,7 @@ import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
+import org.springframework.web.client.HttpClientErrorException;
 import org.springframework.web.client.RestClientException;
 import org.springframework.web.client.RestTemplate;
 
@@ -254,6 +255,11 @@ public class AivenApiService {
       restTemplate.exchange(uri, HttpMethod.DELETE, request, Object.class);
     } catch (Exception e) {
       log.error("Exception:", e);
+      if (e instanceof HttpClientErrorException) {
+        if (((HttpClientErrorException) e).getStatusCode() == HttpStatus.NOT_FOUND) {
+          return ApiResultStatus.SUCCESS.value;
+        }
+      }
       throw new Exception("Error in deleting acls " + e.getMessage());
     }
 


### PR DESCRIPTION
About this change - What it does

when an Aiven acl is deleted from Klaw, and if it doesn't exist in kafka cluster, then return SUCCESS

Resolves: #1387 
Why this way
this is basically caused by manual changes in cluster, and hence return success