### PR TITLE
fix(coral) - Topic/Connector details: fix tab content flicker on select

### DIFF
--- a/coral/src/app/features/connectors/details/components/ConnectorOverviewResourcesTabs.tsx
+++ b/coral/src/app/features/connectors/details/components/ConnectorOverviewResourcesTabs.tsx
@@ -111,34 +111,34 @@ function ConnectorOverviewResourcesTabs({
     );
   }
 
-  return (
-    <div>
-      <Tabs
-        value={currentTab}
-        onChange={(resourceTypeId) => navigateToTab(navigate, resourceTypeId)}
-      >
-        {tabsMap.map((tab) => {
-          return (
-            <Tabs.Tab
-              title={tab.title}
-              value={tab.connectorOverviewTabEnum}
-              aria-label={tab.title}
-              key={tab.title}
-            >
-              {currentTab === tab.connectorOverviewTabEnum && (
-                <div>
-                  <PreviewBanner
-                    linkTarget={`/connectorOverview?connectorName=${connectorName}`}
-                  />
-                  {renderTabContent()}
-                </div>
-              )}
-            </Tabs.Tab>
-          );
-        })}
-      </Tabs>
-    </div>
+  const ConnectorTabs = () => (
+    <Tabs
+      value={currentTab}
+      onChange={(resourceTypeId) => navigateToTab(navigate, resourceTypeId)}
+    >
+      {tabsMap.map((tab) => {
+        return (
+          <Tabs.Tab
+            title={tab.title}
+            value={tab.connectorOverviewTabEnum}
+            aria-label={tab.title}
+            key={tab.title}
+          >
+            {currentTab === tab.connectorOverviewTabEnum && (
+              <div>
+                <PreviewBanner
+                  linkTarget={`/connectorOverview?connectorName=${connectorName}`}
+                />
+                {renderTabContent()}
+              </div>
+            )}
+          </Tabs.Tab>
+        );
+      })}
+    </Tabs>
   );
+
+  return <ConnectorTabs />;
 }
 
 export { ConnectorOverviewResourcesTabs };

--- a/coral/src/app/features/topics/details/components/TopicDetailsResourceTabs.tsx
+++ b/coral/src/app/features/topics/details/components/TopicDetailsResourceTabs.tsx
@@ -87,7 +87,7 @@ function TopicOverviewResourcesTabs({
     },
   ];
 
-  function renderTabContent() {
+  const renderTabContent = () => {
     if (isError) {
       return (
         <Box marginBottom={"l1"} marginTop={"l2"} role="alert">
@@ -135,36 +135,36 @@ function TopicOverviewResourcesTabs({
         />
       </div>
     );
-  }
+  };
 
-  return (
-    <div>
-      <Tabs
-        value={currentTab}
-        onChange={(resourceTypeId) => navigateToTab(navigate, resourceTypeId)}
-      >
-        {tabsMap.map((tab) => {
-          return (
-            <Tabs.Tab
-              title={tab.title}
-              value={tab.topicOverviewTabEnum}
-              aria-label={tab.title}
-              key={tab.title}
-            >
-              {currentTab === tab.topicOverviewTabEnum && (
-                <div>
-                  <PreviewBanner
-                    linkTarget={`/topicOverview?topicname=${topicName}`}
-                  />
-                  {renderTabContent()}
-                </div>
-              )}
-            </Tabs.Tab>
-          );
-        })}
-      </Tabs>
-    </div>
+  const TopicTabs = () => (
+    <Tabs
+      value={currentTab}
+      onChange={(resourceTypeId) => navigateToTab(navigate, resourceTypeId)}
+    >
+      {tabsMap.map((tab) => {
+        return (
+          <Tabs.Tab
+            title={tab.title}
+            value={tab.topicOverviewTabEnum}
+            aria-label={tab.title}
+            key={tab.title}
+          >
+            {currentTab === tab.topicOverviewTabEnum && (
+              <div>
+                <PreviewBanner
+                  linkTarget={`/topicOverview?topicname=${topicName}`}
+                />
+                {renderTabContent()}
+              </div>
+            )}
+          </Tabs.Tab>
+        );
+      })}
+    </Tabs>
   );
+
+  return <TopicTabs />;
 }
 
 export { TopicOverviewResourcesTabs };


### PR DESCRIPTION
## About this change - What it does

I have noticed an unpleasant flicker when switching between tabs in the Topic and Connector details part of the app:

https://github.com/aiven/klaw/assets/20607294/9a243480-78d6-4c29-9ff6-e1b60b6c000f

I was very confused by it, and I assumed either some `StrictMode` shenanigans, or some inefficiency in the React renderer when returning JSX which maps over `tabsMap` every time a tab content changes, and then select the content to show based on the `currentTab` prop. 

It was not `StrictMode` (removing it made the flicker less noticeable, but was still present).

The solution I found was to create a component for the returned value of `TopicOverviewResourcesTabs` and `ConnectorOverviewResourcesTabs`. This completely eliminated the flicker. I assume that the React renderer has a easier time handling a function invocation in the form of a react component than pure JSX in this instance? It's a little mysterious.


https://github.com/aiven/klaw/assets/20607294/192c751c-86e5-4418-9537-05199bce6a62


