### PR TITLE
refactor(coral): Add DYNAMIC_API_PATHS

### DIFF
--- a/coral/src/domain/team/team-api.ts
+++ b/coral/src/domain/team/team-api.ts
@@ -1,4 +1,4 @@
-import api, { API_PATHS } from "src/services/api";
+import api, { API_PATHS, DYNAMIC_API_PATHS } from "src/services/api";
 import { KlawApiRequest, KlawApiResponse } from "types/utils";
 
 const getTeams = () => {
@@ -31,11 +31,7 @@ const updateTeam = ({
 
 const getTeamsOfUser = ({ userName }: { userName: string }) => {
   return api.get<KlawApiResponse<"getSwitchTeams">>(
-    // API_PATH does not cover arguments,
-    // follow up ticket: https://github.com/aiven/klaw/issues/1021
-    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-    // @ts-ignore
-    `/user/${userName}/switchTeamsList`
+    DYNAMIC_API_PATHS.getSwitchTeams({ userId: userName })
   );
 };
 

--- a/coral/src/services/api.ts
+++ b/coral/src/services/api.ts
@@ -193,7 +193,7 @@ const API_PATHS = {
     ApiOperations,
     "getSchemaOfTopicFromSource" | "getSwitchTeams"
   >]: keyof ApiPaths;
-}
+};
 
 type GetSchemaOfTopicFromSource = (params: {
   source: string;
@@ -218,7 +218,7 @@ const DYNAMIC_API_PATHS = {
     ApiOperations,
     "getSchemaOfTopicFromSource" | "getSwitchTeams"
   >]: GetSchemaOfTopicFromSource | GetSwitchTeams;
-}
+};
 
 type Params = URLSearchParams;
 


### PR DESCRIPTION
## About this change - What it does

Separate the API paths with dynamic parts into `DYNAMIC_API_PATHS`, which holds functions returning interpolated values for the dynamic parts of the path


Resolves: #1446

## CI failure

The CI fails because the current version of `prettier` doesn't recognize the `satisfies` syntax. It will be fixed after this is merged: https://github.com/aiven/klaw/pull/1481