### PR TITLE
housekeeping(coral): Upgrade `prettier` to `3.0.0`

### DIFF
--- a/coral/.prettierrc
+++ b/coral/.prettierrc
@@ -1,0 +1,3 @@
+{
+  "trailingComma": "es5"
+}

--- a/coral/package.json
+++ b/coral/package.json
@@ -97,7 +97,7 @@
     "lodash": "^4.17.21",
     "msw": "^0.47.4",
     "openapi-typescript": "^6.2.0",
-    "prettier": "^2.7.1",
+    "prettier": "^3.0.0",
     "react-test-renderer": "^18.2.0",
     "rollup-plugin-visualizer": "^5.9.0",
     "ts-jest": "^29.1.0",

--- a/coral/pnpm-lock.yaml
+++ b/coral/pnpm-lock.yaml
@@ -39,7 +39,7 @@ specifiers:
   monaco-editor: ^0.37.1
   msw: ^0.47.4
   openapi-typescript: ^6.2.0
-  prettier: ^2.7.1
+  prettier: ^3.0.0
   react: ^18.2.0
   react-dom: ^18.2.0
   react-hook-form: ^7.43.9
@@ -120,7 +120,7 @@ devDependencies:
   lodash: 4.17.21
   msw: 0.47.4_typescript@5.0.4
   openapi-typescript: 6.2.0
-  prettier: 2.7.1
+  prettier: 3.0.0
   react-test-renderer: 18.2.0_react@18.2.0
   rollup-plugin-visualizer: 5.9.0
   ts-jest: 29.1.0_tobmchb5uviuq5lwsinkw5fvje
@@ -7492,9 +7492,10 @@ packages:
     engines: {node: '>= 0.8.0'}
     dev: true
 
-  /prettier/2.7.1:
-    resolution: {integrity: sha512-ujppO+MkdPqoVINuDFDRLClm7D78qbDt0/NR+wp5FqEZOoTNAjPHWj17QRhu7geIHJfcNhRk1XVQmF8Bp3ye+g==}
-    engines: {node: '>=10.13.0'}
+  /prettier/3.0.0:
+    resolution: {integrity: sha512-zBf5eHpwHOGPC47h0zrPyNn+eAEIdEzfywMoYn2XPi0P44Zp0tSq64rq0xAREh4auw2cJZHo9QUob+NqCQky4g==}
+    engines: {node: '>=14'}
+    hasBin: true
     dev: true
 
   /pretty-format/27.5.1:

--- a/coral/src/app/components/Form.tsx
+++ b/coral/src/app/components/Form.tsx
@@ -588,7 +588,7 @@ function parseFieldErrorMessage<T extends FieldValues>(
 //
 function _ComplexNativeSelect<
   T extends FieldValues,
-  FieldValue extends string | OptionType
+  FieldValue extends string | OptionType,
 >({
   name,
   formContext: form,
@@ -633,7 +633,7 @@ const ComplexNativeSelectMemo = memo(
 // eslint-disable-next-line import/exports-last,import/group-exports
 export const ComplexNativeSelect = <
   T extends FieldValues,
-  FieldValue extends string | OptionType
+  FieldValue extends string | OptionType,
 >(
   props: FormInputProps<T> &
     Omit<BaseComplexNativeSelectProps<FieldValue>, "value" | "onBlur">

--- a/coral/src/app/features/topics/details/messages/useOffsetFilter.tsx
+++ b/coral/src/app/features/topics/details/messages/useOffsetFilter.tsx
@@ -2,10 +2,10 @@ import { useEffect } from "react";
 import { useSearchParams } from "react-router-dom";
 
 const offsets = ["5", "25", "50"] as const;
-type Offset = typeof offsets[number];
+type Offset = (typeof offsets)[number];
 
 const NAME = "offset";
-const defaultOffset: typeof offsets[0] = "5";
+const defaultOffset: (typeof offsets)[0] = "5";
 
 function isOffset(offset: string | null): offset is Offset {
   return Boolean(offset && offsets.includes(offset as Offset));

--- a/coral/src/app/features/topics/request/utils.ts
+++ b/coral/src/app/features/topics/request/utils.ts
@@ -11,13 +11,16 @@ function transformAdvancedConfigEntries(
   const asObject = JSON.parse(formData);
   return Object.entries(asObject)
     .map(([key, value]) => ({ configKey: key, configValue: value }))
-    .reduce((acc, { configKey, configValue }) => {
-      const valueAsString = coerceToString(configValue);
-      if (isString(valueAsString)) {
-        return acc.concat([{ configKey, configValue: valueAsString }]);
-      }
-      return acc;
-    }, [] as { configKey: string; configValue: string }[]);
+    .reduce(
+      (acc, { configKey, configValue }) => {
+        const valueAsString = coerceToString(configValue);
+        if (isString(valueAsString)) {
+          return acc.concat([{ configKey, configValue: valueAsString }]);
+        }
+        return acc;
+      },
+      [] as { configKey: string; configValue: string }[]
+    );
 }
 
 function coerceToString(value: unknown): string | undefined {

--- a/coral/src/services/api.ts
+++ b/coral/src/services/api.ts
@@ -456,7 +456,7 @@ function handleResponse<TResponse extends SomeObject>(
 
 function withPayloadAndVerb<
   TResponse extends SomeObject,
-  TBody extends SomeObject | URLSearchParams
+  TBody extends SomeObject | URLSearchParams,
 >(
   method: HTTPMethod.POST | HTTPMethod.PUT | HTTPMethod.PATCH,
   pathname: keyof ApiPaths,
@@ -483,7 +483,7 @@ const get = <T extends SomeObject>(pathname: keyof ApiPaths, params?: Params) =>
 
 const post = <
   TResponse extends SomeObject,
-  TBody extends SomeObject | URLSearchParams | never
+  TBody extends SomeObject | URLSearchParams | never,
 >(
   pathname: keyof ApiPaths,
   data?: TBody


### PR DESCRIPTION
 About this change - What it does

This PR also upgrade `prettier` to version `3.0.0`, as our current version did not support the `satisfies` syntax needed for this PR: https://github.com/aiven/klaw/pull/1480

However, given that `3.0.0` is a breaking change which has `all` as the default value for `trailingComma`, this PR also adds a `.prettierc` file to keep the `es5` behaviour. There were also some small changes bug fixes which required running `prettier --write` on the codebase to add missing semicolons and parenthesis: [0672e86](https://github.com/aiven/klaw/pull/1480/commits/0672e8678139b806189dfad94d49e71602c9e63b)




