### PR TITLE
feat(coral): Improve promotion information for schema

### DIFF
--- a/coral/src/app/features/topics/details/components/PromotionBanner.test.tsx
+++ b/coral/src/app/features/topics/details/components/PromotionBanner.test.tsx
@@ -31,6 +31,8 @@ describe("PromotionBanner", () => {
           type={"schema"}
           promoteElement={<></>}
           hasOpenRequest={false}
+          hasError={false}
+          errorMessage={""}
         />
       );
 
@@ -45,6 +47,8 @@ describe("PromotionBanner", () => {
           type={"schema"}
           promoteElement={<></>}
           hasOpenRequest={false}
+          hasError={false}
+          errorMessage={""}
         />
       );
 
@@ -59,6 +63,8 @@ describe("PromotionBanner", () => {
           type={"schema"}
           promoteElement={<></>}
           hasOpenRequest={false}
+          hasError={false}
+          errorMessage={""}
         />
       );
 
@@ -73,6 +79,8 @@ describe("PromotionBanner", () => {
           type={"schema"}
           promoteElement={<></>}
           hasOpenRequest={false}
+          hasError={false}
+          errorMessage={""}
         />
       );
 
@@ -87,6 +95,8 @@ describe("PromotionBanner", () => {
           type={"schema"}
           promoteElement={<></>}
           hasOpenRequest={false}
+          hasError={false}
+          errorMessage={""}
         />
       );
 
@@ -101,6 +111,8 @@ describe("PromotionBanner", () => {
           type={"schema"}
           promoteElement={<></>}
           hasOpenRequest={false}
+          hasError={false}
+          errorMessage={""}
         />
       );
 
@@ -117,6 +129,8 @@ describe("PromotionBanner", () => {
           type={"schema"}
           promoteElement={<></>}
           hasOpenRequest={true}
+          hasError={false}
+          errorMessage={""}
         />
       );
     });
@@ -147,6 +161,8 @@ describe("PromotionBanner", () => {
           type={"topic"}
           promoteElement={<></>}
           hasOpenRequest={true}
+          hasError={false}
+          errorMessage={""}
         />
       );
     });
@@ -177,6 +193,8 @@ describe("PromotionBanner", () => {
           type={"schema"}
           promoteElement={<></>}
           hasOpenRequest={false}
+          hasError={false}
+          errorMessage={""}
         />
       );
     });
@@ -207,6 +225,8 @@ describe("PromotionBanner", () => {
           type={"topic"}
           promoteElement={<></>}
           hasOpenRequest={false}
+          hasError={false}
+          errorMessage={""}
         />
       );
     });
@@ -240,6 +260,8 @@ describe("PromotionBanner", () => {
           type={"schema"}
           promoteElement={promoteElement}
           hasOpenRequest={false}
+          hasError={false}
+          errorMessage={""}
         />
       );
     });
@@ -273,6 +295,8 @@ describe("PromotionBanner", () => {
           type={"topic"}
           promoteElement={promoteElement}
           hasOpenRequest={false}
+          hasError={false}
+          errorMessage={""}
         />
       );
     });
@@ -291,6 +315,61 @@ describe("PromotionBanner", () => {
       const promotionElement = screen.getByTestId("test-promote-element");
 
       expect(promotionElement).toBeVisible();
+    });
+  });
+
+  describe("handles error for promotion (type schema and topic)", () => {
+    const originalConsoleError = console.error;
+
+    beforeEach(() => {
+      console.error = jest.fn();
+    });
+
+    afterEach(() => {
+      console.error = originalConsoleError;
+      jest.resetAllMocks();
+      cleanup();
+    });
+
+    it("shows an alert with a given message", () => {
+      const testErrorMessage = "This is an error";
+      render(
+        <PromotionBanner
+          entityName={testTopicName}
+          promotionDetails={promotionDetails}
+          type={"schema"}
+          promoteElement={<></>}
+          hasOpenRequest={false}
+          hasError={true}
+          errorMessage={testErrorMessage}
+        />
+      );
+
+      const alert = screen.getByRole("alert");
+
+      expect(alert).toBeVisible();
+      expect(alert).toHaveTextContent(testErrorMessage);
+      expect(console.error).not.toHaveBeenCalled();
+    });
+
+    it("logs error for developers and shows generic message if errorMessage is empty string", () => {
+      render(
+        <PromotionBanner
+          entityName={testTopicName}
+          promotionDetails={promotionDetails}
+          type={"schema"}
+          promoteElement={<></>}
+          hasOpenRequest={false}
+          hasError={true}
+          errorMessage={""}
+        />
+      );
+      const alert = screen.getByRole("alert");
+
+      expect(alert).toHaveTextContent("Unexpected error.");
+      expect(console.error).toHaveBeenCalledWith(
+        "Please pass a useful errorMessage for the user!"
+      );
     });
   });
 
