### PR TITLE
feat(coral): Topic details: Add Claim topic banner

### DIFF
--- a/coral/src/app/features/topics/details/TopicDetails.tsx
+++ b/coral/src/app/features/topics/details/TopicDetails.tsx
@@ -1,4 +1,5 @@
-import { useQuery } from "@tanstack/react-query";
+import { useToast } from "@aivenio/aquarium";
+import { useMutation, useQuery } from "@tanstack/react-query";
 import { useEffect, useState } from "react";
 import {
   Navigate,
@@ -7,6 +8,8 @@ import {
   useOutletContext,
 } from "react-router-dom";
 import { EntityDetailsHeader } from "src/app/features/components/EntityDetailsHeader";
+import TopicClaimBanner from "src/app/features/topics/details/components/TopicClaimBanner";
+import { TopicClaimConfirmationModal } from "src/app/features/topics/details/components/TopicClaimConfirmationModal";
 import { TopicOverviewResourcesTabs } from "src/app/features/topics/details/components/TopicDetailsResourceTabs";
 import {
   TOPIC_OVERVIEW_TAB_ID_INTO_PATH,
@@ -14,7 +17,13 @@ import {
   isTopicsOverviewTabEnum,
 } from "src/app/router_utils";
 import { TopicOverview, TopicSchemaOverview } from "src/domain/topic";
-import { getSchemaOfTopic, getTopicOverview } from "src/domain/topic/topic-api";
+import {
+  claimTopic,
+  getSchemaOfTopic,
+  getTopicOverview,
+} from "src/domain/topic/topic-api";
+import { HTTPError } from "src/services/api";
+import { parseErrorMsg } from "src/services/mutation-utils";
 
 type TopicOverviewProps = {
   topicName: string;
@@ -37,6 +46,7 @@ function findMatchingTab(
 function TopicDetails(props: TopicOverviewProps) {
   const { topicName } = props;
   const { state: initialEnvironment }: { state: string | null } = useLocation();
+  const toast = useToast();
 
   const matches = useMatches();
   const currentTab = findMatchingTab(matches);
@@ -47,6 +57,10 @@ function TopicDetails(props: TopicOverviewProps) {
   const [schemaVersion, setSchemaVersion] = useState<number | undefined>(
     undefined
   );
+  const [showClaimModal, setShowClaimModal] = useState(false);
+  const [claimErrorMessage, setClaimErrorMessage] = useState<
+    string | undefined
+  >();
 
   const {
     data: topicData,
@@ -77,6 +91,33 @@ function TopicDetails(props: TopicOverviewProps) {
     enabled: environmentId !== undefined,
   });
 
+  const {
+    mutate: createClaimTopicRequest,
+    isLoading: createClaimTopicRequestIsLoading,
+    isError: createClaimTopicRequestIsError,
+  } = useMutation(
+    (remark?: string) =>
+      claimTopic({
+        topicName: topicData?.topicInfo.topicName || "",
+        env: topicData?.topicInfo.envId || "",
+        remark,
+      }),
+    {
+      onSuccess: () => {
+        setShowClaimModal(false);
+        toast({
+          message: "Topic claim request successfully created",
+          position: "bottom-left",
+          variant: "default",
+        });
+      },
+      onError: (error: HTTPError) => {
+        setShowClaimModal(false);
+        setClaimErrorMessage(parseErrorMsg(error));
+      },
+    }
+  );
+
   useEffect(() => {
     if (
       topicData?.availableEnvironments !== undefined &&
@@ -91,7 +132,14 @@ function TopicDetails(props: TopicOverviewProps) {
   }
 
   return (
-    <div>
+    <>
+      {showClaimModal && (
+        <TopicClaimConfirmationModal
+          onSubmit={createClaimTopicRequest}
+          onClose={() => setShowClaimModal(false)}
+          isLoading={createClaimTopicRequestIsLoading}
+        />
+      )}
       <EntityDetailsHeader
         entity={{ name: topicName, type: "topic" }}
         entityExists={Boolean(topicData?.topicExists)}
@@ -105,7 +153,14 @@ function TopicDetails(props: TopicOverviewProps) {
         environmentId={environmentId}
         setEnvironmentId={setEnvironmentId}
       />
-
+      {topicData?.topicInfo !== undefined &&
+        !topicData.topicInfo.topicOwner && (
+          <TopicClaimBanner
+            setShowClaimModal={setShowClaimModal}
+            isError={createClaimTopicRequestIsError}
+            errorMessage={claimErrorMessage}
+          />
+        )}
       <TopicOverviewResourcesTabs
         isLoading={topicIsLoading || schemaIsLoading}
         isError={topicIsError || schemaIsError}
@@ -120,7 +175,7 @@ function TopicDetails(props: TopicOverviewProps) {
         topicSchemas={schemaData}
         topicSchemasIsRefetching={schemaIsRefetching}
       />
-    </div>
+    </>
   );
 }
 

--- a/coral/src/app/features/topics/details/components/TopicClaimBanner.test.tsx
+++ b/coral/src/app/features/topics/details/components/TopicClaimBanner.test.tsx
@@ -1,0 +1,54 @@
+import { cleanup, render, screen, within } from "@testing-library/react";
+import TopicClaimBanner from "src/app/features/topics/details/components/TopicClaimBanner";
+import userEvent from "@testing-library/user-event";
+
+const mockSetShowClaimModal = jest.fn();
+
+const testProps = {
+  setShowClaimModal: mockSetShowClaimModal,
+  isError: false,
+};
+describe("TopicClaimBanner", () => {
+  afterEach(cleanup);
+
+  it("renders correct elements", () => {
+    render(<TopicClaimBanner {...testProps} />);
+    const description = screen.getByText(
+      "Your team is not the owner of this topic. Click below to create a claim request for this topic."
+    );
+    const button = screen.getByRole("button", { name: "Claim topic" });
+
+    expect(description).toBeVisible();
+    expect(button).toBeEnabled();
+  });
+
+  it("does not render error message when there is no error", () => {
+    render(<TopicClaimBanner {...testProps} />);
+    const error = screen.queryByRole("alert");
+
+    expect(error).not.toBeInTheDocument();
+  });
+
+  it("renders error message when there is an error", () => {
+    render(
+      <TopicClaimBanner
+        {...testProps}
+        isError
+        errorMessage={"There was an error"}
+      />
+    );
+    const error = screen.getByRole("alert");
+    const errorMessage = within(error).getByText("There was an error");
+
+    expect(error).toBeVisible();
+    expect(errorMessage).toBeVisible();
+  });
+
+  it("allows to start claim topic process", async () => {
+    render(<TopicClaimBanner {...testProps} />);
+    const button = screen.getByRole("button", { name: "Claim topic" });
+    await userEvent.click(button);
+
+    expect(mockSetShowClaimModal).toHaveBeenCalled();
+  });
+});

--- a/coral/src/app/features/topics/details/components/TopicClaimBanner.tsx
+++ b/coral/src/app/features/topics/details/components/TopicClaimBanner.tsx
@@ -1,0 +1,44 @@
+import {
+  Alert,
+  Banner,
+  Box,
+  Button,
+  GridItem,
+  Spacing,
+} from "@aivenio/aquarium";
+import { Dispatch, SetStateAction } from "react";
+
+interface TopicClaimBannerProps {
+  setShowClaimModal: Dispatch<SetStateAction<boolean>>;
+  isError: boolean;
+  errorMessage?: string;
+}
+
+const TopicClaimBanner = ({
+  setShowClaimModal,
+  isError,
+  errorMessage,
+}: TopicClaimBannerProps) => {
+  return (
+    <GridItem colSpan={"span-2"} marginBottom={"l1"}>
+      <Banner layout="vertical" title={""}>
+        <Spacing gap={"l1"}>
+          {isError && (
+            <div role="alert">
+              <Alert type="error">{errorMessage}</Alert>
+            </div>
+          )}
+          <Box component={"p"} marginBottom={"l1"}>
+            Your team is not the owner of this topic. Click below to create a
+            claim request for this topic.
+          </Box>
+        </Spacing>
+        <Button.Primary onClick={() => setShowClaimModal(true)}>
+          Claim topic
+        </Button.Primary>
+      </Banner>
+    </GridItem>
+  );
+};
+
+export default TopicClaimBanner;

--- a/coral/src/app/features/topics/details/components/TopicClaimConfirmationModal.test.tsx
+++ b/coral/src/app/features/topics/details/components/TopicClaimConfirmationModal.test.tsx
@@ -1,0 +1,182 @@
+import { TopicClaimConfirmationModal } from "src/app/features/topics/details/components/TopicClaimConfirmationModal";
+import { cleanup, render, screen, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+const mockOnClose = jest.fn();
+const mockOnSubmit = jest.fn();
+describe("TopicClaimConfirmationModal", () => {
+  const user = userEvent.setup();
+
+  describe("renders all necessary elements when isLoading is false", () => {
+    beforeEach(() => {
+      render(
+        <TopicClaimConfirmationModal
+          onClose={mockOnClose}
+          onSubmit={mockOnSubmit}
+          isLoading={false}
+        />
+      );
+    });
+
+    afterEach(() => {
+      cleanup();
+      jest.clearAllMocks();
+    });
+
+    it("shows a dialog element", () => {
+      const dialog = screen.getByRole("dialog");
+
+      expect(dialog).toBeVisible();
+    });
+
+    it("shows more information to claim the topic", () => {
+      const dialog = screen.getByRole("dialog");
+      const headline = within(dialog).getByRole("heading", {
+        name: "Claim topic",
+      });
+      const text = within(dialog).getByText(
+        "Are you sure you would like to claim this topic?"
+      );
+
+      expect(headline).toBeVisible();
+      expect(text).toBeVisible();
+    });
+
+    it("shows a textarea where user can add a comment why they claim the topic", () => {
+      const dialog = screen.getByRole("dialog");
+      const textarea = within(dialog).getByRole("textbox", {
+        name: "You can add the reason to claim the topic (optional)",
+      });
+
+      expect(textarea).toBeEnabled();
+    });
+
+    it("shows a button to cancel process", () => {
+      const dialog = screen.getByRole("dialog");
+      const cancelButton = within(dialog).getByRole("button", {
+        name: "Cancel",
+      });
+
+      expect(cancelButton).toBeEnabled();
+    });
+
+    it("shows a button to claim topic", () => {
+      const dialog = screen.getByRole("dialog");
+      const confirmButton = within(dialog).getByRole("button", {
+        name: "Request claim topic",
+      });
+
+      expect(confirmButton).toBeEnabled();
+    });
+  });
+
+  describe("shows disabled buttons when isLoading is true", () => {
+    beforeAll(() => {
+      render(
+        <TopicClaimConfirmationModal
+          onClose={mockOnClose}
+          onSubmit={mockOnSubmit}
+          isLoading={true}
+        />
+      );
+    });
+
+    afterAll(() => {
+      cleanup();
+      jest.clearAllMocks();
+    });
+
+    it("disables textarea where user can add a comment why they claim the topic", () => {
+      const dialog = screen.getByRole("dialog");
+      const textarea = within(dialog).getByRole("textbox", {
+        name: "You can add the reason to claim the topic (optional)",
+      });
+
+      expect(textarea).toBeDisabled();
+    });
+
+    it("disables button to cancel process", () => {
+      const dialog = screen.getByRole("dialog");
+      const cancelButton = within(dialog).getByRole("button", {
+        name: "Cancel",
+      });
+
+      expect(cancelButton).toBeDisabled();
+    });
+
+    it("disables button to claim topic and shows loading indicator", () => {
+      const dialog = screen.getByRole("dialog");
+      const confirmButton = within(dialog).getByRole("button", {
+        name: "Request claim topic",
+      });
+      const loadingAnimation =
+        within(confirmButton).getByTestId("loading-button");
+
+      expect(confirmButton).toBeDisabled();
+      expect(loadingAnimation).toBeVisible();
+    });
+  });
+
+  describe("enables user to cancel process", () => {
+    beforeEach(() => {
+      render(
+        <TopicClaimConfirmationModal
+          onClose={mockOnClose}
+          onSubmit={mockOnSubmit}
+          isLoading={false}
+        />
+      );
+    });
+
+    afterEach(() => {
+      cleanup();
+      jest.clearAllMocks();
+    });
+
+    it("triggers a given onClose function if user clicks cancel", async () => {
+      const dialog = screen.getByRole("dialog");
+      const cancelButton = within(dialog).getByRole("button", {
+        name: "Cancel",
+      });
+
+      await user.click(cancelButton);
+
+      expect(mockOnClose).toHaveBeenCalledTimes(1);
+      expect(mockOnSubmit).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("enables user to start the claiming process", () => {
+    beforeEach(() => {
+      render(
+        <TopicClaimConfirmationModal
+          onClose={mockOnClose}
+          onSubmit={mockOnSubmit}
+          isLoading={false}
+        />
+      );
+    });
+
+    afterEach(() => {
+      cleanup();
+      jest.clearAllMocks();
+    });
+
+    it("triggers a given submit function with correct date when user adds a reason", async () => {
+      const dialog = screen.getByRole("dialog");
+      const textarea = within(dialog).getByRole("textbox", {
+        name: "You can add the reason to claim the topic (optional)",
+      });
+
+      const confirmationButton = within(dialog).getByRole("button", {
+        name: "Request claim topic",
+      });
+
+      await user.type(textarea, "This is my reason");
+      await user.click(confirmationButton);
+
+      expect(mockOnSubmit).toHaveBeenCalledWith("This is my reason");
+      expect(mockOnClose).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/coral/src/app/features/topics/details/components/TopicClaimConfirmationModal.tsx
+++ b/coral/src/app/features/topics/details/components/TopicClaimConfirmationModal.tsx
@@ -1,0 +1,49 @@
+import { Box, Textarea } from "@aivenio/aquarium";
+import { useState } from "react";
+import { Modal } from "src/app/components/Modal";
+
+interface TopicClaimConfirmationModalProps {
+  onClose: () => void;
+  onSubmit: (remark?: string) => void;
+  isLoading: boolean;
+}
+
+const TopicClaimConfirmationModal = ({
+  onClose,
+  onSubmit,
+  isLoading,
+}: TopicClaimConfirmationModalProps) => {
+  const [remark, setRemark] = useState<string | undefined>(undefined);
+
+  return (
+    <Modal
+      title={"Claim topic"}
+      close={onClose}
+      primaryAction={{
+        text: "Request claim topic",
+        onClick: () => onSubmit(remark),
+        loading: isLoading,
+      }}
+      secondaryAction={{
+        text: "Cancel",
+        onClick: onClose,
+        disabled: isLoading,
+      }}
+    >
+      <Box.Flex flexDirection={"column"} rowGap={"l1"}>
+        <p>Are you sure you would like to claim this topic?</p>
+        <Textarea
+          labelText="You can add the reason to claim the topic (optional)"
+          placeholder="Write a message ..."
+          onChange={(event) =>
+            setRemark(event.target.value ? event.target.value : undefined)
+          }
+          valid={true}
+          disabled={isLoading}
+        />
+      </Box.Flex>
+    </Modal>
+  );
+};
+
+export { TopicClaimConfirmationModal };

--- a/coral/src/app/pages/topics/details/index.test.tsx
+++ b/coral/src/app/pages/topics/details/index.test.tsx
@@ -1,3 +1,4 @@
+import { Context as AquariumContext } from "@aivenio/aquarium";
 import { cleanup, screen } from "@testing-library/react";
 import { TopicDetailsPage } from "src/app/pages/topics/details";
 import { customRender } from "src/services/test-utils/render-with-wrappers";
@@ -35,10 +36,15 @@ describe("TopicOverviewPage", () => {
         },
       ]);
 
-      customRender(<TopicDetailsPage />, {
-        memoryRouter: true,
-        queryClient: true,
-      });
+      customRender(
+        <AquariumContext>
+          <TopicDetailsPage />
+        </AquariumContext>,
+        {
+          memoryRouter: true,
+          queryClient: true,
+        }
+      );
     });
 
     afterAll(() => {

--- a/coral/src/domain/topic/topic-api.ts
+++ b/coral/src/domain/topic/topic-api.ts
@@ -21,6 +21,7 @@ import {
   NoContent,
   TopicAdvancedConfigurationOptions,
   TopicApiResponse,
+  TopicClaimPayload,
   TopicDocumentationMarkdown,
   TopicMessages,
   TopicOverview,
@@ -362,7 +363,12 @@ const getTopicDetailsPerEnv = (
   );
 };
 
-const claimTopic = (payload: KlawApiModel<"TopicClaimRequestModel">) => {
+const claimTopic = (params: TopicClaimPayload) => {
+  const payload: KlawApiModel<"TopicClaimRequestModel"> = {
+    env: params.env,
+    topicName: params.topicName,
+  };
+
   return api.post<
     KlawApiResponse<"createClaimTopicRequest">,
     KlawApiModel<"TopicClaimRequestModel">

--- a/coral/src/domain/topic/topic-types.ts
+++ b/coral/src/domain/topic/topic-types.ts
@@ -76,6 +76,15 @@ type DeleteTopicPayload = ResolveIntersectionTypes<
   }
 >;
 
+// "remark" is currently not implemented in the API
+// and will be added later. We're already preparing
+// our UI and code for that.
+type TopicClaimPayload = ResolveIntersectionTypes<
+  KlawApiModel<"TopicClaimRequestModel"> & {
+    remark?: string;
+  }
+>;
+
 type TopicDetailsPerEnv = KlawApiModel<"TopicDetailsPerEnv">;
 
 export type {
@@ -85,6 +94,7 @@ export type {
   Topic,
   TopicAdvancedConfigurationOptions,
   TopicApiResponse,
+  TopicClaimPayload,
   TopicDetailsPerEnv,
   TopicDocumentationMarkdown,
   TopicMessages,


### PR DESCRIPTION
## About this change - What it does

When user goes to topic overview, if they are not part of the team which is the owner of the topic, they have the option to Claim the topic, which will transfer ownership to their current team.

The request needs to be approved by a member of the team from which ownership is claimed.

https://github.com/aiven/klaw/assets/20607294/77a60c66-cc8b-4dee-bc3c-f92ef8947235



## Follw up

Because the Claim request is opened for the team from which the ownership is taken, `hasOpenRequest` and `hasOpenTopicRequest` stay `false` for the user who just requested the promotion. 

This means that we can't consistently dismiss the banner or change its content after a user has made a claim request.

In this video, a user from team `Ospo` has sent a claim request for `mytesttocpifc` which is owned by `DevRel`, and you can see that `mytesttocpifc` only has open requests when logged in as a `DevRel` user.

https://github.com/aiven/klaw/assets/20607294/11f62de8-83a7-4946-8a33-d47d3c3b637f




Resolves: #1492