@@ -315,6 +394,8 @@ describe("PromotionBanner", () => {
           type={"schema"}
           promoteElement={<></>}
           hasOpenRequest={true}
+          hasError={false}
+          errorMessage={""}
         />
       );
       const button = screen.getByRole("button", { name: "See the request" });
@@ -334,6 +415,8 @@ describe("PromotionBanner", () => {
           type={"topic"}
           promoteElement={<></>}
           hasOpenRequest={true}
+          hasError={false}
+          errorMessage={""}
         />
       );
 
@@ -354,6 +437,8 @@ describe("PromotionBanner", () => {
           type={"schema"}
           promoteElement={<></>}
           hasOpenRequest={false}
+          hasError={false}
+          errorMessage={""}
         />
       );
 
@@ -374,6 +459,8 @@ describe("PromotionBanner", () => {
           type={"topic"}
           promoteElement={<></>}
           hasOpenRequest={false}
+          hasError={false}
+          errorMessage={""}
         />
       );
 

--- a/coral/src/app/features/topics/details/components/PromotionBanner.test.tsx
+++ b/coral/src/app/features/topics/details/components/PromotionBanner.test.tsx
@@ -116,7 +116,7 @@ describe("PromotionBanner", () => {
 
     it("shows information about the open request", () => {
       const information = screen.getByText(
-        `There is an open request for ${testTopicName}.`
+        `There is an open schema request for ${testTopicName}.`
       );
 
       expect(information).toBeVisible();
@@ -150,7 +150,7 @@ describe("PromotionBanner", () => {
 
     it("shows information about the open request", () => {
       const information = screen.getByText(
-        `There is an open request for ${testTopicName}.`
+        `There is an open topic request for ${testTopicName}.`
       );
 
       expect(information).toBeVisible();

--- a/coral/src/app/features/topics/details/components/PromotionBanner.test.tsx
+++ b/coral/src/app/features/topics/details/components/PromotionBanner.test.tsx
@@ -26,7 +26,7 @@ describe("PromotionBanner", () => {
     it("returns null if status is NOT_AUTHORIZED", () => {
       const { container } = render(
         <PromotionBanner
-          topicName={testTopicName}
+          entityName={testTopicName}
           promotionDetails={{ ...promotionDetails, status: "NOT_AUTHORIZED" }}
           type={"schema"}
           promoteElement={<></>}
@@ -40,7 +40,7 @@ describe("PromotionBanner", () => {
     it("returns null if status is NO_PROMOTION", () => {
       const { container } = render(
         <PromotionBanner
-          topicName={testTopicName}
+          entityName={testTopicName}
           promotionDetails={{ ...promotionDetails, status: "NO_PROMOTION" }}
           type={"schema"}
           promoteElement={<></>}
@@ -54,7 +54,7 @@ describe("PromotionBanner", () => {
     it("returns null if status is FAILURE", () => {
       const { container } = render(
         <PromotionBanner
-          topicName={testTopicName}
+          entityName={testTopicName}
           promotionDetails={{ ...promotionDetails, status: "FAILURE" }}
           type={"schema"}
           promoteElement={<></>}
@@ -68,7 +68,7 @@ describe("PromotionBanner", () => {
     it("returns null if targetEnv is undefined", () => {
       const { container } = render(
         <PromotionBanner
-          topicName={testTopicName}
+          entityName={testTopicName}
           promotionDetails={{ ...promotionDetails, targetEnv: undefined }}
           type={"schema"}
           promoteElement={<></>}
@@ -82,7 +82,7 @@ describe("PromotionBanner", () => {
     it("returns null if sourceEnv is undefined", () => {
       const { container } = render(
         <PromotionBanner
-          topicName={testTopicName}
+          entityName={testTopicName}
           promotionDetails={{ ...promotionDetails, sourceEnv: undefined }}
           type={"schema"}
           promoteElement={<></>}
@@ -96,7 +96,7 @@ describe("PromotionBanner", () => {
     it("returns null if targetEnvId is undefined", () => {
       const { container } = render(
         <PromotionBanner
-          topicName={testTopicName}
+          entityName={testTopicName}
           promotionDetails={{ ...promotionDetails, targetEnvId: undefined }}
           type={"schema"}
           promoteElement={<></>}
@@ -112,7 +112,7 @@ describe("PromotionBanner", () => {
     beforeAll(() => {
       render(
         <PromotionBanner
-          topicName={testTopicName}
+          entityName={testTopicName}
           promotionDetails={promotionDetails}
           type={"schema"}
           promoteElement={<></>}
@@ -142,7 +142,7 @@ describe("PromotionBanner", () => {
     beforeAll(() => {
       render(
         <PromotionBanner
-          topicName={testTopicName}
+          entityName={testTopicName}
           promotionDetails={promotionDetails}
           type={"topic"}
           promoteElement={<></>}
@@ -172,7 +172,7 @@ describe("PromotionBanner", () => {
     beforeAll(() => {
       render(
         <PromotionBanner
-          topicName={testTopicName}
+          entityName={testTopicName}
           promotionDetails={{ ...promotionDetails, status: "REQUEST_OPEN" }}
           type={"schema"}
           promoteElement={<></>}
@@ -202,7 +202,7 @@ describe("PromotionBanner", () => {
     beforeAll(() => {
       render(
         <PromotionBanner
-          topicName={testTopicName}
+          entityName={testTopicName}
           promotionDetails={{ ...promotionDetails, status: "REQUEST_OPEN" }}
           type={"topic"}
           promoteElement={<></>}
@@ -235,7 +235,7 @@ describe("PromotionBanner", () => {
     beforeAll(() => {
       render(
         <PromotionBanner
-          topicName={testTopicName}
+          entityName={testTopicName}
           promotionDetails={promotionDetails}
           type={"schema"}
           promoteElement={promoteElement}
@@ -268,7 +268,7 @@ describe("PromotionBanner", () => {
     beforeAll(() => {
       render(
         <PromotionBanner
-          topicName={testTopicName}
+          entityName={testTopicName}
           promotionDetails={promotionDetails}
           type={"topic"}
           promoteElement={promoteElement}
@@ -310,7 +310,7 @@ describe("PromotionBanner", () => {
     it("handles navigating for entity with an open request (type schema)", async () => {
       render(
         <PromotionBanner
-          topicName={testTopicName}
+          entityName={testTopicName}
           promotionDetails={promotionDetails}
           type={"schema"}
           promoteElement={<></>}
@@ -329,7 +329,7 @@ describe("PromotionBanner", () => {
     it("handles navigating for entity with an open request (type topic)", async () => {
       render(
         <PromotionBanner
-          topicName={testTopicName}
+          entityName={testTopicName}
           promotionDetails={promotionDetails}
           type={"topic"}
           promoteElement={<></>}
@@ -349,7 +349,7 @@ describe("PromotionBanner", () => {
     it("handles navigating for entity with an open promotion request (type schema)", async () => {
       render(
         <PromotionBanner
-          topicName={testTopicName}
+          entityName={testTopicName}
           promotionDetails={{ ...promotionDetails, status: "REQUEST_OPEN" }}
           type={"schema"}
           promoteElement={<></>}
@@ -369,7 +369,7 @@ describe("PromotionBanner", () => {
     it("handles navigating for entity with an open promotion request (type topic)", async () => {
       render(
         <PromotionBanner
-          topicName={testTopicName}
+          entityName={testTopicName}
           promotionDetails={{ ...promotionDetails, status: "REQUEST_OPEN" }}
           type={"topic"}
           promoteElement={<></>}

--- a/coral/src/app/features/topics/details/components/PromotionBanner.test.tsx
+++ b/coral/src/app/features/topics/details/components/PromotionBanner.test.tsx
@@ -7,8 +7,9 @@ const promotionDetails: KlawApiModel<"PromotionStatus"> = {
   targetEnv: "TST",
   sourceEnv: "DEV",
   targetEnvId: "2",
-  topicName: "my-test-topic",
 };
+const testTopicName = "my-test-topic";
+
 describe("PromotionBanner", () => {
   describe("does not show a promotion banner at all dependent on promotion details", () => {
     afterEach(cleanup);
@@ -16,6 +17,7 @@ describe("PromotionBanner", () => {
     it("returns null if status is NOT_AUTHORIZED", () => {
       const { container } = render(
         <PromotionBanner
+          topicName={testTopicName}
           promotionDetails={{ ...promotionDetails, status: "NOT_AUTHORIZED" }}
           type={"schema"}
           promoteElement={<></>}
@@ -29,6 +31,7 @@ describe("PromotionBanner", () => {
     it("returns null if status is NO_PROMOTION", () => {
       const { container } = render(
         <PromotionBanner
+          topicName={testTopicName}
           promotionDetails={{ ...promotionDetails, status: "NO_PROMOTION" }}
           type={"schema"}
           promoteElement={<></>}
@@ -42,6 +45,7 @@ describe("PromotionBanner", () => {
     it("returns null if status is FAILURE", () => {
       const { container } = render(
         <PromotionBanner
+          topicName={testTopicName}
           promotionDetails={{ ...promotionDetails, status: "FAILURE" }}
           type={"schema"}
           promoteElement={<></>}
@@ -55,6 +59,7 @@ describe("PromotionBanner", () => {
     it("returns null if targetEnv is undefined", () => {
       const { container } = render(
         <PromotionBanner
+          topicName={testTopicName}
           promotionDetails={{ ...promotionDetails, targetEnv: undefined }}
           type={"schema"}
           promoteElement={<></>}
@@ -68,6 +73,7 @@ describe("PromotionBanner", () => {
     it("returns null if sourceEnv is undefined", () => {
       const { container } = render(
         <PromotionBanner
+          topicName={testTopicName}
           promotionDetails={{ ...promotionDetails, sourceEnv: undefined }}
           type={"schema"}
           promoteElement={<></>}
@@ -81,20 +87,8 @@ describe("PromotionBanner", () => {
     it("returns null if targetEnvId is undefined", () => {
       const { container } = render(
         <PromotionBanner
+          topicName={testTopicName}
           promotionDetails={{ ...promotionDetails, targetEnvId: undefined }}
-          type={"schema"}
-          promoteElement={<></>}
-          hasOpenRequest={false}
-        />
-      );
-
-      expect(container).toBeEmptyDOMElement();
-    });
-
-    it("returns null if topicName is undefined", () => {
-      const { container } = render(
-        <PromotionBanner
-          promotionDetails={{ ...promotionDetails, topicName: undefined }}
           type={"schema"}
           promoteElement={<></>}
           hasOpenRequest={false}
@@ -109,6 +103,7 @@ describe("PromotionBanner", () => {
     beforeAll(() => {
       render(
         <PromotionBanner
+          topicName={testTopicName}
           promotionDetails={promotionDetails}
           type={"schema"}
           promoteElement={<></>}
@@ -121,7 +116,7 @@ describe("PromotionBanner", () => {
 
     it("shows information about the open request", () => {
       const information = screen.getByText(
-        `There is an open request for ${promotionDetails.topicName}.`
+        `There is an open request for ${testTopicName}.`
       );
 
       expect(information).toBeVisible();
@@ -142,6 +137,7 @@ describe("PromotionBanner", () => {
     beforeAll(() => {
       render(
         <PromotionBanner
+          topicName={testTopicName}
           promotionDetails={promotionDetails}
           type={"topic"}
           promoteElement={<></>}
@@ -154,7 +150,7 @@ describe("PromotionBanner", () => {
 
     it("shows information about the open request", () => {
       const information = screen.getByText(
-        `There is an open request for ${promotionDetails.topicName}.`
+        `There is an open request for ${testTopicName}.`
       );
 
       expect(information).toBeVisible();
@@ -175,6 +171,7 @@ describe("PromotionBanner", () => {
     beforeAll(() => {
       render(
         <PromotionBanner
+          topicName={testTopicName}
           promotionDetails={{ ...promotionDetails, status: "REQUEST_OPEN" }}
           type={"schema"}
           promoteElement={<></>}
@@ -187,7 +184,7 @@ describe("PromotionBanner", () => {
 
     it("shows information about the open request", () => {
       const information = screen.getByText(
-        `There is already an open promotion request for ${promotionDetails.topicName}.`
+        `There is already an open promotion request for ${testTopicName}.`
       );
 
       expect(information).toBeVisible();
@@ -208,6 +205,7 @@ describe("PromotionBanner", () => {
     beforeAll(() => {
       render(
         <PromotionBanner
+          topicName={testTopicName}
           promotionDetails={{ ...promotionDetails, status: "REQUEST_OPEN" }}
           type={"topic"}
           promoteElement={<></>}
@@ -220,7 +218,7 @@ describe("PromotionBanner", () => {
 
     it("shows information about the open request", () => {
       const information = screen.getByText(
-        `There is already an open promotion request for ${promotionDetails.topicName}.`
+        `There is already an open promotion request for ${testTopicName}.`
       );
 
       expect(information).toBeVisible();
@@ -242,6 +240,7 @@ describe("PromotionBanner", () => {
     beforeAll(() => {
       render(
         <PromotionBanner
+          topicName={testTopicName}
           promotionDetails={promotionDetails}
           type={"schema"}
           promoteElement={promoteElement}
@@ -274,6 +273,7 @@ describe("PromotionBanner", () => {
     beforeAll(() => {
       render(
         <PromotionBanner
+          topicName={testTopicName}
           promotionDetails={promotionDetails}
           type={"topic"}
           promoteElement={promoteElement}

--- a/coral/src/app/features/topics/details/components/PromotionBanner.test.tsx
+++ b/coral/src/app/features/topics/details/components/PromotionBanner.test.tsx
@@ -1,0 +1,301 @@
+import { KlawApiModel } from "types/utils";
+import { cleanup, render, screen } from "@testing-library/react";
+import { PromotionBanner } from "src/app/features/topics/details/components/PromotionBanner";
+
+const promotionDetails: KlawApiModel<"PromotionStatus"> = {
+  status: "SUCCESS",
+  targetEnv: "TST",
+  sourceEnv: "DEV",
+  targetEnvId: "2",
+  topicName: "my-test-topic",
+};
+describe("PromotionBanner", () => {
+  describe("does not show a promotion banner at all dependent on promotion details", () => {
+    afterEach(cleanup);
+
+    it("returns null if status is NOT_AUTHORIZED", () => {
+      const { container } = render(
+        <PromotionBanner
+          promotionDetails={{ ...promotionDetails, status: "NOT_AUTHORIZED" }}
+          type={"schema"}
+          promoteElement={<></>}
+          hasOpenRequest={false}
+        />
+      );
+
+      expect(container).toBeEmptyDOMElement();
+    });
+
+    it("returns null if status is NO_PROMOTION", () => {
+      const { container } = render(
+        <PromotionBanner
+          promotionDetails={{ ...promotionDetails, status: "NO_PROMOTION" }}
+          type={"schema"}
+          promoteElement={<></>}
+          hasOpenRequest={false}
+        />
+      );
+
+      expect(container).toBeEmptyDOMElement();
+    });
+
+    it("returns null if status is FAILURE", () => {
+      const { container } = render(
+        <PromotionBanner
+          promotionDetails={{ ...promotionDetails, status: "FAILURE" }}
+          type={"schema"}
+          promoteElement={<></>}
+          hasOpenRequest={false}
+        />
+      );
+
+      expect(container).toBeEmptyDOMElement();
+    });
+
+    it("returns null if targetEnv is undefined", () => {
+      const { container } = render(
+        <PromotionBanner
+          promotionDetails={{ ...promotionDetails, targetEnv: undefined }}
+          type={"schema"}
+          promoteElement={<></>}
+          hasOpenRequest={false}
+        />
+      );
+
+      expect(container).toBeEmptyDOMElement();
+    });
+
+    it("returns null if sourceEnv is undefined", () => {
+      const { container } = render(
+        <PromotionBanner
+          promotionDetails={{ ...promotionDetails, sourceEnv: undefined }}
+          type={"schema"}
+          promoteElement={<></>}
+          hasOpenRequest={false}
+        />
+      );
+
+      expect(container).toBeEmptyDOMElement();
+    });
+
+    it("returns null if targetEnvId is undefined", () => {
+      const { container } = render(
+        <PromotionBanner
+          promotionDetails={{ ...promotionDetails, targetEnvId: undefined }}
+          type={"schema"}
+          promoteElement={<></>}
+          hasOpenRequest={false}
+        />
+      );
+
+      expect(container).toBeEmptyDOMElement();
+    });
+
+    it("returns null if topicName is undefined", () => {
+      const { container } = render(
+        <PromotionBanner
+          promotionDetails={{ ...promotionDetails, topicName: undefined }}
+          type={"schema"}
+          promoteElement={<></>}
+          hasOpenRequest={false}
+        />
+      );
+
+      expect(container).toBeEmptyDOMElement();
+    });
+  });
+
+  describe("handles banner for entity with an open request (type schema)", () => {
+    beforeAll(() => {
+      render(
+        <PromotionBanner
+          promotionDetails={promotionDetails}
+          type={"schema"}
+          promoteElement={<></>}
+          hasOpenRequest={true}
+        />
+      );
+    });
+
+    afterAll(cleanup);
+
+    it("shows information about the open request", () => {
+      const information = screen.getByText(
+        `There is an open request for ${promotionDetails.topicName}.`
+      );
+
+      expect(information).toBeVisible();
+    });
+
+    it("shows a link to open requests", () => {
+      const link = screen.getByText("See the request");
+
+      expect(link).toBeVisible();
+      expect(link).toHaveAttribute(
+        "href",
+        "/requests/schemas?search=my-test-topic&status=CREATED&page=1"
+      );
+    });
+  });
+
+  describe("handles banner for entity with an open request (type topic)", () => {
+    beforeAll(() => {
+      render(
+        <PromotionBanner
+          promotionDetails={promotionDetails}
+          type={"topic"}
+          promoteElement={<></>}
+          hasOpenRequest={true}
+        />
+      );
+    });
+
+    afterAll(cleanup);
+
+    it("shows information about the open request", () => {
+      const information = screen.getByText(
+        `There is an open request for ${promotionDetails.topicName}.`
+      );
+
+      expect(information).toBeVisible();
+    });
+
+    it("shows a link to open requests", () => {
+      const link = screen.getByText("See the request");
+
+      expect(link).toBeVisible();
+      expect(link).toHaveAttribute(
+        "href",
+        "/requests/topics?search=my-test-topic&status=CREATED&page=1"
+      );
+    });
+  });
+
+  describe("handles banner for entity with an open promotion request (type schema)", () => {
+    beforeAll(() => {
+      render(
+        <PromotionBanner
+          promotionDetails={{ ...promotionDetails, status: "REQUEST_OPEN" }}
+          type={"schema"}
+          promoteElement={<></>}
+          hasOpenRequest={false}
+        />
+      );
+    });
+
+    afterAll(cleanup);
+
+    it("shows information about the open request", () => {
+      const information = screen.getByText(
+        `There is already an open promotion request for ${promotionDetails.topicName}.`
+      );
+
+      expect(information).toBeVisible();
+    });
+
+    it("shows a link to open requests", () => {
+      const link = screen.getByText("See the request");
+
+      expect(link).toBeVisible();
+      expect(link).toHaveAttribute(
+        "href",
+        "/requests/schemas?search=my-test-topic&requestType=PROMOTE&status=CREATED&page=1"
+      );
+    });
+  });
+
+  describe("handles banner for entity with an open promotion request (type topic)", () => {
+    beforeAll(() => {
+      render(
+        <PromotionBanner
+          promotionDetails={{ ...promotionDetails, status: "REQUEST_OPEN" }}
+          type={"topic"}
+          promoteElement={<></>}
+          hasOpenRequest={false}
+        />
+      );
+    });
+
+    afterAll(cleanup);
+
+    it("shows information about the open request", () => {
+      const information = screen.getByText(
+        `There is already an open promotion request for ${promotionDetails.topicName}.`
+      );
+
+      expect(information).toBeVisible();
+    });
+
+    it("shows a link to open requests", () => {
+      const link = screen.getByText("See the request");
+
+      expect(link).toBeVisible();
+      expect(link).toHaveAttribute(
+        "href",
+        "/requests/topics?search=my-test-topic&requestType=PROMOTE&status=CREATED&page=1"
+      );
+    });
+  });
+
+  describe("handles banner for entity that can be promoted (type schema)", () => {
+    const promoteElement = <div data-testid={"another-test-promote-element"} />;
+    beforeAll(() => {
+      render(
+        <PromotionBanner
+          promotionDetails={promotionDetails}
+          type={"schema"}
+          promoteElement={promoteElement}
+          hasOpenRequest={false}
+        />
+      );
+    });
+
+    afterAll(cleanup);
+
+    it("shows information about possible promotion", () => {
+      const information = screen.getByText(
+        `This schema has not yet been promoted to the ${promotionDetails.targetEnv} environment.`
+      );
+
+      expect(information).toBeVisible();
+    });
+
+    it("renders a given component as element handling the promotion", () => {
+      const promotionElement = screen.getByTestId(
+        "another-test-promote-element"
+      );
+
+      expect(promotionElement).toBeVisible();
+    });
+  });
+
+  describe("handles banner for entity that can be promoted (type topic)", () => {
+    const promoteElement = <div data-testid={"test-promote-element"} />;
+    beforeAll(() => {
+      render(
+        <PromotionBanner
+          promotionDetails={promotionDetails}
+          type={"topic"}
+          promoteElement={promoteElement}
+          hasOpenRequest={false}
+        />
+      );
+    });
+
+    afterAll(cleanup);
+
+    it("shows information about possible promotion", () => {
+      const information = screen.getByText(
+        `This topic has not yet been promoted to the ${promotionDetails.targetEnv} environment.`
+      );
+
+      expect(information).toBeVisible();
+    });
+
+    it("renders a given component as element handling the promotion", () => {
+      const promotionElement = screen.getByTestId("test-promote-element");
+
+      expect(promotionElement).toBeVisible();
+    });
+  });
+});

--- a/coral/src/app/features/topics/details/components/PromotionBanner.tsx
+++ b/coral/src/app/features/topics/details/components/PromotionBanner.tsx
@@ -4,6 +4,11 @@ import { ReactElement } from "react";
 import { KlawApiModel } from "types/utils";
 
 interface PromotionBannerProps {
+  // `topicName` is only optional on
+  // KlawApiModel<"PromotionStatus">
+  // so we can't rely on it to be part of
+  // the promotionDetails
+  topicName: string;
   promotionDetails: KlawApiModel<"PromotionStatus">;
   type: "schema" | "topic";
   promoteElement: ReactElement;
@@ -15,9 +20,9 @@ const PromotionBanner = ({
   hasOpenRequest,
   type,
   promoteElement,
+  topicName,
 }: PromotionBannerProps) => {
-  const { status, sourceEnv, targetEnv, topicName, targetEnvId } =
-    promotionDetails;
+  const { status, sourceEnv, targetEnv, targetEnvId } = promotionDetails;
 
   // if any of these is not true,
   // the entity cannot be promoted

--- a/coral/src/app/features/topics/details/components/PromotionBanner.tsx
+++ b/coral/src/app/features/topics/details/components/PromotionBanner.tsx
@@ -1,0 +1,83 @@
+import { Banner, Box, Button, GridItem } from "@aivenio/aquarium";
+import illustration from "src/app/images/topic-details-schema-Illustration.svg";
+import { ReactElement } from "react";
+import { KlawApiModel } from "types/utils";
+
+interface PromotionBannerProps {
+  promotionDetails: KlawApiModel<"PromotionStatus">;
+  type: "schema" | "topic";
+  promoteElement: ReactElement;
+  hasOpenRequest: boolean;
+}
+
+const PromotionBanner = ({
+  promotionDetails,
+  hasOpenRequest,
+  type,
+  promoteElement,
+}: PromotionBannerProps) => {
+  const { status, sourceEnv, targetEnv, topicName, targetEnvId } =
+    promotionDetails;
+
+  // if any of these is not true,
+  // the entity cannot be promoted
+  const isPromotable =
+    status !== "NOT_AUTHORIZED" &&
+    status !== "NO_PROMOTION" &&
+    status !== "FAILURE" &&
+    targetEnv !== undefined &&
+    sourceEnv !== undefined &&
+    targetEnvId !== undefined &&
+    topicName !== undefined;
+
+  const hasOpenPromotionRequest = status === "REQUEST_OPEN";
+
+  if (!isPromotable) return null;
+
+  if (hasOpenRequest) {
+    return (
+      <GridItem colSpan={"span-2"}>
+        <Banner image={illustration} layout="vertical" title={""}>
+          <Box component={"p"} marginBottom={"l1"}>
+            There is an open request for {topicName}.
+          </Box>
+          <Button.ExternalLink
+            href={`/requests/${type}s?search=${topicName}&status=CREATED&page=1`}
+          >
+            See the request
+          </Button.ExternalLink>
+        </Banner>
+      </GridItem>
+    );
+  }
+
+  if (hasOpenPromotionRequest) {
+    return (
+      <GridItem colSpan={"span-2"}>
+        <Banner image={illustration} layout="vertical" title={""}>
+          <Box component={"p"} marginBottom={"l1"}>
+            There is already an open promotion request for {topicName}.
+          </Box>
+          <Button.ExternalLink
+            href={`/requests/${type}s?search=${topicName}&requestType=PROMOTE&status=CREATED&page=1`}
+          >
+            See the request
+          </Button.ExternalLink>
+        </Banner>
+      </GridItem>
+    );
+  }
+
+  return (
+    <GridItem colSpan={"span-2"}>
+      <Banner image={illustration} layout="vertical" title={""}>
+        <Box component={"p"} marginBottom={"l1"}>
+          This {type} has not yet been promoted to the {targetEnv} environment.
+        </Box>
+        {promoteElement}
+      </Banner>
+    </GridItem>
+  );
+};
+
+export { PromotionBanner };

--- a/coral/src/app/features/topics/details/components/PromotionBanner.tsx
+++ b/coral/src/app/features/topics/details/components/PromotionBanner.tsx
@@ -5,11 +5,11 @@ import { KlawApiModel } from "types/utils";
 import { useNavigate } from "react-router-dom";
 
 interface PromotionBannerProps {
-  // `topicName` is only optional on
+  // `entityName` is only optional on
   // KlawApiModel<"PromotionStatus">
   // so we can't rely on it to be part of
   // the promotionDetails
-  topicName: string;
+  entityName: string;
   promotionDetails: KlawApiModel<"PromotionStatus">;
   type: "schema" | "topic";
   promoteElement: ReactElement;
@@ -21,7 +21,7 @@ const PromotionBanner = ({
   hasOpenRequest,
   type,
   promoteElement,
-  topicName,
+  entityName,
 }: PromotionBannerProps) => {
   const { status, sourceEnv, targetEnv, targetEnvId } = promotionDetails;
   const navigate = useNavigate();
@@ -35,7 +35,7 @@ const PromotionBanner = ({
     targetEnv !== undefined &&
     sourceEnv !== undefined &&
     targetEnvId !== undefined &&
-    topicName !== undefined;
+    entityName !== undefined;
 
   const hasOpenPromotionRequest = status === "REQUEST_OPEN";
 
@@ -46,7 +46,7 @@ const PromotionBanner = ({
       <GridItem colSpan={"span-2"}>
         <Banner image={illustration} layout="vertical" title={""}>
           <Box component={"p"} marginBottom={"l1"}>
-            There is an open {type} request for {topicName}.
+            There is an open {type} request for {entityName}.
           </Box>
           {/*@ TODO DS external link does not support */}
           {/*  internal links and we don't have a component*/}
@@ -56,7 +56,7 @@ const PromotionBanner = ({
           <Button.Primary
             onClick={() =>
               navigate(
-                `/requests/${type}s?search=${topicName}&status=CREATED&page=1`
+                `/requests/${type}s?search=${entityName}&status=CREATED&page=1`
               )
             }
           >
@@ -72,7 +72,7 @@ const PromotionBanner = ({
       <GridItem colSpan={"span-2"}>
         <Banner image={illustration} layout="vertical" title={""}>
           <Box component={"p"} marginBottom={"l1"}>
-            There is already an open promotion request for {topicName}.
+            There is already an open promotion request for {entityName}.
           </Box>
           {/*@ TODO DS external link does not support */}
           {/*  internal links and we don't have a component*/}
@@ -82,7 +82,7 @@ const PromotionBanner = ({
           <Button.Primary
             onClick={() =>
               navigate(
-                `/requests/${type}s?search=${topicName}&requestType=PROMOTE&status=CREATED&page=1`
+                `/requests/${type}s?search=${entityName}&requestType=PROMOTE&status=CREATED&page=1`
               )
             }
           >

--- a/coral/src/app/features/topics/details/components/PromotionBanner.tsx
+++ b/coral/src/app/features/topics/details/components/PromotionBanner.tsx
@@ -1,4 +1,4 @@
-import { Banner, Box, Button } from "@aivenio/aquarium";
+import { Alert, Banner, Box, Button, Spacing } from "@aivenio/aquarium";
 import illustration from "src/app/images/topic-details-schema-Illustration.svg";
 import { ReactElement } from "react";
 import { useNavigate } from "react-router-dom";
@@ -14,6 +14,8 @@ interface PromotionBannerProps {
   type: "schema" | "topic";
   promoteElement: ReactElement;
   hasOpenRequest: boolean;
+  hasError: boolean;
+  errorMessage: string;
 }
 
 const PromotionBanner = ({
@@ -22,10 +24,15 @@ const PromotionBanner = ({
   type,
   promoteElement,
   entityName,
+  hasError,
+  errorMessage,
 }: PromotionBannerProps) => {
   const { status, sourceEnv, targetEnv, targetEnvId } = promotionDetails;
   const navigate = useNavigate();
 
+  if (hasError && errorMessage.length === 0) {
+    console.error("Please pass a useful errorMessage for the user!");
+  }
   // if any of these is not true,
   // the entity cannot be promoted
   const isPromotable =
@@ -91,9 +98,19 @@ const PromotionBanner = ({
 
   return (
     <Banner image={illustration} layout="vertical" title={""}>
-      <Box component={"p"} marginBottom={"l1"}>
-        This {type} has not yet been promoted to the {targetEnv} environment.
-      </Box>
+      <Spacing gap={"l1"}>
+        {hasError && (
+          <div role="alert">
+            <Alert type="error">
+              {errorMessage.length > 0 ? errorMessage : "Unexpected error."}
+            </Alert>
+          </div>
+        )}
+
+        <Box component={"p"} marginBottom={"l1"}>
+          This {type} has not yet been promoted to the {targetEnv} environment.
+        </Box>
+      </Spacing>
       {promoteElement}
     </Banner>
   );

--- a/coral/src/app/features/topics/details/components/PromotionBanner.tsx
+++ b/coral/src/app/features/topics/details/components/PromotionBanner.tsx
@@ -2,6 +2,7 @@ import { Banner, Box, Button, GridItem } from "@aivenio/aquarium";
 import illustration from "src/app/images/topic-details-schema-Illustration.svg";
 import { ReactElement } from "react";
 import { KlawApiModel } from "types/utils";
+import { useNavigate } from "react-router-dom";
 
 interface PromotionBannerProps {
   // `topicName` is only optional on
@@ -23,6 +24,7 @@ const PromotionBanner = ({
   topicName,
 }: PromotionBannerProps) => {
   const { status, sourceEnv, targetEnv, targetEnvId } = promotionDetails;
+  const navigate = useNavigate();
 
   // if any of these is not true,
   // the entity cannot be promoted
@@ -46,11 +48,20 @@ const PromotionBanner = ({
           <Box component={"p"} marginBottom={"l1"}>
             There is an open {type} request for {topicName}.
           </Box>
-          <Button.ExternalLink
-            href={`/requests/${type}s?search=${topicName}&status=CREATED&page=1`}
+          {/*@ TODO DS external link does not support */}
+          {/*  internal links and we don't have a component*/}
+          {/*  from DS that supports that yet. We've to use a */}
+          {/*  button that calls navigate() onClick to support*/}
+          {/*  routing in Coral*/}
+          <Button.Primary
+            onClick={() =>
+              navigate(
+                `/requests/${type}s?search=${topicName}&status=CREATED&page=1`
+              )
+            }
           >
             See the request
-          </Button.ExternalLink>
+          </Button.Primary>
         </Banner>
       </GridItem>
     );
@@ -63,11 +74,20 @@ const PromotionBanner = ({
           <Box component={"p"} marginBottom={"l1"}>
             There is already an open promotion request for {topicName}.
           </Box>
-          <Button.ExternalLink
-            href={`/requests/${type}s?search=${topicName}&requestType=PROMOTE&status=CREATED&page=1`}
+          {/*@ TODO DS external link does not support */}
+          {/*  internal links and we don't have a component*/}
+          {/*  from DS that supports that yet. We've to use a */}
+          {/*  button that calls navigate() onClick to support*/}
+          {/*  routing in Coral*/}
+          <Button.Primary
+            onClick={() =>
+              navigate(
+                `/requests/${type}s?search=${topicName}&requestType=PROMOTE&status=CREATED&page=1`
+              )
+            }
           >
             See the request
-          </Button.ExternalLink>
+          </Button.Primary>
         </Banner>
       </GridItem>
     );

--- a/coral/src/app/features/topics/details/components/PromotionBanner.tsx
+++ b/coral/src/app/features/topics/details/components/PromotionBanner.tsx
@@ -1,8 +1,8 @@
-import { Banner, Box, Button, GridItem } from "@aivenio/aquarium";
+import { Banner, Box, Button } from "@aivenio/aquarium";
 import illustration from "src/app/images/topic-details-schema-Illustration.svg";
 import { ReactElement } from "react";
-import { KlawApiModel } from "types/utils";
 import { useNavigate } from "react-router-dom";
+import { PromotionStatus } from "src/domain/promotion";
 
 interface PromotionBannerProps {
   // `entityName` is only optional on
@@ -10,7 +10,7 @@ interface PromotionBannerProps {
   // so we can't rely on it to be part of
   // the promotionDetails
   entityName: string;
-  promotionDetails: KlawApiModel<"PromotionStatus">;
+  promotionDetails: PromotionStatus;
   type: "schema" | "topic";
   promoteElement: ReactElement;
   hasOpenRequest: boolean;
@@ -43,65 +43,59 @@ const PromotionBanner = ({
 
   if (hasOpenRequest) {
     return (
-      <GridItem colSpan={"span-2"}>
-        <Banner image={illustration} layout="vertical" title={""}>
-          <Box component={"p"} marginBottom={"l1"}>
-            There is an open {type} request for {entityName}.
-          </Box>
-          {/*@ TODO DS external link does not support */}
-          {/*  internal links and we don't have a component*/}
-          {/*  from DS that supports that yet. We've to use a */}
-          {/*  button that calls navigate() onClick to support*/}
-          {/*  routing in Coral*/}
-          <Button.Primary
-            onClick={() =>
-              navigate(
-                `/requests/${type}s?search=${entityName}&status=CREATED&page=1`
-              )
-            }
-          >
-            See the request
-          </Button.Primary>
-        </Banner>
-      </GridItem>
+      <Banner image={illustration} layout="vertical" title={""}>
+        <Box component={"p"} marginBottom={"l1"}>
+          There is an open {type} request for {entityName}.
+        </Box>
+        {/*@ TODO DS external link does not support */}
+        {/*  internal links and we don't have a component*/}
+        {/*  from DS that supports that yet. We've to use a */}
+        {/*  button that calls navigate() onClick to support*/}
+        {/*  routing in Coral*/}
+        <Button.Primary
+          onClick={() =>
+            navigate(
+              `/requests/${type}s?search=${entityName}&status=CREATED&page=1`
+            )
+          }
+        >
+          See the request
+        </Button.Primary>
+      </Banner>
     );
   }
 
   if (hasOpenPromotionRequest) {
     return (
-      <GridItem colSpan={"span-2"}>
-        <Banner image={illustration} layout="vertical" title={""}>
-          <Box component={"p"} marginBottom={"l1"}>
-            There is already an open promotion request for {entityName}.
-          </Box>
-          {/*@ TODO DS external link does not support */}
-          {/*  internal links and we don't have a component*/}
-          {/*  from DS that supports that yet. We've to use a */}
-          {/*  button that calls navigate() onClick to support*/}
-          {/*  routing in Coral*/}
-          <Button.Primary
-            onClick={() =>
-              navigate(
-                `/requests/${type}s?search=${entityName}&requestType=PROMOTE&status=CREATED&page=1`
-              )
-            }
-          >
-            See the request
-          </Button.Primary>
-        </Banner>
-      </GridItem>
+      <Banner image={illustration} layout="vertical" title={""}>
+        <Box component={"p"} marginBottom={"l1"}>
+          There is already an open promotion request for {entityName}.
+        </Box>
+        {/*@ TODO DS external link does not support */}
+        {/*  internal links and we don't have a component*/}
+        {/*  from DS that supports that yet. We've to use a */}
+        {/*  button that calls navigate() onClick to support*/}
+        {/*  routing in Coral*/}
+        <Button.Primary
+          onClick={() =>
+            navigate(
+              `/requests/${type}s?search=${entityName}&requestType=PROMOTE&status=CREATED&page=1`
+            )
+          }
+        >
+          See the request
+        </Button.Primary>
+      </Banner>
     );
   }
 
   return (
-    <GridItem colSpan={"span-2"}>
-      <Banner image={illustration} layout="vertical" title={""}>
-        <Box component={"p"} marginBottom={"l1"}>
-          This {type} has not yet been promoted to the {targetEnv} environment.
-        </Box>
-        {promoteElement}
-      </Banner>
-    </GridItem>
+    <Banner image={illustration} layout="vertical" title={""}>
+      <Box component={"p"} marginBottom={"l1"}>
+        This {type} has not yet been promoted to the {targetEnv} environment.
+      </Box>
+      {promoteElement}
+    </Banner>
   );
 };
 

--- a/coral/src/app/features/topics/details/components/PromotionBanner.tsx
+++ b/coral/src/app/features/topics/details/components/PromotionBanner.tsx
@@ -44,7 +44,7 @@ const PromotionBanner = ({
       <GridItem colSpan={"span-2"}>
         <Banner image={illustration} layout="vertical" title={""}>
           <Box component={"p"} marginBottom={"l1"}>
-            There is an open request for {topicName}.
+            There is an open {type} request for {topicName}.
           </Box>
           <Button.ExternalLink
             href={`/requests/${type}s?search=${topicName}&status=CREATED&page=1`}

--- a/coral/src/app/features/topics/details/overview/TopicOverview.test.tsx
+++ b/coral/src/app/features/topics/details/overview/TopicOverview.test.tsx
@@ -4,8 +4,9 @@ import {
   ClusterDetails as ClusterDetailsType,
   getClusterDetails,
 } from "src/domain/cluster";
-import { RenderResult } from "@testing-library/react";
+import { cleanup, RenderResult, screen } from "@testing-library/react";
 import { getDefinitionList } from "src/services/test-utils/custom-queries";
+import { within } from "@testing-library/react/pure";
 
 const mockedUseTopicDetails = jest.fn();
 jest.mock("src/app/features/topics/details/TopicDetails", () => ({
@@ -35,6 +36,7 @@ const mockUseTopicDetailsDataWithPromotion = {
       showDeleteTopic: false,
       topicDeletable: false,
       envName: "DEV",
+      topicOwner: true,
     },
     aclInfoList: [
       {
@@ -116,6 +118,7 @@ const mockUseTopicDetailsDataWithPromotion = {
     ],
   },
 };
+
 const mockUseTopicDetailsDataWithoutPromotion = {
   topicName: "aivendemotopic",
   environmentId: "1",
@@ -227,9 +230,10 @@ const mockClusterDetails: ClusterDetailsType = {
   clusterStatus: "NOT_KNOWN",
 };
 
-describe("TopicOverview (with promotion banner)", () => {
-  let component: RenderResult;
+describe("TopicOverview", () => {
   describe("with promotion banner", () => {
+    let component: RenderResult;
+
     beforeAll(() => {
       mockedUseTopicDetails.mockReturnValue(
         mockUseTopicDetailsDataWithPromotion
@@ -242,8 +246,23 @@ describe("TopicOverview (with promotion banner)", () => {
       });
     });
 
+    afterAll(() => {
+      cleanup();
+      jest.resetAllMocks();
+    });
+
     it("renders correct DOM according to data from useTopicDetails and getClusterDetails", () => {
-      expect(screen).toMatchSnapshot();
+      expect(component.container).toMatchSnapshot();
+    });
+
+    it("renders the topic promotion banner", () => {
+      const promotionBanner = screen.getByTestId("topic-promotion-banner");
+      const promotionInfo = within(promotionBanner).getByText(
+        "This topic has not yet been promoted to the TST environment."
+      );
+
+      expect(promotionBanner).toBeVisible();
+      expect(promotionInfo).toBeVisible();
     });
 
     it("renders cluster details", () => {
@@ -267,8 +286,19 @@ describe("TopicOverview (with promotion banner)", () => {
       });
     });
 
+    afterAll(() => {
+      cleanup();
+      jest.clearAllMocks();
+    });
+
     it("renders correct DOM according to data from useTopicDetails and getClusterDetails", () => {
-      expect(screen).toMatchSnapshot();
+      expect(component.container).toMatchSnapshot();
+    });
+
+    it("renders no topic promotion banner", () => {
+      const promotionBanner = screen.queryByTestId("topic-promotion-banner");
+
+      expect(promotionBanner).not.toBeInTheDocument();
     });
 
     it("renders cluster details", () => {

--- a/coral/src/app/features/topics/details/overview/TopicOverview.tsx
+++ b/coral/src/app/features/topics/details/overview/TopicOverview.tsx
@@ -74,7 +74,7 @@ function TopicOverview() {
         <TopicPromotionBanner
           topicName={topicName}
           topicPromotionDetails={topicPromotionDetails}
-          hasOpenRequest={hasOpenTopicRequest}
+          hasOpenTopicRequest={hasOpenTopicRequest}
         />
       )}
 

--- a/coral/src/app/features/topics/details/overview/TopicOverview.tsx
+++ b/coral/src/app/features/topics/details/overview/TopicOverview.tsx
@@ -71,11 +71,13 @@ function TopicOverview() {
       </GridItem>
 
       {!topicOverviewIsRefetching && topicOwner && (
-        <TopicPromotionBanner
-          topicName={topicName}
-          topicPromotionDetails={topicPromotionDetails}
-          hasOpenTopicRequest={hasOpenTopicRequest}
-        />
+        <GridItem colSpan={"span-2"}>
+          <TopicPromotionBanner
+            topicName={topicName}
+            topicPromotionDetails={topicPromotionDetails}
+            hasOpenTopicRequest={hasOpenTopicRequest}
+          />
+        </GridItem>
       )}
 
       <GridItem colSpan={"span-2"}>

--- a/coral/src/app/features/topics/details/overview/TopicOverview.tsx
+++ b/coral/src/app/features/topics/details/overview/TopicOverview.tsx
@@ -72,6 +72,7 @@ function TopicOverview() {
 
       {!topicOverviewIsRefetching && topicOwner && (
         <TopicPromotionBanner
+          topicName={topicName}
           topicPromotionDetails={topicPromotionDetails}
           hasOpenRequest={hasOpenTopicRequest}
         />

--- a/coral/src/app/features/topics/details/overview/TopicOverview.tsx
+++ b/coral/src/app/features/topics/details/overview/TopicOverview.tsx
@@ -70,10 +70,9 @@ function TopicOverview() {
         </Card>
       </GridItem>
 
-      {!topicOverviewIsRefetching && (
+      {!topicOverviewIsRefetching && topicOwner && (
         <TopicPromotionBanner
           topicPromotionDetails={topicPromotionDetails}
-          isTopicOwner={topicOwner}
           hasOpenRequest={hasOpenTopicRequest}
         />
       )}

--- a/coral/src/app/features/topics/details/overview/__snapshots__/TopicOverview.test.tsx.snap
+++ b/coral/src/app/features/topics/details/overview/__snapshots__/TopicOverview.test.tsx.snap
@@ -85,12 +85,11 @@ exports[`TopicOverview with promotion banner renders correct DOM according to da
                 TST
                  environment.
               </p>
-              <a
+              <button
                 class="Aquarium-Button Aquarium-Button.Primary text-white bg-primary-80 active:bg-primary-90 active:ring-0 focus-visible:ring-2 focus-visible:ring-primary-100 focus-visible:ring-inset hover:bg-primary-70 disabled:bg-primary-5 inline-block border-0 rounded-sm transition whitespace-nowrap focus:outline-none relative text-center typography-default-strong py-3 px-4 icon-stroke-2"
-                href="/topic/aivendemotopic/request-promotion?sourceEnv=1&targetEnv=2"
               >
                 Promote
-              </a>
+              </button>
             </div>
           </div>
           <div

--- a/coral/src/app/features/topics/details/overview/__snapshots__/TopicOverview.test.tsx.snap
+++ b/coral/src/app/features/topics/details/overview/__snapshots__/TopicOverview.test.tsx.snap
@@ -76,15 +76,19 @@ exports[`TopicOverview with promotion banner renders correct DOM according to da
             <div
               class="typography-default text-grey-90 flex-grow"
             >
-              <p
-                style="margin-bottom: 16px;"
+              <div
+                style="display: flex; flex-direction: column; gap: 16px;"
               >
-                This 
-                topic
-                 has not yet been promoted to the 
-                TST
-                 environment.
-              </p>
+                <p
+                  style="margin-bottom: 16px;"
+                >
+                  This 
+                  topic
+                   has not yet been promoted to the 
+                  TST
+                   environment.
+                </p>
+              </div>
               <button
                 class="Aquarium-Button Aquarium-Button.Primary text-white bg-primary-80 active:bg-primary-90 active:ring-0 focus-visible:ring-2 focus-visible:ring-primary-100 focus-visible:ring-inset hover:bg-primary-70 disabled:bg-primary-5 inline-block border-0 rounded-sm transition whitespace-nowrap focus:outline-none relative text-center typography-default-strong py-3 px-4 icon-stroke-2"
               >

--- a/coral/src/app/features/topics/details/overview/__snapshots__/TopicOverview.test.tsx.snap
+++ b/coral/src/app/features/topics/details/overview/__snapshots__/TopicOverview.test.tsx.snap
@@ -59,10 +59,10 @@ exports[`TopicOverview with promotion banner renders correct DOM according to da
       </div>
     </div>
     <div
-      data-testid="topic-promotion-banner"
+      style="grid-column: span 2 / span 2;"
     >
       <div
-        style="grid-column: span 2 / span 2;"
+        data-testid="topic-promotion-banner"
       >
         <div
           class="Aquarium-Banner rounded flex justify-between gap-7 flex-nowrap p-6 bg-grey-0"

--- a/coral/src/app/features/topics/details/overview/__snapshots__/TopicOverview.test.tsx.snap
+++ b/coral/src/app/features/topics/details/overview/__snapshots__/TopicOverview.test.tsx.snap
@@ -1,5 +1,835 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`TopicOverview (with promotion banner) with promotion banner renders correct DOM according to data from useTopicDetails and getClusterDetails 1`] = `Screen {}`;
+exports[`TopicOverview with promotion banner renders correct DOM according to data from useTopicDetails and getClusterDetails 1`] = `
+<div>
+  <div
+    style="display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); grid-template-rows: auto; gap: 24px;"
+  >
+    <div
+      style="grid-column: span 2 / span 2;"
+    >
+      <div
+        class="border-grey-5 border-[1px] rounded-[2px] relative p-5 flex flex-col gap-5 w-full Aquarium-Card"
+      >
+        <div
+          class="flex flex-col gap-4"
+        >
+          <div
+            class="typography-default-strong text-black"
+          >
+            Topic details
+          </div>
+          <div
+            class="typography-caption text-grey-70"
+          >
+            <div
+              style="display: flex; gap: 160px;"
+            >
+              <div
+                style="display: flex; justify-content: space-around; flex-direction: column;"
+              >
+                <div
+                  class="typography-heading text-grey-80"
+                >
+                  1
+                </div>
+                <div
+                  class="typography-small text-grey-50"
+                >
+                  Replicas
+                </div>
+              </div>
+              <div
+                style="display: flex; justify-content: space-around; flex-direction: column;"
+              >
+                <div
+                  class="typography-heading text-grey-80"
+                >
+                  1
+                </div>
+                <div
+                  class="typography-small text-grey-50"
+                >
+                  Partitions
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      data-testid="topic-promotion-banner"
+    >
+      <div
+        style="grid-column: span 2 / span 2;"
+      >
+        <div
+          class="Aquarium-Banner rounded flex justify-between gap-7 flex-nowrap p-6 bg-grey-0"
+        >
+          <div
+            class="flex w-full flex-col"
+          >
+            <div
+              class="typography-subheading text-grey-100 whitespace-nowrap mb-3"
+            />
+            <div
+              class="typography-default text-grey-90 flex-grow"
+            >
+              <p
+                style="margin-bottom: 16px;"
+              >
+                This 
+                topic
+                 has not yet been promoted to the 
+                TST
+                 environment.
+              </p>
+              <a
+                class="Aquarium-Button Aquarium-Button.Primary text-white bg-primary-80 active:bg-primary-90 active:ring-0 focus-visible:ring-2 focus-visible:ring-primary-100 focus-visible:ring-inset hover:bg-primary-70 disabled:bg-primary-5 inline-block border-0 rounded-sm transition whitespace-nowrap focus:outline-none relative text-center typography-default-strong py-3 px-4 icon-stroke-2"
+                href="/topic/aivendemotopic/request-promotion?sourceEnv=1&targetEnv=2"
+              >
+                Promote
+              </a>
+            </div>
+          </div>
+          <div
+            style="display: inline-flex; align-items: center; margin: -24px -24px -24px 0px;"
+          >
+            <img
+              class="bg-cover object-cover w-full"
+              src="[object Object]"
+            />
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      style="grid-column: span 2 / span 2;"
+    >
+      <div
+        class="border-grey-5 border-[1px] rounded-[2px] relative p-5 flex flex-col gap-5 w-full Aquarium-Card"
+      >
+        <div
+          class="flex flex-col gap-4"
+        >
+          <div
+            class="typography-default-strong text-black"
+          >
+            Cluster details
+          </div>
+          <div
+            class="typography-caption text-grey-70"
+          >
+            <div
+              class="visually-hidden"
+            >
+              Cluster details are updating
+            </div>
+            <div
+              aria-hidden="true"
+            >
+              <dl
+                style="display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); row-gap: 24px;"
+              >
+                <div
+                  style="display: flex; flex-direction: column;"
+                >
+                  <dt
+                    class="inline-block mb-2 typography-small-strong text-grey-60"
+                  >
+                    Bootstrap server
+                  </dt>
+                  <dd
+                    class="typography-small text-grey-80"
+                  >
+                    <div
+                      class="Aquarium-Skeleton bg-grey-5 h-auto before:content-['_'] whitespace-pre origin-[0%_45%] scale-[0.55] block animate-pulse"
+                    />
+                  </dd>
+                </div>
+                <div
+                  style="display: flex; flex-direction: column;"
+                >
+                  <dt
+                    class="inline-block mb-2 typography-small-strong text-grey-60"
+                  >
+                    Protocol
+                  </dt>
+                  <dd
+                    class="typography-small text-grey-80"
+                  >
+                    <div
+                      class="Aquarium-Skeleton bg-grey-5 h-auto before:content-['_'] whitespace-pre origin-[0%_45%] scale-[0.55] block animate-pulse"
+                    />
+                  </dd>
+                </div>
+                <div
+                  style="display: flex; flex-direction: column;"
+                >
+                  <dt
+                    class="inline-block mb-2 typography-small-strong text-grey-60"
+                  >
+                    Kafka flavor
+                  </dt>
+                  <dd
+                    class="typography-small text-grey-80"
+                  >
+                    <div
+                      class="Aquarium-Skeleton bg-grey-5 h-auto before:content-['_'] whitespace-pre origin-[0%_45%] scale-[0.55] block animate-pulse"
+                    />
+                  </dd>
+                </div>
+                <div
+                  style="display: flex; flex-direction: column;"
+                >
+                  <dt
+                    class="inline-block mb-2 typography-small-strong text-grey-60"
+                  >
+                    Rest API
+                  </dt>
+                  <dd
+                    class="typography-small text-grey-80"
+                  >
+                    <div
+                      class="Aquarium-Skeleton bg-grey-5 h-auto before:content-['_'] whitespace-pre origin-[0%_45%] scale-[0.55] block animate-pulse"
+                    />
+                  </dd>
+                </div>
+                <div
+                  style="display: flex; flex-direction: column;"
+                >
+                  <dt
+                    class="inline-block mb-2 typography-small-strong text-grey-60"
+                  >
+                    Cluster name
+                  </dt>
+                  <dd
+                    class="typography-small text-grey-80"
+                  >
+                    <div
+                      class="Aquarium-Skeleton bg-grey-5 h-auto before:content-['_'] whitespace-pre origin-[0%_45%] scale-[0.55] block animate-pulse"
+                    />
+                  </dd>
+                </div>
+                <div
+                  style="display: flex; flex-direction: column;"
+                >
+                  <dt
+                    class="inline-block mb-2 typography-small-strong text-grey-60"
+                  >
+                    Cluster status
+                  </dt>
+                  <dd
+                    class="typography-small text-grey-80"
+                  >
+                    <div
+                      class="Aquarium-Skeleton bg-grey-5 h-auto before:content-['_'] whitespace-pre origin-[0%_45%] scale-[0.55] block animate-pulse"
+                    />
+                  </dd>
+                </div>
+              </dl>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      class="border-grey-5 border-[1px] rounded-[2px] relative p-5 flex flex-col gap-5 w-full Aquarium-Card"
+    >
+      <div
+        class="flex flex-col gap-4"
+      >
+        <div
+          class="typography-default-strong text-black"
+        >
+          Subscriptions
+        </div>
+        <div
+          class="typography-caption text-grey-70"
+        >
+          <div
+            style="display: flex; gap: 160px;"
+          >
+            <div
+              style="display: flex; justify-content: space-around; flex-direction: column;"
+            >
+              <div
+                class="typography-heading text-grey-80"
+              >
+                1
+              </div>
+              <div
+                class="typography-small text-grey-50"
+              >
+                Producers
+              </div>
+            </div>
+            <div
+              style="display: flex; justify-content: space-around; flex-direction: column;"
+            >
+              <div
+                class="typography-heading text-grey-80"
+              >
+                0
+              </div>
+              <div
+                class="typography-small text-grey-50"
+              >
+                Consumers
+              </div>
+            </div>
+          </div>
+          <div
+            style="display: flex; flex-direction: row; padding-top: 24px; gap: 32px;"
+          >
+            <a
+              href="/topic/aivendemotopic/subscribe?env=1"
+            >
+              <button
+                class="Aquarium-Button Aquarium-Button.Ghost text-primary-80 active:text-primary-70 focus-visible:text-grey-90 hover:text-primary-70 disabled:text-primary-40 inline-block border-0 rounded-sm transition whitespace-nowrap focus:outline-none relative text-center typography-default-strong py-3 icon-stroke-2"
+              >
+                <div
+                  style="display: flex; justify-content: center; align-items: center; flex-direction: row; gap: 8px;"
+                >
+                  <span
+                    class="children:inline-block inline-flex justify-center items-center"
+                  >
+                    <svg
+                      aria-hidden="true"
+                      class="Aquarium-InlineIcon"
+                      height="20px"
+                      preserveAspectRatio="xMidYMid meet"
+                      role="img"
+                      style="vertical-align: -0.125em;"
+                      viewBox="0 0 22 22"
+                      width="20px"
+                      xmlns="http://www.w3.org/2000/svg"
+                      xmlns:xlink="http://www.w3.org/1999/xlink"
+                    >
+                      <path
+                        d="M11 7.333v7.334M7.333 11h7.334m5.5 0a9.167 9.167 0 11-18.334 0 9.167 9.167 0 0118.334 0Z"
+                        fill="none"
+                        stroke="currentColor"
+                        stroke-linecap="round"
+                        stroke-linejoin="round"
+                        stroke-width="1.5"
+                      />
+                    </svg>
+                  </span>
+                  <div>
+                    <div
+                      class="typography-small-strong text-primary-80"
+                    >
+                      Request new subscription
+                    </div>
+                  </div>
+                </div>
+              </button>
+            </a>
+            <a
+              href="/topic/aivendemotopic/subscriptions"
+            >
+              <button
+                class="Aquarium-Button Aquarium-Button.Ghost text-primary-80 active:text-primary-70 focus-visible:text-grey-90 hover:text-primary-70 disabled:text-primary-40 inline-block border-0 rounded-sm transition whitespace-nowrap focus:outline-none relative text-center typography-default-strong py-3 icon-stroke-2"
+              >
+                <div
+                  class="typography-small-strong text-primary-80"
+                >
+                  See subscriptions
+                </div>
+              </button>
+            </a>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      class="border-grey-5 border-[1px] rounded-[2px] relative p-5 flex flex-col gap-5 w-full Aquarium-Card"
+    >
+      <div
+        class="flex flex-col gap-4"
+      >
+        <div
+          class="typography-default-strong text-black"
+        >
+          Schemas
+        </div>
+        <div
+          class="typography-caption text-grey-70"
+        >
+          <div
+            style="display: flex; justify-content: space-around; flex-direction: column;"
+          >
+            <div
+              class="typography-heading text-grey-80"
+            >
+              1
+            </div>
+            <div
+              class="typography-small text-grey-50"
+            >
+              Schemas
+            </div>
+          </div>
+          <div
+            style="display: flex; flex-direction: row; padding-top: 24px; gap: 32px;"
+          >
+            <a
+              href="/topic/aivendemotopic/request-schema"
+            >
+              <button
+                class="Aquarium-Button Aquarium-Button.Ghost text-primary-80 active:text-primary-70 focus-visible:text-grey-90 hover:text-primary-70 disabled:text-primary-40 inline-block border-0 rounded-sm transition whitespace-nowrap focus:outline-none relative text-center typography-default-strong py-3 icon-stroke-2"
+              >
+                <div
+                  style="display: flex; justify-content: center; align-items: center; flex-direction: row; gap: 8px;"
+                >
+                  <span
+                    class="children:inline-block inline-flex justify-center items-center"
+                  >
+                    <svg
+                      aria-hidden="true"
+                      class="Aquarium-InlineIcon"
+                      height="20px"
+                      preserveAspectRatio="xMidYMid meet"
+                      role="img"
+                      style="vertical-align: -0.125em;"
+                      viewBox="0 0 22 22"
+                      width="20px"
+                      xmlns="http://www.w3.org/2000/svg"
+                      xmlns:xlink="http://www.w3.org/1999/xlink"
+                    >
+                      <path
+                        d="M11 7.333v7.334M7.333 11h7.334m5.5 0a9.167 9.167 0 11-18.334 0 9.167 9.167 0 0118.334 0Z"
+                        fill="none"
+                        stroke="currentColor"
+                        stroke-linecap="round"
+                        stroke-linejoin="round"
+                        stroke-width="1.5"
+                      />
+                    </svg>
+                  </span>
+                  <div>
+                    <div
+                      class="typography-small-strong text-primary-80"
+                    >
+                      Request new schema
+                    </div>
+                  </div>
+                </div>
+              </button>
+            </a>
+            <a
+              href="/topic/aivendemotopic/schema"
+            >
+              <button
+                class="Aquarium-Button Aquarium-Button.Ghost text-primary-80 active:text-primary-70 focus-visible:text-grey-90 hover:text-primary-70 disabled:text-primary-40 inline-block border-0 rounded-sm transition whitespace-nowrap focus:outline-none relative text-center typography-default-strong py-3 icon-stroke-2"
+              >
+                <div
+                  class="typography-small-strong text-primary-80"
+                >
+                  See schema
+                </div>
+              </button>
+            </a>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
 
-exports[`TopicOverview (with promotion banner) without promotion banner renders correct DOM according to data from useTopicDetails and getClusterDetails 1`] = `Screen {}`;
+exports[`TopicOverview without promotion banner renders correct DOM according to data from useTopicDetails and getClusterDetails 1`] = `
+<div>
+  <div
+    style="display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); grid-template-rows: auto; gap: 24px;"
+  >
+    <div
+      style="grid-column: span 2 / span 2;"
+    >
+      <div
+        class="border-grey-5 border-[1px] rounded-[2px] relative p-5 flex flex-col gap-5 w-full Aquarium-Card"
+      >
+        <div
+          class="flex flex-col gap-4"
+        >
+          <div
+            class="typography-default-strong text-black"
+          >
+            Topic details
+          </div>
+          <div
+            class="typography-caption text-grey-70"
+          >
+            <div
+              style="display: flex; gap: 160px;"
+            >
+              <div
+                style="display: flex; justify-content: space-around; flex-direction: column;"
+              >
+                <div
+                  class="typography-heading text-grey-80"
+                >
+                  1
+                </div>
+                <div
+                  class="typography-small text-grey-50"
+                >
+                  Replicas
+                </div>
+              </div>
+              <div
+                style="display: flex; justify-content: space-around; flex-direction: column;"
+              >
+                <div
+                  class="typography-heading text-grey-80"
+                >
+                  1
+                </div>
+                <div
+                  class="typography-small text-grey-50"
+                >
+                  Partitions
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      style="grid-column: span 2 / span 2;"
+    >
+      <div
+        class="border-grey-5 border-[1px] rounded-[2px] relative p-5 flex flex-col gap-5 w-full Aquarium-Card"
+      >
+        <div
+          class="flex flex-col gap-4"
+        >
+          <div
+            class="typography-default-strong text-black"
+          >
+            Cluster details
+          </div>
+          <div
+            class="typography-caption text-grey-70"
+          >
+            <div
+              class="visually-hidden"
+            >
+              Cluster details are updating
+            </div>
+            <div
+              aria-hidden="true"
+            >
+              <dl
+                style="display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); row-gap: 24px;"
+              >
+                <div
+                  style="display: flex; flex-direction: column;"
+                >
+                  <dt
+                    class="inline-block mb-2 typography-small-strong text-grey-60"
+                  >
+                    Bootstrap server
+                  </dt>
+                  <dd
+                    class="typography-small text-grey-80"
+                  >
+                    <div
+                      class="Aquarium-Skeleton bg-grey-5 h-auto before:content-['_'] whitespace-pre origin-[0%_45%] scale-[0.55] block animate-pulse"
+                    />
+                  </dd>
+                </div>
+                <div
+                  style="display: flex; flex-direction: column;"
+                >
+                  <dt
+                    class="inline-block mb-2 typography-small-strong text-grey-60"
+                  >
+                    Protocol
+                  </dt>
+                  <dd
+                    class="typography-small text-grey-80"
+                  >
+                    <div
+                      class="Aquarium-Skeleton bg-grey-5 h-auto before:content-['_'] whitespace-pre origin-[0%_45%] scale-[0.55] block animate-pulse"
+                    />
+                  </dd>
+                </div>
+                <div
+                  style="display: flex; flex-direction: column;"
+                >
+                  <dt
+                    class="inline-block mb-2 typography-small-strong text-grey-60"
+                  >
+                    Kafka flavor
+                  </dt>
+                  <dd
+                    class="typography-small text-grey-80"
+                  >
+                    <div
+                      class="Aquarium-Skeleton bg-grey-5 h-auto before:content-['_'] whitespace-pre origin-[0%_45%] scale-[0.55] block animate-pulse"
+                    />
+                  </dd>
+                </div>
+                <div
+                  style="display: flex; flex-direction: column;"
+                >
+                  <dt
+                    class="inline-block mb-2 typography-small-strong text-grey-60"
+                  >
+                    Rest API
+                  </dt>
+                  <dd
+                    class="typography-small text-grey-80"
+                  >
+                    <div
+                      class="Aquarium-Skeleton bg-grey-5 h-auto before:content-['_'] whitespace-pre origin-[0%_45%] scale-[0.55] block animate-pulse"
+                    />
+                  </dd>
+                </div>
+                <div
+                  style="display: flex; flex-direction: column;"
+                >
+                  <dt
+                    class="inline-block mb-2 typography-small-strong text-grey-60"
+                  >
+                    Cluster name
+                  </dt>
+                  <dd
+                    class="typography-small text-grey-80"
+                  >
+                    <div
+                      class="Aquarium-Skeleton bg-grey-5 h-auto before:content-['_'] whitespace-pre origin-[0%_45%] scale-[0.55] block animate-pulse"
+                    />
+                  </dd>
+                </div>
+                <div
+                  style="display: flex; flex-direction: column;"
+                >
+                  <dt
+                    class="inline-block mb-2 typography-small-strong text-grey-60"
+                  >
+                    Cluster status
+                  </dt>
+                  <dd
+                    class="typography-small text-grey-80"
+                  >
+                    <div
+                      class="Aquarium-Skeleton bg-grey-5 h-auto before:content-['_'] whitespace-pre origin-[0%_45%] scale-[0.55] block animate-pulse"
+                    />
+                  </dd>
+                </div>
+              </dl>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      class="border-grey-5 border-[1px] rounded-[2px] relative p-5 flex flex-col gap-5 w-full Aquarium-Card"
+    >
+      <div
+        class="flex flex-col gap-4"
+      >
+        <div
+          class="typography-default-strong text-black"
+        >
+          Subscriptions
+        </div>
+        <div
+          class="typography-caption text-grey-70"
+        >
+          <div
+            style="display: flex; gap: 160px;"
+          >
+            <div
+              style="display: flex; justify-content: space-around; flex-direction: column;"
+            >
+              <div
+                class="typography-heading text-grey-80"
+              >
+                1
+              </div>
+              <div
+                class="typography-small text-grey-50"
+              >
+                Producers
+              </div>
+            </div>
+            <div
+              style="display: flex; justify-content: space-around; flex-direction: column;"
+            >
+              <div
+                class="typography-heading text-grey-80"
+              >
+                0
+              </div>
+              <div
+                class="typography-small text-grey-50"
+              >
+                Consumers
+              </div>
+            </div>
+          </div>
+          <div
+            style="display: flex; flex-direction: row; padding-top: 24px; gap: 32px;"
+          >
+            <a
+              href="/topic/aivendemotopic/subscribe?env=1"
+            >
+              <button
+                class="Aquarium-Button Aquarium-Button.Ghost text-primary-80 active:text-primary-70 focus-visible:text-grey-90 hover:text-primary-70 disabled:text-primary-40 inline-block border-0 rounded-sm transition whitespace-nowrap focus:outline-none relative text-center typography-default-strong py-3 icon-stroke-2"
+              >
+                <div
+                  style="display: flex; justify-content: center; align-items: center; flex-direction: row; gap: 8px;"
+                >
+                  <span
+                    class="children:inline-block inline-flex justify-center items-center"
+                  >
+                    <svg
+                      aria-hidden="true"
+                      class="Aquarium-InlineIcon"
+                      height="20px"
+                      preserveAspectRatio="xMidYMid meet"
+                      role="img"
+                      style="vertical-align: -0.125em;"
+                      viewBox="0 0 22 22"
+                      width="20px"
+                      xmlns="http://www.w3.org/2000/svg"
+                      xmlns:xlink="http://www.w3.org/1999/xlink"
+                    >
+                      <path
+                        d="M11 7.333v7.334M7.333 11h7.334m5.5 0a9.167 9.167 0 11-18.334 0 9.167 9.167 0 0118.334 0Z"
+                        fill="none"
+                        stroke="currentColor"
+                        stroke-linecap="round"
+                        stroke-linejoin="round"
+                        stroke-width="1.5"
+                      />
+                    </svg>
+                  </span>
+                  <div>
+                    <div
+                      class="typography-small-strong text-primary-80"
+                    >
+                      Request new subscription
+                    </div>
+                  </div>
+                </div>
+              </button>
+            </a>
+            <a
+              href="/topic/aivendemotopic/subscriptions"
+            >
+              <button
+                class="Aquarium-Button Aquarium-Button.Ghost text-primary-80 active:text-primary-70 focus-visible:text-grey-90 hover:text-primary-70 disabled:text-primary-40 inline-block border-0 rounded-sm transition whitespace-nowrap focus:outline-none relative text-center typography-default-strong py-3 icon-stroke-2"
+              >
+                <div
+                  class="typography-small-strong text-primary-80"
+                >
+                  See subscriptions
+                </div>
+              </button>
+            </a>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      class="border-grey-5 border-[1px] rounded-[2px] relative p-5 flex flex-col gap-5 w-full Aquarium-Card"
+    >
+      <div
+        class="flex flex-col gap-4"
+      >
+        <div
+          class="typography-default-strong text-black"
+        >
+          Schemas
+        </div>
+        <div
+          class="typography-caption text-grey-70"
+        >
+          <div
+            style="display: flex; justify-content: space-around; flex-direction: column;"
+          >
+            <div
+              class="typography-heading text-grey-80"
+            >
+              1
+            </div>
+            <div
+              class="typography-small text-grey-50"
+            >
+              Schemas
+            </div>
+          </div>
+          <div
+            style="display: flex; flex-direction: row; padding-top: 24px; gap: 32px;"
+          >
+            <a
+              href="/topic/aivendemotopic/request-schema"
+            >
+              <button
+                class="Aquarium-Button Aquarium-Button.Ghost text-primary-80 active:text-primary-70 focus-visible:text-grey-90 hover:text-primary-70 disabled:text-primary-40 inline-block border-0 rounded-sm transition whitespace-nowrap focus:outline-none relative text-center typography-default-strong py-3 icon-stroke-2"
+              >
+                <div
+                  style="display: flex; justify-content: center; align-items: center; flex-direction: row; gap: 8px;"
+                >
+                  <span
+                    class="children:inline-block inline-flex justify-center items-center"
+                  >
+                    <svg
+                      aria-hidden="true"
+                      class="Aquarium-InlineIcon"
+                      height="20px"
+                      preserveAspectRatio="xMidYMid meet"
+                      role="img"
+                      style="vertical-align: -0.125em;"
+                      viewBox="0 0 22 22"
+                      width="20px"
+                      xmlns="http://www.w3.org/2000/svg"
+                      xmlns:xlink="http://www.w3.org/1999/xlink"
+                    >
+                      <path
+                        d="M11 7.333v7.334M7.333 11h7.334m5.5 0a9.167 9.167 0 11-18.334 0 9.167 9.167 0 0118.334 0Z"
+                        fill="none"
+                        stroke="currentColor"
+                        stroke-linecap="round"
+                        stroke-linejoin="round"
+                        stroke-width="1.5"
+                      />
+                    </svg>
+                  </span>
+                  <div>
+                    <div
+                      class="typography-small-strong text-primary-80"
+                    >
+                      Request new schema
+                    </div>
+                  </div>
+                </div>
+              </button>
+            </a>
+            <a
+              href="/topic/aivendemotopic/schema"
+            >
+              <button
+                class="Aquarium-Button Aquarium-Button.Ghost text-primary-80 active:text-primary-70 focus-visible:text-grey-90 hover:text-primary-70 disabled:text-primary-40 inline-block border-0 rounded-sm transition whitespace-nowrap focus:outline-none relative text-center typography-default-strong py-3 icon-stroke-2"
+              >
+                <div
+                  class="typography-small-strong text-primary-80"
+                >
+                  See schema
+                </div>
+              </button>
+            </a>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;

--- a/coral/src/app/features/topics/details/overview/components/TopicPromotionBanner.test.tsx
+++ b/coral/src/app/features/topics/details/overview/components/TopicPromotionBanner.test.tsx
@@ -1,7 +1,5 @@
-import { cleanup, screen } from "@testing-library/react";
-import userEvent from "@testing-library/user-event";
+import { cleanup, render, screen } from "@testing-library/react";
 import { TopicPromotionBanner } from "src/app/features/topics/details/overview/components/TopicPromotionBanner";
-import { customRender } from "src/services/test-utils/render-with-wrappers";
 import { TopicOverview } from "src/domain/topic";
 
 const promotionDetailForPromote: TopicOverview["topicPromotionDetails"] = {
@@ -13,7 +11,6 @@ const promotionDetailForPromote: TopicOverview["topicPromotionDetails"] = {
 };
 
 const promoteProps = {
-  isTopicOwner: true,
   topicPromotionDetails: promotionDetailForPromote,
   hasOpenRequest: false,
 };
@@ -26,8 +23,8 @@ const promotionDetailForSeeOpenRequest: TopicOverview["topicPromotionDetails"] =
     targetEnvId: "2",
     topicName: "topic-hello",
   };
+
 const seeOpenRequestProps = {
-  isTopicOwner: false,
   topicPromotionDetails: promotionDetailForSeeOpenRequest,
   hasOpenRequest: true,
 };
@@ -40,8 +37,8 @@ const promotionDetailForSeeOpenPromotionRequest: TopicOverview["topicPromotionDe
     targetEnvId: "2",
     topicName: "topic-hello",
   };
+
 const seeOpenPromotionRequestProps = {
-  isTopicOwner: false,
   topicPromotionDetails: promotionDetailForSeeOpenPromotionRequest,
   hasOpenRequest: false,
 };
@@ -52,7 +49,6 @@ const promotionDetailForNoPromotion: TopicOverview["topicPromotionDetails"] = {
 };
 
 const nullProps = {
-  isTopicOwner: false,
   topicPromotionDetails: promotionDetailForNoPromotion,
   hasOpenRequest: false,
 };
@@ -63,70 +59,56 @@ jest.mock("react-router-dom", () => ({
   useNavigate: () => mockedNavigate,
 }));
 
-describe("TopicPromotionBanner (with promotion banner)", () => {
+describe("TopicPromotionBanner", () => {
   afterEach(cleanup);
 
-  it("renders correct banner (promote topic)", async () => {
-    customRender(<TopicPromotionBanner {...promoteProps} />, {
-      memoryRouter: true,
-    });
+  it("renders correct banner (promote topic)", () => {
+    render(<TopicPromotionBanner {...promoteProps} />);
 
-    const button = screen.getByRole("button", {
+    const link = screen.getByRole("link", {
       name: "Promote",
     });
 
-    expect(button).toBeEnabled();
-
-    await userEvent.click(button);
-    expect(mockedNavigate).toHaveBeenCalledWith(
+    expect(link).toBeEnabled();
+    expect(link).toHaveAttribute(
+      "href",
       `/topic/${promoteProps.topicPromotionDetails.topicName}/request-promotion?sourceEnv=${promoteProps.topicPromotionDetails.sourceEnv}&targetEnv=${promoteProps.topicPromotionDetails.targetEnvId}`
     );
   });
 
-  it("renders correct banner (see open request)", async () => {
-    customRender(<TopicPromotionBanner {...seeOpenRequestProps} />, {
-      memoryRouter: true,
-    });
+  it("renders correct banner (see open request)", () => {
+    render(<TopicPromotionBanner {...seeOpenRequestProps} />);
 
-    const button = screen.getByRole("button", {
+    const link = screen.getByRole("link", {
       name: "See the request",
     });
 
-    expect(button).toBeEnabled();
-
-    await userEvent.click(button);
-
-    expect(mockedNavigate).toHaveBeenCalledWith(
+    expect(link).toBeEnabled();
+    expect(link).toHaveAttribute(
+      "href",
       `/requests/topics?search=${promoteProps.topicPromotionDetails.topicName}&status=CREATED&page=1`
     );
   });
 
-  it("renders correct banner (see open promotion request)", async () => {
-    customRender(<TopicPromotionBanner {...seeOpenPromotionRequestProps} />, {
-      memoryRouter: true,
-    });
+  it("renders correct banner (see open promotion request)", () => {
+    render(<TopicPromotionBanner {...seeOpenPromotionRequestProps} />);
 
-    const button = screen.getByRole("button", {
+    const link = screen.getByRole("link", {
       name: "See the request",
     });
 
-    expect(button).toBeEnabled();
-
-    await userEvent.click(button);
-
-    expect(mockedNavigate).toHaveBeenCalledWith(
+    expect(link).toBeEnabled();
+    expect(link).toHaveAttribute(
+      "href",
       `/requests/topics?search=${promoteProps.topicPromotionDetails.topicName}&requestType=PROMOTE&status=CREATED&page=1`
     );
   });
 
-  it("renders nothing (status === 'NO_PROMOTION', status !== 'NOT_AUTHORIZED')", () => {
-    const { container } = customRender(
-      <TopicPromotionBanner {...nullProps} />,
-      {
-        memoryRouter: true,
-      }
-    );
+  it("renders nothing if status === 'NO_PROMOTION'", () => {
+    render(<TopicPromotionBanner {...nullProps} />);
 
-    expect(container).toBeEmptyDOMElement();
+    const wrapper = screen.getByTestId("topic-promotion-banner");
+
+    expect(wrapper).toBeEmptyDOMElement();
   });
 });

--- a/coral/src/app/features/topics/details/overview/components/TopicPromotionBanner.test.tsx
+++ b/coral/src/app/features/topics/details/overview/components/TopicPromotionBanner.test.tsx
@@ -11,7 +11,7 @@ const promotionDetailForPromote: TopicOverview["topicPromotionDetails"] = {
 
 const promoteProps = {
   topicPromotionDetails: promotionDetailForPromote,
-  hasOpenRequest: false,
+  hasOpenTopicRequest: false,
   topicName: "topic-hello",
 };
 
@@ -25,7 +25,7 @@ const promotionDetailForSeeOpenRequest: TopicOverview["topicPromotionDetails"] =
 
 const seeOpenRequestProps = {
   topicPromotionDetails: promotionDetailForSeeOpenRequest,
-  hasOpenRequest: true,
+  hasOpenTopicRequest: true,
   topicName: "topic-hello",
 };
 
@@ -39,7 +39,7 @@ const promotionDetailForSeeOpenPromotionRequest: TopicOverview["topicPromotionDe
 
 const seeOpenPromotionRequestProps = {
   topicPromotionDetails: promotionDetailForSeeOpenPromotionRequest,
-  hasOpenRequest: false,
+  hasOpenTopicRequest: false,
   topicName: "topic-hello",
 };
 
@@ -49,7 +49,7 @@ const promotionDetailForNoPromotion: TopicOverview["topicPromotionDetails"] = {
 
 const nullProps = {
   topicPromotionDetails: promotionDetailForNoPromotion,
-  hasOpenRequest: false,
+  hasOpenTopicRequest: false,
   topicName: "topic-hello",
 };
 

--- a/coral/src/app/features/topics/details/overview/components/TopicPromotionBanner.test.tsx
+++ b/coral/src/app/features/topics/details/overview/components/TopicPromotionBanner.test.tsx
@@ -1,6 +1,13 @@
 import { cleanup, render, screen } from "@testing-library/react";
 import { TopicPromotionBanner } from "src/app/features/topics/details/overview/components/TopicPromotionBanner";
 import { TopicOverview } from "src/domain/topic";
+import userEvent from "@testing-library/user-event";
+
+const mockedNavigate = jest.fn();
+jest.mock("react-router-dom", () => ({
+  ...jest.requireActual("react-router-dom"),
+  useNavigate: () => mockedNavigate,
+}));
 
 const promotionDetailForPromote: TopicOverview["topicPromotionDetails"] = {
   status: "SUCCESS",
@@ -54,18 +61,32 @@ const nullProps = {
 };
 
 describe("TopicPromotionBanner", () => {
-  afterEach(cleanup);
+  const user = userEvent.setup();
+
+  afterEach(() => {
+    jest.resetAllMocks();
+    cleanup();
+  });
 
   it("renders correct banner (promote topic)", () => {
     render(<TopicPromotionBanner {...promoteProps} />);
 
-    const link = screen.getByRole("link", {
+    const button = screen.getByRole("button", {
       name: "Promote",
     });
 
-    expect(link).toBeEnabled();
-    expect(link).toHaveAttribute(
-      "href",
+    expect(button).toBeEnabled();
+  });
+
+  it("enables navigating correctly (promote topic)", async () => {
+    render(<TopicPromotionBanner {...promoteProps} />);
+    const button = screen.getByRole("button", {
+      name: "Promote",
+    });
+
+    await user.click(button);
+
+    expect(mockedNavigate).toHaveBeenCalledWith(
       `/topic/${promoteProps.topicName}/request-promotion?sourceEnv=${promoteProps.topicPromotionDetails.sourceEnv}&targetEnv=${promoteProps.topicPromotionDetails.targetEnvId}`
     );
   });
@@ -73,13 +94,22 @@ describe("TopicPromotionBanner", () => {
   it("renders correct banner (see open request)", () => {
     render(<TopicPromotionBanner {...seeOpenRequestProps} />);
 
-    const link = screen.getByRole("link", {
+    const button = screen.getByRole("button", {
       name: "See the request",
     });
 
-    expect(link).toBeEnabled();
-    expect(link).toHaveAttribute(
-      "href",
+    expect(button).toBeEnabled();
+  });
+
+  it("enables navigating correctly (see open request)", async () => {
+    render(<TopicPromotionBanner {...seeOpenRequestProps} />);
+
+    const button = screen.getByRole("button", {
+      name: "See the request",
+    });
+
+    await user.click(button);
+    expect(mockedNavigate).toHaveBeenCalledWith(
       `/requests/topics?search=${promoteProps.topicName}&status=CREATED&page=1`
     );
   });
@@ -87,13 +117,22 @@ describe("TopicPromotionBanner", () => {
   it("renders correct banner (see open promotion request)", () => {
     render(<TopicPromotionBanner {...seeOpenPromotionRequestProps} />);
 
-    const link = screen.getByRole("link", {
+    const button = screen.getByRole("button", {
       name: "See the request",
     });
 
-    expect(link).toBeEnabled();
-    expect(link).toHaveAttribute(
-      "href",
+    expect(button).toBeEnabled();
+  });
+
+  it("enables navigating correctly (see open promotion request)", async () => {
+    render(<TopicPromotionBanner {...seeOpenPromotionRequestProps} />);
+
+    const button = screen.getByRole("button", {
+      name: "See the request",
+    });
+    await user.click(button);
+
+    expect(mockedNavigate).toHaveBeenCalledWith(
       `/requests/topics?search=${promoteProps.topicName}&requestType=PROMOTE&status=CREATED&page=1`
     );
   });

--- a/coral/src/app/features/topics/details/overview/components/TopicPromotionBanner.test.tsx
+++ b/coral/src/app/features/topics/details/overview/components/TopicPromotionBanner.test.tsx
@@ -53,12 +53,6 @@ const nullProps = {
   topicName: "topic-hello",
 };
 
-const mockedNavigate = jest.fn();
-jest.mock("react-router-dom", () => ({
-  ...jest.requireActual("react-router-dom"),
-  useNavigate: () => mockedNavigate,
-}));
-
 describe("TopicPromotionBanner", () => {
   afterEach(cleanup);
 

--- a/coral/src/app/features/topics/details/overview/components/TopicPromotionBanner.test.tsx
+++ b/coral/src/app/features/topics/details/overview/components/TopicPromotionBanner.test.tsx
@@ -7,12 +7,12 @@ const promotionDetailForPromote: TopicOverview["topicPromotionDetails"] = {
   targetEnv: "TST",
   sourceEnv: "DEV",
   targetEnvId: "2",
-  topicName: "topic-hello",
 };
 
 const promoteProps = {
   topicPromotionDetails: promotionDetailForPromote,
   hasOpenRequest: false,
+  topicName: "topic-hello",
 };
 
 const promotionDetailForSeeOpenRequest: TopicOverview["topicPromotionDetails"] =
@@ -21,12 +21,12 @@ const promotionDetailForSeeOpenRequest: TopicOverview["topicPromotionDetails"] =
     targetEnv: "TST",
     sourceEnv: "DEV",
     targetEnvId: "2",
-    topicName: "topic-hello",
   };
 
 const seeOpenRequestProps = {
   topicPromotionDetails: promotionDetailForSeeOpenRequest,
   hasOpenRequest: true,
+  topicName: "topic-hello",
 };
 
 const promotionDetailForSeeOpenPromotionRequest: TopicOverview["topicPromotionDetails"] =
@@ -35,22 +35,22 @@ const promotionDetailForSeeOpenPromotionRequest: TopicOverview["topicPromotionDe
     targetEnv: "TST",
     sourceEnv: "DEV",
     targetEnvId: "2",
-    topicName: "topic-hello",
   };
 
 const seeOpenPromotionRequestProps = {
   topicPromotionDetails: promotionDetailForSeeOpenPromotionRequest,
   hasOpenRequest: false,
+  topicName: "topic-hello",
 };
 
 const promotionDetailForNoPromotion: TopicOverview["topicPromotionDetails"] = {
   status: "NO_PROMOTION",
-  topicName: "SchemaTest",
 };
 
 const nullProps = {
   topicPromotionDetails: promotionDetailForNoPromotion,
   hasOpenRequest: false,
+  topicName: "topic-hello",
 };
 
 const mockedNavigate = jest.fn();
@@ -72,7 +72,7 @@ describe("TopicPromotionBanner", () => {
     expect(link).toBeEnabled();
     expect(link).toHaveAttribute(
       "href",
-      `/topic/${promoteProps.topicPromotionDetails.topicName}/request-promotion?sourceEnv=${promoteProps.topicPromotionDetails.sourceEnv}&targetEnv=${promoteProps.topicPromotionDetails.targetEnvId}`
+      `/topic/${promoteProps.topicName}/request-promotion?sourceEnv=${promoteProps.topicPromotionDetails.sourceEnv}&targetEnv=${promoteProps.topicPromotionDetails.targetEnvId}`
     );
   });
 
@@ -86,7 +86,7 @@ describe("TopicPromotionBanner", () => {
     expect(link).toBeEnabled();
     expect(link).toHaveAttribute(
       "href",
-      `/requests/topics?search=${promoteProps.topicPromotionDetails.topicName}&status=CREATED&page=1`
+      `/requests/topics?search=${promoteProps.topicName}&status=CREATED&page=1`
     );
   });
 
@@ -100,7 +100,7 @@ describe("TopicPromotionBanner", () => {
     expect(link).toBeEnabled();
     expect(link).toHaveAttribute(
       "href",
-      `/requests/topics?search=${promoteProps.topicPromotionDetails.topicName}&requestType=PROMOTE&status=CREATED&page=1`
+      `/requests/topics?search=${promoteProps.topicName}&requestType=PROMOTE&status=CREATED&page=1`
     );
   });
 

--- a/coral/src/app/features/topics/details/overview/components/TopicPromotionBanner.tsx
+++ b/coral/src/app/features/topics/details/overview/components/TopicPromotionBanner.tsx
@@ -43,6 +43,8 @@ const TopicPromotionBanner = ({
             Promote
           </Button.Primary>
         }
+        hasError={false}
+        errorMessage={""}
       />
     </div>
   );

--- a/coral/src/app/features/topics/details/overview/components/TopicPromotionBanner.tsx
+++ b/coral/src/app/features/topics/details/overview/components/TopicPromotionBanner.tsx
@@ -4,13 +4,17 @@ import { PromotionBanner } from "src/app/features/topics/details/components/Prom
 
 interface TopicPromotionBannerProps {
   topicPromotionDetails: TopicOverview["topicPromotionDetails"];
-  hasOpenRequest: boolean;
+  /** In case there is an open request for this topic
+   * it can't be promoted, and we want to show that
+   * information to the user.
+   */
+  hasOpenTopicRequest: boolean;
   topicName: string;
 }
 
 const TopicPromotionBanner = ({
   topicPromotionDetails,
-  hasOpenRequest,
+  hasOpenTopicRequest,
   topicName,
 }: TopicPromotionBannerProps) => {
   return (
@@ -18,7 +22,7 @@ const TopicPromotionBanner = ({
       <PromotionBanner
         topicName={topicName}
         promotionDetails={topicPromotionDetails}
-        hasOpenRequest={hasOpenRequest}
+        hasOpenRequest={hasOpenTopicRequest}
         type={"topic"}
         promoteElement={
           <Button.ExternalLink

--- a/coral/src/app/features/topics/details/overview/components/TopicPromotionBanner.tsx
+++ b/coral/src/app/features/topics/details/overview/components/TopicPromotionBanner.tsx
@@ -23,7 +23,7 @@ const TopicPromotionBanner = ({
   return (
     <div data-testid={"topic-promotion-banner"}>
       <PromotionBanner
-        topicName={topicName}
+        entityName={topicName}
         promotionDetails={topicPromotionDetails}
         hasOpenRequest={hasOpenTopicRequest}
         type={"topic"}

--- a/coral/src/app/features/topics/details/overview/components/TopicPromotionBanner.tsx
+++ b/coral/src/app/features/topics/details/overview/components/TopicPromotionBanner.tsx
@@ -5,21 +5,24 @@ import { PromotionBanner } from "src/app/features/topics/details/components/Prom
 interface TopicPromotionBannerProps {
   topicPromotionDetails: TopicOverview["topicPromotionDetails"];
   hasOpenRequest: boolean;
+  topicName: string;
 }
 
 const TopicPromotionBanner = ({
   topicPromotionDetails,
   hasOpenRequest,
+  topicName,
 }: TopicPromotionBannerProps) => {
   return (
     <div data-testid={"topic-promotion-banner"}>
       <PromotionBanner
+        topicName={topicName}
         promotionDetails={topicPromotionDetails}
         hasOpenRequest={hasOpenRequest}
         type={"topic"}
         promoteElement={
           <Button.ExternalLink
-            href={`/topic/${topicPromotionDetails.topicName}/request-promotion?sourceEnv=${topicPromotionDetails.sourceEnv}&targetEnv=${topicPromotionDetails.targetEnvId}`}
+            href={`/topic/${topicName}/request-promotion?sourceEnv=${topicPromotionDetails.sourceEnv}&targetEnv=${topicPromotionDetails.targetEnvId}`}
           >
             Promote
           </Button.ExternalLink>

--- a/coral/src/app/features/topics/details/overview/components/TopicPromotionBanner.tsx
+++ b/coral/src/app/features/topics/details/overview/components/TopicPromotionBanner.tsx
@@ -1,98 +1,32 @@
-import { Banner, Box, Button, GridItem } from "@aivenio/aquarium";
+import { Button } from "@aivenio/aquarium";
 import { TopicOverview } from "src/domain/topic";
-import illustration from "/src/app/images/topic-details-schema-Illustration.svg";
-import { useNavigate } from "react-router-dom";
+import { PromotionBanner } from "src/app/features/topics/details/components/PromotionBanner";
 
 interface TopicPromotionBannerProps {
   topicPromotionDetails: TopicOverview["topicPromotionDetails"];
   hasOpenRequest: boolean;
-  isTopicOwner: boolean;
 }
 
 const TopicPromotionBanner = ({
-  isTopicOwner,
   topicPromotionDetails,
   hasOpenRequest,
 }: TopicPromotionBannerProps) => {
-  const navigate = useNavigate();
-  const { status, targetEnv, sourceEnv, targetEnvId, topicName } =
-    topicPromotionDetails;
-
-  const showRequestPromotionBanner =
-    isTopicOwner &&
-    status === "SUCCESS" &&
-    targetEnv !== undefined &&
-    sourceEnv !== undefined &&
-    targetEnvId !== undefined;
-
-  // hasOpenTopicRequest is true for any request open on the current topic in the current environment (source environment)
-  if (hasOpenRequest) {
-    return (
-      <GridItem colSpan={"span-2"}>
-        <Banner image={illustration} layout="vertical" title={""}>
-          <Box component={"p"} marginBottom={"l1"}>
-            There is an open request for {topicName}.
-          </Box>
-          <Button.Primary
-            onClick={() =>
-              navigate(
-                `/requests/topics?search=${topicName}&status=CREATED&page=1`
-              )
-            }
-          >
-            See the request
-          </Button.Primary>
-        </Banner>
-      </GridItem>
-    );
-  }
-
-  // status is "REQUEST_OPEN" when there is a promotion request open on a topic in the target environment for promotion,
-  // ie not the current topic + source environment
-  if (status === "REQUEST_OPEN") {
-    return (
-      <GridItem colSpan={"span-2"}>
-        <Banner image={illustration} layout="vertical" title={""}>
-          <Box component={"p"} marginBottom={"l1"}>
-            There is already an open promotion request for {topicName}.
-          </Box>
-          <Button.Primary
-            onClick={() =>
-              navigate(
-                `/requests/topics?search=${topicName}&requestType=PROMOTE&status=CREATED&page=1`
-              )
-            }
-          >
-            See the request
-          </Button.Primary>
-        </Banner>
-      </GridItem>
-    );
-  }
-
-  if (showRequestPromotionBanner) {
-    return (
-      <GridItem colSpan={"span-2"}>
-        <Banner image={illustration} layout="vertical" title={""}>
-          <Box component={"p"} marginBottom={"l1"}>
-            This schema has not yet been promoted to the {targetEnv}{" "}
-            environment.
-          </Box>
-          <Button.Primary
-            onClick={() =>
-              navigate(
-                `/topic/${topicName}/request-promotion?sourceEnv=${sourceEnv}&targetEnv=${targetEnvId}`
-              )
-            }
+  return (
+    <div data-testid={"topic-promotion-banner"}>
+      <PromotionBanner
+        promotionDetails={topicPromotionDetails}
+        hasOpenRequest={hasOpenRequest}
+        type={"topic"}
+        promoteElement={
+          <Button.ExternalLink
+            href={`/topic/${topicPromotionDetails.topicName}/request-promotion?sourceEnv=${topicPromotionDetails.sourceEnv}&targetEnv=${topicPromotionDetails.targetEnvId}`}
           >
             Promote
-          </Button.Primary>
-        </Banner>
-      </GridItem>
-    );
-  }
-
-  return null;
+          </Button.ExternalLink>
+        }
+      />
+    </div>
+  );
 };
 
 export { TopicPromotionBanner };

--- a/coral/src/app/features/topics/details/overview/components/TopicPromotionBanner.tsx
+++ b/coral/src/app/features/topics/details/overview/components/TopicPromotionBanner.tsx
@@ -1,6 +1,7 @@
 import { Button } from "@aivenio/aquarium";
 import { TopicOverview } from "src/domain/topic";
 import { PromotionBanner } from "src/app/features/topics/details/components/PromotionBanner";
+import { useNavigate } from "react-router-dom";
 
 interface TopicPromotionBannerProps {
   topicPromotionDetails: TopicOverview["topicPromotionDetails"];
@@ -17,6 +18,8 @@ const TopicPromotionBanner = ({
   hasOpenTopicRequest,
   topicName,
 }: TopicPromotionBannerProps) => {
+  const navigate = useNavigate();
+
   return (
     <div data-testid={"topic-promotion-banner"}>
       <PromotionBanner
@@ -25,11 +28,20 @@ const TopicPromotionBanner = ({
         hasOpenRequest={hasOpenTopicRequest}
         type={"topic"}
         promoteElement={
-          <Button.ExternalLink
-            href={`/topic/${topicName}/request-promotion?sourceEnv=${topicPromotionDetails.sourceEnv}&targetEnv=${topicPromotionDetails.targetEnvId}`}
+          //  @ TODO DS external link does not support
+          // internal links and we don't have a component
+          // from DS that supports that yet. We've to use a
+          // button that calls navigate() onClick to support
+          // routing in Coral
+          <Button.Primary
+            onClick={() =>
+              navigate(
+                `/topic/${topicName}/request-promotion?sourceEnv=${topicPromotionDetails.sourceEnv}&targetEnv=${topicPromotionDetails.targetEnvId}`
+              )
+            }
           >
             Promote
-          </Button.ExternalLink>
+          </Button.Primary>
         }
       />
     </div>

--- a/coral/src/app/features/topics/details/schema/TopicDetailsSchema.test.tsx
+++ b/coral/src/app/features/topics/details/schema/TopicDetailsSchema.test.tsx
@@ -307,14 +307,10 @@ describe("TopicDetailsSchema", () => {
         expect(button).not.toBeInTheDocument();
       });
 
-      it("shows a link to see open schema requests", () => {
-        const link = screen.getByRole("link", { name: "See the request" });
+      it("shows a button to see open schema requests", () => {
+        const link = screen.getByRole("button", { name: "See the request" });
 
-        expect(link).toBeVisible();
-        expect(link).toHaveAttribute(
-          "href",
-          "/requests/schemas?search=topic-name&status=CREATED&page=1"
-        );
+        expect(link).toBeEnabled();
       });
     });
   });

--- a/coral/src/app/features/topics/details/schema/TopicDetailsSchema.tsx
+++ b/coral/src/app/features/topics/details/schema/TopicDetailsSchema.tsx
@@ -1,5 +1,4 @@
 import {
-  Alert,
   Box,
   Button,
   EmptyState,
@@ -49,7 +48,6 @@ function TopicDetailsSchema() {
 
   const toast = useToast();
 
-  const { targetEnvId, sourceEnv, targetEnv } = schemaPromotionDetails;
   const { topicOwner, hasOpenTopicRequest, hasOpenRequest, hasOpenACLRequest } =
     topicOverview.topicInfo;
   const isTopicOwner = topicOwner;
@@ -68,13 +66,16 @@ function TopicDetailsSchema() {
           throw new Error("No schema available");
         }
 
-        if (targetEnvId === undefined || sourceEnv === undefined) {
+        if (
+          schemaPromotionDetails.targetEnvId === undefined ||
+          schemaPromotionDetails.sourceEnv === undefined
+        ) {
           throw new Error("No promotion details available");
         }
 
         return promoteSchemaRequest({
-          targetEnvironment: targetEnvId,
-          sourceEnvironment: sourceEnv,
+          targetEnvironment: schemaPromotionDetails.targetEnvId,
+          sourceEnvironment: schemaPromotionDetails.sourceEnv,
           topicName,
           schemaVersion: String(schemaDetailsPerEnv.version),
           forceRegister,
@@ -116,21 +117,22 @@ function TopicDetailsSchema() {
 
   return (
     <>
-      {showSchemaPromotionModal && targetEnv !== undefined && (
-        <SchemaPromotionModal
-          isLoading={promoteSchemaIsLoading}
-          onSubmit={promoteSchema}
-          onClose={() => setShowSchemaPromotionModal(false)}
-          targetEnvironment={targetEnv}
-          version={schemaDetailsPerEnv.version}
-          // We only allow users to use the forceRegister option when the promotion request failed
-          // And the failure is because of a schema compatibility issue
-          showForceRegister={
-            errorMessage.length > 0 &&
-            errorMessage.includes("Schema is not compatible")
-          }
-        />
-      )}
+      {showSchemaPromotionModal &&
+        schemaPromotionDetails.targetEnv !== undefined && (
+          <SchemaPromotionModal
+            isLoading={promoteSchemaIsLoading}
+            onSubmit={promoteSchema}
+            onClose={() => setShowSchemaPromotionModal(false)}
+            targetEnvironment={schemaPromotionDetails.targetEnv}
+            version={schemaDetailsPerEnv.version}
+            // We only allow users to use the forceRegister option when the promotion request failed
+            // And the failure is because of a schema compatibility issue
+            showForceRegister={
+              errorMessage.length > 0 &&
+              errorMessage.includes("Schema is not compatible")
+            }
+          />
+        )}
       <PageHeader title="Schema" />
       <Box display={"flex"} justifyContent={"space-between"}>
         <Box display={"flex"} colGap={"l1"}>
@@ -177,31 +179,26 @@ function TopicDetailsSchema() {
       </Box>
 
       {!topicSchemasIsRefetching && isTopicOwner && (
-        <>
-          {errorMessage.length > 0 && (
-            <Box marginBottom={"l1"} role={"alert"}>
-              <Alert type="error">{errorMessage}</Alert>
-            </Box>
-          )}
-          <SchemaPromotionBanner
-            schemaPromotionDetails={schemaPromotionDetails}
-            // @TODO backend will implement the property
-            // `hasOpenSchemaRequests`, should be updated
-            // here then, too
-            // until then: `hasOpenRequest` means there is an
-            // open request for topic, acl or schema
-            // if that's true but `hasOpenAclRequest` and
-            // `hasOpenTopicRequest` is false, the open
-            // request has to be a schema request
-            hasOpenSchemaRequest={
-              hasOpenRequest && !hasOpenACLRequest && !hasOpenTopicRequest
-            }
-            topicName={topicName}
-            setShowSchemaPromotionModal={() =>
-              setShowSchemaPromotionModal(!showSchemaPromotionModal)
-            }
-          />
-        </>
+        <SchemaPromotionBanner
+          schemaPromotionDetails={schemaPromotionDetails}
+          // @TODO backend will implement the property
+          // `hasOpenSchemaRequests`, should be updated
+          // here then, too
+          // until then: `hasOpenRequest` means there is an
+          // open request for topic, acl or schema
+          // if that's true but `hasOpenAclRequest` and
+          // `hasOpenTopicRequest` is false, the open
+          // request has to be a schema request
+          hasOpenSchemaRequest={
+            hasOpenRequest && !hasOpenACLRequest && !hasOpenTopicRequest
+          }
+          topicName={topicName}
+          setShowSchemaPromotionModal={() =>
+            setShowSchemaPromotionModal(!showSchemaPromotionModal)
+          }
+          hasError={errorMessage.length > 0}
+          errorMessage={errorMessage}
+        />
       )}
 
       <SchemaStats

--- a/coral/src/app/features/topics/details/schema/TopicDetailsSchema.tsx
+++ b/coral/src/app/features/topics/details/schema/TopicDetailsSchema.tsx
@@ -1,6 +1,5 @@
 import {
   Alert,
-  Banner,
   Box,
   Button,
   EmptyState,
@@ -28,7 +27,7 @@ import {
 } from "src/domain/schema-request";
 import { HTTPError } from "src/services/api";
 import { parseErrorMsg } from "src/services/mutation-utils";
-import illustration from "/src/app/images/topic-details-schema-Illustration.svg";
+import { SchemaPromotionBanner } from "src/app/features/topics/details/schema/components/SchemaPromotionBanner";
 
 function TopicDetailsSchema() {
   const navigate = useNavigate();
@@ -48,13 +47,14 @@ function TopicDetailsSchema() {
     useState(false);
   const [errorMessage, setErrorMessage] = useState("");
 
+  const toast = useToast();
+
+  const { targetEnvId, sourceEnv, targetEnv } = schemaPromotionDetails;
   const isTopicOwner = topicOverview.topicInfo.topicOwner;
   const noSchema =
     allSchemaVersions.length === 0 ||
     schemaDetailsPerEnv === undefined ||
     schemaPromotionDetails === undefined;
-
-  const toast = useToast();
 
   const { mutate: promoteSchema, isLoading: promoteSchemaIsLoading } =
     useMutation(
@@ -65,8 +65,6 @@ function TopicDetailsSchema() {
         if (noSchema) {
           throw new Error("No schema available");
         }
-
-        const { targetEnvId, sourceEnv } = schemaPromotionDetails;
 
         if (targetEnvId === undefined || sourceEnv === undefined) {
           throw new Error("No promotion details available");
@@ -113,8 +111,6 @@ function TopicDetailsSchema() {
       </>
     );
   }
-
-  const { targetEnv, status: promotionStatus } = schemaPromotionDetails;
 
   return (
     <>
@@ -178,28 +174,30 @@ function TopicDetailsSchema() {
         )}
       </Box>
 
-      {!topicSchemasIsRefetching &&
-        isTopicOwner &&
-        promotionStatus !== "NO_PROMOTION" && (
-          <Banner image={illustration} layout="vertical" title={""}>
-            <Box component={"p"} marginBottom={"l1"}>
-              This schema has not yet been promoted to the {targetEnv}{" "}
-              environment.
+      {!topicSchemasIsRefetching && isTopicOwner && (
+        <>
+          {errorMessage.length > 0 && (
+            <Box marginBottom={"l1"} role={"alert"}>
+              <Alert type="error">{errorMessage}</Alert>
             </Box>
-            {errorMessage.length > 0 && (
-              <Box component={"p"} marginBottom={"l1"}>
-                <Alert type="error">{errorMessage}</Alert>
-              </Box>
-            )}
-            <Button.Primary
-              onClick={() =>
-                setShowSchemaPromotionModal(!showSchemaPromotionModal)
-              }
-            >
-              Promote
-            </Button.Primary>
-          </Banner>
-        )}
+          )}
+          <SchemaPromotionBanner
+            schemaPromotionDetails={schemaPromotionDetails}
+            // @TODO backend will implement this property
+            // we show an descriptive error if a promotion
+            // is not possible because there is an open
+            // schema request, this is "only" for showing
+            // that information and preventing user from even
+            // trying to promote
+            hasOpenSchemaRequest={false}
+            topicName={topicName}
+            setShowSchemaPromotionModal={() =>
+              setShowSchemaPromotionModal(!showSchemaPromotionModal)
+            }
+          />
+        </>
+      )}
+
       <SchemaStats
         isLoading={topicSchemasIsRefetching}
         version={schemaDetailsPerEnv.version}

--- a/coral/src/app/features/topics/details/schema/TopicDetailsSchema.tsx
+++ b/coral/src/app/features/topics/details/schema/TopicDetailsSchema.tsx
@@ -50,7 +50,9 @@ function TopicDetailsSchema() {
   const toast = useToast();
 
   const { targetEnvId, sourceEnv, targetEnv } = schemaPromotionDetails;
-  const isTopicOwner = topicOverview.topicInfo.topicOwner;
+  const { topicOwner, hasOpenTopicRequest, hasOpenRequest, hasOpenACLRequest } =
+    topicOverview.topicInfo;
+  const isTopicOwner = topicOwner;
   const noSchema =
     allSchemaVersions.length === 0 ||
     schemaDetailsPerEnv === undefined ||
@@ -183,13 +185,17 @@ function TopicDetailsSchema() {
           )}
           <SchemaPromotionBanner
             schemaPromotionDetails={schemaPromotionDetails}
-            // @TODO backend will implement this property
-            // we show an descriptive error if a promotion
-            // is not possible because there is an open
-            // schema request, this is "only" for showing
-            // that information and preventing user from even
-            // trying to promote
-            hasOpenSchemaRequest={false}
+            // @TODO backend will implement the property
+            // `hasOpenSchemaRequests`, should be updated
+            // here then, too
+            // until then: `hasOpenRequest` means there is an
+            // open request for topic, acl or schema
+            // if that's true but `hasOpenAclRequest` and
+            // `hasOpenTopicRequest` is false, the open
+            // request has to be a schema request
+            hasOpenSchemaRequest={
+              hasOpenRequest && !hasOpenACLRequest && !hasOpenTopicRequest
+            }
             topicName={topicName}
             setShowSchemaPromotionModal={() =>
               setShowSchemaPromotionModal(!showSchemaPromotionModal)

--- a/coral/src/app/features/topics/details/schema/components/SchemaPromotionBanner.test.tsx
+++ b/coral/src/app/features/topics/details/schema/components/SchemaPromotionBanner.test.tsx
@@ -1,0 +1,129 @@
+import { cleanup, render, screen } from "@testing-library/react";
+import { SchemaPromotionBanner } from "src/app/features/topics/details/schema/components/SchemaPromotionBanner";
+import { TopicSchemaOverview } from "src/domain/topic";
+import userEvent from "@testing-library/user-event";
+
+const schemaPromotionDetailsBase: TopicSchemaOverview["schemaPromotionDetails"] =
+  {
+    status: "SUCCESS",
+    sourceEnv: "DEV",
+    targetEnv: "TST",
+    targetEnvId: "2",
+  };
+
+describe("SchemaPromotionBanner", () => {
+  const user = userEvent.setup();
+
+  const mockSetShowSchemaPromotionModal = jest.fn();
+  afterEach(() => {
+    jest.resetAllMocks();
+    cleanup();
+  });
+
+  it("renders correct banner (promote schema)", () => {
+    render(
+      <SchemaPromotionBanner
+        schemaPromotionDetails={schemaPromotionDetailsBase}
+        topicName={"my-test-topic"}
+        setShowSchemaPromotionModal={mockSetShowSchemaPromotionModal}
+        hasOpenSchemaRequest={false}
+      />
+    );
+
+    const button = screen.getByRole("button", {
+      name: "Promote",
+    });
+
+    expect(button).toBeEnabled();
+  });
+
+  it("enables user to promote a schema", async () => {
+    render(
+      <SchemaPromotionBanner
+        schemaPromotionDetails={schemaPromotionDetailsBase}
+        topicName={"my-test-topic"}
+        setShowSchemaPromotionModal={mockSetShowSchemaPromotionModal}
+        hasOpenSchemaRequest={false}
+      />
+    );
+
+    const button = screen.getByRole("button", {
+      name: "Promote",
+    });
+
+    await user.click(button);
+
+    expect(mockSetShowSchemaPromotionModal).toHaveBeenCalled();
+  });
+
+  it("renders correct banner (see open request)", () => {
+    render(
+      <SchemaPromotionBanner
+        schemaPromotionDetails={schemaPromotionDetailsBase}
+        topicName={"my-test-topic"}
+        setShowSchemaPromotionModal={mockSetShowSchemaPromotionModal}
+        hasOpenSchemaRequest={true}
+      />
+    );
+
+    const button = screen.queryByRole("button", {
+      name: "Promote",
+    });
+    const link = screen.getByRole("link", {
+      name: "See the request",
+    });
+
+    expect(link).toBeEnabled();
+    expect(link).toHaveAttribute(
+      "href",
+      `/requests/schemas?search=my-test-topic&status=CREATED&page=1`
+    );
+    expect(button).not.toBeInTheDocument();
+  });
+
+  it("renders correct banner (see open promotion request)", () => {
+    render(
+      <SchemaPromotionBanner
+        schemaPromotionDetails={{
+          ...schemaPromotionDetailsBase,
+          status: "REQUEST_OPEN",
+        }}
+        topicName={"my-test-topic"}
+        setShowSchemaPromotionModal={mockSetShowSchemaPromotionModal}
+        hasOpenSchemaRequest={false}
+      />
+    );
+
+    const button = screen.queryByRole("button", {
+      name: "Promote",
+    });
+    const link = screen.getByRole("link", {
+      name: "See the request",
+    });
+
+    expect(link).toBeEnabled();
+    expect(link).toHaveAttribute(
+      "href",
+      `/requests/schemas?search=my-test-topic&requestType=PROMOTE&status=CREATED&page=1`
+    );
+    expect(button).not.toBeInTheDocument();
+  });
+
+  it("renders nothing if status === 'NO_PROMOTION'", () => {
+    render(
+      <SchemaPromotionBanner
+        schemaPromotionDetails={{
+          ...schemaPromotionDetailsBase,
+          status: "NO_PROMOTION",
+        }}
+        topicName={"my-test-topic"}
+        setShowSchemaPromotionModal={mockSetShowSchemaPromotionModal}
+        hasOpenSchemaRequest={false}
+      />
+    );
+
+    const wrapper = screen.getByTestId("schema-promotion-banner");
+
+    expect(wrapper).toBeEmptyDOMElement();
+  });
+});

--- a/coral/src/app/features/topics/details/schema/components/SchemaPromotionBanner.test.tsx
+++ b/coral/src/app/features/topics/details/schema/components/SchemaPromotionBanner.test.tsx
@@ -3,6 +3,12 @@ import { SchemaPromotionBanner } from "src/app/features/topics/details/schema/co
 import { TopicSchemaOverview } from "src/domain/topic";
 import userEvent from "@testing-library/user-event";
 
+const mockedNavigate = jest.fn();
+jest.mock("react-router-dom", () => ({
+  ...jest.requireActual("react-router-dom"),
+  useNavigate: () => mockedNavigate,
+}));
+
 const schemaPromotionDetailsBase: TopicSchemaOverview["schemaPromotionDetails"] =
   {
     status: "SUCCESS",
@@ -66,19 +72,36 @@ describe("SchemaPromotionBanner", () => {
       />
     );
 
-    const button = screen.queryByRole("button", {
+    const buttonPromote = screen.queryByRole("button", {
       name: "Promote",
     });
-    const link = screen.getByRole("link", {
+    const buttonSeeRequest = screen.getByRole("button", {
       name: "See the request",
     });
 
-    expect(link).toBeEnabled();
-    expect(link).toHaveAttribute(
-      "href",
+    expect(buttonSeeRequest).toBeEnabled();
+    expect(buttonPromote).not.toBeInTheDocument();
+  });
+
+  it("enables navigating correctly (see open request)", async () => {
+    render(
+      <SchemaPromotionBanner
+        schemaPromotionDetails={schemaPromotionDetailsBase}
+        topicName={"my-test-topic"}
+        setShowSchemaPromotionModal={mockSetShowSchemaPromotionModal}
+        hasOpenSchemaRequest={true}
+      />
+    );
+
+    const button = screen.getByRole("button", {
+      name: "See the request",
+    });
+
+    await user.click(button);
+
+    expect(mockedNavigate).toHaveBeenCalledWith(
       `/requests/schemas?search=my-test-topic&status=CREATED&page=1`
     );
-    expect(button).not.toBeInTheDocument();
   });
 
   it("renders correct banner (see open promotion request)", () => {
@@ -94,19 +117,39 @@ describe("SchemaPromotionBanner", () => {
       />
     );
 
-    const button = screen.queryByRole("button", {
+    const buttonPromote = screen.queryByRole("button", {
       name: "Promote",
     });
-    const link = screen.getByRole("link", {
+    const buttonSeeRequest = screen.getByRole("button", {
       name: "See the request",
     });
 
-    expect(link).toBeEnabled();
-    expect(link).toHaveAttribute(
-      "href",
+    expect(buttonSeeRequest).toBeEnabled();
+    expect(buttonPromote).not.toBeInTheDocument();
+  });
+
+  it("enables navigating correctly (see open promotion request)", async () => {
+    render(
+      <SchemaPromotionBanner
+        schemaPromotionDetails={{
+          ...schemaPromotionDetailsBase,
+          status: "REQUEST_OPEN",
+        }}
+        topicName={"my-test-topic"}
+        setShowSchemaPromotionModal={mockSetShowSchemaPromotionModal}
+        hasOpenSchemaRequest={false}
+      />
+    );
+
+    const button = screen.getByRole("button", {
+      name: "See the request",
+    });
+
+    await user.click(button);
+
+    expect(mockedNavigate).toHaveBeenCalledWith(
       `/requests/schemas?search=my-test-topic&requestType=PROMOTE&status=CREATED&page=1`
     );
-    expect(button).not.toBeInTheDocument();
   });
 
   it("renders nothing if status === 'NO_PROMOTION'", () => {

--- a/coral/src/app/features/topics/details/schema/components/SchemaPromotionBanner.tsx
+++ b/coral/src/app/features/topics/details/schema/components/SchemaPromotionBanner.tsx
@@ -22,7 +22,7 @@ const SchemaPromotionBanner = ({
   return (
     <div data-testid={"schema-promotion-banner"}>
       <PromotionBanner
-        topicName={topicName}
+        entityName={topicName}
         promotionDetails={schemaPromotionDetails}
         hasOpenRequest={hasOpenSchemaRequest}
         type={"schema"}

--- a/coral/src/app/features/topics/details/schema/components/SchemaPromotionBanner.tsx
+++ b/coral/src/app/features/topics/details/schema/components/SchemaPromotionBanner.tsx
@@ -1,0 +1,39 @@
+import { Button } from "@aivenio/aquarium";
+import { TopicSchemaOverview } from "src/domain/topic";
+import { PromotionBanner } from "src/app/features/topics/details/components/PromotionBanner";
+
+interface SchemaPromotionBannerProps {
+  schemaPromotionDetails: TopicSchemaOverview["schemaPromotionDetails"];
+  /** In case there is an open request for this schema
+   * it can't be promoted, and we want to show that
+   * information to the user.
+   */
+  hasOpenSchemaRequest: boolean;
+  topicName: string;
+  setShowSchemaPromotionModal: () => void;
+}
+
+const SchemaPromotionBanner = ({
+  schemaPromotionDetails,
+  hasOpenSchemaRequest,
+  topicName,
+  setShowSchemaPromotionModal,
+}: SchemaPromotionBannerProps) => {
+  return (
+    <div data-testid={"schema-promotion-banner"}>
+      <PromotionBanner
+        topicName={topicName}
+        promotionDetails={schemaPromotionDetails}
+        hasOpenRequest={hasOpenSchemaRequest}
+        type={"schema"}
+        promoteElement={
+          <Button.Primary onClick={setShowSchemaPromotionModal}>
+            Promote
+          </Button.Primary>
+        }
+      />
+    </div>
+  );
+};
+
+export { SchemaPromotionBanner };

--- a/coral/src/app/features/topics/details/schema/components/SchemaPromotionBanner.tsx
+++ b/coral/src/app/features/topics/details/schema/components/SchemaPromotionBanner.tsx
@@ -11,6 +11,8 @@ interface SchemaPromotionBannerProps {
   hasOpenSchemaRequest: boolean;
   topicName: string;
   setShowSchemaPromotionModal: () => void;
+  hasError?: boolean;
+  errorMessage?: string;
 }
 
 const SchemaPromotionBanner = ({
@@ -18,6 +20,8 @@ const SchemaPromotionBanner = ({
   hasOpenSchemaRequest,
   topicName,
   setShowSchemaPromotionModal,
+  hasError = false,
+  errorMessage = "",
 }: SchemaPromotionBannerProps) => {
   return (
     <div data-testid={"schema-promotion-banner"}>
@@ -26,6 +30,8 @@ const SchemaPromotionBanner = ({
         promotionDetails={schemaPromotionDetails}
         hasOpenRequest={hasOpenSchemaRequest}
         type={"schema"}
+        hasError={hasError}
+        errorMessage={errorMessage}
         promoteElement={
           <Button.Primary onClick={setShowSchemaPromotionModal}>
             Promote

--- a/coral/src/domain/promotion/index.ts
+++ b/coral/src/domain/promotion/index.ts
@@ -1,0 +1,3 @@
+import { PromotionStatus } from "src/domain/promotion/promotion-types";
+
+export type { PromotionStatus };

--- a/coral/src/domain/promotion/promotion-types.ts
+++ b/coral/src/domain/promotion/promotion-types.ts
@@ -1,0 +1,5 @@
+import { KlawApiModel } from "types/utils";
+
+type PromotionStatus = KlawApiModel<"PromotionStatus">;
+
+export type { PromotionStatus };


### PR DESCRIPTION
# About this change - What it does

- adds a shared component `PromotionBanner` to be used for topics as well as schemas
    - PromotionBanner takes the `PromotionStatus` as well as `hasOpenRequest` and based on that decides what to show. It's up to the components using `PromotionBanner` to decide if it should not be rendered at all because the user is not topicOwner
    - it takes `topicName` as explicit prop. The `topicName` is available on promotion details for topics, but not for schemas.  
- updated `TopicPromotionBanner` to use `PromotionBanner`  internally.  
    - `TopicPromotionBanner`  is responsible for passing the right promote element (which differs for topic and schema) as well as passing the right properties through. I left this as a separate component because that way it is easier to tests this well without making the tests for `TopicOverview` more complex. I used a `data-testid` to enable easier testing in `TopicOverview`. 
-   I updated the test in `TopicOverview` to not only use snapshots but confirm the rendering/absence of banner explicitly. 
- added `SchemaPromotionBanner` with use of `PromotionBanner`  internally (same explanation as above)
- updated `TopicDetailsSchema` to use the new component


### Note: 
There will be a follow up by backend to add  `hasOpenSchemaRequests` to topicInfos, matching the existing properties. For now, we can check for  `hasOpenRequest && !hasOpenACLRequest && !hasOpenTopicReques` -> if `hasOpenRequest` is true but `hasOpenAclRequest` and `hasOpenTopicRequest` are both false, the only open request is a schema request.  

Doing a small follow up for this change does remove pressure from backend to do that urgently. We also don't need to wait for the BE change to be merged (and for testing stating to be updated).